### PR TITLE
Consume Balanced Braces in Trailing Closure Lookahead

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -2294,7 +2294,6 @@ extension Parser.Lookahead {
     //   {...}()
     // by looking ahead for the ()'s, but this has been replaced by do{}, so this
     // probably isn't worthwhile.
-    //
     guard case .basic = flavor else {
       return true
     }
@@ -2317,8 +2316,8 @@ extension Parser.Lookahead {
     var backtrack = self.lookahead()
     backtrack.eat(.leftBrace)
     var loopProgress = LoopProgressCondition()
-    while !backtrack.at(any: [.eof, .rightBrace]) && loopProgress.evaluate(backtrack.currentToken) {
-      backtrack.consumeAnyToken()
+    while !backtrack.at(any: [.eof, .rightBrace, .poundEndifKeyword, .poundElseKeyword, .poundElseifKeyword ]) && loopProgress.evaluate(backtrack.currentToken) {
+      backtrack.skipSingle()
     }
 
     guard backtrack.consume(if: .rightBrace) != nil else {

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -49,6 +49,11 @@ final class StatementTests: XCTestCase {
         DiagnosticSpec(message: "unexpected code '* ! = x' in 'if' statement"),
       ]
     )
+
+    AssertParse(
+      """
+      if includeSavedHints { a = a.flatMap{ $0 } ?? nil }
+      """)
   }
 
   func testNestedIfs() {


### PR DESCRIPTION
Consuming single tokens isn't enough in this position because, as this test case demonstrates, any true trailing closures inside of the braced block will end our lookahead early.

Fixes #983
rdar://101330805