### PR TITLE
Move SyntaxClassifier to a separate module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,7 @@ let package = Package(
     .macCatalyst(.v13),
   ],
   products: [
+    .library(name: "IDEUtils", type: .static, targets: ["IDEUtils"]),
     .library(name: "SwiftDiagnostics", type: .static, targets: ["SwiftDiagnostics"]),
     .library(name: "SwiftOperators", type: .static, targets: ["SwiftOperators"]),
     .library(name: "SwiftParser", type: .static, targets: ["SwiftParser"]),
@@ -79,7 +80,6 @@ let package = Package(
         "Raw/RawSyntaxValidation.swift.gyb",
         "SyntaxAnyVisitor.swift.gyb",
         "SyntaxBaseNodes.swift.gyb",
-        "SyntaxClassification.swift.gyb",
         "SyntaxCollections.swift.gyb",
         "SyntaxEnum.swift.gyb",
         "SyntaxFactory.swift.gyb",
@@ -115,6 +115,13 @@ let package = Package(
     .target(
       name: "_SwiftSyntaxTestSupport",
       dependencies: ["SwiftBasicFormat", "SwiftSyntax", "SwiftSyntaxBuilder"]
+    ),
+    .target(
+      name: "IDEUtils",
+      dependencies: ["SwiftSyntax"],
+      exclude: [
+        "SyntaxClassification.swift.gyb",
+      ]
     ),
     .target(
       name: "SwiftParser",
@@ -160,13 +167,14 @@ let package = Package(
       ]),
     .executableTarget(
       name: "lit-test-helper",
-      dependencies: ["SwiftSyntax", "SwiftSyntaxParser"]
+      dependencies: ["IDEUtils", "SwiftSyntax", "SwiftSyntaxParser"]
     ),
     .executableTarget(
       name: "swift-parser-cli",
       dependencies: ["SwiftDiagnostics", "SwiftSyntax", "SwiftParser", "SwiftParserDiagnostics", "SwiftOperators", "_SwiftSyntaxMacros",
                      .product(name: "ArgumentParser", package: "swift-argument-parser")]
     ),
+    .testTarget(name: "IDEUtilsTest", dependencies: ["_SwiftSyntaxTestSupport", "SwiftParser", "SwiftSyntax", "IDEUtils"]),
     .testTarget(
       name: "SwiftDiagnosticsTest",
       dependencies: ["_SwiftSyntaxTestSupport", "SwiftDiagnostics", "SwiftParser", "SwiftParserDiagnostics"]
@@ -192,7 +200,7 @@ let package = Package(
     ),
     .testTarget(
       name: "PerformanceTest",
-      dependencies: ["SwiftSyntax", "SwiftSyntaxParser", "SwiftParser"],
+      dependencies: ["IDEUtils", "SwiftSyntax", "SwiftSyntaxParser", "SwiftParser"],
       exclude: ["Inputs"]
     ),
     .testTarget(

--- a/Sources/IDEUtils/Syntax+Classifications.swift
+++ b/Sources/IDEUtils/Syntax+Classifications.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public extension SyntaxProtocol {
+
+  /// Sequence of `SyntaxClassifiedRange`s for this syntax node.
+  ///
+  /// The provided classified ranges are consecutive and cover the full source
+  /// text of the node. The ranges may also span multiple tokens, if multiple
+  /// consecutive tokens would have the same classification then a single classified
+  /// range is provided for all of them.
+  var classifications: SyntaxClassifications {
+    let fullRange = ByteSourceRange(offset: 0, length: byteSize)
+    return SyntaxClassifications(_syntaxNode, in: fullRange)
+  }
+
+  /// Sequence of `SyntaxClassifiedRange`s contained in this syntax node within
+  /// a relative range.
+  ///
+  /// The provided classified ranges may extend beyond the provided `range`.
+  /// Active classifications (non-`none`) will extend the range to include the
+  /// full classified range (e.g. from the beginning of the comment block), while
+  /// `none` classified ranges will extend to the beginning or end of the token
+  /// that the `range` touches.
+  /// It is guaranteed that no classified range will be provided that doesn't
+  /// intersect the provided `range`.
+  ///
+  /// - Parameters:
+  ///   - in: The relative byte range to pull `SyntaxClassifiedRange`s from.
+  /// - Returns: Sequence of `SyntaxClassifiedRange`s.
+  func classifications(in range: ByteSourceRange) -> SyntaxClassifications {
+    return SyntaxClassifications(_syntaxNode, in: range)
+  }
+
+  /// The `SyntaxClassifiedRange` for a relative byte offset.
+  /// - Parameters:
+  ///   - at: The relative to the node byte offset.
+  /// - Returns: The `SyntaxClassifiedRange` for the offset or nil if the source text
+  ///   at the given offset is unclassified.
+  func classification(at offset: Int) -> SyntaxClassifiedRange? {
+    let classifications = SyntaxClassifications(_syntaxNode, in: ByteSourceRange(offset: offset, length: 1))
+    var iterator = classifications.makeIterator()
+    return iterator.next()
+  }
+
+  /// The `SyntaxClassifiedRange` for an absolute position.
+  /// - Parameters:
+  ///   - at: The absolute position.
+  /// - Returns: The `SyntaxClassifiedRange` for the position or nil if the source text
+  ///   at the given position is unclassified.
+  func classification(at position: AbsolutePosition) -> SyntaxClassifiedRange? {
+    let relativeOffset = position.utf8Offset - self.position.utf8Offset
+    return self.classification(at: relativeOffset)
+  }
+}

--- a/Sources/IDEUtils/SyntaxClassification.swift.gyb
+++ b/Sources/IDEUtils/SyntaxClassification.swift.gyb
@@ -35,6 +35,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(RawSyntax) import SwiftSyntax
+
 public enum SyntaxClassification {
 % for classification in SYNTAX_CLASSIFICATIONS:
 %   for line in dedented_lines(classification.description):

--- a/Sources/IDEUtils/SyntaxClassifier.swift
+++ b/Sources/IDEUtils/SyntaxClassifier.swift
@@ -10,10 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension SyntaxData {
+@_spi(RawSyntax) import SwiftSyntax
+
+fileprivate extension SyntaxProtocol {
   var contextualClassification: (SyntaxClassification, Bool)? {
     var contextualClassif: (SyntaxClassification, Bool)? = nil
-    var curData = self
+    var curData = Syntax(self)
     repeat {
       guard let parent = curData.parent else { break }
       contextualClassif = SyntaxClassification.classify(parentKind: parent.raw.kind,
@@ -27,10 +29,10 @@ extension SyntaxData {
 extension TokenSyntax {
   /// The `SyntaxClassifiedRange` for the token text, excluding trivia.
   public var tokenClassification: SyntaxClassifiedRange {
-    let contextualClassification = self.data.contextualClassification
-    let relativeOffset = tokenView.leadingTriviaLength.utf8Length
+    let contextualClassification = self.contextualClassification
+    let relativeOffset = leadingTriviaLength.utf8Length
     let absoluteOffset = position.utf8Offset + relativeOffset
-    return TokenKindAndText(kind: tokenView.rawKind, text: tokenView.rawText).classify(
+    return TokenKindAndText(kind: rawTokenKind, text: tokenView.rawText).classify(
       offset: absoluteOffset, contextualClassification: contextualClassification)
   }
 }
@@ -122,7 +124,7 @@ private struct ClassificationVisitor {
       _ = self.visit(Descriptor(
         node: node.raw,
         byteOffset: node.position.utf8Offset,
-        contextualClassification: node.data.contextualClassification))
+        contextualClassification: node.contextualClassification))
     }
   }
 

--- a/Sources/IDEUtils/gyb_generated/SyntaxClassification.swift
+++ b/Sources/IDEUtils/gyb_generated/SyntaxClassification.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(RawSyntax) import SwiftSyntax
+
 public enum SyntaxClassification {
   /// The token should not receive syntax coloring. 
   case none

--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -18,7 +18,6 @@ add_library(SwiftSyntax STATIC
   Syntax.swift
   SyntaxArena.swift
   SyntaxChildren.swift
-  SyntaxClassifier.swift
   SyntaxData.swift
   SyntaxOtherNodes.swift
   SyntaxText.swift
@@ -37,7 +36,6 @@ add_library(SwiftSyntax STATIC
   gyb_generated/Misc.swift
   gyb_generated/SyntaxAnyVisitor.swift
   gyb_generated/SyntaxBaseNodes.swift
-  gyb_generated/SyntaxClassification.swift
   gyb_generated/SyntaxCollections.swift
   gyb_generated/SyntaxEnum.swift
   gyb_generated/SyntaxFactory.swift

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-typealias RawSyntaxBuffer = UnsafeBufferPointer<RawSyntax?>
+@_spi(RawSyntax) public typealias RawSyntaxBuffer = UnsafeBufferPointer<RawSyntax?>
 typealias RawTriviaPieceBuffer = UnsafeBufferPointer<RawTriviaPiece>
 
 fileprivate extension SyntaxKind {
@@ -148,7 +148,8 @@ extension RawSyntax {
   }
 
   /// Whether or not this node is a token one.
-  var isToken: Bool {
+  @_spi(RawSyntax)
+  public var isToken: Bool {
     kind == .token
   }
 
@@ -171,7 +172,7 @@ extension RawSyntax {
       }
       return recursiveFlags
     case .layout(let layoutView):
-      return layoutView.layoutData.recursiveFlags
+      return layoutView.recursiveFlags
     }
   }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntaxLayoutView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxLayoutView.swift
@@ -13,7 +13,8 @@
 extension RawSyntax {
   /// A view into the `RawSyntax` that exposes functionality that's specific to layout nodes.
   /// The token's payload must be a layout, otherwise this traps.
-  var layoutView: RawSyntaxLayoutView? {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView? {
     switch raw.payload {
     case .parsedToken, .materializedToken:
       return nil
@@ -24,7 +25,8 @@ extension RawSyntax {
 }
 
 /// A view into `RawSyntax` that exposes functionality that only applies to layout nodes.
-struct RawSyntaxLayoutView {
+@_spi(RawSyntax)
+public struct RawSyntaxLayoutView {
   private let raw: RawSyntax
 
   fileprivate init(raw: RawSyntax) {
@@ -37,7 +39,7 @@ struct RawSyntaxLayoutView {
     }
   }
 
-  var layoutData: RawSyntaxData.Layout {
+  private var layoutData: RawSyntaxData.Layout {
     switch raw.rawData.payload {
     case .parsedToken(_),
         .materializedToken(_):
@@ -47,8 +49,13 @@ struct RawSyntaxLayoutView {
     }
   }
 
+  var recursiveFlags: RecursiveRawSyntaxFlags {
+    return layoutData.recursiveFlags
+  }
+
   /// Creates a new node of the same kind but with children replaced by `elements`.
-  func replacingLayout<C: Collection>(
+  @_spi(RawSyntax)
+  public func replacingLayout<C: Collection>(
     with elements: C,
     arena: SyntaxArena
   ) -> RawSyntax where C.Element == RawSyntax? {
@@ -60,7 +67,8 @@ struct RawSyntaxLayoutView {
     }
   }
 
-  func insertingChild(
+  @_spi(RawSyntax)
+  public func insertingChild(
     _ newChild: RawSyntax?,
     at index: Int,
     arena: SyntaxArena
@@ -78,7 +86,8 @@ struct RawSyntaxLayoutView {
     }
   }
 
-  func removingChild(
+  @_spi(RawSyntax)
+  public func removingChild(
     at index: Int,
     arena: SyntaxArena
   ) -> RawSyntax {
@@ -101,11 +110,13 @@ struct RawSyntaxLayoutView {
     }
   }
 
-  func appending(_ newChild: RawSyntax?, arena: SyntaxArena) -> RawSyntax {
+  @_spi(RawSyntax)
+  public func appending(_ newChild: RawSyntax?, arena: SyntaxArena) -> RawSyntax {
     insertingChild(newChild, at: children.count, arena: arena)
   }
 
-  func replacingChildSubrange<C: Collection>(
+  @_spi(RawSyntax)
+  public func replacingChildSubrange<C: Collection>(
     _ range: Range<Int>,
     with elements: C,
     arena: SyntaxArena
@@ -130,7 +141,8 @@ struct RawSyntaxLayoutView {
     }
   }
 
-  func replacingChild(
+  @_spi(RawSyntax)
+  public func replacingChild(
     at index: Int,
     with newChild: RawSyntax?,
     arena: SyntaxArena
@@ -144,17 +156,20 @@ struct RawSyntaxLayoutView {
     }
   }
 
-  func formLayoutArray() -> [RawSyntax?] {
+  @_spi(RawSyntax)
+  public func formLayoutArray() -> [RawSyntax?] {
     Array(children)
   }
 
   /// Child nodes.
-  var children: RawSyntaxBuffer {
+  @_spi(RawSyntax)
+  public var children: RawSyntaxBuffer {
     layoutData.layout
   }
 
   /// The number of children, `present` or `missing`, in this node.
-  var numberOfChildren: Int {
+  @_spi(RawSyntax)
+  public var numberOfChildren: Int {
     return children.count
   }
 }

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -68,7 +68,8 @@ extension RawSyntax: RawSyntaxNodeProtocol {
 public struct RawTokenSyntax: RawSyntaxToSyntax, RawSyntaxNodeProtocol {
   public typealias SyntaxType = TokenSyntax
 
-  var tokenView: RawSyntaxTokenView {
+  @_spi(RawSyntax)
+  public var tokenView: RawSyntaxTokenView {
     return raw.tokenView!
   }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodes.swift.gyb
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodes.swift.gyb
@@ -31,7 +31,8 @@ public protocol Raw${node.name}NodeProtocol: Raw${node.base_type}NodeProtocol {}
 public struct Raw${node.name}: Raw${node.name if node.is_base() else node.base_type}NodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ${node.name}
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -13,7 +13,8 @@
 extension RawSyntax {
   /// A view into the `RawSyntax` that exposes functionality that's specific to tokens.
   /// The token's payload must be a token, otherwise this traps.
-  var tokenView: RawSyntaxTokenView? {
+  @_spi(RawSyntax)
+  public var tokenView: RawSyntaxTokenView? {
     switch raw.payload {
     case .parsedToken, .materializedToken:
       return RawSyntaxTokenView(raw: self)
@@ -24,7 +25,8 @@ extension RawSyntax {
 }
 
 /// A view into `RawSyntax` that exposes functionality that only applies to tokens.
-struct RawSyntaxTokenView {
+@_spi(RawSyntax)
+public struct RawSyntaxTokenView {
   let raw: RawSyntax
 
   fileprivate init(raw: RawSyntax) {
@@ -38,7 +40,8 @@ struct RawSyntaxTokenView {
   }
 
   /// Token kind of this node.
-  var rawKind: RawTokenKind {
+  @_spi(RawSyntax)
+  public var rawKind: RawTokenKind {
     switch raw.rawData.payload {
     case .materializedToken(let dat):
       return dat.tokenKind
@@ -50,7 +53,8 @@ struct RawSyntaxTokenView {
   }
 
   /// Token text of this node.
-  var rawText: SyntaxText {
+  @_spi(RawSyntax)
+  public var rawText: SyntaxText {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
       return dat.tokenText
@@ -62,7 +66,8 @@ struct RawSyntaxTokenView {
   }
 
   /// The UTF-8 byte length of the leading trivia.
-  var leadingTriviaByteLength: Int {
+  @_spi(RawSyntax)
+  public var leadingTriviaByteLength: Int {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
       return dat.leadingTriviaText.count
@@ -74,7 +79,8 @@ struct RawSyntaxTokenView {
   }
 
   /// The UTF-8 byte length of the trailing trivia.
-  var trailingTriviaByteLength: Int {
+  @_spi(RawSyntax)
+  public var trailingTriviaByteLength: Int {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
       return dat.trailingTriviaText.count
@@ -85,7 +91,8 @@ struct RawSyntaxTokenView {
     }
   }
 
-  var leadingRawTriviaPieces: [RawTriviaPiece] {
+  @_spi(RawSyntax)
+  public var leadingRawTriviaPieces: [RawTriviaPiece] {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
       return raw.arena.parseTrivia(source: dat.leadingTriviaText, position: .leading)
@@ -96,7 +103,8 @@ struct RawSyntaxTokenView {
     }
   }
 
-  var trailingRawTriviaPieces: [RawTriviaPiece] {
+  @_spi(RawSyntax)
+  public var trailingRawTriviaPieces: [RawTriviaPiece] {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
       return raw.arena.parseTrivia(source: dat.trailingTriviaText, position: .trailing)
@@ -108,28 +116,33 @@ struct RawSyntaxTokenView {
   }
 
   /// Returns the leading `Trivia` length.
-  var leadingTriviaLength: SourceLength {
+  @_spi(RawSyntax)
+  public var leadingTriviaLength: SourceLength {
     return SourceLength(utf8Length: leadingTriviaByteLength)
   }
 
   /// Returns the trailing `Trivia` length.
-  var trailingTriviaLength: SourceLength {
+  @_spi(RawSyntax)
+  public var trailingTriviaLength: SourceLength {
     return SourceLength(utf8Length: trailingTriviaByteLength)
   }
 
   /// Returns the leading `Trivia`.
-  func formLeadingTrivia() -> Trivia {
+  @_spi(RawSyntax)
+  public func formLeadingTrivia() -> Trivia {
     return Trivia(pieces: leadingRawTriviaPieces.map({ TriviaPiece(raw: $0) }))
   }
 
   /// Returns the trailing `Trivia`.
   /// - Returns: nil if called on a layout node.
-  func formTrailingTrivia() -> Trivia {
+  @_spi(RawSyntax)
+  public func formTrailingTrivia() -> Trivia {
     return Trivia(pieces: trailingRawTriviaPieces.map({ TriviaPiece(raw: $0) }))
   }
 
   /// Calls `body` with the token text. The token text value must not escape the closure.
-  func withUnsafeTokenText<Result>(
+  @_spi(RawSyntax)
+  public func withUnsafeTokenText<Result>(
     _ body: (SyntaxText?) -> Result
   ) -> Result {
     body(rawText)
@@ -137,7 +150,8 @@ struct RawSyntaxTokenView {
 
   /// Returns a `RawSyntax` node with the same source text but with the token
   /// kind changed to `newValue`.
-  func withKind(_ newValue: TokenKind) -> RawSyntax {
+  @_spi(RawSyntax)
+  public func withKind(_ newValue: TokenKind) -> RawSyntax {
     switch raw.rawData.payload {
     case .parsedToken(_):
       // The wholeText can't be continuous anymore. Make a materialized token.
@@ -162,7 +176,8 @@ struct RawSyntaxTokenView {
 
   /// The length of the token without leading or trailing trivia, assuming this
   /// is a token node.
-  var textByteLength: Int {
+  @_spi(RawSyntax)
+  public var textByteLength: Int {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
       return dat.tokenText.count
@@ -173,11 +188,13 @@ struct RawSyntaxTokenView {
     }
   }
 
-  var contentLength: SourceLength {
+  @_spi(RawSyntax)
+  public var contentLength: SourceLength {
     SourceLength(utf8Length: textByteLength)
   }
 
-  func formKind() -> TokenKind {
+  @_spi(RawSyntax)
+  public func formKind() -> TokenKind {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
       return TokenKind.fromRaw(kind: dat.tokenKind, text: String(syntaxText: dat.tokenText))
@@ -188,7 +205,8 @@ struct RawSyntaxTokenView {
     }
   }
 
-  var presence: SourcePresence {
+  @_spi(RawSyntax)
+  public var presence: SourcePresence {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
       return dat.presence
@@ -198,5 +216,4 @@ struct RawSyntaxTokenView {
       preconditionFailure("'presence' is a token-only property")
     }
   }
-
 }

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -28,7 +28,8 @@ public protocol RawPatternSyntaxNodeProtocol: RawSyntaxNodeProtocol {}
 public struct RawDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -59,7 +60,8 @@ public struct RawDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -90,7 +92,8 @@ public struct RawExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = StmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -121,7 +124,8 @@ public struct RawStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -152,7 +156,8 @@ public struct RawTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PatternSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -183,7 +188,8 @@ public struct RawPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSyntax 
 public struct RawUnknownDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = UnknownDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -208,7 +214,8 @@ public struct RawUnknownDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawUnknownExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = UnknownExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -233,7 +240,8 @@ public struct RawUnknownExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawUnknownStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = UnknownStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -258,7 +266,8 @@ public struct RawUnknownStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawUnknownTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = UnknownTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -283,7 +292,8 @@ public struct RawUnknownTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawUnknownPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = UnknownPatternSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -308,7 +318,8 @@ public struct RawUnknownPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxTo
 public struct RawMissingSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MissingSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -340,7 +351,8 @@ public struct RawMissingSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawMissingDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MissingDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -415,7 +427,8 @@ public struct RawMissingDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawMissingExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MissingExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -447,7 +460,8 @@ public struct RawMissingExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawMissingStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MissingStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -479,7 +493,8 @@ public struct RawMissingStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawMissingTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MissingTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -511,7 +526,8 @@ public struct RawMissingTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawMissingPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MissingPatternSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -543,7 +559,8 @@ public struct RawMissingPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxTo
 public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = CodeBlockItemSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -634,7 +651,8 @@ public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawCodeBlockItemListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = CodeBlockItemListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -674,7 +692,8 @@ public struct RawCodeBlockItemListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawCodeBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = CodeBlockSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -765,7 +784,8 @@ public struct RawCodeBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawUnexpectedNodesSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = UnexpectedNodesSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -805,7 +825,8 @@ public struct RawUnexpectedNodesSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawInOutExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = InOutExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -880,7 +901,8 @@ public struct RawInOutExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawPoundColumnExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PoundColumnExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -939,7 +961,8 @@ public struct RawPoundColumnExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawTupleExprElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TupleExprElementListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -979,7 +1002,8 @@ public struct RawTupleExprElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
 public struct RawArrayElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ArrayElementListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1019,7 +1043,8 @@ public struct RawArrayElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawDictionaryElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DictionaryElementListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1059,7 +1084,8 @@ public struct RawDictionaryElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
 public struct RawStringLiteralSegmentsSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = StringLiteralSegmentsSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1099,7 +1125,8 @@ public struct RawStringLiteralSegmentsSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
 public struct RawTryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TryExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1190,7 +1217,8 @@ public struct RawTryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawAwaitExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AwaitExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1265,7 +1293,8 @@ public struct RawAwaitExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawMoveExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MoveExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1340,7 +1369,8 @@ public struct RawMoveExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawDeclNameArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DeclNameArgumentSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1415,7 +1445,8 @@ public struct RawDeclNameArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawDeclNameArgumentListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DeclNameArgumentListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1455,7 +1486,8 @@ public struct RawDeclNameArgumentListSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
 public struct RawDeclNameArgumentsSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DeclNameArgumentsSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1546,7 +1578,8 @@ public struct RawDeclNameArgumentsSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawIdentifierExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = IdentifierExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1621,7 +1654,8 @@ public struct RawIdentifierExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawSuperRefExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = SuperRefExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1680,7 +1714,8 @@ public struct RawSuperRefExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawNilLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = NilLiteralExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1739,7 +1774,8 @@ public struct RawNilLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawDiscardAssignmentExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DiscardAssignmentExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1798,7 +1834,8 @@ public struct RawDiscardAssignmentExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
 public struct RawAssignmentExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AssignmentExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1857,7 +1894,8 @@ public struct RawAssignmentExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawSequenceExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = SequenceExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1916,7 +1954,8 @@ public struct RawSequenceExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawExprListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ExprListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -1956,7 +1995,8 @@ public struct RawExprListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawPoundLineExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PoundLineExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -2015,7 +2055,8 @@ public struct RawPoundLineExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawPoundFileExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PoundFileExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -2074,7 +2115,8 @@ public struct RawPoundFileExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawPoundFileIDExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PoundFileIDExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -2133,7 +2175,8 @@ public struct RawPoundFileIDExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawPoundFilePathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PoundFilePathExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -2192,7 +2235,8 @@ public struct RawPoundFilePathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
 public struct RawPoundFunctionExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PoundFunctionExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -2251,7 +2295,8 @@ public struct RawPoundFunctionExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
 public struct RawPoundDsohandleExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PoundDsohandleExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -2310,7 +2355,8 @@ public struct RawPoundDsohandleExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
 public struct RawSymbolicReferenceExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = SymbolicReferenceExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -2385,7 +2431,8 @@ public struct RawSymbolicReferenceExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
 public struct RawPrefixOperatorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PrefixOperatorExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -2460,7 +2507,8 @@ public struct RawPrefixOperatorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
 public struct RawBinaryOperatorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = BinaryOperatorExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -2519,7 +2567,8 @@ public struct RawBinaryOperatorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
 public struct RawArrowExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ArrowExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -2610,7 +2659,8 @@ public struct RawArrowExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawInfixOperatorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = InfixOperatorExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -2701,7 +2751,8 @@ public struct RawInfixOperatorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
 public struct RawFloatLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = FloatLiteralExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -2760,7 +2811,8 @@ public struct RawFloatLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
 public struct RawTupleExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TupleExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -2851,7 +2903,8 @@ public struct RawTupleExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawArrayExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ArrayExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -2942,7 +2995,8 @@ public struct RawArrayExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DictionaryExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -3033,7 +3087,8 @@ public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawTupleExprElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TupleExprElementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -3140,7 +3195,8 @@ public struct RawTupleExprElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawArrayElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ArrayElementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -3215,7 +3271,8 @@ public struct RawArrayElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawDictionaryElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DictionaryElementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -3322,7 +3379,8 @@ public struct RawDictionaryElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawIntegerLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = IntegerLiteralExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -3381,7 +3439,8 @@ public struct RawIntegerLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
 public struct RawBooleanLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = BooleanLiteralExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -3440,7 +3499,8 @@ public struct RawBooleanLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
 public struct RawUnresolvedTernaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = UnresolvedTernaryExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -3531,7 +3591,8 @@ public struct RawUnresolvedTernaryExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
 public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TernaryExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -3654,7 +3715,8 @@ public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawMemberAccessExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MemberAccessExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -3761,7 +3823,8 @@ public struct RawMemberAccessExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
 public struct RawUnresolvedIsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = UnresolvedIsExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -3820,7 +3883,8 @@ public struct RawUnresolvedIsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
 public struct RawIsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = IsExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -3911,7 +3975,8 @@ public struct RawIsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawUnresolvedAsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = UnresolvedAsExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -3986,7 +4051,8 @@ public struct RawUnresolvedAsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
 public struct RawAsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AsExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -4093,7 +4159,8 @@ public struct RawAsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawTypeExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TypeExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -4152,7 +4219,8 @@ public struct RawTypeExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawClosureCaptureItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ClosureCaptureItemSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -4275,7 +4343,8 @@ public struct RawClosureCaptureItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawClosureCaptureItemListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ClosureCaptureItemListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -4315,7 +4384,8 @@ public struct RawClosureCaptureItemListSyntax: RawSyntaxNodeProtocol, RawSyntaxT
 public struct RawClosureCaptureSignatureSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ClosureCaptureSignatureSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -4406,7 +4476,8 @@ public struct RawClosureCaptureSignatureSyntax: RawSyntaxNodeProtocol, RawSyntax
 public struct RawClosureParamSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ClosureParamSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -4481,7 +4552,8 @@ public struct RawClosureParamSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawClosureParamListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ClosureParamListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -4521,7 +4593,8 @@ public struct RawClosureParamListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ClosureSignatureSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -4676,7 +4749,8 @@ public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawClosureExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ClosureExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -4783,7 +4857,8 @@ public struct RawClosureExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawUnresolvedPatternExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = UnresolvedPatternExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -4842,7 +4917,8 @@ public struct RawUnresolvedPatternExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
 public struct RawMultipleTrailingClosureElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MultipleTrailingClosureElementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -4933,7 +5009,8 @@ public struct RawMultipleTrailingClosureElementSyntax: RawSyntaxNodeProtocol, Ra
 public struct RawMultipleTrailingClosureElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MultipleTrailingClosureElementListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -4973,7 +5050,8 @@ public struct RawMultipleTrailingClosureElementListSyntax: RawSyntaxNodeProtocol
 public struct RawFunctionCallExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = FunctionCallExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -5112,7 +5190,8 @@ public struct RawFunctionCallExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
 public struct RawSubscriptExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = SubscriptExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -5251,7 +5330,8 @@ public struct RawSubscriptExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawOptionalChainingExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = OptionalChainingExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -5326,7 +5406,8 @@ public struct RawOptionalChainingExprSyntax: RawExprSyntaxNodeProtocol, RawSynta
 public struct RawForcedValueExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ForcedValueExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -5401,7 +5482,8 @@ public struct RawForcedValueExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawPostfixUnaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PostfixUnaryExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -5476,7 +5558,8 @@ public struct RawPostfixUnaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
 public struct RawSpecializeExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = SpecializeExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -5551,7 +5634,8 @@ public struct RawSpecializeExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawStringSegmentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = StringSegmentSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -5610,7 +5694,8 @@ public struct RawStringSegmentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawExpressionSegmentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ExpressionSegmentSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -5733,7 +5818,8 @@ public struct RawExpressionSegmentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawStringLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = StringLiteralExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -5856,7 +5942,8 @@ public struct RawStringLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
 public struct RawRegexLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = RegexLiteralExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -5915,7 +6002,8 @@ public struct RawRegexLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
 public struct RawKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = KeyPathExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -6006,7 +6094,8 @@ public struct RawKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawKeyPathComponentListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = KeyPathComponentListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -6046,7 +6135,8 @@ public struct RawKeyPathComponentListSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
 public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = KeyPathComponentSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -6121,7 +6211,8 @@ public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawKeyPathPropertyComponentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = KeyPathPropertyComponentSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -6212,7 +6303,8 @@ public struct RawKeyPathPropertyComponentSyntax: RawSyntaxNodeProtocol, RawSynta
 public struct RawKeyPathSubscriptComponentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = KeyPathSubscriptComponentSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -6303,7 +6395,8 @@ public struct RawKeyPathSubscriptComponentSyntax: RawSyntaxNodeProtocol, RawSynt
 public struct RawKeyPathOptionalComponentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = KeyPathOptionalComponentSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -6362,7 +6455,8 @@ public struct RawKeyPathOptionalComponentSyntax: RawSyntaxNodeProtocol, RawSynta
 public struct RawOldKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = OldKeyPathExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -6453,7 +6547,8 @@ public struct RawOldKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawKeyPathBaseExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = KeyPathBaseExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -6512,7 +6607,8 @@ public struct RawKeyPathBaseExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawObjcNamePieceSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ObjcNamePieceSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -6587,7 +6683,8 @@ public struct RawObjcNamePieceSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawObjcNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ObjcNameSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -6627,7 +6724,8 @@ public struct RawObjcNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawObjcKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ObjcKeyPathExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -6734,7 +6832,8 @@ public struct RawObjcKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawObjcSelectorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ObjcSelectorExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -6873,7 +6972,8 @@ public struct RawObjcSelectorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
 public struct RawMacroExpansionExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MacroExpansionExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -7028,7 +7128,8 @@ public struct RawMacroExpansionExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
 public struct RawPostfixIfConfigExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PostfixIfConfigExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -7103,7 +7204,8 @@ public struct RawPostfixIfConfigExprSyntax: RawExprSyntaxNodeProtocol, RawSyntax
 public struct RawEditorPlaceholderExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = EditorPlaceholderExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -7162,7 +7264,8 @@ public struct RawEditorPlaceholderExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
 public struct RawObjectLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ObjectLiteralExprSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -7269,7 +7372,8 @@ public struct RawObjectLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
 public struct RawYieldExprListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = YieldExprListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -7309,7 +7413,8 @@ public struct RawYieldExprListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawYieldExprListElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = YieldExprListElementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -7384,7 +7489,8 @@ public struct RawYieldExprListElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
 public struct RawTypeInitializerClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TypeInitializerClauseSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -7459,7 +7565,8 @@ public struct RawTypeInitializerClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
 public struct RawTypealiasDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TypealiasDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -7614,7 +7721,8 @@ public struct RawTypealiasDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawAssociatedtypeDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AssociatedtypeDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -7769,7 +7877,8 @@ public struct RawAssociatedtypeDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxT
 public struct RawFunctionParameterListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = FunctionParameterListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -7809,7 +7918,8 @@ public struct RawFunctionParameterListSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
 public struct RawParameterClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ParameterClauseSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -7900,7 +8010,8 @@ public struct RawParameterClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawReturnClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ReturnClauseSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -7975,7 +8086,8 @@ public struct RawReturnClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawFunctionSignatureSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = FunctionSignatureSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -8082,7 +8194,8 @@ public struct RawFunctionSignatureSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = IfConfigClauseSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -8173,7 +8286,8 @@ public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax 
 public struct RawIfConfigClauseListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = IfConfigClauseListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -8213,7 +8327,8 @@ public struct RawIfConfigClauseListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawIfConfigDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = IfConfigDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -8288,7 +8403,8 @@ public struct RawIfConfigDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawPoundErrorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PoundErrorDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -8395,7 +8511,8 @@ public struct RawPoundErrorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawPoundWarningDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PoundWarningDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -8502,7 +8619,8 @@ public struct RawPoundWarningDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToS
 public struct RawPoundSourceLocationSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PoundSourceLocationSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -8609,7 +8727,8 @@ public struct RawPoundSourceLocationSyntax: RawDeclSyntaxNodeProtocol, RawSyntax
 public struct RawPoundSourceLocationArgsSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PoundSourceLocationArgsSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -8764,7 +8883,8 @@ public struct RawPoundSourceLocationArgsSyntax: RawSyntaxNodeProtocol, RawSyntax
 public struct RawDeclModifierDetailSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DeclModifierDetailSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -8855,7 +8975,8 @@ public struct RawDeclModifierDetailSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawDeclModifierSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DeclModifierSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -8930,7 +9051,8 @@ public struct RawDeclModifierSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = InheritedTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -9005,7 +9127,8 @@ public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawInheritedTypeListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = InheritedTypeListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -9045,7 +9168,8 @@ public struct RawInheritedTypeListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawTypeInheritanceClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TypeInheritanceClauseSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -9120,7 +9244,8 @@ public struct RawTypeInheritanceClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
 public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ClassDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -9291,7 +9416,8 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ActorDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -9462,7 +9588,8 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = StructDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -9633,7 +9760,8 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax 
 public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ProtocolDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -9804,7 +9932,8 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ExtensionDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -9959,7 +10088,8 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawMemberDeclBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MemberDeclBlockSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -10050,7 +10180,8 @@ public struct RawMemberDeclBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawMemberDeclListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MemberDeclListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -10090,7 +10221,8 @@ public struct RawMemberDeclListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax 
 public struct RawMemberDeclListItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MemberDeclListItemSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -10165,7 +10297,8 @@ public struct RawMemberDeclListItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawSourceFileSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = SourceFileSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -10240,7 +10373,8 @@ public struct RawSourceFileSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawInitializerClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = InitializerClauseSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -10315,7 +10449,8 @@ public struct RawInitializerClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawFunctionParameterSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = FunctionParameterSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -10502,7 +10637,8 @@ public struct RawFunctionParameterSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawModifierListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ModifierListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -10542,7 +10678,8 @@ public struct RawModifierListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawFunctionDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = FunctionDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -10713,7 +10850,8 @@ public struct RawFunctionDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawInitializerDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = InitializerDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -10884,7 +11022,8 @@ public struct RawInitializerDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawDeinitializerDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DeinitializerDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -10991,7 +11130,8 @@ public struct RawDeinitializerDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxTo
 public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = SubscriptDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -11162,7 +11302,8 @@ public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawAccessLevelModifierSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AccessLevelModifierSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -11237,7 +11378,8 @@ public struct RawAccessLevelModifierSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawAccessPathComponentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AccessPathComponentSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -11312,7 +11454,8 @@ public struct RawAccessPathComponentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawAccessPathSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AccessPathSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -11352,7 +11495,8 @@ public struct RawAccessPathSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawImportDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ImportDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -11475,7 +11619,8 @@ public struct RawImportDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax 
 public struct RawAccessorParameterSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AccessorParameterSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -11566,7 +11711,8 @@ public struct RawAccessorParameterSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawAccessorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AccessorDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -11721,7 +11867,8 @@ public struct RawAccessorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawAccessorListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AccessorListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -11761,7 +11908,8 @@ public struct RawAccessorListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawAccessorBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AccessorBlockSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -11852,7 +12000,8 @@ public struct RawAccessorBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PatternBindingSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -11975,7 +12124,8 @@ public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax 
 public struct RawPatternBindingListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PatternBindingListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -12015,7 +12165,8 @@ public struct RawPatternBindingListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawVariableDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = VariableDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -12122,7 +12273,8 @@ public struct RawVariableDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawEnumCaseElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = EnumCaseElementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -12229,7 +12381,8 @@ public struct RawEnumCaseElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawEnumCaseElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = EnumCaseElementListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -12269,7 +12422,8 @@ public struct RawEnumCaseElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawEnumCaseDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = EnumCaseDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -12376,7 +12530,8 @@ public struct RawEnumCaseDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = EnumDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -12547,7 +12702,8 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawOperatorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = OperatorDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -12670,7 +12826,8 @@ public struct RawOperatorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawDesignatedTypeListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DesignatedTypeListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -12710,7 +12867,8 @@ public struct RawDesignatedTypeListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawDesignatedTypeElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DesignatedTypeElementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -12785,7 +12943,8 @@ public struct RawDesignatedTypeElementSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
 public struct RawOperatorPrecedenceAndTypesSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = OperatorPrecedenceAndTypesSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -12876,7 +13035,8 @@ public struct RawOperatorPrecedenceAndTypesSyntax: RawSyntaxNodeProtocol, RawSyn
 public struct RawPrecedenceGroupDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PrecedenceGroupDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -13031,7 +13191,8 @@ public struct RawPrecedenceGroupDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntax
 public struct RawPrecedenceGroupAttributeListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PrecedenceGroupAttributeListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -13071,7 +13232,8 @@ public struct RawPrecedenceGroupAttributeListSyntax: RawSyntaxNodeProtocol, RawS
 public struct RawPrecedenceGroupRelationSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PrecedenceGroupRelationSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -13162,7 +13324,8 @@ public struct RawPrecedenceGroupRelationSyntax: RawSyntaxNodeProtocol, RawSyntax
 public struct RawPrecedenceGroupNameListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PrecedenceGroupNameListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -13202,7 +13365,8 @@ public struct RawPrecedenceGroupNameListSyntax: RawSyntaxNodeProtocol, RawSyntax
 public struct RawPrecedenceGroupNameElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PrecedenceGroupNameElementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -13277,7 +13441,8 @@ public struct RawPrecedenceGroupNameElementSyntax: RawSyntaxNodeProtocol, RawSyn
 public struct RawPrecedenceGroupAssignmentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PrecedenceGroupAssignmentSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -13368,7 +13533,8 @@ public struct RawPrecedenceGroupAssignmentSyntax: RawSyntaxNodeProtocol, RawSynt
 public struct RawPrecedenceGroupAssociativitySyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PrecedenceGroupAssociativitySyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -13459,7 +13625,8 @@ public struct RawPrecedenceGroupAssociativitySyntax: RawSyntaxNodeProtocol, RawS
 public struct RawMacroExpansionDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MacroExpansionDeclSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -13614,7 +13781,8 @@ public struct RawMacroExpansionDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxT
 public struct RawTokenListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TokenListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -13654,7 +13822,8 @@ public struct RawTokenListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawNonEmptyTokenListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = NonEmptyTokenListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -13694,7 +13863,8 @@ public struct RawNonEmptyTokenListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawCustomAttributeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = CustomAttributeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -13817,7 +13987,8 @@ public struct RawCustomAttributeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawAttributeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AttributeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -13956,7 +14127,8 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawAttributeListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AttributeListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -13996,7 +14168,8 @@ public struct RawAttributeListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawSpecializeAttributeSpecListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = SpecializeAttributeSpecListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -14036,7 +14209,8 @@ public struct RawSpecializeAttributeSpecListSyntax: RawSyntaxNodeProtocol, RawSy
 public struct RawAvailabilityEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AvailabilityEntrySyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -14143,7 +14317,8 @@ public struct RawAvailabilityEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawLabeledSpecializeEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = LabeledSpecializeEntrySyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -14250,7 +14425,8 @@ public struct RawLabeledSpecializeEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxT
 public struct RawTargetFunctionEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TargetFunctionEntrySyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -14357,7 +14533,8 @@ public struct RawTargetFunctionEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawNamedAttributeStringArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = NamedAttributeStringArgumentSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -14448,7 +14625,8 @@ public struct RawNamedAttributeStringArgumentSyntax: RawSyntaxNodeProtocol, RawS
 public struct RawDeclNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DeclNameSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -14523,7 +14701,8 @@ public struct RawDeclNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ImplementsAttributeArgumentsSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -14630,7 +14809,8 @@ public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol, RawS
 public struct RawObjCSelectorPieceSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ObjCSelectorPieceSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -14705,7 +14885,8 @@ public struct RawObjCSelectorPieceSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawObjCSelectorSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ObjCSelectorSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -14745,7 +14926,8 @@ public struct RawObjCSelectorSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawDifferentiableAttributeArgumentsSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DifferentiableAttributeArgumentsSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -14868,7 +15050,8 @@ public struct RawDifferentiableAttributeArgumentsSyntax: RawSyntaxNodeProtocol, 
 public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DifferentiabilityParamsClauseSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -14959,7 +15142,8 @@ public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol, Raw
 public struct RawDifferentiabilityParamsSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DifferentiabilityParamsSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -15050,7 +15234,8 @@ public struct RawDifferentiabilityParamsSyntax: RawSyntaxNodeProtocol, RawSyntax
 public struct RawDifferentiabilityParamListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DifferentiabilityParamListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -15090,7 +15275,8 @@ public struct RawDifferentiabilityParamListSyntax: RawSyntaxNodeProtocol, RawSyn
 public struct RawDifferentiabilityParamSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DifferentiabilityParamSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -15165,7 +15351,8 @@ public struct RawDifferentiabilityParamSyntax: RawSyntaxNodeProtocol, RawSyntaxT
 public struct RawDerivativeRegistrationAttributeArgumentsSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DerivativeRegistrationAttributeArgumentsSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -15320,7 +15507,8 @@ public struct RawDerivativeRegistrationAttributeArgumentsSyntax: RawSyntaxNodePr
 public struct RawQualifiedDeclNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = QualifiedDeclNameSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -15427,7 +15615,8 @@ public struct RawQualifiedDeclNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawFunctionDeclNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = FunctionDeclNameSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -15502,7 +15691,8 @@ public struct RawFunctionDeclNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawBackDeployAttributeSpecListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = BackDeployAttributeSpecListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -15593,7 +15783,8 @@ public struct RawBackDeployAttributeSpecListSyntax: RawSyntaxNodeProtocol, RawSy
 public struct RawBackDeployVersionListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = BackDeployVersionListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -15633,7 +15824,8 @@ public struct RawBackDeployVersionListSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
 public struct RawBackDeployVersionArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = BackDeployVersionArgumentSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -15708,7 +15900,8 @@ public struct RawBackDeployVersionArgumentSyntax: RawSyntaxNodeProtocol, RawSynt
 public struct RawOpaqueReturnTypeOfAttributeArgumentsSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = OpaqueReturnTypeOfAttributeArgumentsSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -15799,7 +15992,8 @@ public struct RawOpaqueReturnTypeOfAttributeArgumentsSyntax: RawSyntaxNodeProtoc
 public struct RawConventionAttributeArgumentsSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ConventionAttributeArgumentsSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -15922,7 +16116,8 @@ public struct RawConventionAttributeArgumentsSyntax: RawSyntaxNodeProtocol, RawS
 public struct RawConventionWitnessMethodAttributeArgumentsSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ConventionWitnessMethodAttributeArgumentsSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -16013,7 +16208,8 @@ public struct RawConventionWitnessMethodAttributeArgumentsSyntax: RawSyntaxNodeP
 public struct RawLabeledStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = LabeledStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -16104,7 +16300,8 @@ public struct RawLabeledStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawContinueStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ContinueStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -16179,7 +16376,8 @@ public struct RawContinueStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawWhileStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = WhileStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -16270,7 +16468,8 @@ public struct RawWhileStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawDeferStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DeferStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -16345,7 +16544,8 @@ public struct RawDeferStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawExpressionStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ExpressionStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -16404,7 +16604,8 @@ public struct RawExpressionStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = SwitchCaseListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -16444,7 +16645,8 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax 
 public struct RawRepeatWhileStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = RepeatWhileStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -16551,7 +16753,8 @@ public struct RawRepeatWhileStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawGuardStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = GuardStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -16658,7 +16861,8 @@ public struct RawGuardStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawWhereClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = WhereClauseSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -16733,7 +16937,8 @@ public struct RawWhereClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawForInStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ForInStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -16936,7 +17141,8 @@ public struct RawForInStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawSwitchStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = SwitchStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -17059,7 +17265,8 @@ public struct RawSwitchStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax 
 public struct RawCatchClauseListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = CatchClauseListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -17099,7 +17306,8 @@ public struct RawCatchClauseListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawDoStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DoStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -17190,7 +17398,8 @@ public struct RawDoStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawReturnStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ReturnStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -17265,7 +17474,8 @@ public struct RawReturnStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax 
 public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = YieldStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -17340,7 +17550,8 @@ public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawYieldListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = YieldListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -17431,7 +17642,8 @@ public struct RawYieldListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawFallthroughStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = FallthroughStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -17490,7 +17702,8 @@ public struct RawFallthroughStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawBreakStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = BreakStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -17565,7 +17778,8 @@ public struct RawBreakStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawCaseItemListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = CaseItemListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -17605,7 +17819,8 @@ public struct RawCaseItemListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawCatchItemListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = CatchItemListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -17645,7 +17860,8 @@ public struct RawCatchItemListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawConditionElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ConditionElementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -17720,7 +17936,8 @@ public struct RawConditionElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawAvailabilityConditionSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AvailabilityConditionSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -17827,7 +18044,8 @@ public struct RawAvailabilityConditionSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
 public struct RawMatchingPatternConditionSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MatchingPatternConditionSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -17934,7 +18152,8 @@ public struct RawMatchingPatternConditionSyntax: RawSyntaxNodeProtocol, RawSynta
 public struct RawOptionalBindingConditionSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = OptionalBindingConditionSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -18041,7 +18260,8 @@ public struct RawOptionalBindingConditionSyntax: RawSyntaxNodeProtocol, RawSynta
 public struct RawUnavailabilityConditionSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = UnavailabilityConditionSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -18148,7 +18368,8 @@ public struct RawUnavailabilityConditionSyntax: RawSyntaxNodeProtocol, RawSyntax
 public struct RawHasSymbolConditionSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = HasSymbolConditionSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -18255,7 +18476,8 @@ public struct RawHasSymbolConditionSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawConditionElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ConditionElementListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -18295,7 +18517,8 @@ public struct RawConditionElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
 public struct RawDeclarationStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DeclarationStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -18354,7 +18577,8 @@ public struct RawDeclarationStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawThrowStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ThrowStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -18429,7 +18653,8 @@ public struct RawThrowStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawIfStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = IfStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -18552,7 +18777,8 @@ public struct RawIfStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = SwitchCaseSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -18643,7 +18869,8 @@ public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawSwitchDefaultLabelSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = SwitchDefaultLabelSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -18718,7 +18945,8 @@ public struct RawSwitchDefaultLabelSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawCaseItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = CaseItemSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -18809,7 +19037,8 @@ public struct RawCaseItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawCatchItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = CatchItemSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -18900,7 +19129,8 @@ public struct RawCatchItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawSwitchCaseLabelSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = SwitchCaseLabelSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -18991,7 +19221,8 @@ public struct RawSwitchCaseLabelSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawCatchClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = CatchClauseSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -19082,7 +19313,8 @@ public struct RawCatchClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawPoundAssertStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PoundAssertStmtSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -19221,7 +19453,8 @@ public struct RawPoundAssertStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawGenericWhereClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = GenericWhereClauseSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -19296,7 +19529,8 @@ public struct RawGenericWhereClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawGenericRequirementListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = GenericRequirementListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -19336,7 +19570,8 @@ public struct RawGenericRequirementListSyntax: RawSyntaxNodeProtocol, RawSyntaxT
 public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = GenericRequirementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -19411,7 +19646,8 @@ public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = SameTypeRequirementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -19502,7 +19738,8 @@ public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawLayoutRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = LayoutRequirementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -19673,7 +19910,8 @@ public struct RawLayoutRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
 public struct RawGenericParameterListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = GenericParameterListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -19713,7 +19951,8 @@ public struct RawGenericParameterListSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
 public struct RawGenericParameterSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = GenericParameterSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -19852,7 +20091,8 @@ public struct RawGenericParameterSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawPrimaryAssociatedTypeListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PrimaryAssociatedTypeListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -19892,7 +20132,8 @@ public struct RawPrimaryAssociatedTypeListSyntax: RawSyntaxNodeProtocol, RawSynt
 public struct RawPrimaryAssociatedTypeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PrimaryAssociatedTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -19967,7 +20208,8 @@ public struct RawPrimaryAssociatedTypeSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
 public struct RawGenericParameterClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = GenericParameterClauseSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -20074,7 +20316,8 @@ public struct RawGenericParameterClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxT
 public struct RawConformanceRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ConformanceRequirementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -20165,7 +20408,8 @@ public struct RawConformanceRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxT
 public struct RawPrimaryAssociatedTypeClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PrimaryAssociatedTypeClauseSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -20256,7 +20500,8 @@ public struct RawPrimaryAssociatedTypeClauseSyntax: RawSyntaxNodeProtocol, RawSy
 public struct RawSimpleTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = SimpleTypeIdentifierSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -20331,7 +20576,8 @@ public struct RawSimpleTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol, RawSynta
 public struct RawMemberTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MemberTypeIdentifierSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -20438,7 +20684,8 @@ public struct RawMemberTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol, RawSynta
 public struct RawClassRestrictionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ClassRestrictionTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -20497,7 +20744,8 @@ public struct RawClassRestrictionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSynta
 public struct RawArrayTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ArrayTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -20588,7 +20836,8 @@ public struct RawArrayTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawDictionaryTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = DictionaryTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -20711,7 +20960,8 @@ public struct RawDictionaryTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawMetatypeTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = MetatypeTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -20802,7 +21052,8 @@ public struct RawMetatypeTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawOptionalTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = OptionalTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -20877,7 +21128,8 @@ public struct RawOptionalTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawConstrainedSugarTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ConstrainedSugarTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -20952,7 +21204,8 @@ public struct RawConstrainedSugarTypeSyntax: RawTypeSyntaxNodeProtocol, RawSynta
 public struct RawImplicitlyUnwrappedOptionalTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ImplicitlyUnwrappedOptionalTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -21027,7 +21280,8 @@ public struct RawImplicitlyUnwrappedOptionalTypeSyntax: RawTypeSyntaxNodeProtoco
 public struct RawCompositionTypeElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = CompositionTypeElementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -21102,7 +21356,8 @@ public struct RawCompositionTypeElementSyntax: RawSyntaxNodeProtocol, RawSyntaxT
 public struct RawCompositionTypeElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = CompositionTypeElementListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -21142,7 +21397,8 @@ public struct RawCompositionTypeElementListSyntax: RawSyntaxNodeProtocol, RawSyn
 public struct RawCompositionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = CompositionTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -21201,7 +21457,8 @@ public struct RawCompositionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawPackExpansionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = PackExpansionTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -21276,7 +21533,8 @@ public struct RawPackExpansionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxTo
 public struct RawTupleTypeElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TupleTypeElementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -21447,7 +21705,8 @@ public struct RawTupleTypeElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawTupleTypeElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TupleTypeElementListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -21487,7 +21746,8 @@ public struct RawTupleTypeElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
 public struct RawTupleTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TupleTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -21578,7 +21838,8 @@ public struct RawTupleTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
 public struct RawFunctionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = FunctionTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -21733,7 +21994,8 @@ public struct RawFunctionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSynta
 public struct RawAttributedTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AttributedTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -21824,7 +22086,8 @@ public struct RawAttributedTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyn
 public struct RawGenericArgumentListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = GenericArgumentListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -21864,7 +22127,8 @@ public struct RawGenericArgumentListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawGenericArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = GenericArgumentSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -21939,7 +22203,8 @@ public struct RawGenericArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
 public struct RawGenericArgumentClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = GenericArgumentClauseSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -22030,7 +22295,8 @@ public struct RawGenericArgumentClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
 public struct RawNamedOpaqueReturnTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = NamedOpaqueReturnTypeSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -22105,7 +22371,8 @@ public struct RawNamedOpaqueReturnTypeSyntax: RawTypeSyntaxNodeProtocol, RawSynt
 public struct RawTypeAnnotationSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TypeAnnotationSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -22180,7 +22447,8 @@ public struct RawTypeAnnotationSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax 
 public struct RawEnumCasePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = EnumCasePatternSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -22287,7 +22555,8 @@ public struct RawEnumCasePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxT
 public struct RawIsTypePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = IsTypePatternSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -22362,7 +22631,8 @@ public struct RawIsTypePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToS
 public struct RawOptionalPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = OptionalPatternSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -22437,7 +22707,8 @@ public struct RawOptionalPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxT
 public struct RawIdentifierPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = IdentifierPatternSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -22496,7 +22767,8 @@ public struct RawIdentifierPatternSyntax: RawPatternSyntaxNodeProtocol, RawSynta
 public struct RawAsTypePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AsTypePatternSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -22587,7 +22859,8 @@ public struct RawAsTypePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToS
 public struct RawTuplePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TuplePatternSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -22678,7 +22951,8 @@ public struct RawTuplePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawWildcardPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = WildcardPatternSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -22753,7 +23027,8 @@ public struct RawWildcardPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxT
 public struct RawTuplePatternElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TuplePatternElementSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -22860,7 +23135,8 @@ public struct RawTuplePatternElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
 public struct RawExpressionPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ExpressionPatternSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -22919,7 +23195,8 @@ public struct RawExpressionPatternSyntax: RawPatternSyntaxNodeProtocol, RawSynta
 public struct RawTuplePatternElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TuplePatternElementListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -22959,7 +23236,8 @@ public struct RawTuplePatternElementListSyntax: RawSyntaxNodeProtocol, RawSyntax
 public struct RawValueBindingPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = ValueBindingPatternSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -23034,7 +23312,8 @@ public struct RawValueBindingPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyn
 public struct RawAvailabilitySpecListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AvailabilitySpecListSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -23074,7 +23353,8 @@ public struct RawAvailabilitySpecListSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
 public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AvailabilityArgumentSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -23149,7 +23429,8 @@ public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
 public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AvailabilityLabeledArgumentSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -23240,7 +23521,8 @@ public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol, RawSy
 public struct RawAvailabilityVersionRestrictionSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = AvailabilityVersionRestrictionSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 
@@ -23315,7 +23597,8 @@ public struct RawAvailabilityVersionRestrictionSyntax: RawSyntaxNodeProtocol, Ra
 public struct RawVersionTupleSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = VersionTupleSyntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
   }
 

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -456,56 +456,6 @@ public extension SyntaxProtocol {
     return TokenSequence(_syntaxNode, viewMode: viewMode)
   }
 
-  /// Sequence of `SyntaxClassifiedRange`s for this syntax node.
-  ///
-  /// The provided classified ranges are consecutive and cover the full source
-  /// text of the node. The ranges may also span multiple tokens, if multiple
-  /// consecutive tokens would have the same classification then a single classified
-  /// range is provided for all of them.
-  var classifications: SyntaxClassifications {
-    let fullRange = ByteSourceRange(offset: 0, length: byteSize)
-    return SyntaxClassifications(_syntaxNode, in: fullRange)
-  }
-
-  /// Sequence of `SyntaxClassifiedRange`s contained in this syntax node within
-  /// a relative range.
-  ///
-  /// The provided classified ranges may extend beyond the provided `range`.
-  /// Active classifications (non-`none`) will extend the range to include the
-  /// full classified range (e.g. from the beginning of the comment block), while
-  /// `none` classified ranges will extend to the beginning or end of the token
-  /// that the `range` touches.
-  /// It is guaranteed that no classified range will be provided that doesn't
-  /// intersect the provided `range`.
-  ///
-  /// - Parameters:
-  ///   - in: The relative byte range to pull `SyntaxClassifiedRange`s from.
-  /// - Returns: Sequence of `SyntaxClassifiedRange`s.
-  func classifications(in range: ByteSourceRange) -> SyntaxClassifications {
-    return SyntaxClassifications(_syntaxNode, in: range)
-  }
-
-  /// The `SyntaxClassifiedRange` for a relative byte offset.
-  /// - Parameters:
-  ///   - at: The relative to the node byte offset.
-  /// - Returns: The `SyntaxClassifiedRange` for the offset or nil if the source text
-  ///   at the given offset is unclassified.
-  func classification(at offset: Int) -> SyntaxClassifiedRange? {
-    let classifications = SyntaxClassifications(_syntaxNode, in: ByteSourceRange(offset: offset, length: 1))
-    var iterator = classifications.makeIterator()
-    return iterator.next()
-  }
-
-  /// The `SyntaxClassifiedRange` for an absolute position.
-  /// - Parameters:
-  ///   - at: The absolute position.
-  /// - Returns: The `SyntaxClassifiedRange` for the position or nil if the source text
-  ///   at the given position is unclassified.
-  func classification(at position: AbsolutePosition) -> SyntaxClassifiedRange? {
-    let relativeOffset = position.utf8Offset - self.position.utf8Offset
-    return self.classification(at: relativeOffset)
-  }
-
   /// Returns a value representing the unique identity of the node.
   var id: SyntaxIdentifier {
     return data.nodeId

--- a/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -82,7 +82,8 @@ public struct ${node.name}: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 

--- a/Sources/SwiftSyntax/SyntaxOtherNodes.swift
+++ b/Sources/SwiftSyntax/SyntaxOtherNodes.swift
@@ -55,7 +55,8 @@ extension UnknownSyntax: CustomReflectable {
 public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  var tokenView: RawSyntaxTokenView {
+  @_spi(RawSyntax)
+  public var tokenView: RawSyntaxTokenView {
     return raw.tokenView!
   }
 
@@ -100,7 +101,6 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
     return tokenKind.text
   }
 
-  @_spi(RawSyntax)
   public var rawTokenKind: RawTokenKind {
     return tokenView.rawKind
   }

--- a/Sources/SwiftSyntax/SyntaxTreeViewMode.swift
+++ b/Sources/SwiftSyntax/SyntaxTreeViewMode.swift
@@ -28,7 +28,8 @@ public enum SyntaxTreeViewMode {
   case all
 
   /// Returns whether this traversal node should visit `node` or ignore it.
-  func shouldTraverse(node: RawSyntax) -> Bool {
+  @_spi(RawSyntax)
+  public func shouldTraverse(node: RawSyntax) -> Bool {
     switch self {
     case .sourceAccurate:
       if let tokenView = node.tokenView {

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
@@ -27,7 +27,8 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -277,7 +278,8 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -527,7 +529,8 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -777,7 +780,8 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -1027,7 +1031,8 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -1304,7 +1309,8 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -1554,7 +1560,8 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -1804,7 +1811,8 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -2054,7 +2062,8 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -2304,7 +2313,8 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -2554,7 +2564,8 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -2804,7 +2815,8 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -3054,7 +3066,8 @@ public struct ObjcNameSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -3304,7 +3317,8 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -3554,7 +3568,8 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -3804,7 +3819,8 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -4054,7 +4070,8 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -4304,7 +4321,8 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -4554,7 +4572,8 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -4804,7 +4823,8 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -5054,7 +5074,8 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -5304,7 +5325,8 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -5551,7 +5573,8 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -5801,7 +5824,8 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -6087,7 +6111,8 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -6337,7 +6362,8 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -6587,7 +6613,8 @@ public struct TokenListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -6837,7 +6864,8 @@ public struct NonEmptyTokenListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -7114,7 +7142,8 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -7408,7 +7437,8 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -7658,7 +7688,8 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -7908,7 +7939,8 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -8158,7 +8190,8 @@ public struct BackDeployVersionListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -8435,7 +8468,8 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -8685,7 +8719,8 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -8935,7 +8970,8 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -9185,7 +9221,8 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -9435,7 +9472,8 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -9685,7 +9723,8 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -9935,7 +9974,8 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -10185,7 +10225,8 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -10435,7 +10476,8 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -10685,7 +10727,8 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -10935,7 +10978,8 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -11185,7 +11229,8 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
@@ -11435,7 +11480,8 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  var layoutView: RawSyntaxLayoutView {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 

--- a/Sources/lit-test-helper/ClassifiedSyntaxTreePrinter.swift
+++ b/Sources/lit-test-helper/ClassifiedSyntaxTreePrinter.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import IDEUtils
 import SwiftSyntax
 
 extension SyntaxClassification {

--- a/Tests/IDEUtilsTest/ClassificationTests.swift
+++ b/Tests/IDEUtilsTest/ClassificationTests.swift
@@ -11,8 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+import IDEUtils
 import SwiftSyntax
 import SwiftParser
+import _SwiftSyntaxTestSupport
 
 public class ClassificationTests: XCTestCase {
 

--- a/Tests/PerformanceTest/SyntaxClassifierPerformanceTests.swift
+++ b/Tests/PerformanceTest/SyntaxClassifierPerformanceTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+import IDEUtils
 import SwiftSyntax
 import SwiftSyntaxParser
 

--- a/build-script.py
+++ b/build-script.py
@@ -17,6 +17,7 @@ PACKAGE_DIR = os.path.dirname(os.path.realpath(__file__))
 WORKSPACE_DIR = os.path.dirname(PACKAGE_DIR)
 EXAMPLES_DIR = os.path.join(PACKAGE_DIR, "Examples")
 SOURCES_DIR = os.path.join(PACKAGE_DIR, "Sources")
+IDEUTILS_DIR = os.path.join(SOURCES_DIR, "IDEUtils")
 SWIFTSYNTAX_DIR = os.path.join(SOURCES_DIR, "SwiftSyntax")
 SWIFTSYNTAX_DOCUMENTATION_DIR = \
         os.path.join(SWIFTSYNTAX_DIR, "Documentation.docc")
@@ -300,6 +301,7 @@ def generate_syntax_node_template_gyb_files(
 def gyb_dir_mapping(temp_directories: bool) -> Dict[str, str]:
     source_dirs = [
         SYNTAXSUPPORT_DIR,
+        IDEUTILS_DIR,
         SWIFTSYNTAX_DIR,
         os.path.join(SWIFTSYNTAX_DIR, "Raw"),
         SWIFTSYNTAXBUILDER_DIR,


### PR DESCRIPTION
The goal of this PR is to move `SyntaxClassifier` out of the `SwiftSyntax` module into its own dedicated. I’m not really happy with the PR yet because `SyntaxClassifier` uses `RawSyntax` pretty extensively and this requires us to expose more methods from SwiftSyntax as SPI. AFAICT the options here are:
- Leave the PR as-is, accepting that `SyntaxClassifier` requires the use of SPI
- Rewrite `SyntaxClassifier` in terms of `Syntax` nodes? @rintaro I think you tried this and it wasn’t performant enough, right?
- Expose `RawSyntax` as `UnsafeSyntax` (or something like that) instead of as SPI
- Leave `SyntaxClassifier` in the `SwiftSyntax` module

I thought I set up this PR as a base for discussion.

rdar://98318240