### PR TITLE
Add SwiftDiagnostics as a build product.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,7 @@ let package = Package(
     .macCatalyst(.v13),
   ],
   products: [
+    .library(name: "SwiftDiagnostics", type: .static, targets: ["SwiftDiagnostics"]),
     .library(name: "SwiftOperators", type: .static, targets: ["SwiftOperators"]),
     .library(name: "SwiftParser", type: .static, targets: ["SwiftParser"]),
     .library(name: "SwiftSyntax", type: .static, targets: ["SwiftSyntax"]),


### PR DESCRIPTION
Macros need to use SwiftDiagnostics from outside the package.