### PR TITLE
Start Emitting Lexer Diagnostics

### DIFF
--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(SwiftParser STATIC
   Directives.swift
   Expressions.swift
   Lexer.swift
+  LexerDiagnosticMessages.swift
   Lookahead.swift
   LoopProgressCondition.swift
   Modifiers.swift

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1382,6 +1382,7 @@ extension Parser {
       wholeText: wholeText,
       textRange: textRange,
       presence: .present,
+      hasError: false,
       arena: self.arena
     )
   }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1382,7 +1382,7 @@ extension Parser {
       wholeText: wholeText,
       textRange: textRange,
       presence: .present,
-      hasError: false,
+      hasLexerError: false,
       arena: self.arena
     )
   }
@@ -1486,21 +1486,31 @@ extension Parser {
     var stringLiteralSegmentStart = segment.startIndex
     while let slashIndex = segment.firstIndex(of: UInt8(ascii: "\\")), stringLiteralSegmentStart < segment.endIndex {
       let delimiterStart = text.index(after: slashIndex)
-      guard (delimiterStart < segment.endIndex &&
-             SyntaxText(rebasing: text[delimiterStart...]).hasPrefix(delimiter)) else {
+      guard delimiterStart < segment.endIndex &&
+             SyntaxText(rebasing: text[delimiterStart...]).hasPrefix(delimiter) else {
         // If `\` is not followed by the custom delimiter, it's not a segment delimiter.
         // Restart after the `\`.
-        segment = text[text.index(after: delimiterStart)...]
-        continue
+        if delimiterStart == segment.endIndex {
+          segment = text[segment.endIndex...]
+          break
+        } else {
+          segment = text[text.index(after: delimiterStart)...]
+          continue
+        }
       }
 
       let contentStart = text.index(delimiterStart, offsetBy: delimiter.count)
-      guard (contentStart < segment.endIndex &&
-             text[contentStart] == UInt8(ascii: "(")) else {
-        // If `\` (or `\#`) is not followed by `(`, it's not a segment delimiter.
-        // Restart after the `(`.
-        segment = text[text.index(after: contentStart)...]
-        continue
+      guard contentStart < segment.endIndex &&
+             text[contentStart] == UInt8(ascii: "(") else {
+        if contentStart == segment.endIndex {
+          segment = text[segment.endIndex...]
+          break
+        } else {
+          // If `\` (or `\#`) is not followed by `(`, it's not a segment delimiter.
+          // Restart after the `(`.
+          segment = text[text.index(after: contentStart)...]
+          continue
+        }
       }
 
       // Collect ".stringSegment" before `\`.
@@ -1557,6 +1567,13 @@ extension Parser {
             runexpected = nil
           }
           let rparen = subparser.expectWithoutRecovery(.rightParen)
+          assert(subparser.currentToken.tokenKind == .eof)
+          let trailing: RawUnexpectedNodesSyntax?
+          if subparser.currentToken.byteLength == 0 {
+            trailing = nil
+          } else {
+            trailing = RawUnexpectedNodesSyntax([ subparser.consumeAnyToken() ], arena: self.arena)
+          }
 
           segments.append(.expressionSegment(RawExpressionSegmentSyntax(
             backslash: slashToken,
@@ -1566,6 +1583,7 @@ extension Parser {
             expressions: RawTupleExprElementListSyntax(elements: args, arena: self.arena),
             runexpected,
             rightParen: rparen,
+            trailing,
             arena: self.arena)))
         }
       }

--- a/Sources/SwiftParser/Lexer.swift
+++ b/Sources/SwiftParser/Lexer.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(RawSyntax) import SwiftSyntax
+import SwiftDiagnostics
 
 /// A lexical analyzer for the Swift programming language.
 ///
@@ -32,6 +33,7 @@ public struct Lexer {
 
       public static let isAtStartOfLine = Flags(rawValue: 1 << 0)
       public static let isMultilineStringLiteral = Flags(rawValue: 1 << 1)
+      public static let isErroneous = Flags(rawValue: 1 << 2)
     }
 
     @_spi(RawSyntax)
@@ -217,6 +219,10 @@ extension Lexer {
     }
     func distance(to other: Self) -> Int {
       return self.pointer.distance(to: other.pointer)
+    }
+
+    func absoluteDistance(to other: Self) -> AbsolutePosition {
+      return AbsolutePosition(utf8Offset: self.distance(to: other))
     }
 
     func peek(at offset: Int = 0) -> UInt8 {
@@ -750,14 +756,19 @@ extension Lexer.Cursor {
 }
 
 extension Lexer.Cursor {
-  mutating func nextToken(_ ContentStart: Lexer.Cursor) -> Lexer.Lexeme {
+  mutating func nextToken(
+    _ ContentStart: Lexer.Cursor,
+    diagnosticHandler: ((Int, DiagnosticMessage) -> Void)? = nil
+  ) -> Lexer.Lexeme {
     // Leading trivia.
     let leadingTriviaStart = self
     let newlineInLeadingTrivia = self.lexTrivia(.leading)
 
     // Token text.
     let textStart = self
-    var (kind, flags) = self.lexImpl(ContentStart: ContentStart)
+    var (kind, flags) = self.lexImpl(
+      ContentStart: ContentStart,
+      diagnosticHandler: diagnosticHandler)
 
     // Trailing trivia.
     let trailingTriviaStart = self
@@ -777,7 +788,10 @@ extension Lexer.Cursor {
       trailingTriviaLength: trailingTriviaStart.distance(to: self))
   }
 
-  private mutating func lexImpl(ContentStart: Lexer.Cursor) -> (RawTokenKind, Lexer.Lexeme.Flags) {
+  private mutating func lexImpl(
+    ContentStart: Lexer.Cursor,
+    diagnosticHandler: ((Int, DiagnosticMessage) -> Void)?
+  ) -> (RawTokenKind, Lexer.Lexeme.Flags) {
     let start = self
     switch self.advance() {
     case UInt8(ascii: "@"): return (.atSign, [])
@@ -866,7 +880,7 @@ extension Lexer.Cursor {
          UInt8(ascii: "3"), UInt8(ascii: "4"), UInt8(ascii: "5"),
          UInt8(ascii: "6"), UInt8(ascii: "7"), UInt8(ascii: "8"),
          UInt8(ascii: "9"):
-      return self.lexNumber(start, ContentStart)
+      return self.lexNumber(start, ContentStart, diagnosticHandler)
     case UInt8(ascii: #"'"#), UInt8(ascii: #"""#):
       return self.lexStringLiteral(start)
 
@@ -1109,11 +1123,15 @@ extension Lexer.Cursor {
 //      diagnoseSingleQuoteStringLiteral(TokStart, CurPtr)
 //    }
 
+    var flags: Lexer.Lexeme.Flags = []
+    if IsMultilineString {
+      flags.insert(.isMultilineStringLiteral)
+    }
     if wasErroneous {
-      return (.unknown, [])
+      flags.insert(.isErroneous)
     }
 
-    return (.stringLiteral, IsMultilineString ? .isMultilineStringLiteral : [])
+    return (.stringLiteral, flags)
   }
 }
 
@@ -1298,7 +1316,11 @@ extension Lexer.Cursor {
   ///   floating_literal ::= [0-9][0-9_]*[eE][+-]?[0-9][0-9_]*
   ///   floating_literal ::= 0x[0-9A-Fa-f][0-9A-Fa-f_]*
   ///                          (\.[0-9A-Fa-f][0-9A-Fa-f_]*)?[pP][+-]?[0-9][0-9_]*
-  mutating func lexNumber(_ TokStart: Lexer.Cursor, _ ContentStart: Lexer.Cursor) -> (RawTokenKind, Lexer.Lexeme.Flags) {
+  mutating func lexNumber(
+    _ TokStart: Lexer.Cursor,
+    _ ContentStart: Lexer.Cursor,
+    _ diagnosticHandler: ((Int, DiagnosticMessage) -> Void)? = nil
+  ) -> (RawTokenKind, Lexer.Lexeme.Flags) {
     assert((Unicode.Scalar(self.previous).isDigit || self.previous == UInt8(ascii: ".")),
            "Unexpected start")
 
@@ -1312,7 +1334,7 @@ extension Lexer.Cursor {
 //    }
 
     if !self.isAtEndOfFile && self.previous == UInt8(ascii: "0") && self.peek() == UInt8(ascii: "x") {
-      return self.lexHexNumber(TokStart)
+      return self.lexHexNumber(TokStart, diagnosticHandler)
     }
 
     if !self.isAtEndOfFile && self.previous == UInt8(ascii: "0") && self.peek() == UInt8(ascii: "o") {
@@ -1427,7 +1449,10 @@ extension Lexer.Cursor {
     return (.floatingLiteral, [])
   }
 
-  mutating func lexHexNumber(_ TokStart: Lexer.Cursor) -> (RawTokenKind, Lexer.Lexeme.Flags) {
+  mutating func lexHexNumber(
+    _ TokStart: Lexer.Cursor,
+    _ diagnosticHandler: ((Int, DiagnosticMessage) -> Void)?
+  ) -> (RawTokenKind, Lexer.Lexeme.Flags) {
     // We assume we're starting from the 'x' in a '0x...' floating-point literal.
     assert(self.peek() == UInt8(ascii: "x"), "not a hex literal")
     assert(self.previous == UInt8(ascii: "0"), "not a hex literal")
@@ -1438,9 +1463,10 @@ extension Lexer.Cursor {
       return (.unknown, [])
     }
 
-                                                   let expected_hex_digit = { (loc: Lexer.Cursor) -> (RawTokenKind, Lexer.Lexeme.Flags) in
+    let expected_hex_digit = { (loc: Lexer.Cursor) -> (RawTokenKind, Lexer.Lexeme.Flags) in
 //      diagnose(loc, diag::lex_invalid_digit_in_hex_literal, StringRef(loc, 1),
 //               (unsigned)kind)
+
       return expected_digit(loc)
     }
 
@@ -1477,14 +1503,14 @@ extension Lexer.Cursor {
 
       self.advance(while: { $0.isHexDigit || $0 == Unicode.Scalar("_") })
 
-      if !self.isAtEndOfFile, self.peek() != UInt8(ascii: "p") && self.peek() != UInt8(ascii: "P") {
+      if self.isAtEndOfFile || (self.peek() != UInt8(ascii: "p") && self.peek() != UInt8(ascii: "P")) {
         if !Unicode.Scalar(PtrOnDot!.peek(at: 1)).isDigit {
           // e.g: 0xff.description
           self = PtrOnDot!
           return (.integerLiteral, [])
         }
-//        diagnose(CurPtr, diag::lex_expected_binary_exponent_in_hex_float_literal)
-        return (.unknown, [])
+        diagnosticHandler?(TokStart.distance(to: self), StaticLexerError.lex_expected_binary_exponent_in_hex_float_literal)
+        return (.integerLiteral, [ .isErroneous ])
       }
     } else {
       PtrOnDot = nil

--- a/Sources/SwiftParser/LexerDiagnosticMessages.swift
+++ b/Sources/SwiftParser/LexerDiagnosticMessages.swift
@@ -34,40 +34,12 @@ public extension LexerError {
   }
 }
 
-public protocol LexerNote: NoteMessage {
-  var fixItID: MessageID { get }
-}
-
-public extension LexerNote {
-  static var fixItID: MessageID {
-    return MessageID(domain: diagnosticDomain, id: "\(self)")
-  }
-
-  var fixItID: MessageID {
-    return Self.fixItID
-  }
-}
-
-public protocol LexerFixIt: FixItMessage {
-  var fixItID: MessageID { get }
-}
-
-public extension LexerFixIt {
-  static var fixItID: MessageID {
-    return MessageID(domain: diagnosticDomain, id: "\(self)")
-  }
-
-  var fixItID: MessageID {
-    return Self.fixItID
-  }
-}
-
 // MARK: - Errors (please sort alphabetically)
 
 /// Please order the cases in this enum alphabetically by case name.
 public enum StaticLexerError: String, DiagnosticMessage {
-  case lex_expected_binary_exponent_in_hex_float_literal = "hexadecimal floating point literal must end with an exponent"
-  case lex_expected_digit_in_fp_exponent = "expected a digit in floating point exponent"
+  case expectedBinaryExponentInHexFloatLiteral = "hexadecimal floating point literal must end with an exponent"
+  case expectedDigitInFloatLiteral = "expected a digit in floating point exponent"
 
   public var message: String { self.rawValue }
 
@@ -95,11 +67,11 @@ public struct InvalidFloatingPointExponentDigit: LexerError {
   }
 }
 
-public struct InvalidDigitInIntegerliteral: LexerError {
+public struct InvalidDigitInIntegerLiteral: LexerError {
   public enum Kind {
     case binary(Unicode.Scalar)
     case octal(Unicode.Scalar)
-    case dectal(Unicode.Scalar)
+    case decimal(Unicode.Scalar)
     case hex(Unicode.Scalar)
   }
 
@@ -108,10 +80,10 @@ public struct InvalidDigitInIntegerliteral: LexerError {
   public var message: String {
     switch self.kind {
     case .binary(let digit):
-      return "'\(digit)' is not a validbinary digit (0 or 1) in integer literal"
+      return "'\(digit)' is not a valid binary digit (0 or 1) in integer literal"
     case .octal(let digit):
       return "'\(digit)' is not a valid octal digit (0-7) in integer literal"
-    case .dectal(let digit):
+    case .decimal(let digit):
       return "'\(digit)' is not a valid digit in integer literal"
     case .hex(let digit):
       return "'\(digit)' is not a valid hexadecimal digit (0-9, A-F) in integer literal"

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -196,6 +196,7 @@ public struct Parser: TokenConsumer {
       wholeText: tok.wholeText,
       textRange: tok.textRange,
       presence: .present,
+      hasError: tok.flags.contains(.isErroneous),
       arena: arena
     )
   }
@@ -551,6 +552,7 @@ extension Parser {
       wholeText: SyntaxText(rebasing: current.wholeText[..<endIndex]),
       textRange: current.textRange.lowerBound ..< endIndex,
       presence: .present,
+      hasError: current.flags.contains(.isErroneous),
       arena: self.arena
     )
 

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -196,7 +196,7 @@ public struct Parser: TokenConsumer {
       wholeText: tok.wholeText,
       textRange: tok.textRange,
       presence: .present,
-      hasError: tok.flags.contains(.isErroneous),
+      hasLexerError: tok.flags.contains(.isErroneous),
       arena: arena
     )
   }
@@ -552,7 +552,7 @@ extension Parser {
       wholeText: SyntaxText(rebasing: current.wholeText[..<endIndex]),
       textRange: current.textRange.lowerBound ..< endIndex,
       presence: .present,
-      hasError: current.flags.contains(.isErroneous),
+      hasLexerError: current.flags.contains(.isErroneous),
       arena: self.arena
     )
 

--- a/Sources/SwiftParserDiagnostics/CMakeLists.txt
+++ b/Sources/SwiftParserDiagnostics/CMakeLists.txt
@@ -8,7 +8,6 @@
 
 add_library(SwiftParserDiagnostics STATIC
   DiagnosticExtensions.swift
-  LexerDiagnosticMessages.swift
   MissingNodesError.swift
   ParserDiagnosticMessages.swift
   ParseDiagnosticsGenerator.swift

--- a/Sources/SwiftParserDiagnostics/CMakeLists.txt
+++ b/Sources/SwiftParserDiagnostics/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 add_library(SwiftParserDiagnostics STATIC
   DiagnosticExtensions.swift
+  LexerDiagnosticMessages.swift
   MissingNodesError.swift
   ParserDiagnosticMessages.swift
   ParseDiagnosticsGenerator.swift

--- a/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
@@ -67,7 +67,8 @@ public extension LexerFixIt {
 /// Please order the cases in this enum alphabetically by case name.
 public enum StaticLexerError: String, DiagnosticMessage {
   case lex_expected_binary_exponent_in_hex_float_literal = "hexadecimal floating point literal must end with an exponent"
-  
+  case lex_expected_digit_in_fp_exponent = "expected a digit in floating point exponent"
+
   public var message: String { self.rawValue }
 
   public var diagnosticID: MessageID {
@@ -77,3 +78,43 @@ public enum StaticLexerError: String, DiagnosticMessage {
   public var severity: DiagnosticSeverity { .error }
 }
 
+public struct InvalidFloatingPointExponentDigit: LexerError {
+  public enum Kind {
+    case digit(Unicode.Scalar)
+    case character(Unicode.Scalar)
+  }
+  public let kind: Self.Kind
+
+  public var message: String {
+    switch self.kind {
+    case .digit(let digit):
+      return "'\(digit)' is not a valid digit in floating point exponent"
+    case .character(let char):
+      return "'\(char)' is not a valid first character in floating point exponent"
+    }
+  }
+}
+
+public struct InvalidDigitInIntegerliteral: LexerError {
+  public enum Kind {
+    case binary(Unicode.Scalar)
+    case octal(Unicode.Scalar)
+    case dectal(Unicode.Scalar)
+    case hex(Unicode.Scalar)
+  }
+
+  public let kind: Self.Kind
+
+  public var message: String {
+    switch self.kind {
+    case .binary(let digit):
+      return "'\(digit)' is not a validbinary digit (0 or 1) in integer literal"
+    case .octal(let digit):
+      return "'\(digit)' is not a valid octal digit (0-7) in integer literal"
+    case .dectal(let digit):
+      return "'\(digit)' is not a valid digit in integer literal"
+    case .hex(let digit):
+      return "'\(digit)' is not a valid hexadecimal digit (0-9, A-F) in integer literal"
+    }
+  }
+}

--- a/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
@@ -1,0 +1,79 @@
+//===--- LexerDiagnosticMessages.swift ------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+@_spi(RawSyntax) import SwiftSyntax
+
+fileprivate let diagnosticDomain: String = "SwiftLexer"
+
+/// A error diagnostic whose ID is determined by the diagnostic's type.
+public protocol LexerError: DiagnosticMessage {
+  var diagnosticID: MessageID { get }
+}
+
+public extension LexerError {
+  static var diagnosticID: MessageID {
+    return MessageID(domain: diagnosticDomain, id: "\(self)")
+  }
+
+  var diagnosticID: MessageID {
+    return Self.diagnosticID
+  }
+
+  var severity: DiagnosticSeverity {
+    return .error
+  }
+}
+
+public protocol LexerNote: NoteMessage {
+  var fixItID: MessageID { get }
+}
+
+public extension LexerNote {
+  static var fixItID: MessageID {
+    return MessageID(domain: diagnosticDomain, id: "\(self)")
+  }
+
+  var fixItID: MessageID {
+    return Self.fixItID
+  }
+}
+
+public protocol LexerFixIt: FixItMessage {
+  var fixItID: MessageID { get }
+}
+
+public extension LexerFixIt {
+  static var fixItID: MessageID {
+    return MessageID(domain: diagnosticDomain, id: "\(self)")
+  }
+
+  var fixItID: MessageID {
+    return Self.fixItID
+  }
+}
+
+// MARK: - Errors (please sort alphabetically)
+
+/// Please order the cases in this enum alphabetically by case name.
+public enum StaticLexerError: String, DiagnosticMessage {
+  case lex_expected_binary_exponent_in_hex_float_literal = "hexadecimal floating point literal must end with an exponent"
+  
+  public var message: String { self.rawValue }
+
+  public var diagnosticID: MessageID {
+    MessageID(domain: diagnosticDomain, id: "\(type(of: self)).\(self)")
+  }
+
+  public var severity: DiagnosticSeverity { .error }
+}
+

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -242,6 +242,13 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
       } else {
         return handleMissingSyntax(node)
       }
+    } else if node.hasError {
+      node.syntaxTextBytes.withUnsafeBufferPointer { buf in
+        var cursor = Lexer.Cursor(input: buf, previous: 0)
+        _ = cursor.nextToken(cursor) { [self] offset, diagnostic in
+          self.addDiagnostic(node, position: node.position.advanced(by: offset), diagnostic)
+        }
+      }
     }
     return .skipChildren
   }

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftDiagnostics
-import SwiftParser
+@_spi(LexerDiagnostics) import SwiftParser
 @_spi(RawSyntax) import SwiftSyntax
 
 public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -13,7 +13,7 @@
 import SwiftDiagnostics
 @_spi(RawSyntax) import SwiftSyntax
 
-let diagnosticDomain: String = "SwiftParser"
+fileprivate let diagnosticDomain: String = "SwiftParser"
 
 /// A error diagnostic whose ID is determined by the diagnostic's type.
 public protocol ParserError: DiagnosticMessage {

--- a/Sources/SwiftSyntax/AbsolutePosition.swift
+++ b/Sources/SwiftSyntax/AbsolutePosition.swift
@@ -21,6 +21,10 @@ public struct AbsolutePosition: Comparable {
     self.utf8Offset = utf8Offset
   }
 
+  public func advanced(by offset: Int) -> AbsolutePosition {
+    return AbsolutePosition(utf8Offset: self.utf8Offset + offset)
+  }
+
   public static func <(lhs: AbsolutePosition, rhs: AbsolutePosition) -> Bool {
     return lhs.utf8Offset < rhs.utf8Offset
   }

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -54,6 +54,8 @@ internal struct RawSyntaxData {
     var textRange: Range<SyntaxText.Index>
 
     var presence: SourcePresence
+
+    var hasError: Bool
   }
 
   /// Token typically created with `TokenSyntax.<someToken>`.
@@ -168,7 +170,7 @@ extension RawSyntax {
     switch view {
     case .token(let tokenView):
       var recursiveFlags: RecursiveRawSyntaxFlags = []
-      if tokenView.presence == .missing {
+      if tokenView.hasError || tokenView.presence == .missing {
         recursiveFlags.insert(.hasError)
       }
       return recursiveFlags
@@ -450,7 +452,8 @@ extension RawSyntax {
     wholeText: SyntaxText,
     textRange: Range<SyntaxText.Index>,
     presence: SourcePresence,
-    arena: SyntaxArena
+    arena: SyntaxArena,
+    hasError: Bool
   ) -> RawSyntax {
     assert(arena.contains(text: wholeText),
            "token text must be managed by the arena")
@@ -458,7 +461,8 @@ extension RawSyntax {
       tokenKind: kind,
       wholeText: wholeText,
       textRange: textRange,
-      presence: presence
+      presence: presence,
+      hasError: hasError
     )
     return RawSyntax(arena: arena, payload: .parsedToken(payload))
   }

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -55,7 +55,7 @@ internal struct RawSyntaxData {
 
     var presence: SourcePresence
 
-    var hasError: Bool
+    var hasLexerError: Bool
   }
 
   /// Token typically created with `TokenSyntax.<someToken>`.
@@ -170,7 +170,7 @@ extension RawSyntax {
     switch view {
     case .token(let tokenView):
       var recursiveFlags: RecursiveRawSyntaxFlags = []
-      if tokenView.hasError || tokenView.presence == .missing {
+      if tokenView.hasLexerError || tokenView.presence == .missing {
         recursiveFlags.insert(.hasError)
       }
       return recursiveFlags
@@ -453,7 +453,7 @@ extension RawSyntax {
     textRange: Range<SyntaxText.Index>,
     presence: SourcePresence,
     arena: SyntaxArena,
-    hasError: Bool
+    hasLexerError: Bool
   ) -> RawSyntax {
     assert(arena.contains(text: wholeText),
            "token text must be managed by the arena")
@@ -462,7 +462,7 @@ extension RawSyntax {
       wholeText: wholeText,
       textRange: textRange,
       presence: presence,
-      hasError: hasError
+      hasLexerError: hasLexerError
     )
     return RawSyntax(arena: arena, payload: .parsedToken(payload))
   }

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -132,7 +132,7 @@ public struct RawTokenSyntax: RawSyntaxToSyntax, RawSyntaxNodeProtocol {
     wholeText: SyntaxText,
     textRange: Range<SyntaxText.Index>,
     presence: SourcePresence,
-    hasError: Bool,
+    hasLexerError: Bool,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.parsedToken(
@@ -141,7 +141,7 @@ public struct RawTokenSyntax: RawSyntaxToSyntax, RawSyntaxNodeProtocol {
       textRange: textRange,
       presence: presence,
       arena: arena,
-      hasError: hasError
+      hasLexerError: hasLexerError
     )
     self = RawTokenSyntax(raw: raw)
   }
@@ -163,7 +163,7 @@ public struct RawTokenSyntax: RawSyntaxToSyntax, RawSyntaxNodeProtocol {
         wholeText: text,
         textRange: 0 ..< text.count,
         presence: presence,
-        hasError: false,
+        hasLexerError: false,
         arena: arena
       )
     } else {

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -132,6 +132,7 @@ public struct RawTokenSyntax: RawSyntaxToSyntax, RawSyntaxNodeProtocol {
     wholeText: SyntaxText,
     textRange: Range<SyntaxText.Index>,
     presence: SourcePresence,
+    hasError: Bool,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.parsedToken(
@@ -139,7 +140,8 @@ public struct RawTokenSyntax: RawSyntaxToSyntax, RawSyntaxNodeProtocol {
       wholeText: wholeText,
       textRange: textRange,
       presence: presence,
-      arena: arena
+      arena: arena,
+      hasError: hasError
     )
     self = RawTokenSyntax(raw: raw)
   }
@@ -161,6 +163,7 @@ public struct RawTokenSyntax: RawSyntaxToSyntax, RawSyntaxNodeProtocol {
         wholeText: text,
         textRange: 0 ..< text.count,
         presence: presence,
+        hasError: false,
         arena: arena
       )
     } else {

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -216,4 +216,15 @@ public struct RawSyntaxTokenView {
       preconditionFailure("'presence' is a token-only property")
     }
   }
+
+  var hasError: Bool {
+    switch raw.rawData.payload {
+    case .parsedToken(let dat):
+      return dat.hasError
+    case .materializedToken(_):
+      return false
+    case .layout(_):
+      preconditionFailure("'hasError' is a token-only property")
+    }
+  }
 }

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -217,10 +217,10 @@ public struct RawSyntaxTokenView {
     }
   }
 
-  var hasError: Bool {
+  var hasLexerError: Bool {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
-      return dat.hasError
+      return dat.hasLexerError
     case .materializedToken(_):
       return false
     case .layout(_):

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -540,9 +540,9 @@ final class ExpressionTests: XCTestCase {
     )
 
     AssertParse(
-      ###"1️⃣"\"###,
+      ###""\1️⃣"###,
       diagnostics: [
-        DiagnosticSpec(message: "extraneous code '\"\\' at top level")
+        DiagnosticSpec(message: #"expected '"' to end string literal"#)
       ]
     )
   }

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -703,6 +703,7 @@ public class LexerTests: XCTestCase {
     }
   }
 
+<<<<<<< HEAD
   func testCommentAttribution() {
     var data =
     """
@@ -744,6 +745,16 @@ public class LexerTests: XCTestCase {
         lexeme(.eof, "")
       ])
     }
+=======
+  func testIntegerLiteralDiagnostics() {
+    AssertParse(
+      """
+      var fl_l: Float = 0x1.0#^DIAG^#
+      """,
+    diagnostics: [
+      DiagnosticSpec(message: "hexadecimal floating point literal must end with an exponent")
+    ])
+>>>>>>> e6459ae5 (Propagate an "Error" Bit Into the Lexemes)
   }
 }
 

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -749,10 +749,14 @@ public class LexerTests: XCTestCase {
   func testIntegerLiteralDiagnostics() {
     AssertParse(
       """
-      var fl_l: Float = 0x1.0#^DIAG^#
+      var fl_l: Float = 0x1.0#^MISSING_HEX_EXPONENT_END^#
+
+      var fl_bad_separator2: Double = 0x1p#^BAD_HEX_EXPONENT_START^#_
       """,
     diagnostics: [
-      DiagnosticSpec(message: "hexadecimal floating point literal must end with an exponent")
+      DiagnosticSpec(locationMarker: "MISSING_HEX_EXPONENT_END", message: "hexadecimal floating point literal must end with an exponent"),
+
+      DiagnosticSpec(locationMarker: "BAD_HEX_EXPONENT_START", message: "'_' is not a valid first character in floating point exponent"),
     ])
 >>>>>>> e6459ae5 (Propagate an "Error" Bit Into the Lexemes)
   }

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -145,7 +145,7 @@ public class LexerTests: XCTestCase {
       data.withUTF8 { buf in
         let lexemes = Lexer.lex(buf)
         AssertEqualTokens(lexemes, [
-          lexeme(.unknown, #""\u{12341234}""#),
+          lexeme(.stringLiteral, #""\u{12341234}""#),
           lexeme(.eof, ""),
         ])
       }
@@ -703,7 +703,6 @@ public class LexerTests: XCTestCase {
     }
   }
 
-<<<<<<< HEAD
   func testCommentAttribution() {
     var data =
     """
@@ -745,20 +744,54 @@ public class LexerTests: XCTestCase {
         lexeme(.eof, "")
       ])
     }
-=======
-  func testIntegerLiteralDiagnostics() {
+  }
+
+  func testNumericLiteralDiagnostics() {
     AssertParse(
       """
-      var fl_l: Float = 0x1.0#^MISSING_HEX_EXPONENT_END^#
+      var fl_l: Float = 0x1.01️⃣
 
-      var fl_bad_separator2: Double = 0x1p#^BAD_HEX_EXPONENT_START^#_
+      var fl_bad_separator2: Double = 0x1p2️⃣_
+
+      var invalid_num_literal: Int64 = 03️⃣QWERTY
+      var invalid_bin_literal: Int64 = 0b4️⃣QWERTY
+      var invalid_hex_literal: Int64 = 0x5️⃣QWERTY
+      var invalid_oct_literal: Int64 = 0o6️⃣QWERTY
+
+      var invalid_exp_literal: Double = 1.0e+7️⃣QWERTY
+      var invalid_fp_exp_literal: Double = 0x1p+8️⃣QWERTY
       """,
     diagnostics: [
-      DiagnosticSpec(locationMarker: "MISSING_HEX_EXPONENT_END", message: "hexadecimal floating point literal must end with an exponent"),
+      DiagnosticSpec(locationMarker: "1️⃣", message: "hexadecimal floating point literal must end with an exponent"),
 
-      DiagnosticSpec(locationMarker: "BAD_HEX_EXPONENT_START", message: "'_' is not a valid first character in floating point exponent"),
+      DiagnosticSpec(locationMarker: "2️⃣", message: "'_' is not a valid first character in floating point exponent"),
+
+      DiagnosticSpec(locationMarker: "3️⃣", message: "'Q' is not a valid digit in integer literal"),
+      DiagnosticSpec(locationMarker: "4️⃣", message: "'Q' is not a valid binary digit (0 or 1) in integer literal"),
+      DiagnosticSpec(locationMarker: "5️⃣", message: "'Q' is not a valid hexadecimal digit (0-9, A-F) in integer literal"),
+      DiagnosticSpec(locationMarker: "6️⃣", message: "'Q' is not a valid octal digit (0-7) in integer literal"),
+
+      DiagnosticSpec(locationMarker: "7️⃣", message: "'Q' is not a valid digit in floating point exponent"),
+      DiagnosticSpec(locationMarker: "8️⃣", message: "'Q' is not a valid digit in floating point exponent"),
     ])
->>>>>>> e6459ae5 (Propagate an "Error" Bit Into the Lexemes)
+  }
+
+  func testBadNumericLiteralDigits() {
+    AssertParse(
+      """
+      var invalid_num_literal_prefix: Int64 = 01️⃣a1234567
+      var invalid_num_literal_middle: Int64 = 01232️⃣A5678
+      var invalid_bin_literal_middle: Int64 = 0b103️⃣20101
+      var invalid_oct_literal_middle: Int64 = 0o13574️⃣864
+      var invalid_hex_literal_middle: Int64 = 0x147AD5️⃣G0
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "'a' is not a valid digit in integer literal"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "'A' is not a valid digit in integer literal"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "'2' is not a valid binary digit (0 or 1) in integer literal"),
+        DiagnosticSpec(locationMarker: "4️⃣", message: "'8' is not a valid octal digit (0-7) in integer literal"),
+        DiagnosticSpec(locationMarker: "5️⃣", message: "'G' is not a valid hexadecimal digit (0-9, A-F) in integer literal"),
+      ])
   }
 }
 

--- a/Tests/SwiftParserTest/translated/ConflictMarkersTests.swift
+++ b/Tests/SwiftParserTest/translated/ConflictMarkersTests.swift
@@ -76,15 +76,15 @@ final class ConflictMarkersTests: XCTestCase {
       =======2️⃣
       var a : String = "a"
       var b : String = "B"
-      >>>>>>> 3️⃣18844bc65229786b96b89a9fc7739c0fc897905e:conflict_markers.swift
+      >>>>>>> 188443️⃣bc65229786b96b89a9fc7739c0fc897905e4️⃣:conflict_markers.swift
       print(a + b)
       """#,
       diagnostics: [
         // TODO: Old parser expected error on line 1: source control conflict marker in source file
         DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '<<<<<<< HEAD:conflict_markers.swift' before variable"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in variable"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected expression in variable"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous code at top level"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "'b' is not a valid digit in integer literal"),
+        DiagnosticSpec(locationMarker: "4️⃣", message: "extraneous code at top level"),
       ]
     )
   }
@@ -95,14 +95,14 @@ final class ConflictMarkersTests: XCTestCase {
       1️⃣<<<<<<< HEAD:conflict_markers.swift 
       ======= 
       var d : String = "D"
-      >>>>>>> 2️⃣18844bc65229786b96b89a9fc7739c0fc897905e:conflict_markers.swift
+      >>>>>>> 188442️⃣bc65229786b96b89a9fc7739c0fc897905e3️⃣:conflict_markers.swift
       print(d)
       """#,
       diagnostics: [
         // TODO: Old parser expected error on line 1: source control conflict marker in source file
         DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code before variable"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in variable"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code at top level"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "'b' is not a valid digit in integer literal"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous code at top level"),
       ]
     )
   }
@@ -127,14 +127,14 @@ final class ConflictMarkersTests: XCTestCase {
       <<<<<<<"HEAD:fake_conflict_markers.swift"
       var fake_c : String = "a"
       >>>>>>>"18844bc65229786b96b89a9fc7739c0fc897905e:fake_conflict_markers.swift"
-      >>>>>>> 2️⃣18844bc65229786b96b89a9fc7739c0fc897905e:conflict_markers.swift
+      >>>>>>> 188442️⃣bc65229786b96b89a9fc7739c0fc897905e3️⃣:conflict_markers.swift
       print(fake_b + fake_c)
       """#,
       diagnostics: [
         // TODO: Old parser expected error on line 1: source control conflict marker in source file
         DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code before variable"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous code at top level"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "'b' is not a valid digit in integer literal"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous code at top level"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
+++ b/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
@@ -405,14 +405,12 @@ final class IfconfigExprTests: XCTestCase {
   func testIfconfigExpr29() {
     AssertParse(
       """
-      #if canImport(A, _version: 1️⃣20A301)
+      #if canImport(A, _version: 201️⃣A301)
         let a = 1
       #endif
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: 'A' is not a valid digit in integer literal
-        DiagnosticSpec(message: "expected value in function call"),
-        DiagnosticSpec(message: "unexpected code '20A301' in function call"),
+        DiagnosticSpec(message: "'A' is not a valid digit in integer literal"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
@@ -329,8 +329,6 @@ final class MultilineErrorsTests: XCTestCase {
         """
       """##,
       diagnostics: [
-        DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: "extraneous code at top level"),
         // TODO: Old parser expected error on line 2: invalid escape sequence in literal
       ]
     )
@@ -405,12 +403,11 @@ final class MultilineErrorsTests: XCTestCase {
   func testMultilineErrors26() {
     AssertParse(
       ##"""
-      _ = 1️⃣"""
-        foo\
+      _ = """
+        foo\1️⃣
       """##,
       diagnostics: [
-        DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: "extraneous code at top level"),
+        DiagnosticSpec(message: #"expected '"""' to end string literal"#),
       ]
     )
   }
@@ -459,17 +456,19 @@ final class MultilineErrorsTests: XCTestCase {
   func testMultilineErrors30() {
     AssertParse(
       ##"""
-      let _ = 1️⃣"""
+      let _ = """
         foo
-        \("bar
-        baz
+        \(1️⃣"bar2️⃣
+      3️⃣  baz
         """
       """##,
       diagnostics: [
-        DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: "extraneous code at top level"),
         // TODO: Old parser expected error on line 3: cannot find ')' to match opening '(' in string interpolation
         // TODO: Old parser expected error on line 3: unterminated string literal
+        DiagnosticSpec(locationMarker: "1️⃣", message: #"expected value in string literal"#),
+        DiagnosticSpec(locationMarker: "1️⃣", message: #"unexpected code '"bar' in string literal"#),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected ')' in string literal"#),
+        DiagnosticSpec(locationMarker: "3️⃣", message: #"unexpected code '' in string literal"#),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/RawStringErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/RawStringErrorsTests.swift
@@ -37,8 +37,6 @@ final class RawStringErrorsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: too many '#' characters in delimited escape
         // TODO: Old parser expected error on line 1: invalid escape sequence in literal
-        DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: ###"extraneous code '#"\##("invalid")"#' at top level"###),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/StringLiteralEofTests.swift
+++ b/Tests/SwiftParserTest/translated/StringLiteralEofTests.swift
@@ -49,13 +49,11 @@ final class StringLiteralEofTests: XCTestCase {
   func testStringLiteralEof3() {
     AssertParse(
       ##"""
-      _ = 1️⃣"foo \
+      _ = "foo \1️⃣
       """##,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: unterminated string literal
         // TODO: Old parser expected error on line 1: invalid escape sequence in literal
-        DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: #"extraneous code '"foo \' at top level"#),
+        DiagnosticSpec(message: #"expected '"' to end string literal"#),
       ]
     )
   }
@@ -64,13 +62,12 @@ final class StringLiteralEofTests: XCTestCase {
     AssertParse(
       ##"""
       // NOTE: DO NOT add a newline at EOF.
-      _ = 1️⃣"foo \
+      _ = "foo \1️⃣
       """##,
       diagnostics: [
         // TODO: Old parser expected error on line 2: unterminated string literal
         // TODO: Old parser expected error on line 2: invalid escape sequence in literal
-        DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: #"extraneous code '"foo \' at top level"#),
+        DiagnosticSpec(message: #"expected '"' to end string literal"#),
       ]
     )
   }
@@ -130,15 +127,17 @@ final class StringLiteralEofTests: XCTestCase {
   func testStringLiteralEof8() {
     AssertParse(
       ##"""
-      _ = 1️⃣"""
-          foo
-          \("bar
-          baz
+      _ = """
+          \(1️⃣"bar2️⃣
+      3️⃣    baz4️⃣
       """##,
       diagnostics: [
         // TODO: Old parser expected error on line 1: unterminated string literal
-        DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: "extraneous code at top level"),
+        DiagnosticSpec(message: "expected value in string literal"),
+        DiagnosticSpec(message: #"unexpected code '"bar' in string literal"#),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected ')' in string literal"#),
+        DiagnosticSpec(locationMarker: "3️⃣", message: #"unexpected code '' in string literal"#),
+        DiagnosticSpec(locationMarker: "4️⃣", message: #"expected '"""' to end string literal"#),
         // TODO: Old parser expected error on line 3: cannot find ')' to match opening '(' in string interpolation
         // TODO: Old parser expected error on line 3: unterminated string literal
       ]

--- a/Tests/SwiftSyntaxTest/MultithreadingTests.swift
+++ b/Tests/SwiftSyntaxTest/MultithreadingTests.swift
@@ -39,6 +39,7 @@ public class MultithreadingTests: XCTestCase {
           wholeText: arena.intern(text),
           textRange: 1..<(text.count-1),
           presence: .present,
+          hasError: false,
           arena: arena)
       }
       let identifierExprRaw = RawIdentifierExprSyntax(

--- a/Tests/SwiftSyntaxTest/MultithreadingTests.swift
+++ b/Tests/SwiftSyntaxTest/MultithreadingTests.swift
@@ -39,7 +39,7 @@ public class MultithreadingTests: XCTestCase {
           wholeText: arena.intern(text),
           textRange: 1..<(text.count-1),
           presence: .present,
-          hasError: false,
+          hasLexerError: false,
           arena: arena)
       }
       let identifierExprRaw = RawIdentifierExprSyntax(

--- a/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
@@ -108,7 +108,7 @@ final class RawSyntaxTests: XCTestCase {
       let ident = RawTokenSyntax(
         kind: .identifier, wholeText: arena.intern("\nfoo "), textRange: 1..<4,
         presence: .present,
-        hasError: false,
+        hasLexerError: false,
         arena: arena)
 
       XCTAssertEqual(ident.tokenKind, .identifier)

--- a/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
@@ -108,6 +108,7 @@ final class RawSyntaxTests: XCTestCase {
       let ident = RawTokenSyntax(
         kind: .identifier, wholeText: arena.intern("\nfoo "), textRange: 1..<4,
         presence: .present,
+        hasError: false,
         arena: arena)
 
       XCTAssertEqual(ident.tokenKind, .identifier)


### PR DESCRIPTION
The general idea here is the lexer will tag tokens with an error bit when it detects some recoverable inconsistency. In the diagnostic post-pass, we will visit these erroneous tokens and re-lex them with a diagnostic handler installed.

This approach stands in contrast with our current one of recovering with `unknown` tokens, which lose quite a bit of information and make the parse quite brittle given that the lexer can recover from every error case it handles today. I'm starting small with the numeric literal diagnostics since Strings are the real challenge here.