### PR TITLE
Remove name_for_diagnostics='name'

### DIFF
--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -694,7 +694,7 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     case 6:
       return nil
     case 7:
-      return "name"
+      return nil
     case 8:
       return nil
     case 9:
@@ -1163,7 +1163,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     case 6:
       return nil
     case 7:
-      return "name"
+      return nil
     case 8:
       return nil
     case 9:
@@ -2694,7 +2694,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     case 6:
       return nil
     case 7:
-      return "name"
+      return nil
     case 8:
       return nil
     case 9:
@@ -3214,7 +3214,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     case 6:
       return nil
     case 7:
-      return "name"
+      return nil
     case 8:
       return nil
     case 9:
@@ -3734,7 +3734,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     case 6:
       return nil
     case 7:
-      return "name"
+      return nil
     case 8:
       return nil
     case 9:
@@ -4254,7 +4254,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     case 6:
       return nil
     case 7:
-      return "name"
+      return nil
     case 8:
       return nil
     case 9:
@@ -4728,7 +4728,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     case 6:
       return nil
     case 7:
-      return "name"
+      return nil
     case 8:
       return nil
     case 9:
@@ -5242,7 +5242,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     case 6:
       return nil
     case 7:
-      return "name"
+      return nil
     case 8:
       return nil
     case 9:
@@ -8654,7 +8654,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     case 6:
       return nil
     case 7:
-      return "name"
+      return nil
     case 8:
       return nil
     case 9:
@@ -9048,7 +9048,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     case 6:
       return nil
     case 7:
-      return "name"
+      return nil
     case 8:
       return nil
     case 9:
@@ -9534,7 +9534,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     case 6:
       return nil
     case 7:
-      return "name"
+      return nil
     case 8:
       return nil
     case 9:

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -8282,7 +8282,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
-      return "name"
+      return nil
     case 6:
       return nil
     case 7:
@@ -9739,7 +9739,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
     case 0:
       return nil
     case 1:
-      return "name"
+      return nil
     case 2:
       return nil
     case 3:

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -296,7 +296,7 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     case 0:
       return nil
     case 1:
-      return "name"
+      return "label name"
     case 2:
       return nil
     case 3:

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -55,7 +55,7 @@ final class DeclarationTests: XCTestCase {
     AssertParse(
       "func 1️⃣/^notoperator^/ (lhs: Int, rhs: Int) -> Int { 1 / 2 }",
       diagnostics: [
-        DiagnosticSpec(message: "expected name in function"),
+        DiagnosticSpec(message: "expected identifier in function"),
         DiagnosticSpec(message: "unexpected code '/^notoperator^/' before parameter clause")
       ]
     )
@@ -159,7 +159,7 @@ final class DeclarationTests: XCTestCase {
       "protocol P{1️⃣{}case2️⃣",
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '{}' before enum case"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected name in enum case"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in enum case"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected '}' to end protocol"),
       ])
   }
@@ -689,8 +689,8 @@ final class DeclarationTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "name can only start with a letter or underscore, not a number"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "identifier can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -817,7 +817,7 @@ final class DeclarationTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in parameter"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected name and member block in struct"),
+        DiagnosticSpec(locationMarker: "4️⃣", message: "expected identifier and member block in struct"),
         DiagnosticSpec(locationMarker: "4️⃣", message: "extraneous code ': Int) {}' at top level"),
       ]
     )
@@ -1024,7 +1024,7 @@ final class DeclarationTests: XCTestCase {
     AssertParse(
       "associatedtype 1️⃣5s",
       diagnostics: [
-        DiagnosticSpec(message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -1127,7 +1127,7 @@ final class DeclarationTests: XCTestCase {
     AssertParse(
       "func 1️⃣{}",
       diagnostics: [
-        DiagnosticSpec(message: "expected name and function signature in function")
+        DiagnosticSpec(message: "expected identifier and function signature in function")
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
+++ b/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
@@ -182,7 +182,7 @@ final class DeprecatedWhereTests: XCTestCase {
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected inherited type in generic parameter"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected '>' to end generic parameter clause"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected parameter clause in function signature"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected name and member block in protocol"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier and member block in protocol"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous code '<ProtoA, ProtoB> where T: ProtoC>(x: T) {}' at top level"),
       ]
     )
@@ -199,7 +199,7 @@ final class DeprecatedWhereTests: XCTestCase {
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected inherited type in generic parameter"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected '>' to end generic parameter clause"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected parameter clause in function signature"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected name and member block in protocol"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier and member block in protocol"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous code '<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {}' at top level"),
       ]
     )

--- a/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
+++ b/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
@@ -57,7 +57,7 @@ final class DollarIdentifierTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 9 - 10 = '`$`'
-        DiagnosticSpec(message: "expected name and member block in class"),
+        DiagnosticSpec(message: "expected identifier and member block in class"),
       ]
     )
   }
@@ -71,7 +71,7 @@ final class DollarIdentifierTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 8 - 9 = '`$`'
-        DiagnosticSpec(message: "expected name and member block in enum"),
+        DiagnosticSpec(message: "expected identifier and member block in enum"),
       ]
     )
   }
@@ -85,7 +85,7 @@ final class DollarIdentifierTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 10 - 11 = '`$`'
-        DiagnosticSpec(message: "expected name and member block in struct"),
+        DiagnosticSpec(message: "expected identifier and member block in struct"),
       ]
     )
   }
@@ -102,7 +102,7 @@ final class DollarIdentifierTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 8 - 9 = '`$`'
         // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 10 - 11 = '`$`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected name in function"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in function"),
         DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '$' before parameter clause"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in parameter"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '$ dollarParam: Int' in parameter clause"),

--- a/Tests/SwiftParserTest/translated/EnumTests.swift
+++ b/Tests/SwiftParserTest/translated/EnumTests.swift
@@ -247,7 +247,7 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "identifier can only start with a letter or underscore, not a number"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code ':' in enum"),
       ]
     )
@@ -275,7 +275,7 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected name in enum case"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in enum case"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected ':' and type in parameter"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected type in parameter"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code '0' in parameter clause"),
@@ -331,7 +331,7 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected name in enum case"),
+        DiagnosticSpec(message: "expected identifier in enum case"),
       ]
     )
   }
@@ -344,7 +344,7 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected name in enum case"),
+        DiagnosticSpec(message: "expected identifier in enum case"),
         DiagnosticSpec(message: "unexpected code ':' in enum"),
       ]
     )
@@ -418,7 +418,7 @@ final class EnumTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "'_' cannot be used as an identifier here"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "'_' cannot be used as an identifier here"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected name in enum case"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in enum case"),
       ]
     )
   }
@@ -1287,7 +1287,7 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected name in enum case"),
+        DiagnosticSpec(message: "expected identifier in enum case"),
       ]
     )
   }
@@ -1301,7 +1301,7 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected name in enum case"),
+        DiagnosticSpec(message: "expected identifier in enum case"),
       ]
     )
   }
@@ -1329,8 +1329,8 @@ final class EnumTests: XCTestCase {
       }
       """#,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected name in enum case"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected name in enum case"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in enum case"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/NumberIdentifierErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/NumberIdentifierErrorsTests.swift
@@ -19,7 +19,7 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       func 1️⃣1() {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -30,7 +30,7 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       func 1️⃣2.0() {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -41,7 +41,7 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       func 1️⃣3func() {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -55,8 +55,8 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "name can only start with a letter or underscore, not a number"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "identifier can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -69,8 +69,8 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "name can only start with a letter or underscore, not a number"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "identifier can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -83,8 +83,8 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "name can only start with a letter or underscore, not a number"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "identifier can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -96,7 +96,7 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       typealias 1️⃣10 = Int
       """,
       diagnostics: [
-        DiagnosticSpec(message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -107,7 +107,7 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       typealias 1️⃣11.0 = Int
       """,
       diagnostics: [
-        DiagnosticSpec(message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -118,7 +118,7 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       typealias 1️⃣12typealias = Int
       """,
       diagnostics: [
-        DiagnosticSpec(message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -129,7 +129,7 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       struct 1️⃣13 {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -140,7 +140,7 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       struct 1️⃣14.0 {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -151,7 +151,7 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       struct 1️⃣15struct {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -162,7 +162,7 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       enum 1️⃣16 {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -173,7 +173,7 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       enum 1️⃣17.0 {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -184,7 +184,7 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       enum 1️⃣18enum {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -197,8 +197,8 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "name can only start with a letter or underscore, not a number"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "identifier can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -211,8 +211,8 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "name can only start with a letter or underscore, not a number"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "identifier can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
@@ -226,8 +226,8 @@ final class NumberIdentifierErrorsTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "name can only start with a letter or underscore, not a number"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "name can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "identifier can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
@@ -142,7 +142,7 @@ final class OperatorDeclTests: XCTestCase {
       prefix operator1️⃣
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected name in operator declaration")
+        DiagnosticSpec(message: "expected binary operator in operator declaration")
       ]
     )
   }
@@ -313,7 +313,7 @@ final class OperatorDeclTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected name in precedencegroup"),
+        DiagnosticSpec(message: "expected identifier in precedencegroup"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/SwitchTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchTests.swift
@@ -22,7 +22,7 @@ final class SwitchTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected expression and '{}' to end 'switch' statement"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected name and function signature in function"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier and function signature in function"),
       ]
     )
   }

--- a/gyb_syntax_support/DeclNodes.py
+++ b/gyb_syntax_support/DeclNodes.py
@@ -23,7 +23,7 @@ DECL_NODES = [
              Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('TypealiasKeyword', kind='TypealiasToken'),
-             Child('Identifier', kind='IdentifierToken',  name_for_diagnostics='name'),
+             Child('Identifier', kind='IdentifierToken'),
              Child('GenericParameterClause', kind='GenericParameterClause', name_for_diagnostics='generic parameter clause',
                    is_optional=True),
              Child('Initializer', kind='TypeInitializerClause'),
@@ -44,7 +44,7 @@ DECL_NODES = [
              Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('AssociatedtypeKeyword', kind='AssociatedtypeToken'),
-             Child('Identifier', kind='IdentifierToken',  name_for_diagnostics='name'),
+             Child('Identifier', kind='IdentifierToken'),
              Child('InheritanceClause', kind='TypeInheritanceClause', name_for_diagnostics='inheritance clause',
                    is_optional=True),
              Child('Initializer', kind='TypeInitializerClause',
@@ -223,7 +223,7 @@ DECL_NODES = [
              Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('ClassKeyword', kind='ClassToken'),
-             Child('Identifier', kind='IdentifierToken', name_for_diagnostics='name'),
+             Child('Identifier', kind='IdentifierToken'),
              Child('GenericParameterClause', kind='GenericParameterClause', name_for_diagnostics='generic parameter clause',
                    is_optional=True),
              Child('InheritanceClause', kind='TypeInheritanceClause', name_for_diagnostics='inheritance clause',
@@ -249,7 +249,7 @@ DECL_NODES = [
                    collection_element_name='Modifier', is_optional=True),
              Child('ActorKeyword', kind='ContextualKeywordToken',
                    text_choices=['actor']),
-             Child('Identifier', kind='IdentifierToken', name_for_diagnostics='name'),
+             Child('Identifier', kind='IdentifierToken'),
              Child('GenericParameterClause', kind='GenericParameterClause', name_for_diagnostics='generic parameter clause',
                    is_optional=True),
              Child('InheritanceClause', kind='TypeInheritanceClause', name_for_diagnostics='type inheritance clause',
@@ -273,7 +273,7 @@ DECL_NODES = [
              Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('StructKeyword', kind='StructToken'),
-             Child('Identifier', kind='IdentifierToken', name_for_diagnostics='name'),
+             Child('Identifier', kind='IdentifierToken'),
              Child('GenericParameterClause', kind='GenericParameterClause', name_for_diagnostics='generic parameter clause',
                    is_optional=True),
              Child('InheritanceClause', kind='TypeInheritanceClause', name_for_diagnostics='type inheritance clause',
@@ -291,7 +291,7 @@ DECL_NODES = [
              Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('ProtocolKeyword', kind='ProtocolToken'),
-             Child('Identifier', kind='IdentifierToken', name_for_diagnostics='name'),
+             Child('Identifier', kind='IdentifierToken'),
              Child('PrimaryAssociatedTypeClause',
                    kind='PrimaryAssociatedTypeClause',
                    name_for_diagnostics='primary associated type clause',
@@ -317,7 +317,7 @@ DECL_NODES = [
              Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('ExtensionKeyword', kind='ExtensionToken'),
-             Child('ExtendedType', kind='Type', name_for_diagnostics='name'),
+             Child('ExtendedType', kind='Type'),
              Child('InheritanceClause', kind='TypeInheritanceClause', name_for_diagnostics='inheritance clause',
                    is_optional=True),
              Child('GenericWhereClause', kind='GenericWhereClause', name_for_diagnostics='generic where clause',
@@ -381,7 +381,7 @@ DECL_NODES = [
                    collection_element_name='Attribute', is_optional=True),
              Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
-             Child('FirstName', kind='Token', name_for_diagnostics='name',
+             Child('FirstName', kind='Token',
                    token_choices=[
                        'IdentifierToken',
                        'WildcardToken',
@@ -442,7 +442,7 @@ DECL_NODES = [
              Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('FuncKeyword', kind='FuncToken'),
-             Child('Identifier', kind='Token', name_for_diagnostics='name',
+             Child('Identifier', kind='Token',
                    token_choices=[
                        'IdentifierToken',
                        'UnspacedBinaryOperatorToken',
@@ -637,7 +637,7 @@ DECL_NODES = [
          ''',
          traits=['WithTrailingComma'],
          children=[
-             Child('Identifier', kind='IdentifierToken', name_for_diagnostics='name',
+             Child('Identifier', kind='IdentifierToken',
                    description='The name of this case.'),
              Child('AssociatedValue', kind='ParameterClause', name_for_diagnostics='associated values', is_optional=True,
                    description='The set of associated values of the case.'),
@@ -698,7 +698,7 @@ DECL_NODES = [
                    description='''
                    The `enum` keyword for this declaration.
                    '''),
-             Child('Identifier', kind='IdentifierToken', name_for_diagnostics='name',
+             Child('Identifier', kind='IdentifierToken',
                    description='''
                    The name of this enum.
                    '''),
@@ -743,7 +743,7 @@ DECL_NODES = [
                    declaration.
                    '''),
              Child('OperatorKeyword', kind='OperatorToken'),
-             Child('Identifier', kind='Token', name_for_diagnostics='name',
+             Child('Identifier', kind='Token',
                    classification='OperatorIdentifier',
                    token_choices=[
                        'UnspacedBinaryOperatorToken',
@@ -804,7 +804,7 @@ DECL_NODES = [
                    declaration.
                    '''),
              Child('PrecedencegroupKeyword', kind='PrecedencegroupToken'),
-             Child('Identifier', kind='IdentifierToken', name_for_diagnostics='name',
+             Child('Identifier', kind='IdentifierToken',
                    description='''
                    The name of this precedence group.
                    '''),

--- a/gyb_syntax_support/StmtNodes.py
+++ b/gyb_syntax_support/StmtNodes.py
@@ -5,7 +5,7 @@ STMT_NODES = [
     # labeled-stmt -> label ':' stmt
     Node('LabeledStmt', name_for_diagnostics='labeled statement', kind='Stmt',
          children=[
-             Child('LabelName', kind='IdentifierToken', name_for_diagnostics='name'),
+             Child('LabelName', kind='IdentifierToken', name_for_diagnostics='label name'),
              Child('LabelColon', kind='ColonToken'),
              Child('Statement', kind='Stmt'),
          ]),


### PR DESCRIPTION
@bnbarham We chatted about this before. Do you think the new error messages are better? I don’t really have strong opinions.