### PR TITLE
Diagnose identifier in operator declarations

### DIFF
--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -100,7 +100,7 @@ public struct EffectsSpecifierAfterArrow: ParserError {
   public let effectsSpecifiersAfterArrow: [TokenSyntax]
 
   public var message: String {
-    "\(missingNodesDescription(effectsSpecifiersAfterArrow)) may only occur before '->'"
+    "\(nodesDescription(effectsSpecifiersAfterArrow, format: false)) may only occur before '->'"
   }
 }
 
@@ -109,6 +109,14 @@ public struct ExtaneousCodeAtTopLevel: ParserError {
 
   public var message: String {
     return "extraneous \(extraneousCode.shortSingleLineContentDescription) at top level"
+  }
+}
+
+public struct IdentifierNotAllowedInOperatorName: ParserError {
+  public let identifier: TokenSyntax
+
+  public var message: String {
+    return "\(nodesDescription([identifier], format: false)) is considered an identifier and must not appear within an operator name"
   }
 }
 
@@ -135,6 +143,14 @@ public struct MissingAttributeArgument: ParserError {
 
   public var message: String {
     return "expected argument for '@\(attributeName)' attribute"
+  }
+}
+
+public struct TokensNotAllowedInOperatorName: ParserError {
+  public let tokens: [TokenSyntax]
+
+  public var message: String {
+    return "\(nodesDescription(tokens, format: false)) is not allowed in operator names"
   }
 }
 
@@ -185,7 +201,7 @@ public struct MoveTokensAfterFixIt: ParserFixIt {
   public let after: RawTokenKind
 
   public var message: String {
-    "move \(missingNodesDescription(movedTokens)) after '\(after.nameForDiagnostics)'"
+    "move \(nodesDescription(movedTokens, format: false)) after '\(after.nameForDiagnostics)'"
   }
 }
 
@@ -197,7 +213,7 @@ public struct MoveTokensInFrontOfFixIt: ParserFixIt {
   public let inFrontOf: RawTokenKind
 
   public var message: String {
-    "move \(missingNodesDescription(movedTokens)) in front of '\(inFrontOf.nameForDiagnostics)'"
+    "move \(nodesDescription(movedTokens, format: false)) in front of '\(inFrontOf.nameForDiagnostics)'"
   }
 }
 
@@ -205,15 +221,23 @@ public struct RemoveRedundantFixIt: ParserFixIt {
   public let removeTokens: [TokenSyntax]
 
   public var message: String {
-    "remove redundant \(missingNodesDescription(removeTokens))"
+    "remove redundant \(nodesDescription(removeTokens, format: false))"
   }
 }
 
-public struct RemoveTokensFixIt: ParserFixIt {
-  public let tokensToRemove: [TokenSyntax]
+public struct RemoveNodesFixIt: ParserFixIt {
+  public let nodesToRemove: [Syntax]
+
+  init<SyntaxType: SyntaxProtocol>(_ nodesToRemove: [SyntaxType]) {
+    self.nodesToRemove = nodesToRemove.map(Syntax.init)
+  }
+
+  init<SyntaxType: SyntaxProtocol>(_ nodeToRemove: SyntaxType) {
+    self.nodesToRemove = [Syntax(nodeToRemove)]
+  }
 
   public var message: String {
-    "remove \(missingNodesDescription(tokensToRemove))"
+    "remove \(nodesDescription(nodesToRemove, format: false))"
   }
 }
 
@@ -223,6 +247,6 @@ public struct ReplaceTokensFixIt: ParserFixIt {
   public let replacement: TokenSyntax
 
   public var message: String {
-    "replace \(missingNodesDescription(replaceTokens)) by '\(replacement.text)'"
+    "replace \(nodesDescription(replaceTokens, format: false)) by '\(replacement.text)'"
   }
 }

--- a/Sources/SwiftParser/Diagnostics/Utils.swift
+++ b/Sources/SwiftParser/Diagnostics/Utils.swift
@@ -13,10 +13,11 @@
 extension String {
   /// Remove any leading or trailing spaces.
   /// This is necessary to avoid depending SwiftParser on Foundation.
-  func trimmingSpaces() -> String {
+  func trimmingWhitespace() -> String {
+    let charactersToDrop: [Character] = [" ", "\t", "\n", "\r"]
     var result: Substring = Substring(self)
-    result = result.drop(while: { $0 == " " })
-    while result.last == " " {
+    result = result.drop(while: { charactersToDrop.contains($0) })
+    while let lastCharacter = result.last, charactersToDrop.contains(lastCharacter) {
       result = result.dropLast(1)
     }
     return String(result)

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -516,6 +516,52 @@ enum Operator: RawTokenKindSubset {
   }
 }
 
+/// Tokens that can be used in operator declarations
+enum OperatorLike: RawTokenKindSubset {
+  case `operator`(Operator)
+  case exclamationMark
+  case infixQuestionMark
+  case postfixQuestionMark
+  case equal
+  case arrow
+
+  init?(lexeme: Lexer.Lexeme) {
+    if let op = Operator(lexeme: lexeme) {
+      self = .operator(op)
+      return
+    }
+    switch lexeme.tokenKind {
+    case .exclamationMark: self = .exclamationMark
+    case .infixQuestionMark: self = .infixQuestionMark
+    case .postfixQuestionMark: self = .postfixQuestionMark
+    case .equal: self = .equal
+    case .arrow: self = .arrow
+    default: return nil
+    }
+  }
+
+  static var allCases: [OperatorLike] {
+    return Operator.allCases.map(Self.operator) + [
+      .exclamationMark,
+      .infixQuestionMark,
+      .postfixQuestionMark,
+      .equal,
+      .arrow,
+    ]
+  }
+
+  var rawTokenKind: RawTokenKind {
+    switch self {
+    case .operator(let op): return op.rawTokenKind
+    case .exclamationMark: return .exclamationMark
+    case .infixQuestionMark: return .infixQuestionMark
+    case .postfixQuestionMark: return .postfixQuestionMark
+    case .equal: return .equal
+    case .arrow: return .arrow
+    }
+  }
+}
+
 enum PoundDeclarationStart: RawTokenKindSubset {
   case poundIfKeyword
   case poundWarningKeyword

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -108,8 +108,16 @@ public struct RawTokenSyntax: RawSyntaxToSyntax, RawSyntaxNodeProtocol {
     presence == .missing
   }
 
+  public var leadingTriviaByteLength: Int {
+    return tokenView.leadingTriviaByteLength
+  }
+
   public var leadingTriviaPieces: [RawTriviaPiece] {
     tokenView.leadingRawTriviaPieces
+  }
+
+  public var trailingTriviaByteLength: Int {
+    return tokenView.trailingTriviaByteLength
   }
 
   public var trailingTriviaPieces: [RawTriviaPiece] {

--- a/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
+++ b/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
@@ -280,15 +280,25 @@ final class DollarIdentifierTests: XCTestCase {
   }
 
   func testDollarIdentifier13() {
+    // https://github.com/apple/swift/issues/55538
     AssertParse(
       """
-      // https://github.com/apple/swift/issues/55538
-      infix operator $ 
-      infix operator `$`
+      infix operator 1️⃣$
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: '$' is considered an identifier and must not appear within an operator name
-        // TODO: Old parser expected error on line 3: '$' is considered an identifier and must not appear within an operator name
+        DiagnosticSpec(message: "'$' is not allowed in operator names")
+      ]
+    )
+  }
+
+  func testDollarIdentifier14() {
+    // https://github.com/apple/swift/issues/55538
+    AssertParse(
+      """
+      infix operator 1️⃣`$`
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "'`$`' is considered an identifier and must not appear within an operator name")
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
@@ -139,10 +139,10 @@ final class OperatorDeclTests: XCTestCase {
   func testOperatorDecl9() {
     AssertParse(
       """
-      prefix operator
+      prefix operator1️⃣
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected operator name in operator declaration
+        DiagnosticSpec(message: "expected name in operator")
       ]
     )
   }
@@ -171,10 +171,7 @@ final class OperatorDeclTests: XCTestCase {
     AssertParse(
       """
       postfix operator ??
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: postfix operator names starting with '?' or '!' are disallowed to avoid collisions with built-in unwrapping operators
-      ]
+      """
     )
   }
 
@@ -190,10 +187,7 @@ final class OperatorDeclTests: XCTestCase {
     AssertParse(
       """
       postfix operator !!
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: postfix operator names starting with '?' or '!' are disallowed to avoid collisions with built-in unwrapping operators
-      ]
+      """
     )
   }
 
@@ -203,10 +197,8 @@ final class OperatorDeclTests: XCTestCase {
       postfix operator ?1️⃣$$
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: postfix operator names starting with '?' or '!' are disallowed
-        // TODO: Old parser expected error on line 1: '$$' is considered an identifier
-        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'"),
-      ]
+        DiagnosticSpec(message: "'$$' is considered an identifier and must not appear within an operator name", fixIts: ["remove '$$'"]),
+      ], fixedSource: "postfix operator ?"
     )
   }
 
@@ -217,36 +209,31 @@ final class OperatorDeclTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: 'aa' is considered an identifier and must not appear within an operator name
-        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
-      ]
+        DiagnosticSpec(message: "'aa' is considered an identifier and must not appear within an operator name", fixIts: ["remove 'aa'"])
+      ], fixedSource: "infix operator --"
     )
   }
 
   func testOperatorDecl12b() {
     AssertParse(
       """
-      infix operator aa1️⃣--: A
+      infix operator 1️⃣aa--: A
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: 'aa' is considered an identifier and must not appear within an operator name
-        DiagnosticSpec(message: "extraneous code '--: A' at top level"),
-      ]
+        DiagnosticSpec(message: "'aa' is considered an identifier and must not appear within an operator name", highlight: "aa", fixIts: ["remove 'aa'"]),
+      ], fixedSource: "infix operator --: A"
     )
   }
 
   func testOperatorDecl12c() {
     AssertParse(
       """
-      infix operator <<1️⃣$$2️⃣@3️⃣<
+      infix operator <<1️⃣$$@<
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        // TODO: Old parser expected error on line 1: '$$' is considered an identifier and must not appear within an operator name
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected name in attribute"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected declaration after attribute"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous code '<' at top level"),
-      ]
+        DiagnosticSpec(message: "'$$@<' is not allowed in operator names", fixIts: ["remove '$$@<'"]),
+      ], fixedSource: "infix operator <<"
     )
   }
 
@@ -256,9 +243,7 @@ final class OperatorDeclTests: XCTestCase {
       infix operator !!1️⃣@aa2️⃣
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        // TODO: Old parser expected error on line 1: '@' is not allowed in operator names
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected declaration after attribute"),
+        DiagnosticSpec(message: "'@aa' is not allowed in operator names"),
       ]
     )
   }
@@ -266,12 +251,11 @@ final class OperatorDeclTests: XCTestCase {
   func testOperatorDecl12e() {
     AssertParse(
       """
-      infix operator #1️⃣++=
+      infix operator 1️⃣#++=
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: '#' is not allowed in operator names
-        DiagnosticSpec(message: "extraneous code '++=' at top level"),
-      ]
+        DiagnosticSpec(message: "'#' is not allowed in operator names", highlight: "#", fixIts: ["remove '#'"]),
+      ], fixedSource: "infix operator ++="
     )
   }
 
@@ -281,8 +265,7 @@ final class OperatorDeclTests: XCTestCase {
       infix operator ++=1️⃣#
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: '#' is not allowed in operator names
-        DiagnosticSpec(message: "extraneous code '#' at top level"),
+        DiagnosticSpec(message: "'#' is not allowed in operator names"),
       ]
     )
   }
@@ -293,8 +276,7 @@ final class OperatorDeclTests: XCTestCase {
       infix operator ->1️⃣#
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: '#' is not allowed in operator names
-        DiagnosticSpec(message: "extraneous code '#' at top level"),
+        DiagnosticSpec(message: "'#' is not allowed in operator names"),
       ]
     )
   }
@@ -307,9 +289,7 @@ final class OperatorDeclTests: XCTestCase {
       infix operator =1️⃣#=
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: '#' is not allowed in operator names
-        // TODO: Old parser expected error on line 3: '=' must have consistent whitespace on both sides
-        DiagnosticSpec(message: "extraneous code '#=' at top level"),
+        DiagnosticSpec(message: "'#=' is not allowed in operator names"),
       ]
     )
   }
@@ -459,6 +439,15 @@ final class OperatorDeclTests: XCTestCase {
         // TODO: Old parser expected error on line 1: only infix operators may declare a precedence, Fix-It replacements: 20 - 21 = ''
         DiagnosticSpec(message: "expected identifier in operator"),
         // TODO: Old parser expected error on line 2: expected precedence group name after ':' in operator declaration
+      ]
+    )
+  }
+
+  func testIdentifierAsOperatorName() {
+    AssertParse(
+      "postfix operator 1️⃣aa",
+      diagnostics: [
+        DiagnosticSpec(message: "'aa' is considered an identifier and must not appear within an operator name")
       ]
     )
   }


### PR DESCRIPTION
Diagnose if identifiers are used in operator declarations or if multiple operators occur in the operator name.