### PR TITLE
Improve description of unexpected nodes in diagnostics

### DIFF
--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -107,11 +107,7 @@ public struct ExtaneousCodeAtTopLevel: ParserError {
   public let extraneousCode: UnexpectedNodesSyntax
 
   public var message: String {
-    if let shortContent = extraneousCode.contentForDiagnosticsIfShortSingleLine {
-      return "extraneous '\(shortContent)' at top level"
-    } else {
-      return "extraneous code at top level"
-    }
+    return "extraneous \(extraneousCode.shortSingleLineContentDescription) at top level"
   }
 }
 
@@ -153,10 +149,7 @@ public struct UnexpectedNodesError: ParserError {
   public let unexpectedNodes: UnexpectedNodesSyntax
 
   public var message: String {
-    var message = "unexpected text"
-    if let shortContent = unexpectedNodes.contentForDiagnosticsIfShortSingleLine {
-      message += " '\(shortContent)'"
-    }
+    var message = "unexpected \(unexpectedNodes.shortSingleLineContentDescription)"
     if let parent = unexpectedNodes.parent {
       if let parentTypeName = parent.nodeTypeNameForDiagnostics(allowBlockNames: false), parent.children(viewMode: .sourceAccurate).first?.id == unexpectedNodes.id {
         message += " before \(parentTypeName)"

--- a/Sources/SwiftParser/Diagnostics/SyntaxExtensions.swift
+++ b/Sources/SwiftParser/Diagnostics/SyntaxExtensions.swift
@@ -70,15 +70,23 @@ extension SyntaxProtocol {
     return syntax.as(SyntaxEnum.self).nameForDiagnostics
   }
 
+  /// A short description of this node that can be displayed inline in a single line.
   /// If the syntax node (excluding leading and trailing trivia) only spans a
   /// single line and has less than 100 characters (and thus fits into a
-  /// diagnostic message), return that. Otherwise, return `nil`.
-  var contentForDiagnosticsIfShortSingleLine: String? {
+  /// diagnostic message), return that.
+  /// Otherwise, return a generic message that describes the tokens in this node.
+  var shortSingleLineContentDescription: String {
     let contentWithoutTrivia = self.withoutLeadingTrivia().withoutTrailingTrivia().description
-    if contentWithoutTrivia.contains("\n") || contentWithoutTrivia.count > 100 {
-      return nil
+    if self.children(viewMode: .sourceAccurate).allSatisfy({ $0.as(TokenSyntax.self)?.tokenKind == .rightBrace }) {
+      if self.children(viewMode: .sourceAccurate).count == 1 {
+        return "brace"
+      } else {
+        return "braces"
+      }
+    } else if contentWithoutTrivia.contains("\n") || contentWithoutTrivia.count > 100 {
+      return "code"
     } else {
-      return contentWithoutTrivia
+      return "code '\(contentWithoutTrivia)'"
     }
   }
 

--- a/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
@@ -86,7 +86,7 @@ final class DiagnosticsFormatterTests: XCTestCase {
     let expectedOutput = """
     1 │ t as (..)
       ∣       ├─ expected type in tuple type
-      ∣       ╰─ unexpected text '..' in tuple type
+      ∣       ╰─ unexpected code '..' in tuple type
     
     """
 

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -239,7 +239,11 @@ func AssertDiagnostic<T: SyntaxProtocol>(
       """)
   }
   if let highlight = spec.highlight {
-    AssertStringsEqualWithDiff(diag.highlights.map(\.description).joined(), highlight, file: file, line: line)
+    AssertStringsEqualWithDiff(
+      diag.highlights.map(\.description).joined().trimmingTrailingWhitespace(),
+      highlight.trimmingTrailingWhitespace(),
+      file: file, line: line
+    )
   }
   if let notes = spec.notes {
     if diag.notes.count != notes.count {

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -56,7 +56,7 @@ final class DeclarationTests: XCTestCase {
       "func 1️⃣/^notoperator^/ (lhs: Int, rhs: Int) -> Int { 1 / 2 }",
       diagnostics: [
         DiagnosticSpec(message: "expected identifier in function"),
-        DiagnosticSpec(message: "unexpected text '/^notoperator^/' before parameter clause")
+        DiagnosticSpec(message: "unexpected code '/^notoperator^/' before parameter clause")
       ]
     )
 
@@ -70,7 +70,7 @@ final class DeclarationTests: XCTestCase {
       func foo() {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "unexpected text '}' before function")
+        DiagnosticSpec(message: "unexpected brace before function")
       ]
     )
   }
@@ -132,7 +132,7 @@ final class DeclarationTests: XCTestCase {
       actor Foo {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "unexpected text '}' before actor")
+        DiagnosticSpec(message: "unexpected brace before actor")
       ]
     )
   }
@@ -158,7 +158,7 @@ final class DeclarationTests: XCTestCase {
     AssertParse(
       "protocol P{1️⃣{}case2️⃣",
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '{}' before enum case"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '{}' before enum case"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in enum case"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected '}' to end protocol"),
       ])
@@ -264,7 +264,7 @@ final class DeclarationTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected 'set' in modifier"),
-        DiagnosticSpec(message: "unexpected text 'get' in modifier")
+        DiagnosticSpec(message: "unexpected code 'get' in modifier")
       ]
     )
 
@@ -277,7 +277,7 @@ final class DeclarationTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(message: "expected 'set)' to end modifier"),
         // FIXME: It should print `+` as detail of text.
-        DiagnosticSpec(message: "unexpected text in variable")
+        DiagnosticSpec(message: "unexpected code in variable")
       ]
     )
 
@@ -286,7 +286,7 @@ final class DeclarationTests: XCTestCase {
       private(1️⃣get, set) var a = 0
       """,
       diagnostics: [
-        DiagnosticSpec(message: "unexpected text 'get,' in modifier")
+        DiagnosticSpec(message: "unexpected code 'get,' in modifier")
       ]
     )
 
@@ -295,7 +295,7 @@ final class DeclarationTests: XCTestCase {
       private(1️⃣get: set) var a = 0
       """,
       diagnostics: [
-        DiagnosticSpec(message: "unexpected text 'get:' in modifier")
+        DiagnosticSpec(message: "unexpected code 'get:' in modifier")
       ]
     )
 
@@ -304,7 +304,7 @@ final class DeclarationTests: XCTestCase {
       1️⃣private(
       """,
       diagnostics: [
-        DiagnosticSpec(message: "extraneous 'private(' at top level")
+        DiagnosticSpec(message: "extraneous code 'private(' at top level")
       ]
     )
 
@@ -322,8 +322,8 @@ final class DeclarationTests: XCTestCase {
       private(1️⃣get, set2️⃣, didSet) var a = 0
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text 'get,' in modifier"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text ', didSet' in modifier")
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code 'get,' in modifier"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code ', didSet' in modifier")
       ]
     )
 
@@ -333,7 +333,7 @@ final class DeclarationTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected 'set)' to end modifier"),
-        DiagnosticSpec(message: "unexpected text 'get, didSet' in variable")
+        DiagnosticSpec(message: "unexpected code 'get, didSet' in variable")
       ]
     )
   }
@@ -585,7 +585,7 @@ final class DeclarationTests: XCTestCase {
       "(first second 1️⃣third fourth: Int)",
       { $0.parseFunctionSignature() },
       diagnostics: [
-        DiagnosticSpec(message: "unexpected text 'third fourth' in function parameter")
+        DiagnosticSpec(message: "unexpected code 'third fourth' in function parameter")
       ]
     )
   }
@@ -664,7 +664,7 @@ final class DeclarationTests: XCTestCase {
       1️⃣}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "extraneous '}' at top level")
+        DiagnosticSpec(message: "extraneous brace at top level")
       ]
     )
   }
@@ -722,7 +722,7 @@ final class DeclarationTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: #"unexpected text '/ ###line 25 "line-directive.swift"' in struct"#)
+        DiagnosticSpec(locationMarker: "1️⃣", message: #"unexpected code '/ ###line 25 "line-directive.swift"' in struct"#)
       ]
     )
   }
@@ -735,7 +735,7 @@ final class DeclarationTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "unexpected text 'bogus rethrows set' in variable")
+        DiagnosticSpec(message: "unexpected code 'bogus rethrows set' in variable")
       ]
     )
   }
@@ -750,7 +750,7 @@ final class DeclarationTests: XCTestCase {
         DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "4️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "5️⃣", message: "extraneous ', consectetur adipiscing elit' at top level"),
+        DiagnosticSpec(locationMarker: "5️⃣", message: "extraneous code ', consectetur adipiscing elit' at top level"),
       ]
     )
   }
@@ -772,7 +772,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "unexpected text 'third' in function parameter")
+        DiagnosticSpec(message: "unexpected code 'third' in function parameter")
       ]
     )
   }
@@ -794,7 +794,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "unexpected text 'third fourth' in function parameter")
+        DiagnosticSpec(message: "unexpected code 'third fourth' in function parameter")
       ]
     )
   }
@@ -817,7 +817,7 @@ final class DeclarationTests: XCTestCase {
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in function parameter"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected ')' to end parameter clause"),
         DiagnosticSpec(locationMarker: "4️⃣", message: "expected identifier and member block in struct"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "extraneous ': Int) {}' at top level"),
+        DiagnosticSpec(locationMarker: "4️⃣", message: "extraneous code ': Int) {}' at top level"),
       ]
     )
   }
@@ -844,7 +844,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "unexpected text '[third fourth]' in function parameter")
+        DiagnosticSpec(message: "unexpected code '[third fourth]' in function parameter")
       ]
     )
   }
@@ -870,7 +870,7 @@ final class DeclarationTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in function parameter"),
         DiagnosticSpec(locationMarker: "2️⃣" , message: "expected ']' to end array type"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text 'fourth: Int' in parameter clause")
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code 'fourth: Int' in parameter clause")
       ]
     )
   }
@@ -895,7 +895,7 @@ final class DeclarationTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in function parameter"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous ': Int) {}' at top level")
+        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous code ': Int) {}' at top level")
       ]
     )
   }
@@ -974,7 +974,7 @@ final class DeclarationTests: XCTestCase {
     AssertParse(
       "1️⃣}class C2️⃣",
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '}' before class"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected brace before class"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in class"),
       ],
       fixedSource: """
@@ -983,37 +983,37 @@ final class DeclarationTests: XCTestCase {
     )
     AssertParse("1️⃣}enum C2️⃣",
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '}' before enum"),
+                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected brace before enum"),
                   DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in enum"),
                 ])
     AssertParse("1️⃣}protocol C2️⃣",
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '}' before protocol"),
+                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected brace before protocol"),
                   DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in protocol"),
                 ])
     AssertParse("1️⃣}actor C2️⃣",
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '}' before actor"),
+                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected brace before actor"),
                   DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in actor"),
                 ])
     AssertParse("1️⃣}struct C2️⃣",
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '}' before struct"),
+                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected brace before struct"),
                   DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in struct"),
                 ])
     AssertParse("1️⃣}func C2️⃣",
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '}' before function"),
+                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected brace before function"),
                   DiagnosticSpec(locationMarker: "2️⃣", message: "expected parameter clause in function signature"),
                 ])
     AssertParse("1️⃣}init2️⃣",
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '}' before initializer"),
+                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected brace before initializer"),
                   DiagnosticSpec(locationMarker: "2️⃣", message: "expected parameter clause in function signature"),
                 ])
     AssertParse("1️⃣}subscript2️⃣",
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '}' before subscript"),
+                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected brace before subscript"),
                   DiagnosticSpec(locationMarker: "2️⃣", message: "expected parameter clause in subscript"),
                   DiagnosticSpec(locationMarker: "2️⃣", message: "expected '->' and return type in subscript"),
                 ])
@@ -1051,7 +1051,7 @@ final class DeclarationTests: XCTestCase {
       """
       func nonEphemeralIsolatedConst(@_nonEmphemeral isolated _const _ 1️⃣map: String) {}
       """
-    )
+   )
 
     AssertParse(
       """
@@ -1069,7 +1069,7 @@ final class DeclarationTests: XCTestCase {
       """
       func isolatedConst(isolated _const map1️⃣: String) {}
       """
-    )
+   )
 
     AssertParse(
       """

--- a/Tests/SwiftParserTest/Directives.swift
+++ b/Tests/SwiftParserTest/Directives.swift
@@ -105,8 +105,8 @@ final class DirectiveTests: XCTestCase {
       #endif
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '}' before conditional compilation clause"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '}' in conditional compilation block"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected brace before conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected brace in conditional compilation block"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -315,7 +315,7 @@ final class ExpressionTests: XCTestCase {
       1️⃣"\(()
       """#,
       diagnostics: [
-        DiagnosticSpec(message: #"extraneous '"\(()' at top level"#)
+        DiagnosticSpec(message: #"extraneous code '"\(()' at top level"#)
       ]
     )
   }
@@ -339,7 +339,7 @@ final class ExpressionTests: XCTestCase {
       " >> \( abc 1️⃣} ) << "
       """#,
       diagnostics: [
-        DiagnosticSpec(message: "unexpected text '}' in string literal")
+        DiagnosticSpec(message: "unexpected brace in string literal")
       ]
     )
 
@@ -482,7 +482,7 @@ final class ExpressionTests: XCTestCase {
     AssertParse(
       ###"1️⃣"\"###,
       diagnostics: [
-        DiagnosticSpec(message: "extraneous '\"\\' at top level")
+        DiagnosticSpec(message: "extraneous code '\"\\' at top level")
       ]
     )
   }
@@ -627,7 +627,7 @@ final class ExpressionTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected pattern in variable"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in function type"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '..' in function type"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '..' in function type"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected type in function type"),
       ]
     )

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -46,7 +46,7 @@ final class StatementTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected expression, '=' and expression in pattern matching"),
-        DiagnosticSpec(message: "unexpected text '* ! = x' in 'if' statement"),
+        DiagnosticSpec(message: "unexpected code '* ! = x' in 'if' statement"),
       ]
     )
   }
@@ -214,8 +214,8 @@ final class StatementTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '@s return' in function"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '@unknown return' in function")
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '@s return' in function"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '@unknown return' in function")
       ]
     )
   }
@@ -233,7 +233,7 @@ final class StatementTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text 'foo()' before conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code 'foo()' before conditional compilation clause"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "all statements inside a switch must be covered by a 'case' or 'default' label"),
       ]
     )
@@ -253,7 +253,7 @@ final class StatementTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "unexpected text 'print()' before conditional compilation clause")
+        DiagnosticSpec(message: "unexpected code 'print()' before conditional compilation clause")
       ]
     )
   }
@@ -262,7 +262,7 @@ final class StatementTests: XCTestCase {
     AssertParse(
       "LABEL1️⃣:",
       diagnostics: [
-        DiagnosticSpec(message: "extraneous ':' at top level")
+        DiagnosticSpec(message: "extraneous code ':' at top level")
       ]
     )
   }

--- a/Tests/SwiftParserTest/Types.swift
+++ b/Tests/SwiftParserTest/Types.swift
@@ -42,7 +42,7 @@ final class TypeTests: XCTestCase {
   func testFunctionTypes() throws {
     AssertParse("t as(1️⃣..)->2️⃣", diagnostics: [
       DiagnosticSpec(locationMarker: "1️⃣", message: "expected type in function type"),
-      DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '..' in function type"),
+      DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '..' in function type"),
       DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in function type"),
     ])
   }
@@ -71,21 +71,21 @@ final class TypeTests: XCTestCase {
                 { $0.parseClosureExpression() },
                 diagnostics: [
                   DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in closure capture item"),
-                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text 'class' in closure capture signature"),
+                  DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code 'class' in closure capture signature"),
                   DiagnosticSpec(locationMarker: "2️⃣", message: "expected '}' to end closure"),
                 ])
 
     AssertParse("{[n1️⃣`]in}",
                 { $0.parseClosureExpression() },
                 diagnostics: [
-                  DiagnosticSpec(message: "unexpected text '`' in closure capture signature")
+                  DiagnosticSpec(message: "unexpected code '`' in closure capture signature")
                 ])
 
     AssertParse("{[weak1️⃣^]in}",
                 { $0.parseClosureExpression() },
                 diagnostics: [
                   DiagnosticSpec(message: "expected identifier in closure capture item"),
-                  DiagnosticSpec(message: "unexpected text '^' in closure capture signature"),
+                  DiagnosticSpec(message: "unexpected code '^' in closure capture signature"),
                 ])
   }
 

--- a/Tests/SwiftParserTest/translated/AsyncTests.swift
+++ b/Tests/SwiftParserTest/translated/AsyncTests.swift
@@ -71,7 +71,7 @@ final class AsyncTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: 'throws' may only occur before '->', Fix-It replacements: 28 - 35 = '', 21 - 21 = 'throws '
         // TODO: Old parser expected error on line 1: 'async' may only occur before '->', Fix-It replacements: 35 - 41 = '', 21 - 21 = 'async '
-        DiagnosticSpec(message: "extraneous 'throws async { }' at top level"),
+        DiagnosticSpec(message: "extraneous code 'throws async { }' at top level"),
       ]
     )
   }
@@ -126,12 +126,12 @@ final class AsyncTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 3: deinitializers cannot have a name
         DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive declarations on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '{ }' in function"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '{ }' in function"),
         // TODO: Old parser expected error on line 5: expected '->' for subscript element type
         // TODO: Old parser expected error on line 5: single argument function types require parentheses
         // TODO: Old parser expected error on line 5: cannot find type 'async' in scope
         // TODO: Old parser expected note on line 5: cannot use module 'async' as a type
-        DiagnosticSpec(locationMarker: "4️⃣", message: "unexpected text 'async' in subscript"),
+        DiagnosticSpec(locationMarker: "4️⃣", message: "unexpected code 'async' in subscript"),
         // TODO: Old parser expected error on line 9: 'set' accessor cannot have specifier 'async'
       ]
     )
@@ -177,7 +177,7 @@ final class AsyncTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 5: 'async' must precede 'throws', Fix-It replacements: 22 - 28 = '', 15 - 15 = 'async '
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text 'async' in array element"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code 'async' in array element"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "'async' may only occur before '->'"),
       ]
     )

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
@@ -21,7 +21,7 @@ final class AvailabilityQueryTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 2: #available may only be used as condition of an 'if', 'guard'
         DiagnosticSpec(message: "expected value in tuple"),
-        DiagnosticSpec(message: "unexpected text '#available(OSX 10.51, *)' in tuple"),
+        DiagnosticSpec(message: "unexpected code '#available(OSX 10.51, *)' in tuple"),
       ]
     )
   }
@@ -34,7 +34,7 @@ final class AvailabilityQueryTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: #available may only be used as condition of
         DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: "extraneous '#available(OSX 10.51, *)' at top level"),
+        DiagnosticSpec(message: "extraneous code '#available(OSX 10.51, *)' at top level"),
       ]
     )
   }
@@ -47,7 +47,7 @@ final class AvailabilityQueryTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: #available may only be used as condition of an
         DiagnosticSpec(message: "expected value in tuple"),
-        DiagnosticSpec(message: "unexpected text '#available(OSX 10.51, *) ? 1 : 0' in tuple"),
+        DiagnosticSpec(message: "unexpected code '#available(OSX 10.51, *) ? 1 : 0' in tuple"),
       ]
     )
   }
@@ -63,10 +63,10 @@ final class AvailabilityQueryTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: #available cannot be used as an expression, did you mean to use '#unavailable'?, Fix-It replacements: 4 - 15 = '#unavailable'
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected expression in prefix operator expression"),
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '#available(OSX 10.52, *)' in 'if' statement"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '#available(OSX 10.52, *)' in 'if' statement"),
         // TODO: Old parser expected error on line 3: #available cannot be used as an expression, did you mean to use '#unavailable'?, Fix-It replacements: 25 - 36 = '#unavailable'
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in prefix operator expression"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '#available(OSX 10.52, *)' in 'if' statement"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '#available(OSX 10.52, *)' in 'if' statement"),
       ]
     )
   }
@@ -79,7 +79,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected ',' joining parts of a multi-clause condition, Fix-It replacements: 28 - 31 = ','
-        DiagnosticSpec(message: "unexpected text '&& #available(OSX 10.52, *)' in 'if' statement"),
+        DiagnosticSpec(message: "unexpected code '&& #available(OSX 10.52, *)' in 'if' statement"),
       ]
     )
   }
@@ -373,7 +373,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: '||' cannot be used in an availability condition
-        DiagnosticSpec(message: "unexpected text '|| iOS 8.0' in '#availabile' condition"),
+        DiagnosticSpec(message: "unexpected code '|| iOS 8.0' in '#availabile' condition"),
       ]
     )
   }
@@ -394,7 +394,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: version comparison not needed, Fix-It replacements: 19 - 22 = ''
-        DiagnosticSpec(message: "unexpected text '>= 10.51, *' in '#availabile' condition"),
+        DiagnosticSpec(message: "unexpected code '>= 10.51, *' in '#availabile' condition"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -31,10 +31,10 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
         // TODO: Old parser expected error on line 2: platform wildcard '*' is always implicit in #unavailable, Fix-It replacements: 28 - 29 = ''
         // TODO: Old parser expected error on line 4: #unavailable may only be used as condition of an 'if', 'guard'
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected value in tuple"),
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '#unavailable(OSX 10.51)' in tuple"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '#unavailable(OSX 10.51)' in tuple"),
         // TODO: Old parser expected error on line 5: #unavailable may only be used as condition of
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected expression in variable"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text before variable"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code before variable"),
         // TODO: Old parser expected error on line 6: #unavailable may only be used as condition of an
         // TODO: Old parser expected error on line 7: #unavailable may only be used as condition of an
         // TODO: Old parser expected error on line 9: #unavailable may only be used as condition
@@ -53,7 +53,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected ',' joining parts of a multi-clause condition, Fix-It replacements: 27 - 30 = ','
-        DiagnosticSpec(message: "unexpected text '&& #unavailable(OSX 10.52)' in 'if' statement"),
+        DiagnosticSpec(message: "unexpected code '&& #unavailable(OSX 10.52)' in 'if' statement"),
       ]
     )
   }
@@ -339,7 +339,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: '||' cannot be used in an availability condition
-        DiagnosticSpec(message: "unexpected text '|| iOS 8.0' in '#unavailable' condition"),
+        DiagnosticSpec(message: "unexpected code '|| iOS 8.0' in '#unavailable' condition"),
       ]
     )
   }
@@ -353,7 +353,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: version comparison not needed, Fix-It replacements: 21 - 24 = ''
-        DiagnosticSpec(message: "unexpected text '>= 10.51' in '#unavailable' condition"),
+        DiagnosticSpec(message: "unexpected code '>= 10.51' in '#unavailable' condition"),
       ]
     )
   }
@@ -440,10 +440,10 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: #available cannot be used as an expression, did you mean to use '#unavailable'?, Fix-It replacements: 4 - 14 = '#unavailable', 18 - 27 = ''
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '== false' in 'if' statement"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '== false' in 'if' statement"),
         // TODO: Old parser expected error on line 4: #available cannot be used as an expression, did you mean to use '#unavailable'?, Fix-It replacements: 4 - 15 = '#unavailable'
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in prefix operator expression"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '#available(*)' in 'if' statement"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '#available(*)' in 'if' statement"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/ConflictMarkersTests.swift
+++ b/Tests/SwiftParserTest/translated/ConflictMarkersTests.swift
@@ -69,7 +69,7 @@ final class ConflictMarkersTests: XCTestCase {
       """#,
       diagnostics: [
         // TODO: Old parser expected error on line 1: source control conflict marker in source file
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '<<<<<<< HEAD:conflict_markers.swift' before variable"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '<<<<<<< HEAD:conflict_markers.swift' before variable"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in variable"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected expression in variable"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous code at top level"),
@@ -88,7 +88,7 @@ final class ConflictMarkersTests: XCTestCase {
       """#,
       diagnostics: [
         // TODO: Old parser expected error on line 1: source control conflict marker in source file
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text before variable"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code before variable"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in variable"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code at top level"),
       ]
@@ -120,7 +120,7 @@ final class ConflictMarkersTests: XCTestCase {
       """#,
       diagnostics: [
         // TODO: Old parser expected error on line 1: source control conflict marker in source file
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text before variable"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code before variable"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code at top level"),
       ]
@@ -183,7 +183,7 @@ final class ConflictMarkersTests: XCTestCase {
       """#,
       diagnostics: [
         // TODO: Old parser expected error on line 1: source control conflict marker in source file
-        DiagnosticSpec(message: "unexpected text '>>>> ORIGINAL' before variable"),
+        DiagnosticSpec(message: "unexpected code '>>>> ORIGINAL' before variable"),
       ]
     )
   }
@@ -200,7 +200,7 @@ final class ConflictMarkersTests: XCTestCase {
       """#,
       diagnostics: [
         // TODO: Old parser expected error on line 1: source control conflict marker in source file
-        DiagnosticSpec(message: "unexpected text before variable"),
+        DiagnosticSpec(message: "unexpected code before variable"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
+++ b/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
@@ -183,7 +183,7 @@ final class DeprecatedWhereTests: XCTestCase {
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected '>' to end generic parameter clause"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected parameter clause in function signature"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier and member block in protocol"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous '<ProtoA, ProtoB> where T: ProtoC>(x: T) {}' at top level"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous code '<ProtoA, ProtoB> where T: ProtoC>(x: T) {}' at top level"),
       ]
     )
   }
@@ -200,7 +200,7 @@ final class DeprecatedWhereTests: XCTestCase {
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected '>' to end generic parameter clause"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected parameter clause in function signature"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier and member block in protocol"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous '<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {}' at top level"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous code '<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {}' at top level"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/DiagnoseInitializerAsTypedPatternTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseInitializerAsTypedPatternTests.swift
@@ -49,7 +49,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' ='
         DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous ', ee: Int' at top level"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code ', ee: Int' at top level"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/DiagnosticMissingFuncKeywordTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnosticMissingFuncKeywordTests.swift
@@ -64,7 +64,7 @@ final class DiagnosticMissingFuncKeywordTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: expected 'var' keyword in property declaration, Fix-It replacements: 3 - 3 = 'var '
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text in struct"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code in struct"),
         // TODO: Old parser expected error on line 3: expected 'func' keyword in operator function declaration, Fix-It replacements: 3 - 3 = 'func '
         // TODO: Old parser expected error on line 6: expected 'var' keyword in property declaration, Fix-It replacements: 3 - 3 = 'var '
         // TODO: Old parser expected error on line 7: expected 'var' keyword in property declaration, Fix-It replacements: 3 - 3 = 'var '
@@ -103,7 +103,7 @@ final class DiagnosticMissingFuncKeywordTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: expected '{' in class
-        DiagnosticSpec(message: "unexpected text '()' in class"),
+        DiagnosticSpec(message: "unexpected code '()' in class"),
       ]
     )
   }
@@ -117,7 +117,7 @@ final class DiagnosticMissingFuncKeywordTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: expected declaration
-        DiagnosticSpec(message: "unexpected text '0' in class"),
+        DiagnosticSpec(message: "unexpected code '0' in class"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
+++ b/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
@@ -25,7 +25,7 @@ final class DollarIdentifierTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 7 - 8 = '`$`'
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected pattern in variable"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text in function"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code in function"),
         // TODO: Old parser expected error on line 3: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 3 - 4 = '`$`'
         // TODO: Old parser expected error on line 4: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 9 - 10 = '`$`'
       ]
@@ -103,12 +103,12 @@ final class DollarIdentifierTests: XCTestCase {
         // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 8 - 9 = '`$`'
         // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 10 - 11 = '`$`'
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '$' before parameter clause"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '$' before parameter clause"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in function parameter"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '$ dollarParam: Int' in parameter clause"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '$ dollarParam: Int' in parameter clause"),
         // TODO: Old parser expected error on line 3: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 3 - 4 = '`$`'
         // TODO: Old parser expected error on line 3: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 5 - 6 = '`$`'
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text ': 24' in function call"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code ': 24' in function call"),
       ]
     )
   }
@@ -161,7 +161,7 @@ final class DollarIdentifierTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 3: expected expression
-        DiagnosticSpec(message: "unexpected text in function"),
+        DiagnosticSpec(message: "unexpected code in function"),
       ]
     )
   }
@@ -236,7 +236,7 @@ final class DollarIdentifierTests: XCTestCase {
         // TODO: Old parser expected error on line 32: cannot declare entity named '$Protocol'; the '$' prefix is reserved
         // TODO: Old parser expected error on line 33: cannot declare entity named '$Precedence'; the '$' prefix is reserved
         // TODO: Old parser expected error on line 37: use of unknown directive '#$UnknownDirective'
-        DiagnosticSpec(message: "extraneous '#$UnknownDirective()' at top level"),
+        DiagnosticSpec(message: "extraneous code '#$UnknownDirective()' at top level"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/EffectfulPropertiesTests.swift
+++ b/Tests/SwiftParserTest/translated/EffectfulPropertiesTests.swift
@@ -243,7 +243,7 @@ final class EffectfulPropertiesTests: XCTestCase {
         // TODO: Old parser expected error on line 2: 'willSet' accessor cannot have specifier 'async'
         // TODO: Old parser expected error on line 2: 'willSet' accessor cannot have specifier 'rethrows'
         // TODO: Old parser expected error on line 2: 'willSet' accessor cannot have specifier 'reasync'
-        DiagnosticSpec(message: "unexpected text in variable"),
+        DiagnosticSpec(message: "unexpected code in variable"),
         // TODO: Old parser expected error on line 3: expected '{' to start 'didSet' definition
         // TODO: Old parser expected error on line 3: 'didSet' accessor cannot have specifier 'throws'
       ]
@@ -259,7 +259,7 @@ final class EffectfulPropertiesTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: expected '{' to start getter definition
-        DiagnosticSpec(message: "unexpected text 'bogus rethrows {}' in variable"),
+        DiagnosticSpec(message: "unexpected code 'bogus rethrows {}' in variable"),
       ]
     )
   }
@@ -274,7 +274,7 @@ final class EffectfulPropertiesTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 2: expected '{' to start getter definition
         // TODO: Old parser expected error on line 2: only function declarations may be marked 'rethrows'; did you mean 'throws'?
-        DiagnosticSpec(message: "unexpected text '-> Int { 0 }' in variable"),
+        DiagnosticSpec(message: "unexpected code '-> Int { 0 }' in variable"),
       ]
     )
   }
@@ -319,12 +319,12 @@ final class EffectfulPropertiesTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: expected get or set in a protocol property
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text 'bogus rethrows set' in variable"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code 'bogus rethrows set' in variable"),
         // TODO: Old parser expected error on line 3: only function declarations may be marked 'rethrows'; did you mean 'throws'?
         // TODO: Old parser expected error on line 3: expected get or set in a protocol property
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text 'bogus set' in variable"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code 'bogus set' in variable"),
         // TODO: Old parser expected error on line 4: expected get or set in a protocol property
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text 'bogus set' in variable"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code 'bogus set' in variable"),
         // TODO: Old parser expected error on line 5: 'async' must precede 'throws'
       ]
     )

--- a/Tests/SwiftParserTest/translated/EnumTests.swift
+++ b/Tests/SwiftParserTest/translated/EnumTests.swift
@@ -180,7 +180,7 @@ final class EnumTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
-        DiagnosticSpec(message: "unexpected text ':' in enum"),
+        DiagnosticSpec(message: "unexpected code ':' in enum"),
       ]
     )
   }
@@ -194,7 +194,7 @@ final class EnumTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
-        DiagnosticSpec(message: "unexpected text ':' in enum"),
+        DiagnosticSpec(message: "unexpected code ':' in enum"),
       ]
     )
   }
@@ -208,7 +208,7 @@ final class EnumTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
-        DiagnosticSpec(message: "unexpected text ':' in enum"),
+        DiagnosticSpec(message: "unexpected code ':' in enum"),
       ]
     )
   }
@@ -222,7 +222,7 @@ final class EnumTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
-        DiagnosticSpec(message: "unexpected text 'where true:' in enum"),
+        DiagnosticSpec(message: "unexpected code 'where true:' in enum"),
       ]
     )
   }
@@ -236,7 +236,7 @@ final class EnumTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
-        DiagnosticSpec(message: "unexpected text ':' in enum"),
+        DiagnosticSpec(message: "unexpected code ':' in enum"),
       ]
     )
   }
@@ -250,7 +250,7 @@ final class EnumTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
-        DiagnosticSpec(message: "unexpected text 'where true:' in enum"),
+        DiagnosticSpec(message: "unexpected code 'where true:' in enum"),
       ]
     )
   }
@@ -265,7 +265,7 @@ final class EnumTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
         DiagnosticSpec(message: "expected identifier in enum case"),
-        DiagnosticSpec(message: "unexpected text '0:' in enum"),
+        DiagnosticSpec(message: "unexpected code '0:' in enum"),
       ]
     )
   }
@@ -279,7 +279,7 @@ final class EnumTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "'_' cannot be used as an identifier here"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text ':' in enum"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code ':' in enum"),
       ]
     )
   }
@@ -296,8 +296,8 @@ final class EnumTests: XCTestCase {
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in enum case"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected ':' and type in function parameter"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected type in function parameter"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text '0' in parameter clause"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "unexpected text ':' in enum"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code '0' in parameter clause"),
+        DiagnosticSpec(locationMarker: "4️⃣", message: "unexpected code ':' in enum"),
       ]
     )
   }
@@ -365,7 +365,7 @@ final class EnumTests: XCTestCase {
         // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
         // TODO: Old parser expected error on line 2: expected pattern
         DiagnosticSpec(message: "expected identifier in enum case"),
-        DiagnosticSpec(message: "unexpected text ':' in enum"),
+        DiagnosticSpec(message: "unexpected code ':' in enum"),
       ]
     )
   }
@@ -379,7 +379,7 @@ final class EnumTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
-        DiagnosticSpec(message: "unexpected text ':' in enum"),
+        DiagnosticSpec(message: "unexpected code ':' in enum"),
       ]
     )
   }
@@ -393,7 +393,7 @@ final class EnumTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
-        DiagnosticSpec(message: "unexpected text ':' in enum"),
+        DiagnosticSpec(message: "unexpected code ':' in enum"),
       ]
     )
   }
@@ -411,7 +411,7 @@ final class EnumTests: XCTestCase {
         // TODO: Old parser expected note on line 2: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 12 = '`Self`'
         // TODO: Old parser expected error on line 2: consecutive declarations on a line must be separated by ';', Fix-It replacements: 12 - 12 = ';'
         // TODO: Old parser expected error on line 2: expected declaration
-        DiagnosticSpec(message: "unexpected text 'Self' in enum"),
+        DiagnosticSpec(message: "unexpected code 'Self' in enum"),
       ]
     )
   }
@@ -425,13 +425,13 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: extraneous '.' in enum 'case' declaration, Fix-It replacements: 8 - 9 = ''
+        // TODO: Old parser expected error on line 2: extraneous code '.' in enum 'case' declaration, Fix-It replacements: 8 - 9 = ''
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in enum case"),
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '.UE3' before enum case"),
-        // TODO: Old parser expected error on line 3: extraneous '.' in enum 'case' declaration, Fix-It replacements: 8 - 9 = ''
-        // TODO: Old parser expected error on line 3: extraneous '.' in enum 'case' declaration, Fix-It replacements: 14 - 15 = ''
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '.UE3' before enum case"),
+        // TODO: Old parser expected error on line 3: extraneous code '.' in enum 'case' declaration, Fix-It replacements: 8 - 9 = ''
+        // TODO: Old parser expected error on line 3: extraneous code '.' in enum 'case' declaration, Fix-It replacements: 14 - 15 = ''
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in enum case"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '.UE4, .UE5' in enum"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '.UE4, .UE5' in enum"),
       ]
     )
   }
@@ -1360,7 +1360,7 @@ final class EnumTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "keyword 'let' cannot be used as an identifier here"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '.foo(x, y):' in enum"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '.foo(x, y):' in enum"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/ErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/ErrorsTests.swift
@@ -130,7 +130,7 @@ final class ErrorsTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 4: expected '{'
-        DiagnosticSpec(message: "unexpected text ')' in 'catch' clause"),
+        DiagnosticSpec(message: "unexpected code ')' in 'catch' clause"),
       ]
     )
   }
@@ -187,7 +187,7 @@ final class ErrorsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: 'rethrows' may only occur before '->', Fix-It replacements: 43 - 43 = 'rethrows ', 46 - 55 = ''
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected 'rethrows' in function signature"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text 'rethrows' in function signature"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code 'rethrows' in function signature"),
       ]
     )
   }
@@ -202,7 +202,7 @@ final class ErrorsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 2: 'throws' may only occur before '->', Fix-It replacements: 19 - 26 = '', 12 - 12 = 'throws '
         DiagnosticSpec(message: "expected 'in' in closure signature"),
-        DiagnosticSpec(message: "unexpected text 'throws in' in closure"),
+        DiagnosticSpec(message: "unexpected code 'throws in' in closure"),
       ]
     )
   }
@@ -216,7 +216,7 @@ final class ErrorsTests: XCTestCase {
         // TODO: Old parser expected error on line 1: 'rethrows' has already been specified, Fix-It replacements: 26 - 35 = ''
         // TODO: Old parser expected error on line 1: 'throws' has already been specified, Fix-It replacements: 38 - 45 = ''
         // TODO: Old parser expected error on line 1: 'throw' has already been specified, Fix-It replacements: 49 - 55 = ''
-        DiagnosticSpec(message: "extraneous 'rethrows -> throws Int throw {}' at top level"),
+        DiagnosticSpec(message: "extraneous code 'rethrows -> throws Int throw {}' at top level"),
       ]
     )
   }
@@ -229,7 +229,7 @@ final class ErrorsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: 'rethrows' has already been specified, Fix-It replacements: 35 - 44 = ''
         DiagnosticSpec(message: "expected type in function type"),
-        DiagnosticSpec(message: "unexpected text 'rethrows Int' in parameter clause"),
+        DiagnosticSpec(message: "unexpected code 'rethrows Int' in parameter clause"),
       ]
     )
   }
@@ -247,7 +247,7 @@ final class ErrorsTests: XCTestCase {
         // TODO: Old parser expected error on line 2: 'throws' has already been specified, Fix-It replacements: 16 - 23 = ''
         // TODO: Old parser expected error on line 3: 'throws' has already been specified, Fix-It replacements: 26 - 33 = ''
         DiagnosticSpec(message: "expected 'in' in closure signature"),
-        DiagnosticSpec(message: "unexpected text 'throws in' in closure"),
+        DiagnosticSpec(message: "unexpected code 'throws in' in closure"),
       ]
     )
   }
@@ -263,7 +263,7 @@ final class ErrorsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 3: consecutive statements on a line must be separated by ';'
         // TODO: Old parser expected error on line 3: expected expression
-        DiagnosticSpec(message: "unexpected text 'throws' in function"),
+        DiagnosticSpec(message: "unexpected code 'throws' in function"),
       ]
     )
   }
@@ -286,7 +286,7 @@ final class ErrorsTests: XCTestCase {
         // TODO: Old parser expected error on line 3: expected throwing specifier; did you mean 'throws'?, Fix-It replacements: 20 - 25 = 'throws'
         DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected expression in 'throw' statement"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text '-> Int {}' before function"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code '-> Int {}' before function"),
         // TODO: Old parser expected error on line 7: expected throwing specifier; did you mean 'throws'?, Fix-It replacements: 16 - 21 = 'throws'
       ]
     )
@@ -300,7 +300,7 @@ final class ErrorsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: 'throws' may only occur before '->', Fix-It replacements: 12 - 12 = 'throws ', 15 - 22 = ''
         DiagnosticSpec(message: "expected type in function type"),
-        DiagnosticSpec(message: "extraneous 'throws Void' at top level"),
+        DiagnosticSpec(message: "extraneous code 'throws Void' at top level"),
       ]
     )
   }
@@ -322,7 +322,7 @@ final class ErrorsTests: XCTestCase {
         // TODO: Old parser expected error on line 1: expected throwing specifier; did you mean 'throws'?, Fix-It replacements: 25 - 28 = 'throws'
         DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression after 'try'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous 'where T:ExpressibleByStringLiteral {}' at top level"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code 'where T:ExpressibleByStringLiteral {}' at top level"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
+++ b/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
@@ -158,7 +158,7 @@ final class GenericDisambiguationTests: XCTestCase {
        1️⃣*/
       """,
       diagnostics: [
-        DiagnosticSpec(message: "extraneous '*/' at top level"),
+        DiagnosticSpec(message: "extraneous code '*/' at top level"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
+++ b/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
@@ -94,9 +94,9 @@ final class IfconfigExprTests: XCTestCase {
       """#,
       diagnostics: [
         // TODO: Old parser expected error on line 8: unary operator cannot be separated from its operand
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '+ otherExpr' in conditional compilation block"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '+ otherExpr' in conditional compilation block"),
         // TODO: Old parser expected error on line 13: unexpected tokens in '#if' expression body
-        DiagnosticSpec(locationMarker: "2️⃣", message: #"unexpected text 'print("debug")' in conditional compilation block"#),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"unexpected code 'print("debug")' in conditional compilation block"#),
       ]
     )
   }
@@ -121,7 +121,7 @@ final class IfconfigExprTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 12: unexpected tokens in '#if' expression body
-        DiagnosticSpec(message: "unexpected text '+ 12' in conditional compilation block"),
+        DiagnosticSpec(message: "unexpected code '+ 12' in conditional compilation block"),
       ]
     )
   }
@@ -148,7 +148,7 @@ final class IfconfigExprTests: XCTestCase {
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected expression in conditional compilation clause"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in conditional compilation clause"),
         // TODO: Old parser expected error on line 12: unexpected tokens in '#if' expression body
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text 'return' in conditional compilation block"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code 'return' in conditional compilation block"),
       ]
     )
   }
@@ -283,7 +283,7 @@ final class IfconfigExprTests: XCTestCase {
         // TODO: Old parser expected error on line 47: cannot parse module version '>=2.2'
         // TODO: Old parser expected error on line 50: 'A' is not a valid digit in integer literal
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected value in function call"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text '20A301' in function call"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code '20A301' in function call"),
         // TODO: Old parser expected error on line 53: cannot parse module version '20A301'
       ]
     )

--- a/Tests/SwiftParserTest/translated/InitDeinitTests.swift
+++ b/Tests/SwiftParserTest/translated/InitDeinitTests.swift
@@ -78,11 +78,11 @@ final class InitDeinitTests: XCTestCase {
         // TODO: Old parser expected error on line 3: deinitializers cannot have a name, Fix-It replacements: 10 - 12 = ''
         // TODO: Old parser expected error on line 3: expected '{' for deinitializer
         DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive declarations on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text 'x' before deinitializer"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code 'x' before deinitializer"),
         // TODO: Old parser expected error on line 4: deinitializers cannot have a name, Fix-It replacements: 10 - 11 = ''
         // TODO: Old parser expected error on line 4: no parameter clause allowed on deinitializer, Fix-It replacements: 11 - 13 = ''
         // TODO: Old parser expected error on line 4: expected '{' for deinitializer
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text 'x()' in struct"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code 'x()' in struct"),
       ]
     )
   }
@@ -122,7 +122,7 @@ final class InitDeinitTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: no parameter clause allowed on deinitializer, Fix-It replacements: 9 - 18 = ''
-        DiagnosticSpec(message: "unexpected text '(a : Int) {}' in class"),
+        DiagnosticSpec(message: "unexpected code '(a : Int) {}' in class"),
       ]
     )
   }
@@ -147,7 +147,7 @@ final class InitDeinitTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 2: deinitializers cannot have a name, Fix-It replacements: 10 - 12 = ''
         // TODO: Old parser expected error on line 2: no parameter clause allowed on deinitializer, Fix-It replacements: 12 - 22 = ''
-        DiagnosticSpec(message: "unexpected text 'x (a : Int) {}' in class"),
+        DiagnosticSpec(message: "unexpected code 'x (a : Int) {}' in class"),
       ]
     )
   }
@@ -350,7 +350,7 @@ final class InitDeinitTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 3: missing 'self.' at initializer invocation, Fix-It replacements: 24 - 24 = 'self.'
         DiagnosticSpec(message: "expected type in function parameter"),
-        DiagnosticSpec(message: "unexpected text '1' in parameter clause"),
+        DiagnosticSpec(message: "unexpected code '1' in parameter clause"),
       ]
     )
   }
@@ -367,7 +367,7 @@ final class InitDeinitTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 3: missing 'super.' at initializer invocation, Fix-It replacements: 5 - 5 = 'super.'
         DiagnosticSpec(message: "expected type in function parameter"),
-        DiagnosticSpec(message: "unexpected text '2' in parameter clause"),
+        DiagnosticSpec(message: "unexpected code '2' in parameter clause"),
       ]
     )
   }
@@ -383,7 +383,7 @@ final class InitDeinitTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 3: missing 'self.' at initializer invocation, Fix-It replacements: 12 - 12 = 'self.'
         DiagnosticSpec(message: "expected type in function parameter"),
-        DiagnosticSpec(message: "unexpected text '1' in parameter clause"),
+        DiagnosticSpec(message: "unexpected code '1' in parameter clause"),
       ]
     )
   }
@@ -398,7 +398,7 @@ final class InitDeinitTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 3: missing 'self.' at initializer invocation, Fix-It replacements: 18 - 18 = 'self.'
-        DiagnosticSpec(message: "unexpected text '!' in initializer"),
+        DiagnosticSpec(message: "unexpected code '!' in initializer"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/InvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidTests.swift
@@ -14,7 +14,7 @@ final class InvalidTests: XCTestCase {
         // TODO: Old parser expected error on line 2: 'inout' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 12 - 17 = '', 26 - 26 = 'inout '
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected type in type"),
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code ') {}' at top level"),
       ]
     )
   }
@@ -29,7 +29,7 @@ final class InvalidTests: XCTestCase {
         // TODO: Old parser expected error on line 1: 'inout' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 12 - 17 = '', 26 - 26 = 'inout '
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected type in type"),
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code ') {}' at top level"),
       ]
     )
   }
@@ -41,7 +41,7 @@ final class InvalidTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: 'inout' before a parameter name is not allowed, place it before the parameter type instead
-        DiagnosticSpec(locationMarker: "5️⃣", message: "unexpected text 'x : Int' in function type"),
+        DiagnosticSpec(locationMarker: "5️⃣", message: "unexpected code 'x : Int' in function type"),
       ]
     )
   }
@@ -56,7 +56,7 @@ final class InvalidTests: XCTestCase {
         // TODO: Old parser expected error on line 1: '__shared' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 21 = '', 30 - 30 = '__shared '
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected type in type"),
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code ') {}' at top level"),
       ]
     )
   }
@@ -71,7 +71,7 @@ final class InvalidTests: XCTestCase {
         // TODO: Old parser expected error on line 1: '__shared' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 21 = '', 30 - 30 = '__shared '
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected type in type"),
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code ') {}' at top level"),
       ]
     )
   }
@@ -86,7 +86,7 @@ final class InvalidTests: XCTestCase {
         // TODO: Old parser expected error on line 1: '__owned' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 20 = ''
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected type in type"),
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code ') {}' at top level"),
       ]
     )
   }
@@ -101,7 +101,7 @@ final class InvalidTests: XCTestCase {
         // TODO: Old parser expected error on line 2: '__owned' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 20 = ''
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected type in type"),
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code ') {}' at top level"),
       ]
     )
   }
@@ -206,7 +206,7 @@ final class InvalidTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 4: expected ',' separator, Fix-It replacements: 18 - 18 = ','
         // TODO: Old parser expected error on line 4: expected expression in list of expressions
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '}' in string literal"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected brace in string literal"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected '}' to end function"),
       ]
     )
@@ -224,7 +224,7 @@ final class InvalidTests: XCTestCase {
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' in function type"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected type in function type"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "4️⃣", message: "extraneous code ') {}' at top level"),
       ]
     )
   }
@@ -302,16 +302,16 @@ final class InvalidTests: XCTestCase {
         // TODO: Old parser expected error on line 1: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 19 - 25 = ''
         // TODO: Old parser expected error on line 2: inout' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 15 - 20 = '', 30 - 30 = 'inout '
         // TODO: Old parser expected error on line 2: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 21 - 27 = ''
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text ': Int' in parameter clause"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code ': Int' in parameter clause"),
         // TODO: Old parser expected warning on line 3: 'let' in this position is interpreted as an argument label, Fix-It replacements: 15 - 18 = '`let`'
         // TODO: Old parser expected error on line 3: expected ',' separator, Fix-It replacements: 22 - 22 = ','
         // TODO: Old parser expected error on line 3: expected ':' following argument label and parameter name
         // TODO: Old parser expected warning on line 3: extraneous duplicate parameter name; 'let' already has an argument label, Fix-It replacements: 15 - 19 = ''
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text 'a' in function parameter"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code 'a' in function parameter"),
         // TODO: Old parser expected error on line 4: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 15 - 20 = ''
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text ': inout String' in parameter clause"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code ': inout String' in parameter clause"),
         // TODO: Old parser expected error on line 5: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 15 - 20 = ''
-        DiagnosticSpec(locationMarker: "4️⃣", message: "unexpected text ': inout Int' in parameter clause"),
+        DiagnosticSpec(locationMarker: "4️⃣", message: "unexpected code ': inout Int' in parameter clause"),
       ]
     )
   }
@@ -345,7 +345,7 @@ final class InvalidTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 15 - 20 = ''
-        DiagnosticSpec(message: "unexpected text ': inout String' in parameter clause"),
+        DiagnosticSpec(message: "unexpected code ': inout String' in parameter clause"),
       ]
     )
   }
@@ -357,7 +357,7 @@ final class InvalidTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 15 - 20 = ''
-        DiagnosticSpec(message: "unexpected text ': inout Int' in parameter clause"),
+        DiagnosticSpec(message: "unexpected code ': inout Int' in parameter clause"),
       ]
     )
   }
@@ -395,7 +395,7 @@ final class InvalidTests: XCTestCase {
         // TODO: Old parser expected error on line 1: found an unexpected second identifier in function declaration; is there an accidental break?
         // TODO: Old parser expected note on line 1: join the identifiers together, Fix-It replacements: 6 - 13 = 'dogcow'
         // TODO: Old parser expected note on line 1: join the identifiers together with camel-case, Fix-It replacements: 6 - 13 = 'dogCow'
-        DiagnosticSpec(message: "unexpected text 'cow' before parameter clause"),
+        DiagnosticSpec(message: "unexpected code 'cow' before parameter clause"),
       ]
     )
   }
@@ -408,7 +408,7 @@ final class InvalidTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: found an unexpected second identifier in function declaration; is there an accidental break?
         // TODO: Old parser expected note on line 1: join the identifiers together, Fix-It replacements: 6 - 15 = 'catMouse'
-        DiagnosticSpec(message: "unexpected text 'Mouse' before parameter clause"),
+        DiagnosticSpec(message: "unexpected code 'Mouse' before parameter clause"),
       ]
     )
   }
@@ -422,7 +422,7 @@ final class InvalidTests: XCTestCase {
         // TODO: Old parser expected error on line 1: found an unexpected second identifier in function declaration; is there an accidental break?
         // TODO: Old parser expected note on line 1: join the identifiers together, Fix-It replacements: 6 - 17 = 'friendship'
         // TODO: Old parser expected note on line 1: join the identifiers together with camel-case, Fix-It replacements: 6 - 17 = 'friendShip'
-        DiagnosticSpec(message: "unexpected text 'ship<T>' before parameter clause"),
+        DiagnosticSpec(message: "unexpected code 'ship<T>' before parameter clause"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
+++ b/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
@@ -521,7 +521,7 @@ final class MatchingPatternsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 2: expected ',' separator, Fix-It replacements: 25 - 25 = ','
         // TODO: Old parser expected error on line 2: expected pattern
-        DiagnosticSpec(message: "unexpected text '?' in tuple pattern"),
+        DiagnosticSpec(message: "unexpected code '?' in tuple pattern"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/NumberIdentifierErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/NumberIdentifierErrorsTests.swift
@@ -23,10 +23,10 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: function name can only start with a letter or underscore, not a number
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '1' before parameter clause"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '1' before parameter clause"),
         // TODO: Old parser expected error on line 2: function name can only start with a letter or underscore, not a number
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '2.0' before parameter clause"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '2.0' before parameter clause"),
         // TODO: Old parser expected error on line 3: function name can only start with a letter or underscore, not a number
         // TODO: Old parser expected error on line 3: 'f' is not a valid digit in integer literal
         DiagnosticSpec(locationMarker: "3️⃣", message: "identifier can only start with a letter or underscore, not a number"),
@@ -95,10 +95,10 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: typealias name can only start with a letter or underscore, not a number
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in typealias declaration"),
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '10' in typealias declaration"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '10' in typealias declaration"),
         // TODO: Old parser expected error on line 2: typealias name can only start with a letter or underscore, not a number
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in typealias declaration"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '11.0' in typealias declaration"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '11.0' in typealias declaration"),
         // TODO: Old parser expected error on line 3: typealias name can only start with a letter or underscore, not a number
         // TODO: Old parser expected error on line 3: 't' is not a valid digit in integer literal
         DiagnosticSpec(locationMarker: "3️⃣", message: "identifier can only start with a letter or underscore, not a number"),
@@ -192,7 +192,7 @@ final class NumberIdentifierErrorsTests: XCTestCase {
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier and member block in class"),
         // TODO: Old parser expected error on line 2: function name can only start with a letter or underscore, not a number
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '20' before parameter clause"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '20' before parameter clause"),
       ]
     )
   }
@@ -209,7 +209,7 @@ final class NumberIdentifierErrorsTests: XCTestCase {
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier and member block in class"),
         // TODO: Old parser expected error on line 2: function name can only start with a letter or underscore, not a number
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '22.0' before parameter clause"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '22.0' before parameter clause"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/ObjectLiteralsTests.swift
+++ b/Tests/SwiftParserTest/translated/ObjectLiteralsTests.swift
@@ -12,11 +12,11 @@ final class ObjectLiteralsTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: '[#Color(...)#]' has been renamed to '#colorLiteral(...), Fix-It replacements: 9 - 10 = '', 11 - 16 = 'colorLiteral', 17 - 32 = 'red', 78 - 80 = ''
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '#Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha)#' in array"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '#Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha)#' in array"),
         // TODO: Old parser expected error on line 2: '[#Image(...)#]' has been renamed to '#imageLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 16 = 'imageLiteral', 17 - 29 = 'resourceName', 57 - 59 = ''
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '#Image(imageLiteral: localResourceNameAsString)#' in array"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '#Image(imageLiteral: localResourceNameAsString)#' in array"),
         // TODO: Old parser expected error on line 3: '[#FileReference(...)#]' has been renamed to '#fileLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 24 = 'fileLiteral', 25 - 45 = 'resourceName', 73 - 75 = ''
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text '#FileReference(fileReferenceLiteral: localResourceNameAsString)#' in array"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code '#FileReference(fileReferenceLiteral: localResourceNameAsString)#' in array"),
       ]
     )
   }
@@ -29,7 +29,7 @@ final class ObjectLiteralsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: '#Color(...)' has been renamed to '#colorLiteral(...), Fix-It replacements: 10 - 15 = 'colorLiteral', 16 - 31 = 'red'
         DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: "extraneous '#Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha)' at top level"),
+        DiagnosticSpec(message: "extraneous code '#Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha)' at top level"),
       ]
     )
   }
@@ -42,7 +42,7 @@ final class ObjectLiteralsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: '#Image(...)' has been renamed to '#imageLiteral(...)', Fix-It replacements: 10 - 15 = 'imageLiteral', 16 - 28 = 'resourceName'
         DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: "extraneous '#Image(imageLiteral: localResourceNameAsString)' at top level"),
+        DiagnosticSpec(message: "extraneous code '#Image(imageLiteral: localResourceNameAsString)' at top level"),
       ]
     )
   }
@@ -56,7 +56,7 @@ final class ObjectLiteralsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: '#FileReference(...)' has been renamed to '#fileLiteral(...)', Fix-It replacements: 10 - 23 = 'fileLiteral', 24 - 44 = 'resourceName'
         DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: "extraneous '#FileReference(fileReferenceLiteral: localResourceNameAsString)' at top level"),
+        DiagnosticSpec(message: "extraneous code '#FileReference(fileReferenceLiteral: localResourceNameAsString)' at top level"),
       ]
     )
   }
@@ -70,7 +70,7 @@ final class ObjectLiteralsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: use of unknown directive '#notAPound'
         DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: "extraneous '#notAPound' at top level"),
+        DiagnosticSpec(message: "extraneous code '#notAPound' at top level"),
       ]
     )
   }
@@ -83,7 +83,7 @@ final class ObjectLiteralsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: use of unknown directive '#notAPound'
         DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: "extraneous '#notAPound(1, 2)' at top level"),
+        DiagnosticSpec(message: "extraneous code '#notAPound(1, 2)' at top level"),
       ]
     )
   }
@@ -96,7 +96,7 @@ final class ObjectLiteralsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected argument list in object literal
         DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: "extraneous '#Color' at top level"),
+        DiagnosticSpec(message: "extraneous code '#Color' at top level"),
       ]
     )
   }
@@ -108,7 +108,7 @@ final class ObjectLiteralsTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected expression in container literal
-        DiagnosticSpec(message: "unexpected text '##' in array"),
+        DiagnosticSpec(message: "unexpected code '##' in array"),
       ]
     )
   }
@@ -121,7 +121,7 @@ final class ObjectLiteralsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: '[#Color(...)#]' has been renamed to '#colorLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 16 = 'colorLiteral', 17 - 18 = 'red'
         DiagnosticSpec(message: "expected ']' to end array"),
-        DiagnosticSpec(message: "extraneous '#Color(_: 1, green: 1, 2)' at top level"),
+        DiagnosticSpec(message: "extraneous code '#Color(_: 1, green: 1, 2)' at top level"),
       ]
     )
   }
@@ -134,7 +134,7 @@ final class ObjectLiteralsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: '[#Color(...)#]' has been renamed to '#colorLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 16 = 'colorLiteral', 17 - 20 = 'red', 43 - 44 = ''
         DiagnosticSpec(message: "expected ']' to end array"),
-        DiagnosticSpec(message: "extraneous '#Color(red: 1, green: 1, blue: 1)#' at top level"),
+        DiagnosticSpec(message: "extraneous code '#Color(red: 1, green: 1, blue: 1)#' at top level"),
       ]
     )
   }
@@ -146,7 +146,7 @@ final class ObjectLiteralsTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: '[#Color(...)#]' has been renamed to '#colorLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 16 = 'colorLiteral', 17 - 24 = 'red', 51 - 53 = ''
-        DiagnosticSpec(message: "unexpected text '#Color(withRed: 1, green: 1, whatever: 2)#' in array"),
+        DiagnosticSpec(message: "unexpected code '#Color(withRed: 1, green: 1, whatever: 2)#' in array"),
       ]
     )
   }
@@ -159,7 +159,7 @@ final class ObjectLiteralsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: '#Color(...)' has been renamed to '#colorLiteral(...)', Fix-It replacements: 10 - 15 = 'colorLiteral', 16 - 17 = 'red'
         DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: "extraneous '#Color(_: 1, green: 1)' at top level"),
+        DiagnosticSpec(message: "extraneous code '#Color(_: 1, green: 1)' at top level"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
@@ -169,7 +169,7 @@ final class OperatorDeclTests: XCTestCase {
       prefix operator %%+
       """,
       diagnostics: [
-        DiagnosticSpec(message: "unexpected text before operator"),
+        DiagnosticSpec(message: "unexpected code before operator"),
       ]
     )
   }
@@ -244,7 +244,7 @@ final class OperatorDeclTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: 'aa' is considered an identifier and must not appear within an operator name
-        DiagnosticSpec(message: "extraneous '--: A' at top level"),
+        DiagnosticSpec(message: "extraneous code '--: A' at top level"),
       ]
     )
   }
@@ -260,7 +260,7 @@ final class OperatorDeclTests: XCTestCase {
         // TODO: Old parser expected error on line 1: '$$' is considered an identifier and must not appear within an operator name
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected name in attribute"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected declaration after attribute"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous '<' at top level"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous code '<' at top level"),
       ]
     )
   }
@@ -285,7 +285,7 @@ final class OperatorDeclTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: '#' is not allowed in operator names
-        DiagnosticSpec(message: "extraneous '++=' at top level"),
+        DiagnosticSpec(message: "extraneous code '++=' at top level"),
       ]
     )
   }
@@ -297,7 +297,7 @@ final class OperatorDeclTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: '#' is not allowed in operator names
-        DiagnosticSpec(message: "extraneous '#' at top level"),
+        DiagnosticSpec(message: "extraneous code '#' at top level"),
       ]
     )
   }
@@ -309,7 +309,7 @@ final class OperatorDeclTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: '#' is not allowed in operator names
-        DiagnosticSpec(message: "extraneous '#' at top level"),
+        DiagnosticSpec(message: "extraneous code '#' at top level"),
       ]
     )
   }
@@ -324,7 +324,7 @@ final class OperatorDeclTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 3: '#' is not allowed in operator names
         // TODO: Old parser expected error on line 3: '=' must have consistent whitespace on both sides
-        DiagnosticSpec(message: "extraneous '#=' at top level"),
+        DiagnosticSpec(message: "extraneous code '#=' at top level"),
       ]
     )
   }
@@ -371,11 +371,11 @@ final class OperatorDeclTests: XCTestCase {
         // TODO: Old parser expected error on line 5: expected colon after attribute name in precedence group
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected ':' in 'associativity' property of precedencegroup"),
         // TODO: Old parser expected error on line 8: 'precedence' is not a valid precedence group attribute
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text 'precedence 123' in precedencegroup"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code 'precedence 123' in precedencegroup"),
         // TODO: Old parser expected error on line 11: expected 'none', 'left', or 'right' after 'associativity'
         // TODO: Old parser expected error on line 14: expected 'true' or 'false' after 'assignment'
         DiagnosticSpec(locationMarker: "4️⃣", message: "expected 'true' in 'assignment' property of precedencegroup"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "unexpected text 'no' in precedencegroup"),
+        DiagnosticSpec(locationMarker: "4️⃣", message: "unexpected code 'no' in precedencegroup"),
         DiagnosticSpec(locationMarker: "5️⃣", message: "expected identifier in 'relation' property of precedencegroup"),
         // TODO: Old parser expected error on line 18: expected name of related precedence group after 'higherThan'
       ]

--- a/Tests/SwiftParserTest/translated/OptionalTests.swift
+++ b/Tests/SwiftParserTest/translated/OptionalTests.swift
@@ -22,7 +22,7 @@ final class OptionalTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 2: consecutive statements on a line, Fix-It replacements: 10 - 10 = ';'
         // TODO: Old parser expected error on line 2: expected expression
-        DiagnosticSpec(message: "extraneous '?' at top level"),
+        DiagnosticSpec(message: "extraneous code '?' at top level"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/RawStringErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/RawStringErrorsTests.swift
@@ -12,7 +12,7 @@ final class RawStringErrorsTests: XCTestCase {
         // TODO: Old parser expected error on line 1: too many '#' characters in closing delimiter
         // TODO: Old parser expected error on line 1: expected ',' separator
         // TODO: Old parser expected error on line 1: expected expression in list of expressions
-        DiagnosticSpec(message: "unexpected text '#' in string literal"),
+        DiagnosticSpec(message: "unexpected code '#' in string literal"),
       ]
     )
   }
@@ -26,7 +26,7 @@ final class RawStringErrorsTests: XCTestCase {
         // TODO: Old parser expected error on line 1: too many '#' characters in delimited escape
         // TODO: Old parser expected error on line 1: invalid escape sequence in literal
         DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: ###"extraneous '#"\##("invalid")"#' at top level"###),
+        DiagnosticSpec(message: ###"extraneous code '#"\##("invalid")"#' at top level"###),
       ]
     )
   }
@@ -40,7 +40,7 @@ final class RawStringErrorsTests: XCTestCase {
         // TODO: Old parser expected error on line 1: too many '#' characters in closing delimiter, Fix-It replacements: 26 - 29 = ''
         // TODO: Old parser expected error on line 1: consecutive statements on a line must be separated by ';'
         // TODO: Old parser expected error on line 1: expected expression
-        DiagnosticSpec(message: "extraneous '###' at top level"),
+        DiagnosticSpec(message: "extraneous code '###' at top level"),
       ]
     )
   }
@@ -66,7 +66,7 @@ final class RawStringErrorsTests: XCTestCase {
         // TODO: Old parser expected error on line 1: too many '#' characters in closing delimiter, Fix-It replacements: 24 - 27 = ''
         // TODO: Old parser expected error on line 1: consecutive statements on a line must be separated by ';'
         // TODO: Old parser expected error on line 1: expected expression
-        DiagnosticSpec(message: "extraneous '###' at top level"),
+        DiagnosticSpec(message: "extraneous code '###' at top level"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/RecoveryLibraryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryLibraryTests.swift
@@ -3,16 +3,7 @@
 import XCTest
 
 final class RecoveryLibraryTests: XCTestCase {
-  func testRecoveryLibrary1() {
-    AssertParse(
-      """
-      //===--- Recovery for extra braces at top level.
-      //===--- Keep this test the first one in the file.
-      """
-    )
-  }
-
-  func testRecoveryLibrary2() {
+  func testRecoveryLibrary() {
     AssertParse(
       """
       // Check that we handle multiple consecutive right braces.
@@ -30,15 +21,13 @@ final class RecoveryLibraryTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: extraneous '}' at top level, Fix-It replacements: 1 - 3 = ''
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text before function"),
-        // TODO: Old parser expected error on line 3: extraneous '}' at top level, Fix-It replacements: 1 - 3 = ''
-        // TODO: Old parser expected error on line 6: extraneous '}' at top level, Fix-It replacements: 1 - 3 = ''
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text before function"),
-        // TODO: Old parser expected error on line 7: extraneous '}' at top level, Fix-It replacements: 1 - 3 = ''
-        // TODO: Old parser expected error on line 12: extraneous '}' at top level, Fix-It replacements: 1 - 3 = ''
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous code at top level"),
-        // TODO: Old parser expected error on line 13: extraneous '}' at top level, Fix-It replacements: 1 - 3 = ''
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected braces before function", highlight: """
+        // Check that we handle multiple consecutive right braces.
+        }
+        }
+        """),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected braces before function"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous braces at top level"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/StringLiteralEofTests.swift
+++ b/Tests/SwiftParserTest/translated/StringLiteralEofTests.swift
@@ -13,7 +13,7 @@ final class StringLiteralEofTests: XCTestCase {
         // TODO: Old parser expected error on line 2: unterminated string literal
         // TODO: Old parser expected error on line 2: cannot find ')' to match opening '(' in string interpolation
         DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: #"extraneous '"foo\(' at top level"#),
+        DiagnosticSpec(message: #"extraneous code '"foo\(' at top level"#),
       ]
     )
   }
@@ -28,7 +28,7 @@ final class StringLiteralEofTests: XCTestCase {
         // TODO: Old parser expected error on line 2: cannot find ')' to match opening '(' in string interpolation
         // TODO: Old parser expected error on line 2: unterminated string literal
         DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: #"extraneous '"foo\("bar' at top level"#),
+        DiagnosticSpec(message: #"extraneous code '"foo\("bar' at top level"#),
       ]
     )
   }
@@ -43,7 +43,7 @@ final class StringLiteralEofTests: XCTestCase {
         // TODO: Old parser expected error on line 1: unterminated string literal
         // TODO: Old parser expected error on line 1: invalid escape sequence in literal
         DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: #"extraneous '"foo \' at top level"#),
+        DiagnosticSpec(message: #"extraneous code '"foo \' at top level"#),
       ]
     )
   }
@@ -58,7 +58,7 @@ final class StringLiteralEofTests: XCTestCase {
         // TODO: Old parser expected error on line 2: unterminated string literal
         // TODO: Old parser expected error on line 2: invalid escape sequence in literal
         DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: #"extraneous '"foo \' at top level"#),
+        DiagnosticSpec(message: #"extraneous code '"foo \' at top level"#),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/SubscriptingTests.swift
+++ b/Tests/SwiftParserTest/translated/SubscriptingTests.swift
@@ -325,7 +325,7 @@ final class SubscriptingTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "unexpected text '(j: Int)' in subscript"),
+        DiagnosticSpec(message: "unexpected code '(j: Int)' in subscript"),
       ]
     )
   }
@@ -372,7 +372,7 @@ final class SubscriptingTests: XCTestCase {
         }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "unexpected text in struct", highlight: """
+        DiagnosticSpec(message: "unexpected code in struct", highlight: """
 
               get {
                 return stored

--- a/Tests/SwiftParserTest/translated/SwitchTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchTests.swift
@@ -980,8 +980,8 @@ final class SwitchTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '(garbage)' in switch case"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '(foobar)' in switch case"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '(garbage)' in switch case"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '(foobar)' in switch case"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/TypealiasTests.swift
+++ b/Tests/SwiftParserTest/translated/TypealiasTests.swift
@@ -132,7 +132,7 @@ final class TypealiasTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected '=' in typealias declaration", fixIts: ["replace ':' by '='"]),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous ', Float' at top level"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code ', Float' at top level"),
       ]
     )
   }
@@ -144,7 +144,7 @@ final class TypealiasTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected type in typealias declaration"),
-        DiagnosticSpec(message: "extraneous '=' at top level"),
+        DiagnosticSpec(message: "extraneous code '=' at top level"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/UnclosedStringInterpolationTests.swift
+++ b/Tests/SwiftParserTest/translated/UnclosedStringInterpolationTests.swift
@@ -20,7 +20,7 @@ final class UnclosedStringInterpolationTests: XCTestCase {
         // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
         // TODO: Old parser expected error on line 1: unterminated string literal
         DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: #"extraneous '"mid == \(pete"' at top level"#),
+        DiagnosticSpec(message: #"extraneous code '"mid == \(pete"' at top level"#),
       ]
     )
   }
@@ -34,7 +34,7 @@ final class UnclosedStringInterpolationTests: XCTestCase {
         // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
         // TODO: Old parser expected error on line 1: unterminated string literal
         DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: #"extraneous '"kanye \("' at top level"#),
+        DiagnosticSpec(message: #"extraneous code '"kanye \("' at top level"#),
       ]
     )
   }
@@ -48,7 +48,7 @@ final class UnclosedStringInterpolationTests: XCTestCase {
         // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
         // TODO: Old parser expected error on line 1: unterminated string literal
         DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: #"extraneous '"2 + 2 = \(2 + 2"' at top level"#),
+        DiagnosticSpec(message: #"extraneous code '"2 + 2 = \(2 + 2"' at top level"#),
       ]
     )
   }
@@ -62,7 +62,7 @@ final class UnclosedStringInterpolationTests: XCTestCase {
         // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
         // TODO: Old parser expected error on line 1: unterminated string literal
         DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: #"extraneous '"\(x"; print(x)' at top level"#),
+        DiagnosticSpec(message: #"extraneous code '"\(x"; print(x)' at top level"#),
       ]
     )
   }
@@ -76,7 +76,7 @@ final class UnclosedStringInterpolationTests: XCTestCase {
         // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
         // TODO: Old parser expected error on line 1: unterminated string literal
         DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: #"extraneous '"\(x; print(x)' at top level"#),
+        DiagnosticSpec(message: #"extraneous code '"\(x; print(x)' at top level"#),
       ]
     )
   }
@@ -90,7 +90,7 @@ final class UnclosedStringInterpolationTests: XCTestCase {
         // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
         // TODO: Old parser expected error on line 1: unterminated string literal
         DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: #"extraneous '"The Life Of \("Pablo"' at top level"#),
+        DiagnosticSpec(message: #"extraneous code '"The Life Of \("Pablo"' at top level"#),
       ]
     )
   }


### PR DESCRIPTION
Basically the idea its to make “extraneous code” and “unexpected text” diagnostics more similar wording-wise.