### PR TITLE
Don't treat a `#` as starting a declaration.

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -174,10 +174,14 @@ extension Parser {
       return RawDeclSyntax(directive)
     case (.poundWarningKeyword, _)?, (.poundErrorKeyword, _)?:
       return self.parsePoundDiagnosticDeclaration()
-    case (.pound, _)?:
-      return RawDeclSyntax(self.parseMacroExpansionDeclaration())
     case nil:
       break
+    }
+
+    if (self.at(.pound)) {
+      // FIXME: If we can have attributes for macro expansions, handle this
+      // via DeclarationStart.
+      return RawDeclSyntax(self.parseMacroExpansionDeclaration())
     }
 
     let attrs = DeclAttributes(

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -574,14 +574,12 @@ enum PoundDeclarationStart: RawTokenKindSubset {
   case poundIfKeyword
   case poundWarningKeyword
   case poundErrorKeyword
-  case pound
 
   init?(lexeme: Lexer.Lexeme) {
     switch lexeme.tokenKind {
     case .poundIfKeyword: self = .poundIfKeyword
     case .poundWarningKeyword: self = .poundWarningKeyword
     case .poundErrorKeyword: self = .poundErrorKeyword
-    case .pound: self = .pound
     default: return nil
     }
   }
@@ -591,7 +589,6 @@ enum PoundDeclarationStart: RawTokenKindSubset {
     case .poundIfKeyword: return .poundIfKeyword
     case .poundWarningKeyword: return .poundWarningKeyword
     case .poundErrorKeyword: return .poundErrorKeyword
-    case .pound: return .pound
     }
   }
 }

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -238,6 +238,10 @@ final class ExpressionTests: XCTestCase {
       __COLUMN__
       __FUNCTION__
       __DSO_HANDLE__
+
+      func f() {
+        return #function
+      }
       """
     )
   }

--- a/Tests/SwiftParserTest/translated/RawStringErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/RawStringErrorsTests.swift
@@ -41,9 +41,9 @@ final class RawStringErrorsTests: XCTestCase {
         // TODO: Old parser expected error on line 1: consecutive statements on a line must be separated by ';'
         // TODO: Old parser expected error on line 1: expected expression
         DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in pound literal declaration"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in pound literal declaration"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected identifier in pound literal declaration"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in pound literal expression"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in pound literal expression"),
+        DiagnosticSpec(locationMarker: "4️⃣", message: "expected identifier in pound literal expression"),
       ]
     )
   }
@@ -70,9 +70,9 @@ final class RawStringErrorsTests: XCTestCase {
         // TODO: Old parser expected error on line 1: consecutive statements on a line must be separated by ';'
         // TODO: Old parser expected error on line 1: expected expression
         DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in pound literal declaration"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in pound literal declaration"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected identifier in pound literal declaration"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in pound literal expression"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in pound literal expression"),
+        DiagnosticSpec(locationMarker: "4️⃣", message: "expected identifier in pound literal expression"),
       ]
     )
   }

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -43,20 +43,20 @@ final class MacroSystemTests: XCTestCase {
       struct X {
         var computed: String {
           get {
-            (#function)
+            #function
           }
         }
 
         init(from: String) {
-          (#function)
+          #function
         }
 
         subscript(a: Int) -> String {
-          (#function)
+          #function
         }
 
         subscript(a a: Int) -> String {
-          (#function)
+          #function
         }
       }
 
@@ -81,20 +81,20 @@ final class MacroSystemTests: XCTestCase {
       struct X {
         var computed: String {
           get {
-            ("computed")
+            "computed"
           }
         }
 
         init(from: String) {
-          ("init(from:)")
+          "init(from:)"
         }
 
         subscript(a: Int) -> String {
-          ("subscript(_:)")
+          "subscript(_:)"
         }
 
         subscript(a a: Int) -> String {
-          ("subscript(a:)")
+          "subscript(a:)"
         }
       }
 


### PR DESCRIPTION
The recent change to rely on the general macro-expansion expression nodes for `#line` et al broke return statements because we were classifying the expression as a declaration.