### PR TITLE
Rename nameForDiagnostics 'function parameter' -> 'parameter'

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
@@ -98,7 +98,7 @@ public let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "FunctionParameterList",
-       nameForDiagnostics: "function parameter list",
+       nameForDiagnostics: "parameter list",
        kind: "SyntaxCollection",
        element: "FunctionParameter"),
 
@@ -712,7 +712,7 @@ public let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "FunctionParameter",
-       nameForDiagnostics: "function parameter",
+       nameForDiagnostics: "parameter",
        kind: "Syntax",
        traits: [
          "WithTrailingComma"

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -504,7 +504,7 @@ public enum SyntaxEnum {
     case .associatedtypeDecl:
       return "associatedtype declaration"
     case .functionParameterList:
-      return "function parameter list"
+      return "parameter list"
     case .parameterClause:
       return "parameter clause"
     case .returnClause:
@@ -556,7 +556,7 @@ public enum SyntaxEnum {
     case .initializerClause:
       return nil
     case .functionParameter:
-      return "function parameter"
+      return "parameter"
     case .modifierList:
       return nil
     case .functionDecl:

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -574,7 +574,7 @@ final class DeclarationTests: XCTestCase {
       "(first second 1️⃣Int)",
       { $0.parseFunctionSignature() },
       diagnostics: [
-        DiagnosticSpec(message: "expected ':' in function parameter")
+        DiagnosticSpec(message: "expected ':' in parameter")
       ]
     )
   }
@@ -584,7 +584,7 @@ final class DeclarationTests: XCTestCase {
       "(first second 1️⃣third fourth: Int)",
       { $0.parseFunctionSignature() },
       diagnostics: [
-        DiagnosticSpec(message: "unexpected code 'third fourth' in function parameter")
+        DiagnosticSpec(message: "unexpected code 'third fourth' in parameter")
       ]
     )
   }
@@ -771,7 +771,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "unexpected code 'third' in function parameter")
+        DiagnosticSpec(message: "unexpected code 'third' in parameter")
       ]
     )
   }
@@ -793,7 +793,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "unexpected code 'third fourth' in function parameter")
+        DiagnosticSpec(message: "unexpected code 'third fourth' in parameter")
       ]
     )
   }
@@ -813,7 +813,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in function parameter"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in parameter"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected ')' to end parameter clause"),
         DiagnosticSpec(locationMarker: "4️⃣", message: "expected name and member block in struct"),
         DiagnosticSpec(locationMarker: "4️⃣", message: "extraneous code ': Int) {}' at top level"),
@@ -843,7 +843,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "unexpected code '[third fourth]' in function parameter")
+        DiagnosticSpec(message: "unexpected code '[third fourth]' in parameter")
       ]
     )
   }
@@ -867,7 +867,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in function parameter"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in parameter"),
         DiagnosticSpec(locationMarker: "2️⃣" , message: "expected ']' to end array type"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code 'fourth: Int' in parameter clause")
       ]
@@ -892,7 +892,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in function parameter"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in parameter"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end parameter clause"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous code ': Int) {}' at top level")
       ]

--- a/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
+++ b/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
@@ -104,7 +104,7 @@ final class DollarIdentifierTests: XCTestCase {
         // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 10 - 11 = '`$`'
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected name in function"),
         DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '$' before parameter clause"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in function parameter"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in parameter"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '$ dollarParam: Int' in parameter clause"),
         // TODO: Old parser expected error on line 3: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 3 - 4 = '`$`'
         // TODO: Old parser expected error on line 3: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 5 - 6 = '`$`'

--- a/Tests/SwiftParserTest/translated/EnumTests.swift
+++ b/Tests/SwiftParserTest/translated/EnumTests.swift
@@ -104,7 +104,6 @@ final class EnumTests: XCTestCase {
       1️⃣case FloatingCase
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: enum 'case' is not allowed outside of an enum
         DiagnosticSpec(message: "'case' can only appear inside a 'switch' statement or 'enum' declaration"),
       ]
     )
@@ -116,10 +115,7 @@ final class EnumTests: XCTestCase {
       struct SomeStruct {
         case StructCase 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: enum 'case' is not allowed outside of an enum
-      ]
+      """
     )
   }
 
@@ -129,10 +125,7 @@ final class EnumTests: XCTestCase {
       class SomeClass {
         case ClassCase 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: enum 'case' is not allowed outside of an enum
-      ]
+      """
     )
   }
 
@@ -145,10 +138,7 @@ final class EnumTests: XCTestCase {
       extension EnumWithExtension1 {
         case A2 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 5: enum 'case' is not allowed outside of an enum
-      ]
+      """
     )
   }
 
@@ -179,7 +169,6 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
         DiagnosticSpec(message: "unexpected code ':' in enum"),
       ]
     )
@@ -193,7 +182,6 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
         DiagnosticSpec(message: "unexpected code ':' in enum"),
       ]
     )
@@ -207,7 +195,6 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
         DiagnosticSpec(message: "unexpected code ':' in enum"),
       ]
     )
@@ -221,7 +208,6 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
         DiagnosticSpec(message: "unexpected code 'where true:' in enum"),
       ]
     )
@@ -235,7 +221,6 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
         DiagnosticSpec(message: "unexpected code ':' in enum"),
       ]
     )
@@ -249,7 +234,6 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
         DiagnosticSpec(message: "unexpected code 'where true:' in enum"),
       ]
     )
@@ -263,7 +247,6 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
         DiagnosticSpec(locationMarker: "1️⃣", message: "name can only start with a letter or underscore, not a number"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code ':' in enum"),
       ]
@@ -294,8 +277,8 @@ final class EnumTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected name in enum case"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ':' and type in function parameter"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected type in function parameter"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ':' and type in parameter"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "expected type in parameter"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code '0' in parameter clause"),
         DiagnosticSpec(locationMarker: "4️⃣", message: "unexpected code ':' in enum"),
       ]

--- a/Tests/SwiftParserTest/translated/InitDeinitTests.swift
+++ b/Tests/SwiftParserTest/translated/InitDeinitTests.swift
@@ -339,7 +339,7 @@ final class InitDeinitTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 3: missing 'self.' at initializer invocation, Fix-It replacements: 24 - 24 = 'self.'
-        DiagnosticSpec(message: "expected type in function parameter"),
+        DiagnosticSpec(message: "expected type in parameter"),
         DiagnosticSpec(message: "unexpected code '1' in parameter clause"),
       ]
     )
@@ -356,7 +356,7 @@ final class InitDeinitTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 3: missing 'super.' at initializer invocation, Fix-It replacements: 5 - 5 = 'super.'
-        DiagnosticSpec(message: "expected type in function parameter"),
+        DiagnosticSpec(message: "expected type in parameter"),
         DiagnosticSpec(message: "unexpected code '2' in parameter clause"),
       ]
     )
@@ -372,7 +372,7 @@ final class InitDeinitTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 3: missing 'self.' at initializer invocation, Fix-It replacements: 12 - 12 = 'self.'
-        DiagnosticSpec(message: "expected type in function parameter"),
+        DiagnosticSpec(message: "expected type in parameter"),
         DiagnosticSpec(message: "unexpected code '1' in parameter clause"),
       ]
     )

--- a/Tests/SwiftParserTest/translated/InvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidTests.swift
@@ -227,7 +227,7 @@ final class InvalidTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected ':' and type in function parameter"),
+        DiagnosticSpec(message: "expected ':' and type in parameter"),
       ]
     )
   }
@@ -283,7 +283,7 @@ final class InvalidTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected warning on line 3: 'let' in this position is interpreted as an argument label, Fix-It replacements: 15 - 18 = '`let`'
-        DiagnosticSpec(message: "unexpected code 'a' in function parameter"),
+        DiagnosticSpec(message: "unexpected code 'a' in parameter"),
       ]
     )
   }

--- a/gyb_syntax_support/DeclNodes.py
+++ b/gyb_syntax_support/DeclNodes.py
@@ -53,7 +53,7 @@ DECL_NODES = [
                    is_optional=True),
          ]),
 
-    Node('FunctionParameterList', name_for_diagnostics='function parameter list',
+    Node('FunctionParameterList', name_for_diagnostics='parameter list',
          kind='SyntaxCollection', element='FunctionParameter'),
 
     Node('ParameterClause', name_for_diagnostics='parameter clause', kind='Syntax',
@@ -374,7 +374,7 @@ DECL_NODES = [
     # parameter ->
     # external-parameter-name? local-parameter-name ':'
     #   type '...'? '='? expression? ','?
-    Node('FunctionParameter', name_for_diagnostics='function parameter', kind='Syntax',
+    Node('FunctionParameter', name_for_diagnostics='parameter', kind='Syntax',
          traits=['WithTrailingComma'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',


### PR DESCRIPTION
This node is also used to model enum parameters.