### PR TITLE
Allow leading dot syntax for StaticParserError

### DIFF
--- a/Sources/SwiftParser/Diagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParser/Diagnostics/DiagnosticExtensions.swift
@@ -14,14 +14,18 @@ import SwiftDiagnostics
 import SwiftSyntax
 
 extension FixIt {
-  init(message: StaticParserFixIt, changes: Changes) {
-    self.init(message: message as FixItMessage, changes: changes)
-  }
-
   public init(message: FixItMessage, changes: [Changes]) {
     self.init(message: message, changes: FixIt.Changes(combining: changes))
   }
 
+  // These overloads shouldn't be needed, but are currently required for the
+  // Swift 5.5 compiler to handle non-trivial FixIt initializations using
+  // leading-dot syntax.
+  // TODO: These can be dropped once we require a minimum of Swift 5.6 to
+  // compile the library.
+  init(message: StaticParserFixIt, changes: Changes) {
+    self.init(message: message as FixItMessage, changes: changes)
+  }
   init(message: StaticParserFixIt, changes: [Changes]) {
     self.init(message: message as FixItMessage, changes: FixIt.Changes(combining: changes))
   }

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -281,18 +281,43 @@ public struct UnknownDirectiveError: ParserError {
 
 // MARK: - Fix-Its (please sort alphabetically)
 
-public enum StaticParserFixIt: String, FixItMessage {
-  case insertSemicolon = "insert ';'"
-  case insertAttributeArguments = "insert attribute argument"
-  case joinIdentifiers = "join the identifiers together"
-  case joinIdentifiersWithCamelCase = "join the identifiers together with camel-case"
-  case removeOperatorBody = "remove operator body"
-  case wrapKeywordInBackticks = "if this name is unavoidable, use backticks to escape it"
+/// A parser fix-it with a static message.
+public struct StaticParserFixIt: FixItMessage {
+  public let message: String
+  private let messageID: String
 
-  public var message: String { self.rawValue }
+  /// This should only be called within a static var on FixItMessage, such
+  /// as the examples below. This allows us to pick up the messageID from the
+  /// var name.
+  fileprivate init(_ message: String, messageID: String = #function) {
+    self.message = message
+    self.messageID = messageID
+  }
 
   public var fixItID: MessageID {
-    MessageID(domain: diagnosticDomain, id: "\(type(of: self)).\(self)")
+    MessageID(domain: diagnosticDomain, id: "\(type(of: self)).\(messageID)")
+  }
+}
+
+extension FixItMessage where Self == StaticParserFixIt {
+  /// Please order alphabetically by property name.
+  public static var insertSemicolon: Self {
+    .init("insert ';'")
+  }
+  public static var insertAttributeArguments: Self {
+    .init("insert attribute argument")
+  }
+  public static var joinIdentifiers: Self {
+    .init("join the identifiers together")
+  }
+  public static var joinIdentifiersWithCamelCase: Self {
+    .init("join the identifiers together with camel-case")
+  }
+  public static var removeOperatorBody: Self {
+    .init("remove operator body")
+  }
+  public static var wrapKeywordInBackticks: Self {
+    .init("if this name is unavoidable, use backticks to escape it")
   }
 }
 

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -64,40 +64,100 @@ public extension ParserFixIt {
 
 // MARK: - Errors (please sort alphabetically)
 
-/// Please order the cases in this enum alphabetically by case name.
-public enum StaticParserError: String, DiagnosticMessage {
-  case allStatmentsInSwitchMustBeCoveredByCase = "all statements inside a switch must be covered by a 'case' or 'default' label"
-  case caseOutsideOfSwitchOrEnum = "'case' can only appear inside a 'switch' statement or 'enum' declaration"
-  case classConstraintCanOnlyBeUsedInProtocol = "'class' constraint can only appear on protocol declarations"
-  case consecutiveDeclarationsOnSameLine = "consecutive declarations on a line must be separated by ';'"
-  case consecutiveStatementsOnSameLine = "consecutive statements on a line must be separated by ';'"
-  case cStyleForLoop = "C-style for statement has been removed in Swift 3"
-  case defaultCannotBeUsedWithWhere = "'default' cannot be used with a 'where' guard expression"
-  case defaultOutsideOfSwitch = "'default' label can only appear inside a 'switch' statement"
-  case deinitCannotHaveName = "deinitializers cannot have a name"
-  case deinitCannotHaveParameters = "deinitializers cannot have parameters"
-  case editorPlaceholderInSourceFile = "editor placeholder in source file"
-  case expectedExpressionAfterTry = "expected expression after 'try'"
-  case invalidFlagAfterPrecedenceGroupAssignment = "expected 'true' or 'false' after 'assignment'"
-  case missingColonAndExprInTernaryExpr = "expected ':' and expression after '? ...' in ternary expression"
-  case missingColonInTernaryExpr = "expected ':' after '? ...' in ternary expression"
-  case operatorShouldBeDeclaredWithoutBody = "operator should not be declared with body"
-  case standaloneSemicolonStatement = "standalone ';' statements are not allowed"
-  case subscriptsCannotHaveNames = "subscripts cannot have a name"
-  case throwsInReturnPosition = "'throws' may only occur before '->'"
-  case tryMustBePlacedOnReturnedExpr = "'try' must be placed on the returned expression"
-  case tryMustBePlacedOnThrownExpr = "'try' must be placed on the thrown expression"
-  case tryOnInitialValueExpression = "'try' must be placed on the initial value expression"
-  case unexpectedSemicolon = "unexpected ';' separator"
-  case associatedTypeCannotUsePack = "associated types cannot be variadic"
+/// A parser error with a static message.
+public struct StaticParserError: DiagnosticMessage {
+  public let message: String
+  private let messageID: String
 
-  public var message: String { self.rawValue }
+  /// This should only be called within a static var on DiagnosticMessage, such
+  /// as the examples below. This allows us to pick up the messageID from the
+  /// var name.
+  fileprivate init(_ message: String, messageID: String = #function) {
+    self.message = message
+    self.messageID = messageID
+  }
 
   public var diagnosticID: MessageID {
-    MessageID(domain: diagnosticDomain, id: "\(type(of: self)).\(self)")
+    MessageID(domain: diagnosticDomain, id: "\(type(of: self)).\(messageID)")
   }
 
   public var severity: DiagnosticSeverity { .error }
+}
+
+extension DiagnosticMessage where Self == StaticParserError {
+  /// Please order the diagnostics alphabetically by property name.
+  public static var allStatmentsInSwitchMustBeCoveredByCase: Self {
+    .init("all statements inside a switch must be covered by a 'case' or 'default' label")
+  }
+  public static var associatedTypeCannotUsePack: Self {
+    .init("associated types cannot be variadic")
+  }
+  public static var caseOutsideOfSwitchOrEnum: Self {
+    .init("'case' can only appear inside a 'switch' statement or 'enum' declaration")
+  }
+  public static var classConstraintCanOnlyBeUsedInProtocol: Self {
+    .init("'class' constraint can only appear on protocol declarations")
+  }
+  public static var consecutiveDeclarationsOnSameLine: Self {
+    .init("consecutive declarations on a line must be separated by ';'")
+  }
+  public static var consecutiveStatementsOnSameLine: Self {
+    .init("consecutive statements on a line must be separated by ';'")
+  }
+  public static var cStyleForLoop: Self {
+    .init("C-style for statement has been removed in Swift 3")
+  }
+  public static var defaultCannotBeUsedWithWhere: Self {
+    .init("'default' cannot be used with a 'where' guard expression")
+  }
+  public static var defaultOutsideOfSwitch: Self {
+    .init("'default' label can only appear inside a 'switch' statement")
+  }
+  public static var deinitCannotHaveName: Self {
+    .init("deinitializers cannot have a name")
+  }
+  public static var deinitCannotHaveParameters: Self {
+    .init("deinitializers cannot have parameters")
+  }
+  public static var editorPlaceholderInSourceFile: Self {
+    .init("editor placeholder in source file")
+  }
+  public static var expectedExpressionAfterTry: Self {
+    .init("expected expression after 'try'")
+  }
+  public static var invalidFlagAfterPrecedenceGroupAssignment: Self {
+    .init("expected 'true' or 'false' after 'assignment'")
+  }
+  public static var missingColonAndExprInTernaryExpr: Self {
+    .init("expected ':' and expression after '? ...' in ternary expression")
+  }
+  public static var missingColonInTernaryExpr: Self {
+    .init("expected ':' after '? ...' in ternary expression")
+  }
+  public static var operatorShouldBeDeclaredWithoutBody: Self {
+    .init("operator should not be declared with body")
+  }
+  public static var standaloneSemicolonStatement: Self {
+    .init("standalone ';' statements are not allowed")
+  }
+  public static var subscriptsCannotHaveNames: Self {
+    .init("subscripts cannot have a name")
+  }
+  public static var throwsInReturnPosition: Self {
+    .init("'throws' may only occur before '->'")
+  }
+  public static var tryMustBePlacedOnReturnedExpr: Self {
+    .init("'try' must be placed on the returned expression")
+  }
+  public static var tryMustBePlacedOnThrownExpr: Self {
+    .init("'try' must be placed on the thrown expression")
+  }
+  public static var tryOnInitialValueExpression: Self {
+    .init("'try' must be placed on the initial value expression")
+  }
+  public static var unexpectedSemicolon: Self {
+    .init("unexpected ';' separator")
+  }
 }
 
 // MARK: - Diagnostics (please sort alphabetically)

--- a/Tests/SwiftParserTest/DiagnosticInfrastructureTests.swift
+++ b/Tests/SwiftParserTest/DiagnosticInfrastructureTests.swift
@@ -15,5 +15,10 @@ public class DiagnosticInfrastructureTests: XCTestCase {
 
     XCTAssertEqual(StaticParserError.throwsInReturnPosition.diagnosticID, MessageID(domain: "SwiftParser", id: "StaticParserError.throwsInReturnPosition"))
     XCTAssertEqual(StaticParserError.throwsInReturnPosition.severity, .error)
+
+    XCTAssertEqual(
+      StaticParserFixIt.insertSemicolon.fixItID,
+      MessageID(domain: "SwiftParser", id: "StaticParserFixIt.insertSemicolon")
+    )
   }
 }

--- a/Tests/SwiftParserTest/Types.swift
+++ b/Tests/SwiftParserTest/Types.swift
@@ -354,5 +354,13 @@ final class TypeParameterPackTests: XCTestCase {
       }
       """)
   }
+  func testParameterPacks28() throws {
+    // We allow whitespace between the generic parameter and the '...', this is
+    // consistent with regular variadic parameters.
+    AssertParse(
+      """
+      func f1<T ...>(_ x: T ...) -> (T ...) {}
+      """)
+  }
 }
 


### PR DESCRIPTION
Convert StaticParserError into a struct, and define the diagnostics in a `DiagnosticMessage where Self == StaticParserError` extension. This allows us to use leading dot syntax to pass a StaticParserError anywhere a DiagnosticMessage is expected. Also, do the same for StaticParserFixIt.

To compute the diagnostic ID, we can (ab)use `#function` to pick up the name of the property