### PR TITLE
Diagnose ';' statements

### DIFF
--- a/Sources/SwiftParser/Diagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParser/Diagnostics/DiagnosticExtensions.swift
@@ -37,7 +37,7 @@ extension FixIt.Changes {
         newNode: Syntax(TokenSyntax(node.tokenKind, leadingTrivia: [], trailingTrivia: [], presence: .missing))
       )
     ]
-    if !node.leadingTrivia.isEmpty, let nextToken = node.nextToken(viewMode: .sourceAccurate) {
+    if !node.leadingTrivia.isEmpty, let nextToken = node.nextToken(viewMode: .sourceAccurate), !nextToken.leadingTrivia.contains(where: { $0.isNewline }) {
       changes.append(.replaceLeadingTrivia(token: nextToken, newTrivia: node.leadingTrivia))
     }
     return FixIt.Changes(changes: changes)

--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -232,6 +232,13 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
         handledNodes.append(semicolon.id)
       }
     }
+    if let semicolon = node.semicolon, semicolon.presence == .present, node.item.isMissingAllTokens {
+      addDiagnostic(node, .stanaloneSemicolonStatement, fixIts: [
+        FixIt(message: RemoveTokensFixIt(tokensToRemove: [semicolon]), changes: [
+          .makeMissing(node: semicolon)
+        ])
+      ], handledNodes: [node.item.id])
+    }
     return .visitChildren
   }
 

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -72,6 +72,7 @@ public enum StaticParserError: String, DiagnosticMessage {
   case editorPlaceholderInSourceFile = "editor placeholder in source file"
   case missingColonInTernaryExprDiagnostic = "expected ':' after '? ...' in ternary expression"
   case missingFunctionParameterClause = "expected argument list in function declaration"
+  case stanaloneSemicolonStatement = "';' statements are not allowed"
   case throwsInReturnPosition = "'throws' may only occur before '->'"
   case tryMustBePlacedOnReturnedExpr = "'try' must be placed on the returned expression"
   case tryMustBePlacedOnThrownExpr = "'try' must be placed on the thrown expression"

--- a/Tests/SwiftParserTest/translated/SwitchTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchTests.swift
@@ -228,17 +228,22 @@ final class SwitchTests: XCTestCase {
   func testSwitch15() {
     AssertParse(
       """
-      switch x { 
-      case 0:1️⃣
-        ; 
+      switch x {
+      case 0:
+        1️⃣;
       case 1:
         x = 0
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected expression in switch case"),
-        // TODO: Old parser expected error on line 3: ';' statements are not allowed, Fix-It replacements: 3 - 5 = ''
-      ]
+        DiagnosticSpec(message: "';' statements are not allowed", fixIts: ["remove ';'"]),
+      ], fixedSource: """
+      switch x {
+      case 0:
+      case 1:
+        x = 0
+      }
+      """
     )
   }
 


### PR DESCRIPTION
Add diagnostics for code block items that only contain a semicolon.