### PR TITLE
Remove `print-init` subcommand from `swift-parser-cli`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -142,8 +142,7 @@ let package = Package(
     ),
     .executableTarget(
       name: "swift-parser-cli",
-      dependencies: ["_SwiftSyntaxTestSupport", "SwiftDiagnostics",
-                     "SwiftSyntax", "SwiftParser", "SwiftOperators",
+      dependencies: ["SwiftDiagnostics", "SwiftSyntax", "SwiftParser", "SwiftOperators",
                      .product(name: "ArgumentParser", package: "swift-argument-parser")]
     ),
     .testTarget(

--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _SwiftSyntaxTestSupport
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftParser
@@ -187,45 +186,6 @@ class PrintDiags: ParsableCommand {
       if diags.isEmpty {
         print("No diagnostics produced")
       }
-    }
-  }
-}
-
-class PrintInitCall: ParsableCommand {
-  static var configuration = CommandConfiguration(
-    commandName: "print-init",
-    abstract: "Print a Swift expression that creates this tree"
-  )
-
-  required init() {}
-
-  @Argument(help: "The source file that should be parsed; if omitted, use stdin")
-  var sourceFile: String?
-
-  @Option(name: .long, help: "Interpret input according to a specific Swift language version number")
-  var swiftVersion: String?
-
-  @Option(name: .long, help: "Enable or disable the use of forward slash regular-expression literal syntax")
-  var enableBareSlashRegex: Bool?
-
-  @Flag(name: .long, help: "Perform sequence folding with the standard operators")
-  var foldSequences: Bool = false
-
-  func run() throws {
-    let source = try getContentsOfSourceFile(at: sourceFile)
-
-    try source.withUnsafeBufferPointer { sourceBuffer in
-      var tree = try Parser.parse(
-        source: sourceBuffer,
-        languageVersion: swiftVersion,
-        enableBareSlashRegexLiteral: enableBareSlashRegex
-      )
-
-      if foldSequences {
-        tree = foldAllSequences(tree).0.as(SourceFileSyntax.self)!
-      }
-
-      print(tree.debugInitCall)
     }
   }
 }


### PR DESCRIPTION
`debugInitCall`, which is the backbone of `swift-parser-cli` is defined in `_SwiftSyntaxTestSupport`, which links against XCTest. If `swift-parser-cli` links against `_SwiftSyntaxTestSupport`, it also links against `XCTest`, causing its execution to fail with a dyld error outside of Xcode.

The solution would be to move `debugInitCall` into a new module that `swift-parser-cli` can link against but IMHO the `print-init` subcommand doesn’t provide sufficent value for that since you most likely want to use it in test cases where you can use a debugger command to get the `debugInitCall` result: `e print(tree.debugInitCall)`.