### PR TITLE
Parse (unspaced) binary operators within a key path, e.g., .?..

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -916,12 +916,13 @@ extension Parser {
         continue
       }
 
-      // Check for a postfix operator starting with '.' that contains only
+      // Check for an operator starting with '.' that contains only
       // periods, '?'s, and '!'s. Expand that into key path components.
       if self.at(any: [
             .postfixOperator, .postfixQuestionMark,
-            .exclamationMark, .prefixOperator]
-         ),
+            .exclamationMark, .prefixOperator,
+            .unspacedBinaryOperator
+          ]),
          let numComponents = getNumOptionalKeyPathPostfixComponents(
           self.currentToken.tokenText) {
         components.append(

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -92,6 +92,45 @@ final class ExpressionTests: XCTestCase {
   func testKeypathExpression() {
     AssertParse(
       #"""
+      \.?.foo
+      """#,
+      substructure: Syntax(
+        CodeBlockItemListSyntax([
+          CodeBlockItemSyntax(
+            item: Syntax(
+              KeyPathExprSyntax(
+              backslash: .backslashToken(),
+              root: nil,
+              components: KeyPathComponentListSyntax([
+                KeyPathComponentSyntax(
+                  period: .periodToken(),
+                  component: Syntax(
+                    KeyPathOptionalComponentSyntax(
+                      questionOrExclamationMark: .postfixQuestionMarkToken()
+                    )
+                  )
+                ),
+                KeyPathComponentSyntax(
+                  period: .periodToken(),
+                  component: Syntax(
+                    KeyPathPropertyComponentSyntax(
+                      identifier: .identifier("foo"),
+                      declNameArguments: nil,
+                      genericArgumentClause: nil
+                    )
+                  )
+                )
+              ])
+            )),
+            semicolon: nil,
+            errorTokens: nil
+          )
+        ])
+      )
+    )
+
+    AssertParse(
+      #"""
       children.filter(\.type.defaultInitialization.isEmpty)
       """#
     )


### PR DESCRIPTION
Fixes https://github.com/apple/swift-syntax/issues/928.