### PR TITLE
Change trivia attribution rule to make comments trailing trivia unless separated by a newline

### DIFF
--- a/Sources/SwiftParser/Diagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParser/Diagnostics/MissingNodesError.swift
@@ -28,14 +28,16 @@ fileprivate enum NodesDescriptionPart {
 
   func description(format: Bool) -> String? {
     switch self {
-    case .tokensWithDefaultText(let tokens):
-      let tokenContents: String
+    case .tokensWithDefaultText(var tokens):
       if format {
-        tokenContents = tokens.map({ BasicFormat().visit($0).description }).joined()
-      } else {
-        tokenContents = tokens.map(\.description).joined()
+        tokens = tokens.map({ BasicFormat().visit($0) })
       }
-      return "'\(tokenContents.trimmingWhitespace())'"
+      if !tokens.isEmpty {
+        tokens[0] = tokens[0].withLeadingTrivia([])
+        tokens[tokens.count - 1] = tokens[tokens.count - 1].withTrailingTrivia([])
+      }
+      let tokenContents = tokens.map(\.description).joined()
+      return "'\(tokenContents)'"
     case .tokenWithoutDefaultText(let token):
       if let childName = token.childNameInParent {
         return childName

--- a/Sources/SwiftParser/Lexer.swift
+++ b/Sources/SwiftParser/Lexer.swift
@@ -921,10 +921,6 @@ extension Lexer.Cursor {
         guard !self.isAtEndOfFile else {
           break
         }
-        if case .trailing = position {
-          // Don't lex comments as trailing trivia (for now).
-          break
-        }
 
         switch self.peek() {
         case UInt8(ascii: "/"):

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -27,24 +27,30 @@ func AssertEqualTokens(_ actual: [Lexer.Lexeme], _ expected: [Lexer.Lexeme], fil
     }
 
     guard l.leadingTriviaText == r.leadingTriviaText else {
-      return XCTFail("""
-        Token at index \(idx) does not have matching leading trivia! \
-        \(l.leadingTriviaText.debugDescription) != \(r.leadingTriviaText.debugDescription)
-        """, file: file, line: line)
+      return FailStringsEqualWithDiff(
+        String(syntaxText: l.leadingTriviaText),
+        String(syntaxText: r.leadingTriviaText),
+        "Token at index \(idx) does not have matching leading trivia",
+        file: file, line: line
+      )
     }
 
-    guard l.tokenText == r.tokenText else {
-      return XCTFail("""
-        Text at index \(idx) does not have matching text! \
-        \(l.tokenText.debugDescription) != \(r.tokenText.debugDescription)"
-        """, file: file, line: line)
+    guard l.tokenText.debugDescription == r.tokenText.debugDescription else {
+      return FailStringsEqualWithDiff(
+        l.tokenText.debugDescription,
+        r.tokenText.debugDescription,
+        "Text at index \(idx) does not have matching text",
+        file: file, line: line
+      )
     }
 
     guard l.trailingTriviaText == r.trailingTriviaText else {
-      return XCTFail("""
-        Token at index \(idx) does not have matching trailing trivia! \
-        \(l.trailingTriviaText.debugDescription) != \(r.trailingTriviaText.debugDescription)
-        """, file: file, line: line)
+      return FailStringsEqualWithDiff(
+        String(syntaxText: l.trailingTriviaText),
+        String(syntaxText: r.trailingTriviaText),
+        "Token at index \(idx) does not have matching trailing trivia",
+        file: file, line: line
+      )
     }
   }
 }

--- a/Tests/SwiftParserTest/ClassificationTests.swift
+++ b/Tests/SwiftParserTest/ClassificationTests.swift
@@ -5,7 +5,10 @@ import SwiftParser
 public class ClassificationTests: XCTestCase {
 
   public func testClassification() {
-    let source = "// blah.\nlet x/*yo*/ = 0"
+    let source = """
+    // blah.
+    let x/*yo*/ = 0
+    """
     let tree = Parser.parse(source: source)
     do {
       let classif = Array(tree.classifications)
@@ -56,13 +59,13 @@ public class ClassificationTests: XCTestCase {
         return
       }
       XCTAssertEqual(classif[0].kind, .none)
-      XCTAssertEqual(classif[0].range, ByteSourceRange(offset: 20, length: 3))
+      XCTAssertEqual(classif[0].range, ByteSourceRange(offset: 21, length: 2))
     }
     do {
-      let initializer = (tree.statements[0].item.as(VariableDeclSyntax.self)!).bindings[0].initializer!
-      XCTAssertEqual(initializer.description, "/*yo*/ = 0")
+      let pattern = (tree.statements[0].item.as(VariableDeclSyntax.self)!).bindings[0].pattern
+      XCTAssertEqual(pattern.description, "x/*yo*/ ")
       // Classify with a relative range inside this node.
-      let classif = Array(initializer.classifications(in: ByteSourceRange(offset: 5, length: 2)))
+      let classif = Array(pattern.classifications(in: ByteSourceRange(offset: 5, length: 2)))
       XCTAssertEqual(classif.count, 2)
       guard classif.count == 2 else {
         return
@@ -70,14 +73,14 @@ public class ClassificationTests: XCTestCase {
       XCTAssertEqual(classif[0].kind, .blockComment)
       XCTAssertEqual(classif[0].range, ByteSourceRange(offset: 14, length: 6))
       XCTAssertEqual(classif[1].kind, .none)
-      XCTAssertEqual(classif[1].range, ByteSourceRange(offset: 20, length: 3))
+      XCTAssertEqual(classif[1].range, ByteSourceRange(offset: 20, length: 1))
 
       do {
-        let singleClassif = initializer.classification(at: 5)
+        let singleClassif = pattern.classification(at: 5)
         XCTAssertEqual(singleClassif, classif[0])
       }
       do {
-        let singleClassif = initializer.classification(at: AbsolutePosition(utf8Offset: 19))
+        let singleClassif = pattern.classification(at: AbsolutePosition(utf8Offset: 19))
         XCTAssertEqual(singleClassif, classif[0])
       }
     }

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -6,16 +6,16 @@ import XCTest
 private func lexeme(
   _ kind: RawTokenKind,
   _ wholeText: SyntaxText,
-  leading: Int = 0,
-  trailing: Int = 0
+  leadingLength: Int = 0,
+  trailingLength: Int = 0
 ) -> Lexer.Lexeme {
   return Lexer.Lexeme(
     tokenKind: kind,
     flags: [.isAtStartOfLine],
     start: wholeText.baseAddress!,
-    leadingTriviaLength: leading,
-    textLength: wholeText.count - leading - trailing,
-    trailingTriviaLength: trailing)
+    leadingTriviaLength: leadingLength,
+    textLength: wholeText.count - leadingLength - trailingLength,
+    trailingTriviaLength: trailingLength)
 }
 
 public class LexerTests: XCTestCase {
@@ -27,7 +27,7 @@ public class LexerTests: XCTestCase {
     data.withUTF8 { buf in
       let lexemes = Lexer.lex(buf)
       AssertEqualTokens(lexemes, [
-        lexeme(.identifier, "Hello ", trailing: 1),
+        lexeme(.identifier, "Hello ", trailingLength: 1),
         lexeme(.identifier, "World"),
         lexeme(.eof, ""),
       ])
@@ -42,8 +42,8 @@ public class LexerTests: XCTestCase {
     data.withUTF8 { buf in
       let lexemes = Lexer.lex(buf)
       AssertEqualTokens(lexemes, [
-        lexeme(.identifier, "`Hello` ", trailing: 1),
-        lexeme(.identifier, "`World` ", trailing: 1),
+        lexeme(.identifier, "`Hello` ", trailingLength: 1),
+        lexeme(.identifier, "`World` ", trailingLength: 1),
         lexeme(.identifier, "`$`"),
         lexeme(.eof, ""),
      ])
@@ -61,10 +61,10 @@ public class LexerTests: XCTestCase {
       data.withUTF8 { buf in
         let lexemes = Lexer.lex(buf)
         AssertEqualTokens(lexemes, [
-          lexeme(.funcKeyword, "/*/ */\nfunc ", leading: 7, trailing: 1),
+          lexeme(.funcKeyword, "/*/ */\nfunc ", leadingLength: 7, trailingLength: 1),
           lexeme(.identifier, "not_doc5"),
           lexeme(.leftParen, "("),
-          lexeme(.rightParen, ") ", trailing: 1),
+          lexeme(.rightParen, ") ", trailingLength: 1),
           lexeme(.leftBrace, "{"),
           lexeme(.rightBrace, "}"),
           lexeme(.eof, ""),
@@ -83,7 +83,7 @@ public class LexerTests: XCTestCase {
       data.withUTF8 { buf in
         let lexemes = Lexer.lex(buf)
         AssertEqualTokens(lexemes, [
-          lexeme(.eof, "/* */\n/**/\n/* /* */ */", leading: 22),
+          lexeme(.eof, "/* */\n/**/\n/* /* */ */", leadingLength: 22),
         ])
       }
     }
@@ -160,18 +160,18 @@ public class LexerTests: XCTestCase {
       let lexemes = Lexer.lex(buf)
       AssertEqualTokens(lexemes, [
         lexeme(.integerLiteral, "1234567890"),
-        lexeme(.integerLiteral, "\n0b1010101", leading: 1),
-        lexeme(.integerLiteral, "\n0xABC", leading: 1),
-        lexeme(.floatingLiteral, "\n1.0", leading: 1),
-        lexeme(.floatingLiteral, "\n1.0e10", leading: 1),
-        lexeme(.floatingLiteral, "\n1.0E10", leading: 1),
-        lexeme(.integerLiteral, "\n0xfeed_beef", leading: 1),
-        lexeme(.floatingLiteral, "\n0xff.0p2", leading: 1),
-        lexeme(.prefixOperator, "\n-", leading: 1),
+        lexeme(.integerLiteral, "\n0b1010101", leadingLength: 1),
+        lexeme(.integerLiteral, "\n0xABC", leadingLength: 1),
+        lexeme(.floatingLiteral, "\n1.0", leadingLength: 1),
+        lexeme(.floatingLiteral, "\n1.0e10", leadingLength: 1),
+        lexeme(.floatingLiteral, "\n1.0E10", leadingLength: 1),
+        lexeme(.integerLiteral, "\n0xfeed_beef", leadingLength: 1),
+        lexeme(.floatingLiteral, "\n0xff.0p2", leadingLength: 1),
+        lexeme(.prefixOperator, "\n-", leadingLength: 1),
         lexeme(.floatingLiteral, "0xff.0p2"),
-        lexeme(.prefixOperator, "\n+", leading: 1),
+        lexeme(.prefixOperator, "\n+", leadingLength: 1),
         lexeme(.floatingLiteral, "0xff.0p2"),
-        lexeme(.floatingLiteral, "\n0x1.921fb4p1", leading: 1),
+        lexeme(.floatingLiteral, "\n0x1.921fb4p1", leadingLength: 1),
         lexeme(.eof, ""),
       ])
     }
@@ -246,9 +246,9 @@ public class LexerTests: XCTestCase {
     data.withUTF8 { buf in
       let lexemes = Lexer.lex(buf)
       AssertEqualTokens(lexemes, [
-        lexeme(.letKeyword, "#!/usr/bin/swiftc\nlet ", leading: 18, trailing: 1),
-        lexeme(.identifier, "x ", trailing: 1),
-        lexeme(.equal, "= ", trailing: 1),
+        lexeme(.letKeyword, "#!/usr/bin/swiftc\nlet ", leadingLength: 18, trailingLength: 1),
+        lexeme(.identifier, "x ", trailingLength: 1),
+        lexeme(.equal, "= ", trailingLength: 1),
         lexeme(.integerLiteral, "42"),
         lexeme(.eof, ""),
       ])
@@ -265,11 +265,11 @@ public class LexerTests: XCTestCase {
     data.withUTF8 { buf in
       let lexemes = Lexer.lex(buf)
       AssertEqualTokens(lexemes, [
-        lexeme(.varKeyword, "/** hello */\nvar ", leading: 13, trailing: 1),
+        lexeme(.varKeyword, "/** hello */\nvar ", leadingLength: 13, trailingLength: 1),
         lexeme(.identifier, "x"),
-        lexeme(.colon, ": ", trailing: 1),
+        lexeme(.colon, ": ", trailingLength: 1),
         lexeme(.identifier, "Int"),
-        lexeme(.eof, "\n/* regular comment */", leading: 22),
+        lexeme(.eof, "\n/* regular comment */", leadingLength: 22),
       ])
     }
   }
@@ -287,23 +287,23 @@ public class LexerTests: XCTestCase {
     data.withUTF8 { buf in
       let lexemes = Lexer.lex(buf)
       AssertEqualTokens(lexemes, [
-        lexeme(.atSign, "/* TestApp */\n@", leading: 14),
-        lexeme(.identifier, "main ", trailing: 1),
-        lexeme(.structKeyword, "struct ", trailing: 1),
-        lexeme(.identifier, "TestApp ", trailing: 1),
+        lexeme(.atSign, "/* TestApp */\n@", leadingLength: 14),
+        lexeme(.identifier, "main ", trailingLength: 1),
+        lexeme(.structKeyword, "struct ", trailingLength: 1),
+        lexeme(.identifier, "TestApp ", trailingLength: 1),
         lexeme(.leftBrace, "{"),
-        lexeme(.staticKeyword, "\n  static ", leading: 3, trailing: 1),
-        lexeme(.funcKeyword, "func ", trailing: 1),
+        lexeme(.staticKeyword, "\n  static ", leadingLength: 3, trailingLength: 1),
+        lexeme(.funcKeyword, "func ", trailingLength: 1),
         lexeme(.identifier, "main"),
         lexeme(.leftParen, "("),
-        lexeme(.rightParen, ") ", trailing: 1),
+        lexeme(.rightParen, ") ", trailingLength: 1),
         lexeme(.leftBrace, "{"),
-        lexeme(.identifier, "\n    print", leading: 5),
+        lexeme(.identifier, "\n    print", leadingLength: 5),
         lexeme(.leftParen, "("),
         lexeme(.stringLiteral, "\"Hello World\""),
         lexeme(.rightParen, ")"),
-        lexeme(.rightBrace, "\n  }", leading: 3),
-        lexeme(.rightBrace, "\n}", leading: 1),
+        lexeme(.rightBrace, "\n  }", leadingLength: 3),
+        lexeme(.rightBrace, "\n}", leadingLength: 1),
         lexeme(.eof, ""),
       ])
     }
@@ -356,7 +356,7 @@ public class LexerTests: XCTestCase {
         lexeme(.pound, "#"),
         lexeme(.unspacedBinaryOperator, "/"),
         lexeme(.identifier, "abc"),
-        lexeme(.prefixOperator, "\n/", leading: 1),
+        lexeme(.prefixOperator, "\n/", leadingLength: 1),
         lexeme(.pound, "#"),
         lexeme(.eof, ""),
       ]),
@@ -364,7 +364,7 @@ public class LexerTests: XCTestCase {
         lexeme(.pound, "#"),
         lexeme(.unspacedBinaryOperator, "/"),
         lexeme(.identifier, "abc"),
-        lexeme(.prefixOperator, "\r/", leading: 1),
+        lexeme(.prefixOperator, "\r/", leadingLength: 1),
         lexeme(.pound, "#"),
         lexeme(.eof, ""),
       ]),
@@ -390,10 +390,10 @@ public class LexerTests: XCTestCase {
     data.withUTF8 { buf in
       let lexemes = Lexer.lex(buf)
       AssertEqualTokens(lexemes, [
-        lexeme(.staticKeyword, "static ", trailing: 1),
-        lexeme(.funcKeyword, "func �", trailing: 4),
+        lexeme(.staticKeyword, "static ", trailingLength: 1),
+        lexeme(.funcKeyword, "func �", trailingLength: 4),
         lexeme(.leftParen, "("),
-        lexeme(.rightParen, ") ", trailing: 1),
+        lexeme(.rightParen, ") ", trailingLength: 1),
         lexeme(.leftBrace, "{"),
         lexeme(.rightBrace, "}"),
         lexeme(.eof, ""),
@@ -410,7 +410,7 @@ public class LexerTests: XCTestCase {
     data.withUTF8 { buf in
       let lexemes = Lexer.lex(buf)
       AssertEqualTokens(lexemes, [
-        lexeme(.identifier, "\u{feff}Hello", leading: 3),
+        lexeme(.identifier, "\u{feff}Hello", leadingLength: 3),
         lexeme(.eof, "")
       ])
     }
@@ -442,7 +442,7 @@ public class LexerTests: XCTestCase {
                  var a : String = "a"
                  var b : String = "B"
                  >>>>>>> 18844bc65229786b96b89a9fc7739c0fc897905e:conflict_markers.swift
-                 """, leading: 300)
+                 """, leadingLength: 300)
         ])
       }
 
@@ -481,7 +481,7 @@ public class LexerTests: XCTestCase {
                  var b : String = "B"
                  <<<<
 
-                 """, leading: 204),
+                 """, leadingLength: 204),
         ])
       }
     }
@@ -517,12 +517,12 @@ public class LexerTests: XCTestCase {
         lexeme(.leftParen, "("),
         lexeme(.identifier, "reduced"),
         lexeme(.period, "."),
-        lexeme(.identifier, "count ", trailing: 1),
-        lexeme(.spacedBinaryOperator, "/ ", trailing: 1),
+        lexeme(.identifier, "count ", trailingLength: 1),
+        lexeme(.spacedBinaryOperator, "/ ", trailingLength: 1),
         lexeme(.integerLiteral, "2"),
-        lexeme(.comma, ", ", trailing: 1),
-        lexeme(.identifier, "chunkSize ", trailing: 1),
-        lexeme(.spacedBinaryOperator, "/ ", trailing: 1),
+        lexeme(.comma, ", ", trailingLength: 1),
+        lexeme(.identifier, "chunkSize ", trailingLength: 1),
+        lexeme(.spacedBinaryOperator, "/ ", trailingLength: 1),
         lexeme(.integerLiteral, "2"),
         lexeme(.rightParen, ")"),
         lexeme(.eof, ""),
@@ -543,17 +543,17 @@ public class LexerTests: XCTestCase {
         Lexer.lex(buf)
       }
       AssertEqualTokens(lexemes, [
-        lexeme(.varKeyword, "var ", trailing: 1),
+        lexeme(.varKeyword, "var ", trailingLength: 1),
         lexeme(.identifier, "x"),
-        lexeme(.colon, ": ", trailing: 1),
-        lexeme(.identifier, "Int ", trailing: 1),
+        lexeme(.colon, ": ", trailingLength: 1),
+        lexeme(.identifier, "Int ", trailingLength: 1),
         lexeme(.leftBrace, "{"),
-        lexeme(.returnKeyword, "\n  return ", leading: 3, trailing: 1),
-        lexeme(.integerLiteral, "0 ", trailing: 1),
-        lexeme(.spacedBinaryOperator, "/", trailing: 0),
-        lexeme(.identifier, "\n         x", leading: 10),
-        lexeme(.rightBrace, "\n}", leading: 1),
-        lexeme(.eof, "\n\n///", leading: 5),
+        lexeme(.returnKeyword, "\n  return ", leadingLength: 3, trailingLength: 1),
+        lexeme(.integerLiteral, "0 ", trailingLength: 1),
+        lexeme(.spacedBinaryOperator, "/", trailingLength: 0),
+        lexeme(.identifier, "\n         x", leadingLength: 10),
+        lexeme(.rightBrace, "\n}", leadingLength: 1),
+        lexeme(.eof, "\n\n///", leadingLength: 5),
       ])
     }
 
@@ -565,10 +565,10 @@ public class LexerTests: XCTestCase {
       data.withUTF8 { buf in
         let lexemes = Lexer.lex(buf)
         AssertEqualTokens(lexemes, [
-          lexeme(.identifier, "n ", trailing: 1),
-          lexeme(.spacedBinaryOperator, "/= ", trailing: 1),
-          lexeme(.integerLiteral, "2 ", trailing: 1),
-          lexeme(.eof, "// foo", leading: 6),
+          lexeme(.identifier, "n ", trailingLength: 1),
+          lexeme(.spacedBinaryOperator, "/= ", trailingLength: 1),
+          lexeme(.integerLiteral, "2 // foo", trailingLength: 7),
+          lexeme(.eof, ""),
         ])
       }
     }
@@ -584,13 +584,13 @@ public class LexerTests: XCTestCase {
           lexeme(.identifier, "UIColor"),
           lexeme(.leftParen, "("),
           lexeme(.identifier, "white"),
-          lexeme(.colon, ": ", trailing: 1),
+          lexeme(.colon, ": ", trailingLength: 1),
           lexeme(.floatingLiteral, "216.0"),
           lexeme(.unspacedBinaryOperator, "/"),
           lexeme(.floatingLiteral, "255.0"),
-          lexeme(.comma, ", ", trailing: 1),
+          lexeme(.comma, ", ", trailingLength: 1),
           lexeme(.identifier, "alpha"),
-          lexeme(.colon, ": ", trailing: 1),
+          lexeme(.colon, ": ", trailingLength: 1),
           lexeme(.floatingLiteral, "44.0"),
           lexeme(.unspacedBinaryOperator, "/"),
           lexeme(.floatingLiteral, "255.0"),
@@ -631,9 +631,9 @@ public class LexerTests: XCTestCase {
         let lexemes = Lexer.lex(buf)
         AssertEqualTokens(lexemes, [
           lexeme(.leftParen, "("),
-          lexeme(.rightParen, ") ", trailing: 1),
-          lexeme(.arrow, "-> ", trailing: 1),
-          lexeme(.leftParen, "(\u{feff}", trailing: 3),
+          lexeme(.rightParen, ") ", trailingLength: 1),
+          lexeme(.arrow, "-> ", trailingLength: 1),
+          lexeme(.leftParen, "(\u{feff}", trailingLength: 3),
           lexeme(.rightParen, ")"),
           lexeme(.eof, ""),
         ])
@@ -648,8 +648,8 @@ public class LexerTests: XCTestCase {
       data.withUTF8 { buf in
         let lexemes = Lexer.lex(buf)
         AssertEqualTokens(lexemes, [
-          lexeme(.identifier, "y\u{fffe} ", trailing: 4),
-          lexeme(.spacedBinaryOperator, "+ ", trailing: 1),
+          lexeme(.identifier, "y\u{fffe} ", trailingLength: 4),
+          lexeme(.spacedBinaryOperator, "+ ", trailingLength: 1),
           lexeme(.identifier, "z"),
           lexeme(.eof, ""),
         ])
@@ -682,11 +682,54 @@ public class LexerTests: XCTestCase {
       let lexemes = Lexer.lex(buf)
       AssertEqualTokens(lexemes, [
         lexeme(.prefixOperator, "!"),
-        lexeme(.identifier, "<#b1#> ", trailing: 1),
-        lexeme(.spacedBinaryOperator, "&& ", trailing: 1),
+        lexeme(.identifier, "<#b1#> ", trailingLength: 1),
+        lexeme(.spacedBinaryOperator, "&& ", trailingLength: 1),
         lexeme(.prefixOperator, "!"),
         lexeme(.identifier, "<#b2#>"),
         lexeme(.eof, ""),
+      ])
+    }
+  }
+
+  func testCommentAttribution() {
+    var data =
+    """
+    func foo() { // comment
+        // new comment
+        bar()
+    }
+    """
+    data.withUTF8 { buf in
+      let lexemes = Lexer.lex(buf)
+      AssertEqualTokens(lexemes, [
+        lexeme(.funcKeyword, "func ", trailingLength: 1),
+        lexeme(.identifier, "foo"),
+        lexeme(.leftParen, "("),
+        lexeme(.rightParen, ") ", trailingLength: 1),
+        lexeme(.leftBrace, "{ // comment", trailingLength: 11),
+        lexeme(.identifier, """
+
+            // new comment
+            bar
+        """, leadingLength: 24),
+        lexeme(.leftParen, "("),
+        lexeme(.rightParen, ")"),
+        lexeme(.rightBrace, "\n}", leadingLength: 1),
+        lexeme(.eof, ""),
+      ])
+    }
+  }
+
+  func testCommentAttribution2() {
+    // Example from https://forums.swift.org/t/changing-comment-trivia-attribution-from-trailing-trivia-to-leading-trivia/50773
+    var data = "/*X_START*/x/*X_END*/ + /*Y_START*/y/*Y_END*/"
+    data.withUTF8 { buf in
+      let lexemes = Lexer.lex(buf)
+      AssertEqualTokens(lexemes, [
+        lexeme(.identifier, "/*X_START*/x/*X_END*/ ", leadingLength: 11, trailingLength: 10),
+        lexeme(.spacedBinaryOperator, "+ /*Y_START*/", trailingLength: 12),
+        lexeme(.identifier, "y/*Y_END*/", trailingLength: 9),
+        lexeme(.eof, "")
       ])
     }
   }

--- a/Tests/SwiftParserTest/translated/DiagnoseInitializerAsTypedPatternTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseInitializerAsTypedPatternTests.swift
@@ -60,7 +60,7 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
     )
   }
 
-  func testDiagnoseInitializerAsTypedPattern5() {
+  func testDiagnoseInitializerAsTypedPattern5a() {
     AssertParse(
       """
       let f1️⃣:/*comment*/[X]()
@@ -70,6 +70,18 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
       ], fixedSource: "let f=/*comment*/[X]()"
     )
   }
+
+  func testDiagnoseInitializerAsTypedPattern5b() {
+    AssertParse(
+      """
+      let f/*comment*/1️⃣:[X]()
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "unexpected initializer in pattern; did you mean to use '='?", fixIts: ["replace ':' by '='"]),
+      ], fixedSource: "let f/*comment*/=[X]()"
+    )
+  }
+
 
   func testDiagnoseInitializerAsTypedPattern6() {
     AssertParse(


### PR DESCRIPTION
This changes the trivia attribution rule in the new parser to consider all trivia up to the next newline as trailing trivia. Previously, comments were always considered trailing trivia.

This was discussed last year in https://forums.swift.org/t/changing-comment-trivia-attribution-from-trailing-trivia-to-leading-trivia/50773.

My idea is that right now is probably one of the best times to change this because switching from the old to the new parser is an active source change for all clients.

Resolves rdar://68234477
Resolves rdar://95639215
Fixes #438

CC @allevato @jpsim 