### PR TITLE
If a node’s child has `node_choices` or a collection has `element_choices` use an enum to ensure there are only matching child nodes

### DIFF
--- a/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
@@ -26,6 +26,18 @@ public extension Child {
     )
   }
 
+  var parameterBaseType: String {
+    if !self.nodeChoices.isEmpty {
+      return self.name
+    } else {
+      return type.parameterBaseType
+    }
+  }
+
+  var parameterType: Type {
+    return self.type.optionalWrapped(type: Type(parameterBaseType))
+  }
+
   /// If the child node has documentation associated with it, return it as single
   /// line string. Otherwise return an empty string.
   var documentation: String {

--- a/CodeGeneration/Sources/generate-swiftsyntaxbuilder/BuildableCollectionNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntaxbuilder/BuildableCollectionNodesFile.swift
@@ -35,25 +35,31 @@ let buildableCollectionNodesFile = SourceFile {
       inheritanceClause: TypeInheritanceClause { InheritedType(typeName: Type("ExpressibleByArrayLiteral")) }
     ) {
       // Generate initializers
-      if elementType.isBaseType {
+      if elementType.isBaseType && node.collectionElementChoices?.isEmpty ?? true {
         InitializerDecl(
           """
-          /// Creates a `\(node.type.shorthandName)` with the provided list of elements.
-          /// - Parameters:
-          ///   - elements: A list of `\(elementType.parameterType)`
           public init(_ elements: \(ArrayType(elementType: elementType.parameterType))) {
             self = \(node.type.syntaxBaseName)(elements.map { \(elementType.syntax)(fromProtocol: $0) })
           }
           """
         )
+
+        InitializerDecl(
+          """
+          public init(arrayLiteral elements: \(elementType.parameterType)...) {
+            self.init(elements)
+          }
+          """
+        )
+      } else {
+        InitializerDecl(
+          """
+          public init(arrayLiteral elements: Element...) {
+            self.init(elements)
+          }
+          """
+        )
       }
-      InitializerDecl(
-        """
-        public init(arrayLiteral elements: \(elementType.parameterType)...) {
-          self.init(elements)
-        }
-        """
-      )
     }
   }
 }

--- a/CodeGeneration/Sources/generate-swiftsyntaxbuilder/BuildableNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntaxbuilder/BuildableNodesFile.swift
@@ -63,7 +63,7 @@ let buildableNodesFile = SourceFile {
 }
 
 private func convertFromSyntaxProtocolToSyntaxType(child: Child) -> Expr {
-  if child.type.isBaseType {
+  if child.type.isBaseType && child.nodeChoices.isEmpty {
     return Expr(FunctionCallExpr("\(child.type.syntaxBaseName)(fromProtocol: \(child.swiftName))"))
   } else {
     return Expr(IdentifierExpr(child.swiftName))
@@ -100,7 +100,7 @@ private func createDefaultInitializer(node: Node) -> InitializerDecl {
           FunctionParameter(
             firstName: .identifier(child.swiftName),
             colon: .colon,
-            type: child.type.parameterType,
+            type: child.parameterType,
             defaultArgument: child.type.defaultInitialization.map { InitializerClause(value: $0) }
           )
         }
@@ -192,7 +192,7 @@ private func createConvenienceInitializer(node: Node) -> InitializerDecl? {
       normalParameters.append(FunctionParameter(
         firstName: .identifier(child.swiftName),
         colon: .colon,
-        type: child.type.parameterType,
+        type: child.parameterType,
         defaultArgument: child.type.defaultInitialization.map { InitializerClause(value: $0) }
       ))
     }

--- a/Examples/MigrateToNewIfLetSyntax.swift
+++ b/Examples/MigrateToNewIfLetSyntax.swift
@@ -35,7 +35,7 @@ class MigrateToNewIfLetSyntax: SyntaxRewriter {
         if index != node.conditions.count - 1 {
           binding.pattern = binding.pattern.withoutTrailingTrivia()
         }
-        conditionCopy.condition = Syntax(binding)
+        conditionCopy.condition = .optionalBinding(binding)
       }
       return conditionCopy
     }

--- a/Sources/SwiftOperators/OperatorTable+Semantics.swift
+++ b/Sources/SwiftOperators/OperatorTable+Semantics.swift
@@ -20,7 +20,7 @@ extension PrecedenceGroup {
     self.syntax = syntax
 
     for attr in syntax.groupAttributes {
-      switch attr.as(SyntaxEnum.self) {
+      switch attr {
       // Relation (lowerThan, higherThan)
       case .precedenceGroupRelation(let relation):
         let isLowerThan = relation.higherThanOrLowerThan.text == "lowerThan"
@@ -52,9 +52,6 @@ extension PrecedenceGroup {
         default:
           break
         }
-
-      default:
-        break
       }
     }
   }

--- a/Sources/SwiftOperators/SyntaxSynthesis.swift
+++ b/Sources/SwiftOperators/SyntaxSynthesis.swift
@@ -74,12 +74,12 @@ extension PrecedenceGroup {
       TokenSyntax.identifier(name, leadingTrivia: .space)
     let leftBrace = TokenSyntax.leftBraceToken(leadingTrivia: .space)
 
-    var groupAttributes: [Syntax] = []
+    var groupAttributes: [PrecedenceGroupAttributeListSyntax.Element] = []
 
     switch associativity {
     case .left, .right:
       groupAttributes.append(
-        Syntax(
+        .init(
           PrecedenceGroupAssociativitySyntax(
             associativityKeyword:
                 .identifier(
@@ -99,7 +99,7 @@ extension PrecedenceGroup {
 
     if assignment {
       groupAttributes.append(
-        Syntax(
+        .init(
           PrecedenceGroupAssignmentSyntax(
             assignmentKeyword:
                 .identifier(
@@ -115,7 +115,7 @@ extension PrecedenceGroup {
 
     for relation in relations {
       groupAttributes.append(
-        Syntax(
+        .init(
           relation.synthesizedSyntax()
         )
       )

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -589,7 +589,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     }
     if node.unknownAttr?.isMissingAllTokens != false && node.label.isMissingAllTokens {
       addDiagnostic(node.statements, .allStatmentsInSwitchMustBeCoveredByCase, fixIts: [
-        FixIt(message: InsertTokenFixIt(missingNodes: [node.label]), changes: .makePresent(node.label, leadingTrivia: .newline))
+        FixIt(message: InsertTokenFixIt(missingNodes: [Syntax(node.label)]), changes: .makePresent(node.label, leadingTrivia: .newline))
       ], handledNodes: [node.label.id])
     }
     return .visitChildren

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -59,13 +59,13 @@ public struct Syntax: SyntaxProtocol, SyntaxHashable {
 }
 
 // Casting functions to specialized syntax nodes.
-extension Syntax {
+extension SyntaxProtocol {
   public func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
     return self.as(syntaxType) != nil
   }
 
   public func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
-    return S.init(self)
+    return S.init(self._syntaxNode)
   }
 
   func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
@@ -622,6 +622,16 @@ public extension SyntaxProtocol {
                          converter: converter, mark: mark, indentLevel: childIndentLevel)
       }
     }
+  }
+}
+
+/// Protocol for the enums nested inside `Syntax` nodes that enumerate all the
+/// possible types a child node might have.
+public protocol SyntaxChildChoices: SyntaxProtocol {}
+
+public extension SyntaxChildChoices {
+  func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return Syntax(self).childNameForDiagnostics(index)
   }
 }
 

--- a/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -38,6 +38,48 @@ public protocol SyntaxCollection: SyntaxProtocol, Sequence {
 /// versions of the collection with different children.
 % end
 public struct ${node.name}: SyntaxCollection, SyntaxHashable {
+% if node.collection_element_choices:
+  public enum Element: SyntaxChildChoices {
+%   for choice_name in node.collection_element_choices:
+%     choice = NODE_MAP[choice_name]
+    case `${choice.swift_syntax_kind}`(${choice.name})
+%   end
+    public var _syntaxNode: Syntax {
+      switch self {
+%   for choice_name in node.collection_element_choices:
+%     choice = NODE_MAP[choice_name]
+      case .${choice.swift_syntax_kind}(let node): return node._syntaxNode
+%   end
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+%   for choice_name in node.collection_element_choices:
+%     choice_node = NODE_MAP.get(choice_name)
+%     if choice_node and choice_node.is_base():
+    public init<Node: ${choice_node.name}Protocol>(_ node: Node) {
+      self = .${choice_node.swift_syntax_kind}(${choice_node.name}(node))
+    }
+%     else:
+    public init(_ node: ${choice_node.name}) {
+      self = .${choice_node.swift_syntax_kind}(node)
+    }
+%     end
+%   end
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+%   for choice_name in node.collection_element_choices:
+%     choice = NODE_MAP[choice_name]
+      if let node = syntaxNode.as(${choice.name}.self) {
+        self = .${choice.swift_syntax_kind}(node)
+        return
+      }
+%   end
+      return nil
+    }
+  }
+% else:
+  public typealias Element = ${node.collection_element_type}
+% end
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -59,7 +101,7 @@ public struct ${node.name}: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [${node.collection_element_type}]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.${node.swift_syntax_kind},
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -87,8 +129,7 @@ public struct ${node.name}: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `${node.name}` with that element appended to the end.
-  public func appending(
-    _ syntax: ${node.collection_element_type}) -> ${node.name} {
+  public func appending(_ syntax: Element) -> ${node.name} {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -100,8 +141,7 @@ public struct ${node.name}: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `${node.name}` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: ${node.collection_element_type}) -> ${node.name} {
+  public func prepending(_ syntax: Element) -> ${node.name} {
     return inserting(syntax, at: 0)
   }
 
@@ -113,8 +153,7 @@ public struct ${node.name}: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `${node.name}` with that element appended to the end.
-  public func inserting(_ syntax: ${node.collection_element_type},
-                        at index: Int) -> ${node.name} {
+  public func inserting(_ syntax: Element, at index: Int) -> ${node.name} {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -131,8 +170,7 @@ public struct ${node.name}: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `${node.name}` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: ${node.collection_element_type}) -> ${node.name} {
+  public func replacing(childAt index: Int, with syntax: Element) -> ${node.name} {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -225,7 +263,6 @@ public struct ${node.name}: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `${node.name}` to the `BidirectionalCollection` protocol.
 extension ${node.name}: BidirectionalCollection {
-  public typealias Element = ${node.collection_element_type}
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -237,13 +274,13 @@ extension ${node.name}: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> ${node.collection_element_type}? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return ${node.collection_element_type}(data)
+      return Element(data)
     }
   }
 
@@ -278,11 +315,11 @@ extension ${node.name}: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> ${node.collection_element_type} {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return ${node.collection_element_type}(data)
+    return Element(data)
   }
 }
 %   end

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
@@ -47,6 +47,70 @@ nodes whose base kind are that specified kind.
 /// ${line}
 %     end
 public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
+%     for child in node.children:
+%       if child.node_choices:
+  public enum ${child.name}: SyntaxChildChoices {
+%         for choice in child.node_choices:
+    case `${choice.swift_name}`(${choice.type_name})
+%         end
+    public var _syntaxNode: Syntax {
+      switch self {
+%         for choice in child.node_choices:
+      case .${choice.swift_name}(let node): return node._syntaxNode
+%         end
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+%         for choice in child.node_choices:
+%           choice_node = NODE_MAP.get(choice.syntax_kind)
+%           # We don't add 'init(_: TokenSyntax)' because we need to check the
+%           # token kind.
+%           if choice.is_token():
+%             pass
+%           elif choice_node and choice_node.is_base():
+    public init<Node: ${choice_node.name}Protocol>(_ node: Node) {
+      self = .${choice.swift_name}(${choice_node.name}(node))
+    }
+%           else:
+    public init(_ node: ${choice.type_name}) {
+      self = .${choice.swift_name}(node)
+    }
+%           end
+%         end
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+%         token_choices = []
+%         other_choices = []
+%         for choice in child.node_choices:
+%           if choice.is_token():
+%             token_choices += [choice]
+%           else:
+%             other_choices += [choice]
+%           end
+%         end
+%
+%         if token_choices:
+      if let tok = syntaxNode.as(TokenSyntax.self) {
+        switch tok.rawTokenKind {
+%           for choice in token_choices:
+        case .${choice.token.swift_kind()}: self = .${choice.swift_name}(tok)
+%           end
+        default: return nil
+        }
+        return
+      }
+%         end
+%         for choice in other_choices:
+      if let node = syntaxNode.as(${choice.type_name}.self) {
+        self = .${choice.swift_name}(node)
+        return
+      }
+%         end
+      return nil
+    }
+  }
+
+%       end
+%     end
 %     # ==============
 %     # Initialization
 %     # ==============
@@ -71,7 +135,7 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
   public init(
 %     for (index, child) in enumerate(node.children):
 %       comma = ',' if index != len(node.children) - 1 else ''
-%       param_type = child.type_name
+%       param_type = child.name if child.node_choices else child.type_name
 %       if child.is_optional:
 %         param_type = param_type + "?"
 %       if child.is_unexpected_nodes():
@@ -102,21 +166,21 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
 %       # Children properties
 %       # ===================
 %
-%       ret_type = child.type_name
-%       if child.is_optional:
-%         ret_type += '?'
-%       end
+%       child_type = child.type_name
+%       if child.node_choices:
+%         child_type = child.name
+%       optional_mark = "?" if child.is_optional else ""
 
 %       for line in dedented_lines(child.description):
   /// ${line}
 %       end
-  public var ${child.swift_name}: ${ret_type} {
+  public var ${child.swift_name}: ${child_type}${optional_mark} {
     get {
       let childData = data.child(at: ${idx}, parent: Syntax(self))
 %       if child.is_optional:
       if childData == nil { return nil }
 %       end
-      return ${child.type_name}(childData!)
+      return ${child_type}(childData!)
     }
     set(value) {
       self = with${child.name}(value)
@@ -161,7 +225,7 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
   /// - param newChild: The new `${child.swift_name}` to replace the node's
   ///                   current `${child.swift_name}`, if present.
   public func with${child.name}(
-    _ newChild: ${child.type_name}?) -> ${node.name} {
+    _ newChild: ${child_type}?) -> ${node.name} {
 %       if child.is_optional:
     let raw = newChild?.raw
 %       else:

--- a/Sources/SwiftSyntax/SyntaxOtherNodes.swift
+++ b/Sources/SwiftSyntax/SyntaxOtherNodes.swift
@@ -100,6 +100,11 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
     return tokenKind.text
   }
 
+  @_spi(RawSyntax)
+  public var rawTokenKind: RawTokenKind {
+    return tokenView.rawKind
+  }
+
   /// Returns a new TokenSyntax with its kind replaced
   /// by the provided token kind.
   public func withKind(_ tokenKind: TokenKind) -> TokenSyntax {

--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -86,6 +86,10 @@ open class SyntaxRewriter {
     return visit(node.data)
   }
 
+  public func visit<T: SyntaxChildChoices>(_ node: T) -> T {
+    return visit(Syntax(node)).cast(T.self)
+  }
+
 % for base_kind in [base_kind for base_kind in SYNTAX_BASE_KINDS if base_kind not in ['Syntax', 'SyntaxCollection']]:
   /// Visit any ${base_kind}Syntax node.
   ///   - Parameter node: the node that is being visited

--- a/Sources/SwiftSyntax/SyntaxTransform.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxTransform.swift.gyb
@@ -80,6 +80,10 @@ extension SyntaxTransformVisitor {
     visit(Syntax(node))
   }
 
+  public func visit<T: SyntaxChildChoices>(_ node: T) -> ResultType {
+    return visit(Syntax(node))
+  }
+
   public func visitChildren<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) -> [ResultType] {
     let syntaxNode = Syntax(node)
     return NonNilRawSyntaxChildren(syntaxNode, viewMode: .sourceAccurate).map { rawChild in

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
@@ -23,6 +23,8 @@ public protocol SyntaxCollection: SyntaxProtocol, Sequence {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = CodeBlockItemSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -44,7 +46,7 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [CodeBlockItemSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -72,8 +74,7 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `CodeBlockItemListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: CodeBlockItemSyntax) -> CodeBlockItemListSyntax {
+  public func appending(_ syntax: Element) -> CodeBlockItemListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -85,8 +86,7 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `CodeBlockItemListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: CodeBlockItemSyntax) -> CodeBlockItemListSyntax {
+  public func prepending(_ syntax: Element) -> CodeBlockItemListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -98,8 +98,7 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `CodeBlockItemListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: CodeBlockItemSyntax,
-                        at index: Int) -> CodeBlockItemListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> CodeBlockItemListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -116,8 +115,7 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `CodeBlockItemListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: CodeBlockItemSyntax) -> CodeBlockItemListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> CodeBlockItemListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -210,7 +208,6 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `CodeBlockItemListSyntax` to the `BidirectionalCollection` protocol.
 extension CodeBlockItemListSyntax: BidirectionalCollection {
-  public typealias Element = CodeBlockItemSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -222,13 +219,13 @@ extension CodeBlockItemListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> CodeBlockItemSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return CodeBlockItemSyntax(data)
+      return Element(data)
     }
   }
 
@@ -263,11 +260,11 @@ extension CodeBlockItemListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> CodeBlockItemSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return CodeBlockItemSyntax(data)
+    return Element(data)
   }
 }
 
@@ -276,6 +273,8 @@ extension CodeBlockItemListSyntax: BidirectionalCollection {
 /// could not be used to form a valid syntax tree.
 /// 
 public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = Syntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -297,7 +296,7 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [Syntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.unexpectedNodes,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -325,8 +324,7 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `UnexpectedNodesSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: Syntax) -> UnexpectedNodesSyntax {
+  public func appending(_ syntax: Element) -> UnexpectedNodesSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -338,8 +336,7 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `UnexpectedNodesSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: Syntax) -> UnexpectedNodesSyntax {
+  public func prepending(_ syntax: Element) -> UnexpectedNodesSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -351,8 +348,7 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `UnexpectedNodesSyntax` with that element appended to the end.
-  public func inserting(_ syntax: Syntax,
-                        at index: Int) -> UnexpectedNodesSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> UnexpectedNodesSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -369,8 +365,7 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `UnexpectedNodesSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: Syntax) -> UnexpectedNodesSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> UnexpectedNodesSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -463,7 +458,6 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `UnexpectedNodesSyntax` to the `BidirectionalCollection` protocol.
 extension UnexpectedNodesSyntax: BidirectionalCollection {
-  public typealias Element = Syntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -475,13 +469,13 @@ extension UnexpectedNodesSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> Syntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return Syntax(data)
+      return Element(data)
     }
   }
 
@@ -516,11 +510,11 @@ extension UnexpectedNodesSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> Syntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return Syntax(data)
+    return Element(data)
   }
 }
 
@@ -529,6 +523,8 @@ extension UnexpectedNodesSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = TupleExprElementSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -550,7 +546,7 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [TupleExprElementSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -578,8 +574,7 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `TupleExprElementListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: TupleExprElementSyntax) -> TupleExprElementListSyntax {
+  public func appending(_ syntax: Element) -> TupleExprElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -591,8 +586,7 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `TupleExprElementListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: TupleExprElementSyntax) -> TupleExprElementListSyntax {
+  public func prepending(_ syntax: Element) -> TupleExprElementListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -604,8 +598,7 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `TupleExprElementListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: TupleExprElementSyntax,
-                        at index: Int) -> TupleExprElementListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> TupleExprElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -622,8 +615,7 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `TupleExprElementListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: TupleExprElementSyntax) -> TupleExprElementListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> TupleExprElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -716,7 +708,6 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `TupleExprElementListSyntax` to the `BidirectionalCollection` protocol.
 extension TupleExprElementListSyntax: BidirectionalCollection {
-  public typealias Element = TupleExprElementSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -728,13 +719,13 @@ extension TupleExprElementListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> TupleExprElementSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return TupleExprElementSyntax(data)
+      return Element(data)
     }
   }
 
@@ -769,11 +760,11 @@ extension TupleExprElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> TupleExprElementSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return TupleExprElementSyntax(data)
+    return Element(data)
   }
 }
 
@@ -782,6 +773,8 @@ extension TupleExprElementListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = ArrayElementSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -803,7 +796,7 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [ArrayElementSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayElementList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -831,8 +824,7 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `ArrayElementListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: ArrayElementSyntax) -> ArrayElementListSyntax {
+  public func appending(_ syntax: Element) -> ArrayElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -844,8 +836,7 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `ArrayElementListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: ArrayElementSyntax) -> ArrayElementListSyntax {
+  public func prepending(_ syntax: Element) -> ArrayElementListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -857,8 +848,7 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `ArrayElementListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: ArrayElementSyntax,
-                        at index: Int) -> ArrayElementListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> ArrayElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -875,8 +865,7 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `ArrayElementListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: ArrayElementSyntax) -> ArrayElementListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> ArrayElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -969,7 +958,6 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `ArrayElementListSyntax` to the `BidirectionalCollection` protocol.
 extension ArrayElementListSyntax: BidirectionalCollection {
-  public typealias Element = ArrayElementSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -981,13 +969,13 @@ extension ArrayElementListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> ArrayElementSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return ArrayElementSyntax(data)
+      return Element(data)
     }
   }
 
@@ -1022,11 +1010,11 @@ extension ArrayElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> ArrayElementSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return ArrayElementSyntax(data)
+    return Element(data)
   }
 }
 
@@ -1035,6 +1023,8 @@ extension ArrayElementListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = DictionaryElementSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -1056,7 +1046,7 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [DictionaryElementSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryElementList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -1084,8 +1074,7 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `DictionaryElementListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: DictionaryElementSyntax) -> DictionaryElementListSyntax {
+  public func appending(_ syntax: Element) -> DictionaryElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -1097,8 +1086,7 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `DictionaryElementListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: DictionaryElementSyntax) -> DictionaryElementListSyntax {
+  public func prepending(_ syntax: Element) -> DictionaryElementListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -1110,8 +1098,7 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `DictionaryElementListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: DictionaryElementSyntax,
-                        at index: Int) -> DictionaryElementListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> DictionaryElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -1128,8 +1115,7 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `DictionaryElementListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: DictionaryElementSyntax) -> DictionaryElementListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> DictionaryElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -1222,7 +1208,6 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `DictionaryElementListSyntax` to the `BidirectionalCollection` protocol.
 extension DictionaryElementListSyntax: BidirectionalCollection {
-  public typealias Element = DictionaryElementSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -1234,13 +1219,13 @@ extension DictionaryElementListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> DictionaryElementSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return DictionaryElementSyntax(data)
+      return Element(data)
     }
   }
 
@@ -1275,11 +1260,11 @@ extension DictionaryElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> DictionaryElementSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return DictionaryElementSyntax(data)
+    return Element(data)
   }
 }
 
@@ -1288,6 +1273,35 @@ extension DictionaryElementListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
+  public enum Element: SyntaxChildChoices {
+    case `stringSegment`(StringSegmentSyntax)
+    case `expressionSegment`(ExpressionSegmentSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .stringSegment(let node): return node._syntaxNode
+      case .expressionSegment(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: StringSegmentSyntax) {
+      self = .stringSegment(node)
+    }
+    public init(_ node: ExpressionSegmentSyntax) {
+      self = .expressionSegment(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(StringSegmentSyntax.self) {
+        self = .stringSegment(node)
+        return
+      }
+      if let node = syntaxNode.as(ExpressionSegmentSyntax.self) {
+        self = .expressionSegment(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -1309,7 +1323,7 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [Syntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralSegments,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -1337,8 +1351,7 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `StringLiteralSegmentsSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: Syntax) -> StringLiteralSegmentsSyntax {
+  public func appending(_ syntax: Element) -> StringLiteralSegmentsSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -1350,8 +1363,7 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `StringLiteralSegmentsSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: Syntax) -> StringLiteralSegmentsSyntax {
+  public func prepending(_ syntax: Element) -> StringLiteralSegmentsSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -1363,8 +1375,7 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `StringLiteralSegmentsSyntax` with that element appended to the end.
-  public func inserting(_ syntax: Syntax,
-                        at index: Int) -> StringLiteralSegmentsSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> StringLiteralSegmentsSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -1381,8 +1392,7 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `StringLiteralSegmentsSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: Syntax) -> StringLiteralSegmentsSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> StringLiteralSegmentsSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -1475,7 +1485,6 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `StringLiteralSegmentsSyntax` to the `BidirectionalCollection` protocol.
 extension StringLiteralSegmentsSyntax: BidirectionalCollection {
-  public typealias Element = Syntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -1487,13 +1496,13 @@ extension StringLiteralSegmentsSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> Syntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return Syntax(data)
+      return Element(data)
     }
   }
 
@@ -1528,11 +1537,11 @@ extension StringLiteralSegmentsSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> Syntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return Syntax(data)
+    return Element(data)
   }
 }
 
@@ -1541,6 +1550,8 @@ extension StringLiteralSegmentsSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = DeclNameArgumentSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -1562,7 +1573,7 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [DeclNameArgumentSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgumentList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -1590,8 +1601,7 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `DeclNameArgumentListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: DeclNameArgumentSyntax) -> DeclNameArgumentListSyntax {
+  public func appending(_ syntax: Element) -> DeclNameArgumentListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -1603,8 +1613,7 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `DeclNameArgumentListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: DeclNameArgumentSyntax) -> DeclNameArgumentListSyntax {
+  public func prepending(_ syntax: Element) -> DeclNameArgumentListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -1616,8 +1625,7 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `DeclNameArgumentListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: DeclNameArgumentSyntax,
-                        at index: Int) -> DeclNameArgumentListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> DeclNameArgumentListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -1634,8 +1642,7 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `DeclNameArgumentListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: DeclNameArgumentSyntax) -> DeclNameArgumentListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> DeclNameArgumentListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -1728,7 +1735,6 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `DeclNameArgumentListSyntax` to the `BidirectionalCollection` protocol.
 extension DeclNameArgumentListSyntax: BidirectionalCollection {
-  public typealias Element = DeclNameArgumentSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -1740,13 +1746,13 @@ extension DeclNameArgumentListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> DeclNameArgumentSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return DeclNameArgumentSyntax(data)
+      return Element(data)
     }
   }
 
@@ -1781,11 +1787,11 @@ extension DeclNameArgumentListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> DeclNameArgumentSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return DeclNameArgumentSyntax(data)
+    return Element(data)
   }
 }
 
@@ -1794,6 +1800,8 @@ extension DeclNameArgumentListSyntax: BidirectionalCollection {
 /// by a `SequenceExprSyntax`.
 /// 
 public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = ExprSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -1815,7 +1823,7 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [ExprSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.exprList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -1843,8 +1851,7 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `ExprListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: ExprSyntax) -> ExprListSyntax {
+  public func appending(_ syntax: Element) -> ExprListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -1856,8 +1863,7 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `ExprListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: ExprSyntax) -> ExprListSyntax {
+  public func prepending(_ syntax: Element) -> ExprListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -1869,8 +1875,7 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `ExprListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: ExprSyntax,
-                        at index: Int) -> ExprListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> ExprListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -1887,8 +1892,7 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `ExprListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: ExprSyntax) -> ExprListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> ExprListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -1981,7 +1985,6 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `ExprListSyntax` to the `BidirectionalCollection` protocol.
 extension ExprListSyntax: BidirectionalCollection {
-  public typealias Element = ExprSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -1993,13 +1996,13 @@ extension ExprListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> ExprSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return ExprSyntax(data)
+      return Element(data)
     }
   }
 
@@ -2034,11 +2037,11 @@ extension ExprListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> ExprSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return ExprSyntax(data)
+    return Element(data)
   }
 }
 
@@ -2047,6 +2050,8 @@ extension ExprListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = ClosureCaptureItemSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -2068,7 +2073,7 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [ClosureCaptureItemSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItemList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -2096,8 +2101,7 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `ClosureCaptureItemListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: ClosureCaptureItemSyntax) -> ClosureCaptureItemListSyntax {
+  public func appending(_ syntax: Element) -> ClosureCaptureItemListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -2109,8 +2113,7 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `ClosureCaptureItemListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: ClosureCaptureItemSyntax) -> ClosureCaptureItemListSyntax {
+  public func prepending(_ syntax: Element) -> ClosureCaptureItemListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -2122,8 +2125,7 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `ClosureCaptureItemListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: ClosureCaptureItemSyntax,
-                        at index: Int) -> ClosureCaptureItemListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> ClosureCaptureItemListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -2140,8 +2142,7 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `ClosureCaptureItemListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: ClosureCaptureItemSyntax) -> ClosureCaptureItemListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> ClosureCaptureItemListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -2234,7 +2235,6 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `ClosureCaptureItemListSyntax` to the `BidirectionalCollection` protocol.
 extension ClosureCaptureItemListSyntax: BidirectionalCollection {
-  public typealias Element = ClosureCaptureItemSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -2246,13 +2246,13 @@ extension ClosureCaptureItemListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> ClosureCaptureItemSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return ClosureCaptureItemSyntax(data)
+      return Element(data)
     }
   }
 
@@ -2287,11 +2287,11 @@ extension ClosureCaptureItemListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> ClosureCaptureItemSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return ClosureCaptureItemSyntax(data)
+    return Element(data)
   }
 }
 
@@ -2300,6 +2300,8 @@ extension ClosureCaptureItemListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = ClosureParamSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -2321,7 +2323,7 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [ClosureParamSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParamList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -2349,8 +2351,7 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `ClosureParamListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: ClosureParamSyntax) -> ClosureParamListSyntax {
+  public func appending(_ syntax: Element) -> ClosureParamListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -2362,8 +2363,7 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `ClosureParamListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: ClosureParamSyntax) -> ClosureParamListSyntax {
+  public func prepending(_ syntax: Element) -> ClosureParamListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -2375,8 +2375,7 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `ClosureParamListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: ClosureParamSyntax,
-                        at index: Int) -> ClosureParamListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> ClosureParamListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -2393,8 +2392,7 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `ClosureParamListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: ClosureParamSyntax) -> ClosureParamListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> ClosureParamListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -2487,7 +2485,6 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `ClosureParamListSyntax` to the `BidirectionalCollection` protocol.
 extension ClosureParamListSyntax: BidirectionalCollection {
-  public typealias Element = ClosureParamSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -2499,13 +2496,13 @@ extension ClosureParamListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> ClosureParamSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return ClosureParamSyntax(data)
+      return Element(data)
     }
   }
 
@@ -2540,11 +2537,11 @@ extension ClosureParamListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> ClosureParamSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return ClosureParamSyntax(data)
+    return Element(data)
   }
 }
 
@@ -2553,6 +2550,8 @@ extension ClosureParamListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = MultipleTrailingClosureElementSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -2574,7 +2573,7 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [MultipleTrailingClosureElementSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElementList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -2602,8 +2601,7 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `MultipleTrailingClosureElementListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: MultipleTrailingClosureElementSyntax) -> MultipleTrailingClosureElementListSyntax {
+  public func appending(_ syntax: Element) -> MultipleTrailingClosureElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -2615,8 +2613,7 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `MultipleTrailingClosureElementListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: MultipleTrailingClosureElementSyntax) -> MultipleTrailingClosureElementListSyntax {
+  public func prepending(_ syntax: Element) -> MultipleTrailingClosureElementListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -2628,8 +2625,7 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `MultipleTrailingClosureElementListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: MultipleTrailingClosureElementSyntax,
-                        at index: Int) -> MultipleTrailingClosureElementListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> MultipleTrailingClosureElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -2646,8 +2642,7 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `MultipleTrailingClosureElementListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: MultipleTrailingClosureElementSyntax) -> MultipleTrailingClosureElementListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> MultipleTrailingClosureElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -2740,7 +2735,6 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
 
 /// Conformance for `MultipleTrailingClosureElementListSyntax` to the `BidirectionalCollection` protocol.
 extension MultipleTrailingClosureElementListSyntax: BidirectionalCollection {
-  public typealias Element = MultipleTrailingClosureElementSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -2752,13 +2746,13 @@ extension MultipleTrailingClosureElementListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> MultipleTrailingClosureElementSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return MultipleTrailingClosureElementSyntax(data)
+      return Element(data)
     }
   }
 
@@ -2793,11 +2787,11 @@ extension MultipleTrailingClosureElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> MultipleTrailingClosureElementSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return MultipleTrailingClosureElementSyntax(data)
+    return Element(data)
   }
 }
 
@@ -2806,6 +2800,8 @@ extension MultipleTrailingClosureElementListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = KeyPathComponentSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -2827,7 +2823,7 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [KeyPathComponentSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathComponentList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -2855,8 +2851,7 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `KeyPathComponentListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: KeyPathComponentSyntax) -> KeyPathComponentListSyntax {
+  public func appending(_ syntax: Element) -> KeyPathComponentListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -2868,8 +2863,7 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `KeyPathComponentListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: KeyPathComponentSyntax) -> KeyPathComponentListSyntax {
+  public func prepending(_ syntax: Element) -> KeyPathComponentListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -2881,8 +2875,7 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `KeyPathComponentListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: KeyPathComponentSyntax,
-                        at index: Int) -> KeyPathComponentListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> KeyPathComponentListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -2899,8 +2892,7 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `KeyPathComponentListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: KeyPathComponentSyntax) -> KeyPathComponentListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> KeyPathComponentListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -2993,7 +2985,6 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `KeyPathComponentListSyntax` to the `BidirectionalCollection` protocol.
 extension KeyPathComponentListSyntax: BidirectionalCollection {
-  public typealias Element = KeyPathComponentSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -3005,13 +2996,13 @@ extension KeyPathComponentListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> KeyPathComponentSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return KeyPathComponentSyntax(data)
+      return Element(data)
     }
   }
 
@@ -3046,11 +3037,11 @@ extension KeyPathComponentListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> KeyPathComponentSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return KeyPathComponentSyntax(data)
+    return Element(data)
   }
 }
 
@@ -3059,6 +3050,8 @@ extension KeyPathComponentListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct ObjcNameSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = ObjcNamePieceSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -3080,7 +3073,7 @@ public struct ObjcNameSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [ObjcNamePieceSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcName,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -3108,8 +3101,7 @@ public struct ObjcNameSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `ObjcNameSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: ObjcNamePieceSyntax) -> ObjcNameSyntax {
+  public func appending(_ syntax: Element) -> ObjcNameSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -3121,8 +3113,7 @@ public struct ObjcNameSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `ObjcNameSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: ObjcNamePieceSyntax) -> ObjcNameSyntax {
+  public func prepending(_ syntax: Element) -> ObjcNameSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -3134,8 +3125,7 @@ public struct ObjcNameSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `ObjcNameSyntax` with that element appended to the end.
-  public func inserting(_ syntax: ObjcNamePieceSyntax,
-                        at index: Int) -> ObjcNameSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> ObjcNameSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -3152,8 +3142,7 @@ public struct ObjcNameSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `ObjcNameSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: ObjcNamePieceSyntax) -> ObjcNameSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> ObjcNameSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -3246,7 +3235,6 @@ public struct ObjcNameSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `ObjcNameSyntax` to the `BidirectionalCollection` protocol.
 extension ObjcNameSyntax: BidirectionalCollection {
-  public typealias Element = ObjcNamePieceSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -3258,13 +3246,13 @@ extension ObjcNameSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> ObjcNamePieceSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return ObjcNamePieceSyntax(data)
+      return Element(data)
     }
   }
 
@@ -3299,11 +3287,11 @@ extension ObjcNameSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> ObjcNamePieceSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return ObjcNamePieceSyntax(data)
+    return Element(data)
   }
 }
 
@@ -3312,6 +3300,8 @@ extension ObjcNameSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = YieldExprListElementSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -3333,7 +3323,7 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [YieldExprListElementSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -3361,8 +3351,7 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `YieldExprListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: YieldExprListElementSyntax) -> YieldExprListSyntax {
+  public func appending(_ syntax: Element) -> YieldExprListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -3374,8 +3363,7 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `YieldExprListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: YieldExprListElementSyntax) -> YieldExprListSyntax {
+  public func prepending(_ syntax: Element) -> YieldExprListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -3387,8 +3375,7 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `YieldExprListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: YieldExprListElementSyntax,
-                        at index: Int) -> YieldExprListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> YieldExprListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -3405,8 +3392,7 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `YieldExprListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: YieldExprListElementSyntax) -> YieldExprListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> YieldExprListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -3499,7 +3485,6 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `YieldExprListSyntax` to the `BidirectionalCollection` protocol.
 extension YieldExprListSyntax: BidirectionalCollection {
-  public typealias Element = YieldExprListElementSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -3511,13 +3496,13 @@ extension YieldExprListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> YieldExprListElementSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return YieldExprListElementSyntax(data)
+      return Element(data)
     }
   }
 
@@ -3552,11 +3537,11 @@ extension YieldExprListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> YieldExprListElementSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return YieldExprListElementSyntax(data)
+    return Element(data)
   }
 }
 
@@ -3565,6 +3550,8 @@ extension YieldExprListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = FunctionParameterSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -3586,7 +3573,7 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [FunctionParameterSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionParameterList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -3614,8 +3601,7 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `FunctionParameterListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: FunctionParameterSyntax) -> FunctionParameterListSyntax {
+  public func appending(_ syntax: Element) -> FunctionParameterListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -3627,8 +3613,7 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `FunctionParameterListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: FunctionParameterSyntax) -> FunctionParameterListSyntax {
+  public func prepending(_ syntax: Element) -> FunctionParameterListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -3640,8 +3625,7 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `FunctionParameterListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: FunctionParameterSyntax,
-                        at index: Int) -> FunctionParameterListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> FunctionParameterListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -3658,8 +3642,7 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `FunctionParameterListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: FunctionParameterSyntax) -> FunctionParameterListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> FunctionParameterListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -3752,7 +3735,6 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `FunctionParameterListSyntax` to the `BidirectionalCollection` protocol.
 extension FunctionParameterListSyntax: BidirectionalCollection {
-  public typealias Element = FunctionParameterSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -3764,13 +3746,13 @@ extension FunctionParameterListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> FunctionParameterSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return FunctionParameterSyntax(data)
+      return Element(data)
     }
   }
 
@@ -3805,11 +3787,11 @@ extension FunctionParameterListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> FunctionParameterSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return FunctionParameterSyntax(data)
+    return Element(data)
   }
 }
 
@@ -3818,6 +3800,8 @@ extension FunctionParameterListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = IfConfigClauseSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -3839,7 +3823,7 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [IfConfigClauseSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClauseList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -3867,8 +3851,7 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `IfConfigClauseListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: IfConfigClauseSyntax) -> IfConfigClauseListSyntax {
+  public func appending(_ syntax: Element) -> IfConfigClauseListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -3880,8 +3863,7 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `IfConfigClauseListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: IfConfigClauseSyntax) -> IfConfigClauseListSyntax {
+  public func prepending(_ syntax: Element) -> IfConfigClauseListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -3893,8 +3875,7 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `IfConfigClauseListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: IfConfigClauseSyntax,
-                        at index: Int) -> IfConfigClauseListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> IfConfigClauseListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -3911,8 +3892,7 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `IfConfigClauseListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: IfConfigClauseSyntax) -> IfConfigClauseListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> IfConfigClauseListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -4005,7 +3985,6 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `IfConfigClauseListSyntax` to the `BidirectionalCollection` protocol.
 extension IfConfigClauseListSyntax: BidirectionalCollection {
-  public typealias Element = IfConfigClauseSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -4017,13 +3996,13 @@ extension IfConfigClauseListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> IfConfigClauseSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return IfConfigClauseSyntax(data)
+      return Element(data)
     }
   }
 
@@ -4058,11 +4037,11 @@ extension IfConfigClauseListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> IfConfigClauseSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return IfConfigClauseSyntax(data)
+    return Element(data)
   }
 }
 
@@ -4071,6 +4050,8 @@ extension IfConfigClauseListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = InheritedTypeSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -4092,7 +4073,7 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [InheritedTypeSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.inheritedTypeList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -4120,8 +4101,7 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `InheritedTypeListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: InheritedTypeSyntax) -> InheritedTypeListSyntax {
+  public func appending(_ syntax: Element) -> InheritedTypeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -4133,8 +4113,7 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `InheritedTypeListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: InheritedTypeSyntax) -> InheritedTypeListSyntax {
+  public func prepending(_ syntax: Element) -> InheritedTypeListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -4146,8 +4125,7 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `InheritedTypeListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: InheritedTypeSyntax,
-                        at index: Int) -> InheritedTypeListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> InheritedTypeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -4164,8 +4142,7 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `InheritedTypeListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: InheritedTypeSyntax) -> InheritedTypeListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> InheritedTypeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -4258,7 +4235,6 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `InheritedTypeListSyntax` to the `BidirectionalCollection` protocol.
 extension InheritedTypeListSyntax: BidirectionalCollection {
-  public typealias Element = InheritedTypeSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -4270,13 +4246,13 @@ extension InheritedTypeListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> InheritedTypeSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return InheritedTypeSyntax(data)
+      return Element(data)
     }
   }
 
@@ -4311,11 +4287,11 @@ extension InheritedTypeListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> InheritedTypeSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return InheritedTypeSyntax(data)
+    return Element(data)
   }
 }
 
@@ -4324,6 +4300,8 @@ extension InheritedTypeListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = MemberDeclListItemSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -4345,7 +4323,7 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [MemberDeclListItemSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -4373,8 +4351,7 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `MemberDeclListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: MemberDeclListItemSyntax) -> MemberDeclListSyntax {
+  public func appending(_ syntax: Element) -> MemberDeclListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -4386,8 +4363,7 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `MemberDeclListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: MemberDeclListItemSyntax) -> MemberDeclListSyntax {
+  public func prepending(_ syntax: Element) -> MemberDeclListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -4399,8 +4375,7 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `MemberDeclListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: MemberDeclListItemSyntax,
-                        at index: Int) -> MemberDeclListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> MemberDeclListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -4417,8 +4392,7 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `MemberDeclListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: MemberDeclListItemSyntax) -> MemberDeclListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> MemberDeclListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -4511,7 +4485,6 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `MemberDeclListSyntax` to the `BidirectionalCollection` protocol.
 extension MemberDeclListSyntax: BidirectionalCollection {
-  public typealias Element = MemberDeclListItemSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -4523,13 +4496,13 @@ extension MemberDeclListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> MemberDeclListItemSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return MemberDeclListItemSyntax(data)
+      return Element(data)
     }
   }
 
@@ -4564,11 +4537,11 @@ extension MemberDeclListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> MemberDeclListItemSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return MemberDeclListItemSyntax(data)
+    return Element(data)
   }
 }
 
@@ -4577,6 +4550,8 @@ extension MemberDeclListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = DeclModifierSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -4598,7 +4573,7 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [DeclModifierSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -4626,8 +4601,7 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `ModifierListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: DeclModifierSyntax) -> ModifierListSyntax {
+  public func appending(_ syntax: Element) -> ModifierListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -4639,8 +4613,7 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `ModifierListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: DeclModifierSyntax) -> ModifierListSyntax {
+  public func prepending(_ syntax: Element) -> ModifierListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -4652,8 +4625,7 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `ModifierListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: DeclModifierSyntax,
-                        at index: Int) -> ModifierListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> ModifierListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -4670,8 +4642,7 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `ModifierListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: DeclModifierSyntax) -> ModifierListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> ModifierListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -4764,7 +4735,6 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `ModifierListSyntax` to the `BidirectionalCollection` protocol.
 extension ModifierListSyntax: BidirectionalCollection {
-  public typealias Element = DeclModifierSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -4776,13 +4746,13 @@ extension ModifierListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> DeclModifierSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return DeclModifierSyntax(data)
+      return Element(data)
     }
   }
 
@@ -4817,11 +4787,11 @@ extension ModifierListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> DeclModifierSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return DeclModifierSyntax(data)
+    return Element(data)
   }
 }
 
@@ -4830,6 +4800,8 @@ extension ModifierListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = AccessPathComponentSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -4851,7 +4823,7 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [AccessPathComponentSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessPath,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -4879,8 +4851,7 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `AccessPathSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: AccessPathComponentSyntax) -> AccessPathSyntax {
+  public func appending(_ syntax: Element) -> AccessPathSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -4892,8 +4863,7 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `AccessPathSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: AccessPathComponentSyntax) -> AccessPathSyntax {
+  public func prepending(_ syntax: Element) -> AccessPathSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -4905,8 +4875,7 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `AccessPathSyntax` with that element appended to the end.
-  public func inserting(_ syntax: AccessPathComponentSyntax,
-                        at index: Int) -> AccessPathSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> AccessPathSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -4923,8 +4892,7 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `AccessPathSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: AccessPathComponentSyntax) -> AccessPathSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> AccessPathSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -5017,7 +4985,6 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `AccessPathSyntax` to the `BidirectionalCollection` protocol.
 extension AccessPathSyntax: BidirectionalCollection {
-  public typealias Element = AccessPathComponentSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -5029,13 +4996,13 @@ extension AccessPathSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> AccessPathComponentSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return AccessPathComponentSyntax(data)
+      return Element(data)
     }
   }
 
@@ -5070,11 +5037,11 @@ extension AccessPathSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> AccessPathComponentSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return AccessPathComponentSyntax(data)
+    return Element(data)
   }
 }
 
@@ -5083,6 +5050,8 @@ extension AccessPathSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = AccessorDeclSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -5104,7 +5073,7 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [AccessorDeclSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -5132,8 +5101,7 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `AccessorListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: AccessorDeclSyntax) -> AccessorListSyntax {
+  public func appending(_ syntax: Element) -> AccessorListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -5145,8 +5113,7 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `AccessorListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: AccessorDeclSyntax) -> AccessorListSyntax {
+  public func prepending(_ syntax: Element) -> AccessorListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -5158,8 +5125,7 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `AccessorListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: AccessorDeclSyntax,
-                        at index: Int) -> AccessorListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> AccessorListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -5176,8 +5142,7 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `AccessorListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: AccessorDeclSyntax) -> AccessorListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> AccessorListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -5270,7 +5235,6 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `AccessorListSyntax` to the `BidirectionalCollection` protocol.
 extension AccessorListSyntax: BidirectionalCollection {
-  public typealias Element = AccessorDeclSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -5282,13 +5246,13 @@ extension AccessorListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> AccessorDeclSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return AccessorDeclSyntax(data)
+      return Element(data)
     }
   }
 
@@ -5323,11 +5287,11 @@ extension AccessorListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> AccessorDeclSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return AccessorDeclSyntax(data)
+    return Element(data)
   }
 }
 
@@ -5336,6 +5300,8 @@ extension AccessorListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = PatternBindingSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -5357,7 +5323,7 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [PatternBindingSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.patternBindingList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -5385,8 +5351,7 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `PatternBindingListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: PatternBindingSyntax) -> PatternBindingListSyntax {
+  public func appending(_ syntax: Element) -> PatternBindingListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -5398,8 +5363,7 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `PatternBindingListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: PatternBindingSyntax) -> PatternBindingListSyntax {
+  public func prepending(_ syntax: Element) -> PatternBindingListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -5411,8 +5375,7 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `PatternBindingListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: PatternBindingSyntax,
-                        at index: Int) -> PatternBindingListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> PatternBindingListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -5429,8 +5392,7 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `PatternBindingListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: PatternBindingSyntax) -> PatternBindingListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> PatternBindingListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -5523,7 +5485,6 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `PatternBindingListSyntax` to the `BidirectionalCollection` protocol.
 extension PatternBindingListSyntax: BidirectionalCollection {
-  public typealias Element = PatternBindingSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -5535,13 +5496,13 @@ extension PatternBindingListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> PatternBindingSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return PatternBindingSyntax(data)
+      return Element(data)
     }
   }
 
@@ -5576,16 +5537,18 @@ extension PatternBindingListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> PatternBindingSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return PatternBindingSyntax(data)
+    return Element(data)
   }
 }
 
 /// A collection of 0 or more `EnumCaseElement`s.
 public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = EnumCaseElementSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -5607,7 +5570,7 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [EnumCaseElementSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElementList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -5635,8 +5598,7 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `EnumCaseElementListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: EnumCaseElementSyntax) -> EnumCaseElementListSyntax {
+  public func appending(_ syntax: Element) -> EnumCaseElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -5648,8 +5610,7 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `EnumCaseElementListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: EnumCaseElementSyntax) -> EnumCaseElementListSyntax {
+  public func prepending(_ syntax: Element) -> EnumCaseElementListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -5661,8 +5622,7 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `EnumCaseElementListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: EnumCaseElementSyntax,
-                        at index: Int) -> EnumCaseElementListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> EnumCaseElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -5679,8 +5639,7 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `EnumCaseElementListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: EnumCaseElementSyntax) -> EnumCaseElementListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> EnumCaseElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -5773,7 +5732,6 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `EnumCaseElementListSyntax` to the `BidirectionalCollection` protocol.
 extension EnumCaseElementListSyntax: BidirectionalCollection {
-  public typealias Element = EnumCaseElementSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -5785,13 +5743,13 @@ extension EnumCaseElementListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> EnumCaseElementSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return EnumCaseElementSyntax(data)
+      return Element(data)
     }
   }
 
@@ -5826,11 +5784,11 @@ extension EnumCaseElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> EnumCaseElementSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return EnumCaseElementSyntax(data)
+    return Element(data)
   }
 }
 
@@ -5839,6 +5797,8 @@ extension EnumCaseElementListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = DesignatedTypeElementSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -5860,7 +5820,7 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [DesignatedTypeElementSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -5888,8 +5848,7 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `DesignatedTypeListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: DesignatedTypeElementSyntax) -> DesignatedTypeListSyntax {
+  public func appending(_ syntax: Element) -> DesignatedTypeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -5901,8 +5860,7 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `DesignatedTypeListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: DesignatedTypeElementSyntax) -> DesignatedTypeListSyntax {
+  public func prepending(_ syntax: Element) -> DesignatedTypeListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -5914,8 +5872,7 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `DesignatedTypeListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: DesignatedTypeElementSyntax,
-                        at index: Int) -> DesignatedTypeListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> DesignatedTypeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -5932,8 +5889,7 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `DesignatedTypeListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: DesignatedTypeElementSyntax) -> DesignatedTypeListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> DesignatedTypeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -6026,7 +5982,6 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `DesignatedTypeListSyntax` to the `BidirectionalCollection` protocol.
 extension DesignatedTypeListSyntax: BidirectionalCollection {
-  public typealias Element = DesignatedTypeElementSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -6038,13 +5993,13 @@ extension DesignatedTypeListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> DesignatedTypeElementSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return DesignatedTypeElementSyntax(data)
+      return Element(data)
     }
   }
 
@@ -6079,11 +6034,11 @@ extension DesignatedTypeListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> DesignatedTypeElementSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return DesignatedTypeElementSyntax(data)
+    return Element(data)
   }
 }
 
@@ -6092,6 +6047,44 @@ extension DesignatedTypeListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashable {
+  public enum Element: SyntaxChildChoices {
+    case `precedenceGroupRelation`(PrecedenceGroupRelationSyntax)
+    case `precedenceGroupAssignment`(PrecedenceGroupAssignmentSyntax)
+    case `precedenceGroupAssociativity`(PrecedenceGroupAssociativitySyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .precedenceGroupRelation(let node): return node._syntaxNode
+      case .precedenceGroupAssignment(let node): return node._syntaxNode
+      case .precedenceGroupAssociativity(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: PrecedenceGroupRelationSyntax) {
+      self = .precedenceGroupRelation(node)
+    }
+    public init(_ node: PrecedenceGroupAssignmentSyntax) {
+      self = .precedenceGroupAssignment(node)
+    }
+    public init(_ node: PrecedenceGroupAssociativitySyntax) {
+      self = .precedenceGroupAssociativity(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(PrecedenceGroupRelationSyntax.self) {
+        self = .precedenceGroupRelation(node)
+        return
+      }
+      if let node = syntaxNode.as(PrecedenceGroupAssignmentSyntax.self) {
+        self = .precedenceGroupAssignment(node)
+        return
+      }
+      if let node = syntaxNode.as(PrecedenceGroupAssociativitySyntax.self) {
+        self = .precedenceGroupAssociativity(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -6113,7 +6106,7 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [Syntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAttributeList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -6141,8 +6134,7 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `PrecedenceGroupAttributeListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: Syntax) -> PrecedenceGroupAttributeListSyntax {
+  public func appending(_ syntax: Element) -> PrecedenceGroupAttributeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -6154,8 +6146,7 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `PrecedenceGroupAttributeListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: Syntax) -> PrecedenceGroupAttributeListSyntax {
+  public func prepending(_ syntax: Element) -> PrecedenceGroupAttributeListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -6167,8 +6158,7 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `PrecedenceGroupAttributeListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: Syntax,
-                        at index: Int) -> PrecedenceGroupAttributeListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> PrecedenceGroupAttributeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -6185,8 +6175,7 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `PrecedenceGroupAttributeListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: Syntax) -> PrecedenceGroupAttributeListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> PrecedenceGroupAttributeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -6279,7 +6268,6 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
 
 /// Conformance for `PrecedenceGroupAttributeListSyntax` to the `BidirectionalCollection` protocol.
 extension PrecedenceGroupAttributeListSyntax: BidirectionalCollection {
-  public typealias Element = Syntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -6291,13 +6279,13 @@ extension PrecedenceGroupAttributeListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> Syntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return Syntax(data)
+      return Element(data)
     }
   }
 
@@ -6332,11 +6320,11 @@ extension PrecedenceGroupAttributeListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> Syntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return Syntax(data)
+    return Element(data)
   }
 }
 
@@ -6345,6 +6333,8 @@ extension PrecedenceGroupAttributeListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = PrecedenceGroupNameElementSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -6366,7 +6356,7 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [PrecedenceGroupNameElementSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -6394,8 +6384,7 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `PrecedenceGroupNameListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: PrecedenceGroupNameElementSyntax) -> PrecedenceGroupNameListSyntax {
+  public func appending(_ syntax: Element) -> PrecedenceGroupNameListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -6407,8 +6396,7 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `PrecedenceGroupNameListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: PrecedenceGroupNameElementSyntax) -> PrecedenceGroupNameListSyntax {
+  public func prepending(_ syntax: Element) -> PrecedenceGroupNameListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -6420,8 +6408,7 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `PrecedenceGroupNameListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: PrecedenceGroupNameElementSyntax,
-                        at index: Int) -> PrecedenceGroupNameListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> PrecedenceGroupNameListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -6438,8 +6425,7 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `PrecedenceGroupNameListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: PrecedenceGroupNameElementSyntax) -> PrecedenceGroupNameListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> PrecedenceGroupNameListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -6532,7 +6518,6 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `PrecedenceGroupNameListSyntax` to the `BidirectionalCollection` protocol.
 extension PrecedenceGroupNameListSyntax: BidirectionalCollection {
-  public typealias Element = PrecedenceGroupNameElementSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -6544,13 +6529,13 @@ extension PrecedenceGroupNameListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> PrecedenceGroupNameElementSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return PrecedenceGroupNameElementSyntax(data)
+      return Element(data)
     }
   }
 
@@ -6585,11 +6570,11 @@ extension PrecedenceGroupNameListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> PrecedenceGroupNameElementSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return PrecedenceGroupNameElementSyntax(data)
+    return Element(data)
   }
 }
 
@@ -6598,6 +6583,8 @@ extension PrecedenceGroupNameListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct TokenListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = TokenSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -6619,7 +6606,7 @@ public struct TokenListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [TokenSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tokenList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -6647,8 +6634,7 @@ public struct TokenListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `TokenListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: TokenSyntax) -> TokenListSyntax {
+  public func appending(_ syntax: Element) -> TokenListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -6660,8 +6646,7 @@ public struct TokenListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `TokenListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: TokenSyntax) -> TokenListSyntax {
+  public func prepending(_ syntax: Element) -> TokenListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -6673,8 +6658,7 @@ public struct TokenListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `TokenListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: TokenSyntax,
-                        at index: Int) -> TokenListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> TokenListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -6691,8 +6675,7 @@ public struct TokenListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `TokenListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: TokenSyntax) -> TokenListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> TokenListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -6785,7 +6768,6 @@ public struct TokenListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `TokenListSyntax` to the `BidirectionalCollection` protocol.
 extension TokenListSyntax: BidirectionalCollection {
-  public typealias Element = TokenSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -6797,13 +6779,13 @@ extension TokenListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> TokenSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return TokenSyntax(data)
+      return Element(data)
     }
   }
 
@@ -6838,11 +6820,11 @@ extension TokenListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> TokenSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return TokenSyntax(data)
+    return Element(data)
   }
 }
 
@@ -6851,6 +6833,8 @@ extension TokenListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct NonEmptyTokenListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = TokenSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -6872,7 +6856,7 @@ public struct NonEmptyTokenListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [TokenSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.nonEmptyTokenList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -6900,8 +6884,7 @@ public struct NonEmptyTokenListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `NonEmptyTokenListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: TokenSyntax) -> NonEmptyTokenListSyntax {
+  public func appending(_ syntax: Element) -> NonEmptyTokenListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -6913,8 +6896,7 @@ public struct NonEmptyTokenListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `NonEmptyTokenListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: TokenSyntax) -> NonEmptyTokenListSyntax {
+  public func prepending(_ syntax: Element) -> NonEmptyTokenListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -6926,8 +6908,7 @@ public struct NonEmptyTokenListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `NonEmptyTokenListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: TokenSyntax,
-                        at index: Int) -> NonEmptyTokenListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> NonEmptyTokenListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -6944,8 +6925,7 @@ public struct NonEmptyTokenListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `NonEmptyTokenListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: TokenSyntax) -> NonEmptyTokenListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> NonEmptyTokenListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -7038,7 +7018,6 @@ public struct NonEmptyTokenListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `NonEmptyTokenListSyntax` to the `BidirectionalCollection` protocol.
 extension NonEmptyTokenListSyntax: BidirectionalCollection {
-  public typealias Element = TokenSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -7050,13 +7029,13 @@ extension NonEmptyTokenListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> TokenSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return TokenSyntax(data)
+      return Element(data)
     }
   }
 
@@ -7091,11 +7070,11 @@ extension NonEmptyTokenListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> TokenSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return TokenSyntax(data)
+    return Element(data)
   }
 }
 
@@ -7104,6 +7083,35 @@ extension NonEmptyTokenListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
+  public enum Element: SyntaxChildChoices {
+    case `attribute`(AttributeSyntax)
+    case `customAttribute`(CustomAttributeSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .attribute(let node): return node._syntaxNode
+      case .customAttribute(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: AttributeSyntax) {
+      self = .attribute(node)
+    }
+    public init(_ node: CustomAttributeSyntax) {
+      self = .customAttribute(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(AttributeSyntax.self) {
+        self = .attribute(node)
+        return
+      }
+      if let node = syntaxNode.as(CustomAttributeSyntax.self) {
+        self = .customAttribute(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -7125,7 +7133,7 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [Syntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -7153,8 +7161,7 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `AttributeListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: Syntax) -> AttributeListSyntax {
+  public func appending(_ syntax: Element) -> AttributeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -7166,8 +7173,7 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `AttributeListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: Syntax) -> AttributeListSyntax {
+  public func prepending(_ syntax: Element) -> AttributeListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -7179,8 +7185,7 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `AttributeListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: Syntax,
-                        at index: Int) -> AttributeListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> AttributeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -7197,8 +7202,7 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `AttributeListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: Syntax) -> AttributeListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> AttributeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -7291,7 +7295,6 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `AttributeListSyntax` to the `BidirectionalCollection` protocol.
 extension AttributeListSyntax: BidirectionalCollection {
-  public typealias Element = Syntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -7303,13 +7306,13 @@ extension AttributeListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> Syntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return Syntax(data)
+      return Element(data)
     }
   }
 
@@ -7344,11 +7347,11 @@ extension AttributeListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> Syntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return Syntax(data)
+    return Element(data)
   }
 }
 
@@ -7356,6 +7359,53 @@ extension AttributeListSyntax: BidirectionalCollection {
 /// A collection of arguments for the `@_specialize` attribute
 /// 
 public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashable {
+  public enum Element: SyntaxChildChoices {
+    case `labeledSpecializeEntry`(LabeledSpecializeEntrySyntax)
+    case `availabilityEntry`(AvailabilityEntrySyntax)
+    case `targetFunctionEntry`(TargetFunctionEntrySyntax)
+    case `genericWhereClause`(GenericWhereClauseSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .labeledSpecializeEntry(let node): return node._syntaxNode
+      case .availabilityEntry(let node): return node._syntaxNode
+      case .targetFunctionEntry(let node): return node._syntaxNode
+      case .genericWhereClause(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: LabeledSpecializeEntrySyntax) {
+      self = .labeledSpecializeEntry(node)
+    }
+    public init(_ node: AvailabilityEntrySyntax) {
+      self = .availabilityEntry(node)
+    }
+    public init(_ node: TargetFunctionEntrySyntax) {
+      self = .targetFunctionEntry(node)
+    }
+    public init(_ node: GenericWhereClauseSyntax) {
+      self = .genericWhereClause(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(LabeledSpecializeEntrySyntax.self) {
+        self = .labeledSpecializeEntry(node)
+        return
+      }
+      if let node = syntaxNode.as(AvailabilityEntrySyntax.self) {
+        self = .availabilityEntry(node)
+        return
+      }
+      if let node = syntaxNode.as(TargetFunctionEntrySyntax.self) {
+        self = .targetFunctionEntry(node)
+        return
+      }
+      if let node = syntaxNode.as(GenericWhereClauseSyntax.self) {
+        self = .genericWhereClause(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -7377,7 +7427,7 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [Syntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.specializeAttributeSpecList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -7405,8 +7455,7 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `SpecializeAttributeSpecListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: Syntax) -> SpecializeAttributeSpecListSyntax {
+  public func appending(_ syntax: Element) -> SpecializeAttributeSpecListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -7418,8 +7467,7 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `SpecializeAttributeSpecListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: Syntax) -> SpecializeAttributeSpecListSyntax {
+  public func prepending(_ syntax: Element) -> SpecializeAttributeSpecListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -7431,8 +7479,7 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `SpecializeAttributeSpecListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: Syntax,
-                        at index: Int) -> SpecializeAttributeSpecListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> SpecializeAttributeSpecListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -7449,8 +7496,7 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `SpecializeAttributeSpecListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: Syntax) -> SpecializeAttributeSpecListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> SpecializeAttributeSpecListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -7543,7 +7589,6 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
 
 /// Conformance for `SpecializeAttributeSpecListSyntax` to the `BidirectionalCollection` protocol.
 extension SpecializeAttributeSpecListSyntax: BidirectionalCollection {
-  public typealias Element = Syntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -7555,13 +7600,13 @@ extension SpecializeAttributeSpecListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> Syntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return Syntax(data)
+      return Element(data)
     }
   }
 
@@ -7596,11 +7641,11 @@ extension SpecializeAttributeSpecListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> Syntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return Syntax(data)
+    return Element(data)
   }
 }
 
@@ -7609,6 +7654,8 @@ extension SpecializeAttributeSpecListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = ObjCSelectorPieceSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -7630,7 +7677,7 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [ObjCSelectorPieceSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.objCSelector,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -7658,8 +7705,7 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `ObjCSelectorSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: ObjCSelectorPieceSyntax) -> ObjCSelectorSyntax {
+  public func appending(_ syntax: Element) -> ObjCSelectorSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -7671,8 +7717,7 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `ObjCSelectorSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: ObjCSelectorPieceSyntax) -> ObjCSelectorSyntax {
+  public func prepending(_ syntax: Element) -> ObjCSelectorSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -7684,8 +7729,7 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `ObjCSelectorSyntax` with that element appended to the end.
-  public func inserting(_ syntax: ObjCSelectorPieceSyntax,
-                        at index: Int) -> ObjCSelectorSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> ObjCSelectorSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -7702,8 +7746,7 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `ObjCSelectorSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: ObjCSelectorPieceSyntax) -> ObjCSelectorSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> ObjCSelectorSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -7796,7 +7839,6 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `ObjCSelectorSyntax` to the `BidirectionalCollection` protocol.
 extension ObjCSelectorSyntax: BidirectionalCollection {
-  public typealias Element = ObjCSelectorPieceSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -7808,13 +7850,13 @@ extension ObjCSelectorSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> ObjCSelectorPieceSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return ObjCSelectorPieceSyntax(data)
+      return Element(data)
     }
   }
 
@@ -7849,11 +7891,11 @@ extension ObjCSelectorSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> ObjCSelectorPieceSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return ObjCSelectorPieceSyntax(data)
+    return Element(data)
   }
 }
 
@@ -7862,6 +7904,8 @@ extension ObjCSelectorSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = DifferentiabilityParamSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -7883,7 +7927,7 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [DifferentiabilityParamSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -7911,8 +7955,7 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `DifferentiabilityParamListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: DifferentiabilityParamSyntax) -> DifferentiabilityParamListSyntax {
+  public func appending(_ syntax: Element) -> DifferentiabilityParamListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -7924,8 +7967,7 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `DifferentiabilityParamListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: DifferentiabilityParamSyntax) -> DifferentiabilityParamListSyntax {
+  public func prepending(_ syntax: Element) -> DifferentiabilityParamListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -7937,8 +7979,7 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `DifferentiabilityParamListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: DifferentiabilityParamSyntax,
-                        at index: Int) -> DifferentiabilityParamListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> DifferentiabilityParamListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -7955,8 +7996,7 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `DifferentiabilityParamListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: DifferentiabilityParamSyntax) -> DifferentiabilityParamListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> DifferentiabilityParamListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -8049,7 +8089,6 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
 
 /// Conformance for `DifferentiabilityParamListSyntax` to the `BidirectionalCollection` protocol.
 extension DifferentiabilityParamListSyntax: BidirectionalCollection {
-  public typealias Element = DifferentiabilityParamSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -8061,13 +8100,13 @@ extension DifferentiabilityParamListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> DifferentiabilityParamSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return DifferentiabilityParamSyntax(data)
+      return Element(data)
     }
   }
 
@@ -8102,11 +8141,11 @@ extension DifferentiabilityParamListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> DifferentiabilityParamSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return DifferentiabilityParamSyntax(data)
+    return Element(data)
   }
 }
 
@@ -8115,6 +8154,8 @@ extension DifferentiabilityParamListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct BackDeployVersionListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = BackDeployVersionArgumentSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -8136,7 +8177,7 @@ public struct BackDeployVersionListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [BackDeployVersionArgumentSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployVersionList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -8164,8 +8205,7 @@ public struct BackDeployVersionListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `BackDeployVersionListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: BackDeployVersionArgumentSyntax) -> BackDeployVersionListSyntax {
+  public func appending(_ syntax: Element) -> BackDeployVersionListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -8177,8 +8217,7 @@ public struct BackDeployVersionListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `BackDeployVersionListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: BackDeployVersionArgumentSyntax) -> BackDeployVersionListSyntax {
+  public func prepending(_ syntax: Element) -> BackDeployVersionListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -8190,8 +8229,7 @@ public struct BackDeployVersionListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `BackDeployVersionListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: BackDeployVersionArgumentSyntax,
-                        at index: Int) -> BackDeployVersionListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> BackDeployVersionListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -8208,8 +8246,7 @@ public struct BackDeployVersionListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `BackDeployVersionListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: BackDeployVersionArgumentSyntax) -> BackDeployVersionListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> BackDeployVersionListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -8302,7 +8339,6 @@ public struct BackDeployVersionListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `BackDeployVersionListSyntax` to the `BidirectionalCollection` protocol.
 extension BackDeployVersionListSyntax: BidirectionalCollection {
-  public typealias Element = BackDeployVersionArgumentSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -8314,13 +8350,13 @@ extension BackDeployVersionListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> BackDeployVersionArgumentSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return BackDeployVersionArgumentSyntax(data)
+      return Element(data)
     }
   }
 
@@ -8355,11 +8391,11 @@ extension BackDeployVersionListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> BackDeployVersionArgumentSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return BackDeployVersionArgumentSyntax(data)
+    return Element(data)
   }
 }
 
@@ -8368,6 +8404,35 @@ extension BackDeployVersionListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
+  public enum Element: SyntaxChildChoices {
+    case `switchCase`(SwitchCaseSyntax)
+    case `ifConfigDecl`(IfConfigDeclSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .switchCase(let node): return node._syntaxNode
+      case .ifConfigDecl(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: SwitchCaseSyntax) {
+      self = .switchCase(node)
+    }
+    public init(_ node: IfConfigDeclSyntax) {
+      self = .ifConfigDecl(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(SwitchCaseSyntax.self) {
+        self = .switchCase(node)
+        return
+      }
+      if let node = syntaxNode.as(IfConfigDeclSyntax.self) {
+        self = .ifConfigDecl(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -8389,7 +8454,7 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [Syntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -8417,8 +8482,7 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `SwitchCaseListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: Syntax) -> SwitchCaseListSyntax {
+  public func appending(_ syntax: Element) -> SwitchCaseListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -8430,8 +8494,7 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `SwitchCaseListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: Syntax) -> SwitchCaseListSyntax {
+  public func prepending(_ syntax: Element) -> SwitchCaseListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -8443,8 +8506,7 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `SwitchCaseListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: Syntax,
-                        at index: Int) -> SwitchCaseListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> SwitchCaseListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -8461,8 +8523,7 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `SwitchCaseListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: Syntax) -> SwitchCaseListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> SwitchCaseListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -8555,7 +8616,6 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `SwitchCaseListSyntax` to the `BidirectionalCollection` protocol.
 extension SwitchCaseListSyntax: BidirectionalCollection {
-  public typealias Element = Syntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -8567,13 +8627,13 @@ extension SwitchCaseListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> Syntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return Syntax(data)
+      return Element(data)
     }
   }
 
@@ -8608,11 +8668,11 @@ extension SwitchCaseListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> Syntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return Syntax(data)
+    return Element(data)
   }
 }
 
@@ -8621,6 +8681,8 @@ extension SwitchCaseListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = CatchClauseSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -8642,7 +8704,7 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [CatchClauseSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchClauseList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -8670,8 +8732,7 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `CatchClauseListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: CatchClauseSyntax) -> CatchClauseListSyntax {
+  public func appending(_ syntax: Element) -> CatchClauseListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -8683,8 +8744,7 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `CatchClauseListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: CatchClauseSyntax) -> CatchClauseListSyntax {
+  public func prepending(_ syntax: Element) -> CatchClauseListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -8696,8 +8756,7 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `CatchClauseListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: CatchClauseSyntax,
-                        at index: Int) -> CatchClauseListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> CatchClauseListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -8714,8 +8773,7 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `CatchClauseListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: CatchClauseSyntax) -> CatchClauseListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> CatchClauseListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -8808,7 +8866,6 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `CatchClauseListSyntax` to the `BidirectionalCollection` protocol.
 extension CatchClauseListSyntax: BidirectionalCollection {
-  public typealias Element = CatchClauseSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -8820,13 +8877,13 @@ extension CatchClauseListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> CatchClauseSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return CatchClauseSyntax(data)
+      return Element(data)
     }
   }
 
@@ -8861,11 +8918,11 @@ extension CatchClauseListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> CatchClauseSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return CatchClauseSyntax(data)
+    return Element(data)
   }
 }
 
@@ -8874,6 +8931,8 @@ extension CatchClauseListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = CaseItemSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -8895,7 +8954,7 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [CaseItemSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.caseItemList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -8923,8 +8982,7 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `CaseItemListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: CaseItemSyntax) -> CaseItemListSyntax {
+  public func appending(_ syntax: Element) -> CaseItemListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -8936,8 +8994,7 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `CaseItemListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: CaseItemSyntax) -> CaseItemListSyntax {
+  public func prepending(_ syntax: Element) -> CaseItemListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -8949,8 +9006,7 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `CaseItemListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: CaseItemSyntax,
-                        at index: Int) -> CaseItemListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> CaseItemListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -8967,8 +9023,7 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `CaseItemListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: CaseItemSyntax) -> CaseItemListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> CaseItemListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -9061,7 +9116,6 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `CaseItemListSyntax` to the `BidirectionalCollection` protocol.
 extension CaseItemListSyntax: BidirectionalCollection {
-  public typealias Element = CaseItemSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -9073,13 +9127,13 @@ extension CaseItemListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> CaseItemSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return CaseItemSyntax(data)
+      return Element(data)
     }
   }
 
@@ -9114,11 +9168,11 @@ extension CaseItemListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> CaseItemSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return CaseItemSyntax(data)
+    return Element(data)
   }
 }
 
@@ -9127,6 +9181,8 @@ extension CaseItemListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = CatchItemSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -9148,7 +9204,7 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [CatchItemSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchItemList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -9176,8 +9232,7 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `CatchItemListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: CatchItemSyntax) -> CatchItemListSyntax {
+  public func appending(_ syntax: Element) -> CatchItemListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -9189,8 +9244,7 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `CatchItemListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: CatchItemSyntax) -> CatchItemListSyntax {
+  public func prepending(_ syntax: Element) -> CatchItemListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -9202,8 +9256,7 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `CatchItemListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: CatchItemSyntax,
-                        at index: Int) -> CatchItemListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> CatchItemListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -9220,8 +9273,7 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `CatchItemListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: CatchItemSyntax) -> CatchItemListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> CatchItemListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -9314,7 +9366,6 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `CatchItemListSyntax` to the `BidirectionalCollection` protocol.
 extension CatchItemListSyntax: BidirectionalCollection {
-  public typealias Element = CatchItemSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -9326,13 +9377,13 @@ extension CatchItemListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> CatchItemSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return CatchItemSyntax(data)
+      return Element(data)
     }
   }
 
@@ -9367,11 +9418,11 @@ extension CatchItemListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> CatchItemSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return CatchItemSyntax(data)
+    return Element(data)
   }
 }
 
@@ -9380,6 +9431,8 @@ extension CatchItemListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = ConditionElementSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -9401,7 +9454,7 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [ConditionElementSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.conditionElementList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -9429,8 +9482,7 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `ConditionElementListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: ConditionElementSyntax) -> ConditionElementListSyntax {
+  public func appending(_ syntax: Element) -> ConditionElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -9442,8 +9494,7 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `ConditionElementListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: ConditionElementSyntax) -> ConditionElementListSyntax {
+  public func prepending(_ syntax: Element) -> ConditionElementListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -9455,8 +9506,7 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `ConditionElementListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: ConditionElementSyntax,
-                        at index: Int) -> ConditionElementListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> ConditionElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -9473,8 +9523,7 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `ConditionElementListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: ConditionElementSyntax) -> ConditionElementListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> ConditionElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -9567,7 +9616,6 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `ConditionElementListSyntax` to the `BidirectionalCollection` protocol.
 extension ConditionElementListSyntax: BidirectionalCollection {
-  public typealias Element = ConditionElementSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -9579,13 +9627,13 @@ extension ConditionElementListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> ConditionElementSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return ConditionElementSyntax(data)
+      return Element(data)
     }
   }
 
@@ -9620,11 +9668,11 @@ extension ConditionElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> ConditionElementSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return ConditionElementSyntax(data)
+    return Element(data)
   }
 }
 
@@ -9633,6 +9681,8 @@ extension ConditionElementListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = GenericRequirementSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -9654,7 +9704,7 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [GenericRequirementSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirementList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -9682,8 +9732,7 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `GenericRequirementListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: GenericRequirementSyntax) -> GenericRequirementListSyntax {
+  public func appending(_ syntax: Element) -> GenericRequirementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -9695,8 +9744,7 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `GenericRequirementListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: GenericRequirementSyntax) -> GenericRequirementListSyntax {
+  public func prepending(_ syntax: Element) -> GenericRequirementListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -9708,8 +9756,7 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `GenericRequirementListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: GenericRequirementSyntax,
-                        at index: Int) -> GenericRequirementListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> GenericRequirementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -9726,8 +9773,7 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `GenericRequirementListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: GenericRequirementSyntax) -> GenericRequirementListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> GenericRequirementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -9820,7 +9866,6 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `GenericRequirementListSyntax` to the `BidirectionalCollection` protocol.
 extension GenericRequirementListSyntax: BidirectionalCollection {
-  public typealias Element = GenericRequirementSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -9832,13 +9877,13 @@ extension GenericRequirementListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> GenericRequirementSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return GenericRequirementSyntax(data)
+      return Element(data)
     }
   }
 
@@ -9873,11 +9918,11 @@ extension GenericRequirementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> GenericRequirementSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return GenericRequirementSyntax(data)
+    return Element(data)
   }
 }
 
@@ -9886,6 +9931,8 @@ extension GenericRequirementListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = GenericParameterSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -9907,7 +9954,7 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [GenericParameterSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -9935,8 +9982,7 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `GenericParameterListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: GenericParameterSyntax) -> GenericParameterListSyntax {
+  public func appending(_ syntax: Element) -> GenericParameterListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -9948,8 +9994,7 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `GenericParameterListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: GenericParameterSyntax) -> GenericParameterListSyntax {
+  public func prepending(_ syntax: Element) -> GenericParameterListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -9961,8 +10006,7 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `GenericParameterListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: GenericParameterSyntax,
-                        at index: Int) -> GenericParameterListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> GenericParameterListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -9979,8 +10023,7 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `GenericParameterListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: GenericParameterSyntax) -> GenericParameterListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> GenericParameterListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -10073,7 +10116,6 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `GenericParameterListSyntax` to the `BidirectionalCollection` protocol.
 extension GenericParameterListSyntax: BidirectionalCollection {
-  public typealias Element = GenericParameterSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -10085,13 +10127,13 @@ extension GenericParameterListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> GenericParameterSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return GenericParameterSyntax(data)
+      return Element(data)
     }
   }
 
@@ -10126,11 +10168,11 @@ extension GenericParameterListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> GenericParameterSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return GenericParameterSyntax(data)
+    return Element(data)
   }
 }
 
@@ -10139,6 +10181,8 @@ extension GenericParameterListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = PrimaryAssociatedTypeSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -10160,7 +10204,7 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [PrimaryAssociatedTypeSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -10188,8 +10232,7 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `PrimaryAssociatedTypeListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: PrimaryAssociatedTypeSyntax) -> PrimaryAssociatedTypeListSyntax {
+  public func appending(_ syntax: Element) -> PrimaryAssociatedTypeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -10201,8 +10244,7 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `PrimaryAssociatedTypeListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: PrimaryAssociatedTypeSyntax) -> PrimaryAssociatedTypeListSyntax {
+  public func prepending(_ syntax: Element) -> PrimaryAssociatedTypeListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -10214,8 +10256,7 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `PrimaryAssociatedTypeListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: PrimaryAssociatedTypeSyntax,
-                        at index: Int) -> PrimaryAssociatedTypeListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> PrimaryAssociatedTypeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -10232,8 +10273,7 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `PrimaryAssociatedTypeListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: PrimaryAssociatedTypeSyntax) -> PrimaryAssociatedTypeListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> PrimaryAssociatedTypeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -10326,7 +10366,6 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
 
 /// Conformance for `PrimaryAssociatedTypeListSyntax` to the `BidirectionalCollection` protocol.
 extension PrimaryAssociatedTypeListSyntax: BidirectionalCollection {
-  public typealias Element = PrimaryAssociatedTypeSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -10338,13 +10377,13 @@ extension PrimaryAssociatedTypeListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> PrimaryAssociatedTypeSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return PrimaryAssociatedTypeSyntax(data)
+      return Element(data)
     }
   }
 
@@ -10379,11 +10418,11 @@ extension PrimaryAssociatedTypeListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> PrimaryAssociatedTypeSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return PrimaryAssociatedTypeSyntax(data)
+    return Element(data)
   }
 }
 
@@ -10392,6 +10431,8 @@ extension PrimaryAssociatedTypeListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = CompositionTypeElementSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -10413,7 +10454,7 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [CompositionTypeElementSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElementList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -10441,8 +10482,7 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `CompositionTypeElementListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: CompositionTypeElementSyntax) -> CompositionTypeElementListSyntax {
+  public func appending(_ syntax: Element) -> CompositionTypeElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -10454,8 +10494,7 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `CompositionTypeElementListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: CompositionTypeElementSyntax) -> CompositionTypeElementListSyntax {
+  public func prepending(_ syntax: Element) -> CompositionTypeElementListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -10467,8 +10506,7 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `CompositionTypeElementListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: CompositionTypeElementSyntax,
-                        at index: Int) -> CompositionTypeElementListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> CompositionTypeElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -10485,8 +10523,7 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `CompositionTypeElementListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: CompositionTypeElementSyntax) -> CompositionTypeElementListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> CompositionTypeElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -10579,7 +10616,6 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
 
 /// Conformance for `CompositionTypeElementListSyntax` to the `BidirectionalCollection` protocol.
 extension CompositionTypeElementListSyntax: BidirectionalCollection {
-  public typealias Element = CompositionTypeElementSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -10591,13 +10627,13 @@ extension CompositionTypeElementListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> CompositionTypeElementSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return CompositionTypeElementSyntax(data)
+      return Element(data)
     }
   }
 
@@ -10632,11 +10668,11 @@ extension CompositionTypeElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> CompositionTypeElementSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return CompositionTypeElementSyntax(data)
+    return Element(data)
   }
 }
 
@@ -10645,6 +10681,8 @@ extension CompositionTypeElementListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = TupleTypeElementSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -10666,7 +10704,7 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [TupleTypeElementSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElementList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -10694,8 +10732,7 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `TupleTypeElementListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: TupleTypeElementSyntax) -> TupleTypeElementListSyntax {
+  public func appending(_ syntax: Element) -> TupleTypeElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -10707,8 +10744,7 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `TupleTypeElementListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: TupleTypeElementSyntax) -> TupleTypeElementListSyntax {
+  public func prepending(_ syntax: Element) -> TupleTypeElementListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -10720,8 +10756,7 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `TupleTypeElementListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: TupleTypeElementSyntax,
-                        at index: Int) -> TupleTypeElementListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> TupleTypeElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -10738,8 +10773,7 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `TupleTypeElementListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: TupleTypeElementSyntax) -> TupleTypeElementListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> TupleTypeElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -10832,7 +10866,6 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `TupleTypeElementListSyntax` to the `BidirectionalCollection` protocol.
 extension TupleTypeElementListSyntax: BidirectionalCollection {
-  public typealias Element = TupleTypeElementSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -10844,13 +10877,13 @@ extension TupleTypeElementListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> TupleTypeElementSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return TupleTypeElementSyntax(data)
+      return Element(data)
     }
   }
 
@@ -10885,11 +10918,11 @@ extension TupleTypeElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> TupleTypeElementSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return TupleTypeElementSyntax(data)
+    return Element(data)
   }
 }
 
@@ -10898,6 +10931,8 @@ extension TupleTypeElementListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = GenericArgumentSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -10919,7 +10954,7 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [GenericArgumentSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -10947,8 +10982,7 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `GenericArgumentListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: GenericArgumentSyntax) -> GenericArgumentListSyntax {
+  public func appending(_ syntax: Element) -> GenericArgumentListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -10960,8 +10994,7 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `GenericArgumentListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: GenericArgumentSyntax) -> GenericArgumentListSyntax {
+  public func prepending(_ syntax: Element) -> GenericArgumentListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -10973,8 +11006,7 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `GenericArgumentListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: GenericArgumentSyntax,
-                        at index: Int) -> GenericArgumentListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> GenericArgumentListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -10991,8 +11023,7 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `GenericArgumentListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: GenericArgumentSyntax) -> GenericArgumentListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> GenericArgumentListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -11085,7 +11116,6 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `GenericArgumentListSyntax` to the `BidirectionalCollection` protocol.
 extension GenericArgumentListSyntax: BidirectionalCollection {
-  public typealias Element = GenericArgumentSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -11097,13 +11127,13 @@ extension GenericArgumentListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> GenericArgumentSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return GenericArgumentSyntax(data)
+      return Element(data)
     }
   }
 
@@ -11138,11 +11168,11 @@ extension GenericArgumentListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> GenericArgumentSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return GenericArgumentSyntax(data)
+    return Element(data)
   }
 }
 
@@ -11151,6 +11181,8 @@ extension GenericArgumentListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = TuplePatternElementSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -11172,7 +11204,7 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [TuplePatternElementSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElementList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -11200,8 +11232,7 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `TuplePatternElementListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: TuplePatternElementSyntax) -> TuplePatternElementListSyntax {
+  public func appending(_ syntax: Element) -> TuplePatternElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -11213,8 +11244,7 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `TuplePatternElementListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: TuplePatternElementSyntax) -> TuplePatternElementListSyntax {
+  public func prepending(_ syntax: Element) -> TuplePatternElementListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -11226,8 +11256,7 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `TuplePatternElementListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: TuplePatternElementSyntax,
-                        at index: Int) -> TuplePatternElementListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> TuplePatternElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -11244,8 +11273,7 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `TuplePatternElementListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: TuplePatternElementSyntax) -> TuplePatternElementListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> TuplePatternElementListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -11338,7 +11366,6 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `TuplePatternElementListSyntax` to the `BidirectionalCollection` protocol.
 extension TuplePatternElementListSyntax: BidirectionalCollection {
-  public typealias Element = TuplePatternElementSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -11350,13 +11377,13 @@ extension TuplePatternElementListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> TuplePatternElementSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return TuplePatternElementSyntax(data)
+      return Element(data)
     }
   }
 
@@ -11391,11 +11418,11 @@ extension TuplePatternElementListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> TuplePatternElementSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return TuplePatternElementSyntax(data)
+    return Element(data)
   }
 }
 
@@ -11404,6 +11431,8 @@ extension TuplePatternElementListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = AvailabilityArgumentSyntax
+
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
@@ -11425,7 +11454,7 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [AvailabilityArgumentSyntax]) {
+  public init(_ children: [Element]) {
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilitySpecList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
@@ -11453,8 +11482,7 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
   ///
   /// - Parameter syntax: The element to append.
   /// - Returns: A new `AvailabilitySpecListSyntax` with that element appended to the end.
-  public func appending(
-    _ syntax: AvailabilityArgumentSyntax) -> AvailabilitySpecListSyntax {
+  public func appending(_ syntax: Element) -> AvailabilitySpecListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
@@ -11466,8 +11494,7 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter syntax: The element to prepend.
   /// - Returns: A new `AvailabilitySpecListSyntax` with that element prepended to the
   ///            beginning.
-  public func prepending(
-    _ syntax: AvailabilityArgumentSyntax) -> AvailabilitySpecListSyntax {
+  public func prepending(_ syntax: Element) -> AvailabilitySpecListSyntax {
     return inserting(syntax, at: 0)
   }
 
@@ -11479,8 +11506,7 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - index: The index at which to insert the element in the collection.
   ///
   /// - Returns: A new `AvailabilitySpecListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: AvailabilityArgumentSyntax,
-                        at index: Int) -> AvailabilitySpecListSyntax {
+  public func inserting(_ syntax: Element, at index: Int) -> AvailabilitySpecListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -11497,8 +11523,7 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
   ///   - syntax: The element to replace with.
   ///
   /// - Returns: A new `AvailabilitySpecListSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int,
-                        with syntax: AvailabilityArgumentSyntax) -> AvailabilitySpecListSyntax {
+  public func replacing(childAt index: Int, with syntax: Element) -> AvailabilitySpecListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -11591,7 +11616,6 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `AvailabilitySpecListSyntax` to the `BidirectionalCollection` protocol.
 extension AvailabilitySpecListSyntax: BidirectionalCollection {
-  public typealias Element = AvailabilityArgumentSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -11603,13 +11627,13 @@ extension AvailabilitySpecListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> AvailabilityArgumentSyntax? {
+    public mutating func next() -> Element? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return AvailabilityArgumentSyntax(data)
+      return Element(data)
     }
   }
 
@@ -11644,11 +11668,11 @@ extension AvailabilitySpecListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> AvailabilityArgumentSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> Element {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return AvailabilityArgumentSyntax(data)
+    return Element(data)
   }
 }
 

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -2010,6 +2010,10 @@ open class SyntaxRewriter {
     return visit(node.data)
   }
 
+  public func visit<T: SyntaxChildChoices>(_ node: T) -> T {
+    return visit(Syntax(node)).cast(T.self)
+  }
+
   /// Visit any DeclSyntax node.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
@@ -3389,6 +3389,10 @@ extension SyntaxTransformVisitor {
     visit(Syntax(node))
   }
 
+  public func visit<T: SyntaxChildChoices>(_ node: T) -> ResultType {
+    return visit(Syntax(node))
+  }
+
   public func visitChildren<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) -> [ResultType] {
     let syntaxNode = Syntax(node)
     return NonNilRawSyntaxChildren(syntaxNode, viewMode: .sourceAccurate).map { rawChild in

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -6129,6 +6129,35 @@ extension DeinitializerDeclSyntax: CustomReflectable {
 // MARK: - SubscriptDeclSyntax
 
 public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+  public enum Accessor: SyntaxChildChoices {
+    case `accessors`(AccessorBlockSyntax)
+    case `getter`(CodeBlockSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .accessors(let node): return node._syntaxNode
+      case .getter(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: AccessorBlockSyntax) {
+      self = .accessors(node)
+    }
+    public init(_ node: CodeBlockSyntax) {
+      self = .getter(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(AccessorBlockSyntax.self) {
+        self = .accessors(node)
+        return
+      }
+      if let node = syntaxNode.as(CodeBlockSyntax.self) {
+        self = .getter(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SubscriptDeclSyntax` if possible. Returns
@@ -6162,7 +6191,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenResultAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndAccessor: UnexpectedNodesSyntax? = nil,
-    accessor: Syntax?,
+    accessor: Accessor?,
     _ unexpectedAfterAccessor: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
@@ -6538,11 +6567,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return SubscriptDeclSyntax(newData)
   }
 
-  public var accessor: Syntax? {
+  public var accessor: Accessor? {
     get {
       let childData = data.child(at: 15, parent: Syntax(self))
       if childData == nil { return nil }
-      return Syntax(childData!)
+      return Accessor(childData!)
     }
     set(value) {
       self = withAccessor(value)
@@ -6553,7 +6582,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `accessor` to replace the node's
   ///                   current `accessor`, if present.
   public func withAccessor(
-    _ newChild: Syntax?) -> SubscriptDeclSyntax {
+    _ newChild: Accessor?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 15)
     return SubscriptDeclSyntax(newData)

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -4032,6 +4032,35 @@ extension ArrayExprSyntax: CustomReflectable {
 // MARK: - DictionaryExprSyntax
 
 public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+  public enum Content: SyntaxChildChoices {
+    case `colon`(TokenSyntax)
+    case `elements`(DictionaryElementListSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .colon(let node): return node._syntaxNode
+      case .elements(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: DictionaryElementListSyntax) {
+      self = .elements(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let tok = syntaxNode.as(TokenSyntax.self) {
+        switch tok.rawTokenKind {
+        case .colon: self = .colon(tok)
+        default: return nil
+        }
+        return
+      }
+      if let node = syntaxNode.as(DictionaryElementListSyntax.self) {
+        self = .elements(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DictionaryExprSyntax` if possible. Returns
@@ -4053,7 +4082,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeLeftSquare: UnexpectedNodesSyntax? = nil,
     leftSquare: TokenSyntax,
     _ unexpectedBetweenLeftSquareAndContent: UnexpectedNodesSyntax? = nil,
-    content: Syntax,
+    content: Content,
     _ unexpectedBetweenContentAndRightSquare: UnexpectedNodesSyntax? = nil,
     rightSquare: TokenSyntax,
     _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil
@@ -4135,10 +4164,10 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return DictionaryExprSyntax(newData)
   }
 
-  public var content: Syntax {
+  public var content: Content {
     get {
       let childData = data.child(at: 3, parent: Syntax(self))
-      return Syntax(childData!)
+      return Content(childData!)
     }
     set(value) {
       self = withContent(value)
@@ -4149,7 +4178,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `content` to replace the node's
   ///                   current `content`, if present.
   public func withContent(
-    _ newChild: Syntax?) -> DictionaryExprSyntax {
+    _ newChild: Content?) -> DictionaryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return DictionaryExprSyntax(newData)
@@ -8896,6 +8925,44 @@ extension KeyPathExprSyntax: CustomReflectable {
 // MARK: - OldKeyPathExprSyntax
 
 public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+  public enum RootExpr: SyntaxChildChoices {
+    case `identifierExpr`(IdentifierExprSyntax)
+    case `specializeExpr`(SpecializeExprSyntax)
+    case `optionalChainingExpr`(OptionalChainingExprSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .identifierExpr(let node): return node._syntaxNode
+      case .specializeExpr(let node): return node._syntaxNode
+      case .optionalChainingExpr(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: IdentifierExprSyntax) {
+      self = .identifierExpr(node)
+    }
+    public init(_ node: SpecializeExprSyntax) {
+      self = .specializeExpr(node)
+    }
+    public init(_ node: OptionalChainingExprSyntax) {
+      self = .optionalChainingExpr(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(IdentifierExprSyntax.self) {
+        self = .identifierExpr(node)
+        return
+      }
+      if let node = syntaxNode.as(SpecializeExprSyntax.self) {
+        self = .specializeExpr(node)
+        return
+      }
+      if let node = syntaxNode.as(OptionalChainingExprSyntax.self) {
+        self = .optionalChainingExpr(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `OldKeyPathExprSyntax` if possible. Returns
@@ -8917,7 +8984,7 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil,
     backslash: TokenSyntax,
     _ unexpectedBetweenBackslashAndRootExpr: UnexpectedNodesSyntax? = nil,
-    rootExpr: ExprSyntax?,
+    rootExpr: RootExpr?,
     _ unexpectedBetweenRootExprAndExpression: UnexpectedNodesSyntax? = nil,
     expression: ExprSyntax,
     _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
@@ -8999,11 +9066,11 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return OldKeyPathExprSyntax(newData)
   }
 
-  public var rootExpr: ExprSyntax? {
+  public var rootExpr: RootExpr? {
     get {
       let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
-      return ExprSyntax(childData!)
+      return RootExpr(childData!)
     }
     set(value) {
       self = withRootExpr(value)
@@ -9014,7 +9081,7 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `rootExpr` to replace the node's
   ///                   current `rootExpr`, if present.
   public func withRootExpr(
-    _ newChild: ExprSyntax?) -> OldKeyPathExprSyntax {
+    _ newChild: RootExpr?) -> OldKeyPathExprSyntax {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return OldKeyPathExprSyntax(newData)

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -65,6 +65,62 @@ extension MissingSyntax: CustomReflectable {
 /// a CodeBlock.
 /// 
 public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum Item: SyntaxChildChoices {
+    case `decl`(DeclSyntax)
+    case `stmt`(StmtSyntax)
+    case `expr`(ExprSyntax)
+    case `tokenList`(TokenListSyntax)
+    case `nonEmptyTokenList`(NonEmptyTokenListSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .decl(let node): return node._syntaxNode
+      case .stmt(let node): return node._syntaxNode
+      case .expr(let node): return node._syntaxNode
+      case .tokenList(let node): return node._syntaxNode
+      case .nonEmptyTokenList(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init<Node: DeclSyntaxProtocol>(_ node: Node) {
+      self = .decl(DeclSyntax(node))
+    }
+    public init<Node: StmtSyntaxProtocol>(_ node: Node) {
+      self = .stmt(StmtSyntax(node))
+    }
+    public init<Node: ExprSyntaxProtocol>(_ node: Node) {
+      self = .expr(ExprSyntax(node))
+    }
+    public init(_ node: TokenListSyntax) {
+      self = .tokenList(node)
+    }
+    public init(_ node: NonEmptyTokenListSyntax) {
+      self = .nonEmptyTokenList(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(DeclSyntax.self) {
+        self = .decl(node)
+        return
+      }
+      if let node = syntaxNode.as(StmtSyntax.self) {
+        self = .stmt(node)
+        return
+      }
+      if let node = syntaxNode.as(ExprSyntax.self) {
+        self = .expr(node)
+        return
+      }
+      if let node = syntaxNode.as(TokenListSyntax.self) {
+        self = .tokenList(node)
+        return
+      }
+      if let node = syntaxNode.as(NonEmptyTokenListSyntax.self) {
+        self = .nonEmptyTokenList(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `CodeBlockItemSyntax` if possible. Returns
@@ -84,7 +140,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeItem: UnexpectedNodesSyntax? = nil,
-    item: Syntax,
+    item: Item,
     _ unexpectedBetweenItemAndSemicolon: UnexpectedNodesSyntax? = nil,
     semicolon: TokenSyntax?,
     _ unexpectedBetweenSemicolonAndErrorTokens: UnexpectedNodesSyntax? = nil,
@@ -128,10 +184,10 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   }
 
   /// The underlying node inside the code block.
-  public var item: Syntax {
+  public var item: Item {
     get {
       let childData = data.child(at: 1, parent: Syntax(self))
-      return Syntax(childData!)
+      return Item(childData!)
     }
     set(value) {
       self = withItem(value)
@@ -142,7 +198,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `item` to replace the node's
   ///                   current `item`, if present.
   public func withItem(
-    _ newChild: Syntax?) -> CodeBlockItemSyntax {
+    _ newChild: Item?) -> CodeBlockItemSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return CodeBlockItemSyntax(newData)
@@ -2445,6 +2501,35 @@ extension ClosureParamSyntax: CustomReflectable {
 // MARK: - ClosureSignatureSyntax
 
 public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum Input: SyntaxChildChoices {
+    case `simpleInput`(ClosureParamListSyntax)
+    case `input`(ParameterClauseSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .simpleInput(let node): return node._syntaxNode
+      case .input(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: ClosureParamListSyntax) {
+      self = .simpleInput(node)
+    }
+    public init(_ node: ParameterClauseSyntax) {
+      self = .input(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(ClosureParamListSyntax.self) {
+        self = .simpleInput(node)
+        return
+      }
+      if let node = syntaxNode.as(ParameterClauseSyntax.self) {
+        self = .input(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ClosureSignatureSyntax` if possible. Returns
@@ -2468,7 +2553,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenAttributesAndCapture: UnexpectedNodesSyntax? = nil,
     capture: ClosureCaptureSignatureSyntax?,
     _ unexpectedBetweenCaptureAndInput: UnexpectedNodesSyntax? = nil,
-    input: Syntax?,
+    input: Input?,
     _ unexpectedBetweenInputAndAsyncKeyword: UnexpectedNodesSyntax? = nil,
     asyncKeyword: TokenSyntax?,
     _ unexpectedBetweenAsyncKeywordAndThrowsTok: UnexpectedNodesSyntax? = nil,
@@ -2625,11 +2710,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     return ClosureSignatureSyntax(newData)
   }
 
-  public var input: Syntax? {
+  public var input: Input? {
     get {
       let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
-      return Syntax(childData!)
+      return Input(childData!)
     }
     set(value) {
       self = withInput(value)
@@ -2640,7 +2725,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `input` to replace the node's
   ///                   current `input`, if present.
   public func withInput(
-    _ newChild: Syntax?) -> ClosureSignatureSyntax {
+    _ newChild: Input?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 5)
     return ClosureSignatureSyntax(newData)
@@ -3588,6 +3673,44 @@ extension ExpressionSegmentSyntax: CustomReflectable {
 // MARK: - KeyPathComponentSyntax
 
 public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum Component: SyntaxChildChoices {
+    case `property`(KeyPathPropertyComponentSyntax)
+    case `subscript`(KeyPathSubscriptComponentSyntax)
+    case `optional`(KeyPathOptionalComponentSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .property(let node): return node._syntaxNode
+      case .subscript(let node): return node._syntaxNode
+      case .optional(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: KeyPathPropertyComponentSyntax) {
+      self = .property(node)
+    }
+    public init(_ node: KeyPathSubscriptComponentSyntax) {
+      self = .subscript(node)
+    }
+    public init(_ node: KeyPathOptionalComponentSyntax) {
+      self = .optional(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(KeyPathPropertyComponentSyntax.self) {
+        self = .property(node)
+        return
+      }
+      if let node = syntaxNode.as(KeyPathSubscriptComponentSyntax.self) {
+        self = .subscript(node)
+        return
+      }
+      if let node = syntaxNode.as(KeyPathOptionalComponentSyntax.self) {
+        self = .optional(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `KeyPathComponentSyntax` if possible. Returns
@@ -3609,7 +3732,7 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforePeriod: UnexpectedNodesSyntax? = nil,
     period: TokenSyntax?,
     _ unexpectedBetweenPeriodAndComponent: UnexpectedNodesSyntax? = nil,
-    component: Syntax,
+    component: Component,
     _ unexpectedAfterComponent: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
@@ -3688,10 +3811,10 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
     return KeyPathComponentSyntax(newData)
   }
 
-  public var component: Syntax {
+  public var component: Component {
     get {
       let childData = data.child(at: 3, parent: Syntax(self))
-      return Syntax(childData!)
+      return Component(childData!)
     }
     set(value) {
       self = withComponent(value)
@@ -3702,7 +3825,7 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `component` to replace the node's
   ///                   current `component`, if present.
   public func withComponent(
-    _ newChild: Syntax?) -> KeyPathComponentSyntax {
+    _ newChild: Component?) -> KeyPathComponentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return KeyPathComponentSyntax(newData)
@@ -5566,6 +5689,53 @@ extension FunctionSignatureSyntax: CustomReflectable {
 // MARK: - IfConfigClauseSyntax
 
 public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum Elements: SyntaxChildChoices {
+    case `statements`(CodeBlockItemListSyntax)
+    case `switchCases`(SwitchCaseListSyntax)
+    case `decls`(MemberDeclListSyntax)
+    case `postfixExpression`(ExprSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .statements(let node): return node._syntaxNode
+      case .switchCases(let node): return node._syntaxNode
+      case .decls(let node): return node._syntaxNode
+      case .postfixExpression(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: CodeBlockItemListSyntax) {
+      self = .statements(node)
+    }
+    public init(_ node: SwitchCaseListSyntax) {
+      self = .switchCases(node)
+    }
+    public init(_ node: MemberDeclListSyntax) {
+      self = .decls(node)
+    }
+    public init<Node: ExprSyntaxProtocol>(_ node: Node) {
+      self = .postfixExpression(ExprSyntax(node))
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(CodeBlockItemListSyntax.self) {
+        self = .statements(node)
+        return
+      }
+      if let node = syntaxNode.as(SwitchCaseListSyntax.self) {
+        self = .switchCases(node)
+        return
+      }
+      if let node = syntaxNode.as(MemberDeclListSyntax.self) {
+        self = .decls(node)
+        return
+      }
+      if let node = syntaxNode.as(ExprSyntax.self) {
+        self = .postfixExpression(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `IfConfigClauseSyntax` if possible. Returns
@@ -5589,7 +5759,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenPoundKeywordAndCondition: UnexpectedNodesSyntax? = nil,
     condition: ExprSyntax?,
     _ unexpectedBetweenConditionAndElements: UnexpectedNodesSyntax? = nil,
-    elements: Syntax?,
+    elements: Elements?,
     _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
@@ -5711,11 +5881,11 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return IfConfigClauseSyntax(newData)
   }
 
-  public var elements: Syntax? {
+  public var elements: Elements? {
     get {
       let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
-      return Syntax(childData!)
+      return Elements(childData!)
     }
     set(value) {
       self = withElements(value)
@@ -5726,7 +5896,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `elements` to replace the node's
   ///                   current `elements`, if present.
   public func withElements(
-    _ newChild: Syntax?) -> IfConfigClauseSyntax {
+    _ newChild: Elements?) -> IfConfigClauseSyntax {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 5)
     return IfConfigClauseSyntax(newData)
@@ -9158,6 +9328,35 @@ extension AccessorBlockSyntax: CustomReflectable {
 // MARK: - PatternBindingSyntax
 
 public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum Accessor: SyntaxChildChoices {
+    case `accessors`(AccessorBlockSyntax)
+    case `getter`(CodeBlockSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .accessors(let node): return node._syntaxNode
+      case .getter(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: AccessorBlockSyntax) {
+      self = .accessors(node)
+    }
+    public init(_ node: CodeBlockSyntax) {
+      self = .getter(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(AccessorBlockSyntax.self) {
+        self = .accessors(node)
+        return
+      }
+      if let node = syntaxNode.as(CodeBlockSyntax.self) {
+        self = .getter(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PatternBindingSyntax` if possible. Returns
@@ -9183,7 +9382,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil,
     initializer: InitializerClauseSyntax?,
     _ unexpectedBetweenInitializerAndAccessor: UnexpectedNodesSyntax? = nil,
-    accessor: Syntax?,
+    accessor: Accessor?,
     _ unexpectedBetweenAccessorAndTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingComma: TokenSyntax?,
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
@@ -9353,11 +9552,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
     return PatternBindingSyntax(newData)
   }
 
-  public var accessor: Syntax? {
+  public var accessor: Accessor? {
     get {
       let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
-      return Syntax(childData!)
+      return Accessor(childData!)
     }
     set(value) {
       self = withAccessor(value)
@@ -9368,7 +9567,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `accessor` to replace the node's
   ///                   current `accessor`, if present.
   public func withAccessor(
-    _ newChild: Syntax?) -> PatternBindingSyntax {
+    _ newChild: Accessor?) -> PatternBindingSyntax {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 7)
     return PatternBindingSyntax(newData)
@@ -11454,6 +11653,131 @@ extension CustomAttributeSyntax: CustomReflectable {
 /// An `@` attribute.
 /// 
 public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum Argument: SyntaxChildChoices {
+    case `identifier`(TokenSyntax)
+    case `string`(TokenSyntax)
+    case `integer`(TokenSyntax)
+    case `availability`(AvailabilitySpecListSyntax)
+    case `specializeArguments`(SpecializeAttributeSpecListSyntax)
+    case `objCName`(ObjCSelectorSyntax)
+    case `implementsArguments`(ImplementsAttributeArgumentsSyntax)
+    case `differentiableArguments`(DifferentiableAttributeArgumentsSyntax)
+    case `derivativeRegistrationArguments`(DerivativeRegistrationAttributeArgumentsSyntax)
+    case `namedAttributeString`(NamedAttributeStringArgumentSyntax)
+    case `backDeployArguments`(BackDeployAttributeSpecListSyntax)
+    case `conventionArguments`(ConventionAttributeArgumentsSyntax)
+    case `conventionWitnessMethodArguments`(ConventionWitnessMethodAttributeArgumentsSyntax)
+    case `tokenList`(TokenListSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .identifier(let node): return node._syntaxNode
+      case .string(let node): return node._syntaxNode
+      case .integer(let node): return node._syntaxNode
+      case .availability(let node): return node._syntaxNode
+      case .specializeArguments(let node): return node._syntaxNode
+      case .objCName(let node): return node._syntaxNode
+      case .implementsArguments(let node): return node._syntaxNode
+      case .differentiableArguments(let node): return node._syntaxNode
+      case .derivativeRegistrationArguments(let node): return node._syntaxNode
+      case .namedAttributeString(let node): return node._syntaxNode
+      case .backDeployArguments(let node): return node._syntaxNode
+      case .conventionArguments(let node): return node._syntaxNode
+      case .conventionWitnessMethodArguments(let node): return node._syntaxNode
+      case .tokenList(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: AvailabilitySpecListSyntax) {
+      self = .availability(node)
+    }
+    public init(_ node: SpecializeAttributeSpecListSyntax) {
+      self = .specializeArguments(node)
+    }
+    public init(_ node: ObjCSelectorSyntax) {
+      self = .objCName(node)
+    }
+    public init(_ node: ImplementsAttributeArgumentsSyntax) {
+      self = .implementsArguments(node)
+    }
+    public init(_ node: DifferentiableAttributeArgumentsSyntax) {
+      self = .differentiableArguments(node)
+    }
+    public init(_ node: DerivativeRegistrationAttributeArgumentsSyntax) {
+      self = .derivativeRegistrationArguments(node)
+    }
+    public init(_ node: NamedAttributeStringArgumentSyntax) {
+      self = .namedAttributeString(node)
+    }
+    public init(_ node: BackDeployAttributeSpecListSyntax) {
+      self = .backDeployArguments(node)
+    }
+    public init(_ node: ConventionAttributeArgumentsSyntax) {
+      self = .conventionArguments(node)
+    }
+    public init(_ node: ConventionWitnessMethodAttributeArgumentsSyntax) {
+      self = .conventionWitnessMethodArguments(node)
+    }
+    public init(_ node: TokenListSyntax) {
+      self = .tokenList(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let tok = syntaxNode.as(TokenSyntax.self) {
+        switch tok.rawTokenKind {
+        case .identifier: self = .identifier(tok)
+        case .stringLiteral: self = .string(tok)
+        case .integerLiteral: self = .integer(tok)
+        default: return nil
+        }
+        return
+      }
+      if let node = syntaxNode.as(AvailabilitySpecListSyntax.self) {
+        self = .availability(node)
+        return
+      }
+      if let node = syntaxNode.as(SpecializeAttributeSpecListSyntax.self) {
+        self = .specializeArguments(node)
+        return
+      }
+      if let node = syntaxNode.as(ObjCSelectorSyntax.self) {
+        self = .objCName(node)
+        return
+      }
+      if let node = syntaxNode.as(ImplementsAttributeArgumentsSyntax.self) {
+        self = .implementsArguments(node)
+        return
+      }
+      if let node = syntaxNode.as(DifferentiableAttributeArgumentsSyntax.self) {
+        self = .differentiableArguments(node)
+        return
+      }
+      if let node = syntaxNode.as(DerivativeRegistrationAttributeArgumentsSyntax.self) {
+        self = .derivativeRegistrationArguments(node)
+        return
+      }
+      if let node = syntaxNode.as(NamedAttributeStringArgumentSyntax.self) {
+        self = .namedAttributeString(node)
+        return
+      }
+      if let node = syntaxNode.as(BackDeployAttributeSpecListSyntax.self) {
+        self = .backDeployArguments(node)
+        return
+      }
+      if let node = syntaxNode.as(ConventionAttributeArgumentsSyntax.self) {
+        self = .conventionArguments(node)
+        return
+      }
+      if let node = syntaxNode.as(ConventionWitnessMethodAttributeArgumentsSyntax.self) {
+        self = .conventionWitnessMethodArguments(node)
+        return
+      }
+      if let node = syntaxNode.as(TokenListSyntax.self) {
+        self = .tokenList(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AttributeSyntax` if possible. Returns
@@ -11479,7 +11803,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodesSyntax? = nil,
     leftParen: TokenSyntax?,
     _ unexpectedBetweenLeftParenAndArgument: UnexpectedNodesSyntax? = nil,
-    argument: Syntax?,
+    argument: Argument?,
     _ unexpectedBetweenArgumentAndRightParen: UnexpectedNodesSyntax? = nil,
     rightParen: TokenSyntax?,
     _ unexpectedBetweenRightParenAndTokenList: UnexpectedNodesSyntax? = nil,
@@ -11662,11 +11986,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// takes multiple arguments, they are gather in the
   /// appropriate takes first.
   /// 
-  public var argument: Syntax? {
+  public var argument: Argument? {
     get {
       let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
-      return Syntax(childData!)
+      return Argument(childData!)
     }
     set(value) {
       self = withArgument(value)
@@ -11677,7 +12001,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `argument` to replace the node's
   ///                   current `argument`, if present.
   public func withArgument(
-    _ newChild: Syntax?) -> AttributeSyntax {
+    _ newChild: Argument?) -> AttributeSyntax {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 7)
     return AttributeSyntax(newData)
@@ -12742,6 +13066,35 @@ extension TargetFunctionEntrySyntax: CustomReflectable {
 /// "Src.swift"`
 /// 
 public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum StringOrDeclname: SyntaxChildChoices {
+    case `string`(TokenSyntax)
+    case `declname`(DeclNameSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .string(let node): return node._syntaxNode
+      case .declname(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: DeclNameSyntax) {
+      self = .declname(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let tok = syntaxNode.as(TokenSyntax.self) {
+        switch tok.rawTokenKind {
+        case .stringLiteral: self = .string(tok)
+        default: return nil
+        }
+        return
+      }
+      if let node = syntaxNode.as(DeclNameSyntax.self) {
+        self = .declname(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `NamedAttributeStringArgumentSyntax` if possible. Returns
@@ -12765,7 +13118,7 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
     _ unexpectedBetweenNameTokAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndStringOrDeclname: UnexpectedNodesSyntax? = nil,
-    stringOrDeclname: Syntax,
+    stringOrDeclname: StringOrDeclname,
     _ unexpectedAfterStringOrDeclname: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
@@ -12888,10 +13241,10 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
     return NamedAttributeStringArgumentSyntax(newData)
   }
 
-  public var stringOrDeclname: Syntax {
+  public var stringOrDeclname: StringOrDeclname {
     get {
       let childData = data.child(at: 5, parent: Syntax(self))
-      return Syntax(childData!)
+      return StringOrDeclname(childData!)
     }
     set(value) {
       self = withStringOrDeclname(value)
@@ -12902,7 +13255,7 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   /// - param newChild: The new `stringOrDeclname` to replace the node's
   ///                   current `stringOrDeclname`, if present.
   public func withStringOrDeclname(
-    _ newChild: Syntax?) -> NamedAttributeStringArgumentSyntax {
+    _ newChild: StringOrDeclname?) -> NamedAttributeStringArgumentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return NamedAttributeStringArgumentSyntax(newData)
@@ -12968,6 +13321,29 @@ extension NamedAttributeStringArgumentSyntax: CustomReflectable {
 // MARK: - DeclNameSyntax
 
 public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum DeclBaseName: SyntaxChildChoices {
+    case `identifier`(TokenSyntax)
+    case `operator`(TokenSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .identifier(let node): return node._syntaxNode
+      case .operator(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let tok = syntaxNode.as(TokenSyntax.self) {
+        switch tok.rawTokenKind {
+        case .identifier: self = .identifier(tok)
+        case .prefixOperator: self = .operator(tok)
+        default: return nil
+        }
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DeclNameSyntax` if possible. Returns
@@ -12987,7 +13363,7 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeDeclBaseName: UnexpectedNodesSyntax? = nil,
-    declBaseName: Syntax,
+    declBaseName: DeclBaseName,
     _ unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
     declNameArguments: DeclNameArgumentsSyntax?,
     _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil
@@ -13029,10 +13405,10 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   /// The base name of the protocol's requirement.
   /// 
-  public var declBaseName: Syntax {
+  public var declBaseName: DeclBaseName {
     get {
       let childData = data.child(at: 1, parent: Syntax(self))
-      return Syntax(childData!)
+      return DeclBaseName(childData!)
     }
     set(value) {
       self = withDeclBaseName(value)
@@ -13043,7 +13419,7 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `declBaseName` to replace the node's
   ///                   current `declBaseName`, if present.
   public func withDeclBaseName(
-    _ newChild: Syntax?) -> DeclNameSyntax {
+    _ newChild: DeclBaseName?) -> DeclNameSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return DeclNameSyntax(newData)
@@ -13967,6 +14343,35 @@ extension DifferentiableAttributeArgumentsSyntax: CustomReflectable {
 
 /// A clause containing differentiability parameters.
 public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum Parameters: SyntaxChildChoices {
+    case `parameter`(DifferentiabilityParamSyntax)
+    case `parameterList`(DifferentiabilityParamsSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .parameter(let node): return node._syntaxNode
+      case .parameterList(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: DifferentiabilityParamSyntax) {
+      self = .parameter(node)
+    }
+    public init(_ node: DifferentiabilityParamsSyntax) {
+      self = .parameterList(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(DifferentiabilityParamSyntax.self) {
+        self = .parameter(node)
+        return
+      }
+      if let node = syntaxNode.as(DifferentiabilityParamsSyntax.self) {
+        self = .parameterList(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DifferentiabilityParamsClauseSyntax` if possible. Returns
@@ -13990,7 +14395,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
     _ unexpectedBetweenWrtLabelAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndParameters: UnexpectedNodesSyntax? = nil,
-    parameters: Syntax,
+    parameters: Parameters,
     _ unexpectedAfterParameters: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
@@ -14115,10 +14520,10 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
     return DifferentiabilityParamsClauseSyntax(newData)
   }
 
-  public var parameters: Syntax {
+  public var parameters: Parameters {
     get {
       let childData = data.child(at: 5, parent: Syntax(self))
-      return Syntax(childData!)
+      return Parameters(childData!)
     }
     set(value) {
       self = withParameters(value)
@@ -14129,7 +14534,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   /// - param newChild: The new `parameters` to replace the node's
   ///                   current `parameters`, if present.
   public func withParameters(
-    _ newChild: Syntax?) -> DifferentiabilityParamsClauseSyntax {
+    _ newChild: Parameters?) -> DifferentiabilityParamsClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return DifferentiabilityParamsClauseSyntax(newData)
@@ -14443,6 +14848,32 @@ extension DifferentiabilityParamsSyntax: CustomReflectable {
 /// parameter name, or a function parameter index.
 /// 
 public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum Parameter: SyntaxChildChoices {
+    case `self`(TokenSyntax)
+    case `name`(TokenSyntax)
+    case `index`(TokenSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .self(let node): return node._syntaxNode
+      case .name(let node): return node._syntaxNode
+      case .index(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let tok = syntaxNode.as(TokenSyntax.self) {
+        switch tok.rawTokenKind {
+        case .selfKeyword: self = .self(tok)
+        case .identifier: self = .name(tok)
+        case .integerLiteral: self = .index(tok)
+        default: return nil
+        }
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DifferentiabilityParamSyntax` if possible. Returns
@@ -14462,7 +14893,7 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeParameter: UnexpectedNodesSyntax? = nil,
-    parameter: Syntax,
+    parameter: Parameter,
     _ unexpectedBetweenParameterAndTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingComma: TokenSyntax?,
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
@@ -14501,10 +14932,10 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
     return DifferentiabilityParamSyntax(newData)
   }
 
-  public var parameter: Syntax {
+  public var parameter: Parameter {
     get {
       let childData = data.child(at: 1, parent: Syntax(self))
-      return Syntax(childData!)
+      return Parameter(childData!)
     }
     set(value) {
       self = withParameter(value)
@@ -14515,7 +14946,7 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `parameter` to replace the node's
   ///                   current `parameter`, if present.
   public func withParameter(
-    _ newChild: Syntax?) -> DifferentiabilityParamSyntax {
+    _ newChild: Parameter?) -> DifferentiabilityParamSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return DifferentiabilityParamSyntax(newData)
@@ -15358,6 +15789,32 @@ extension QualifiedDeclNameSyntax: CustomReflectable {
 
 /// A function declaration name (e.g. `foo(_:_:)`).
 public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum Name: SyntaxChildChoices {
+    case `identifier`(TokenSyntax)
+    case `prefixOperator`(TokenSyntax)
+    case `spacedBinaryOperator`(TokenSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .identifier(let node): return node._syntaxNode
+      case .prefixOperator(let node): return node._syntaxNode
+      case .spacedBinaryOperator(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let tok = syntaxNode.as(TokenSyntax.self) {
+        switch tok.rawTokenKind {
+        case .identifier: self = .identifier(tok)
+        case .prefixOperator: self = .prefixOperator(tok)
+        case .spacedBinaryOperator: self = .spacedBinaryOperator(tok)
+        default: return nil
+        }
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `FunctionDeclNameSyntax` if possible. Returns
@@ -15377,7 +15834,7 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeName: UnexpectedNodesSyntax? = nil,
-    name: Syntax,
+    name: Name,
     _ unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? = nil,
     arguments: DeclNameArgumentsSyntax?,
     _ unexpectedAfterArguments: UnexpectedNodesSyntax? = nil
@@ -15419,10 +15876,10 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   /// The base name of the referenced function.
   /// 
-  public var name: Syntax {
+  public var name: Name {
     get {
       let childData = data.child(at: 1, parent: Syntax(self))
-      return Syntax(childData!)
+      return Name(childData!)
     }
     set(value) {
       self = withName(value)
@@ -15433,7 +15890,7 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
   public func withName(
-    _ newChild: Syntax?) -> FunctionDeclNameSyntax {
+    _ newChild: Name?) -> FunctionDeclNameSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return FunctionDeclNameSyntax(newData)
@@ -17179,6 +17636,71 @@ extension YieldListSyntax: CustomReflectable {
 // MARK: - ConditionElementSyntax
 
 public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum Condition: SyntaxChildChoices {
+    case `expression`(ExprSyntax)
+    case `availability`(AvailabilityConditionSyntax)
+    case `unavailability`(UnavailabilityConditionSyntax)
+    case `matchingPattern`(MatchingPatternConditionSyntax)
+    case `optionalBinding`(OptionalBindingConditionSyntax)
+    case `hasSymbol`(HasSymbolConditionSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .expression(let node): return node._syntaxNode
+      case .availability(let node): return node._syntaxNode
+      case .unavailability(let node): return node._syntaxNode
+      case .matchingPattern(let node): return node._syntaxNode
+      case .optionalBinding(let node): return node._syntaxNode
+      case .hasSymbol(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init<Node: ExprSyntaxProtocol>(_ node: Node) {
+      self = .expression(ExprSyntax(node))
+    }
+    public init(_ node: AvailabilityConditionSyntax) {
+      self = .availability(node)
+    }
+    public init(_ node: UnavailabilityConditionSyntax) {
+      self = .unavailability(node)
+    }
+    public init(_ node: MatchingPatternConditionSyntax) {
+      self = .matchingPattern(node)
+    }
+    public init(_ node: OptionalBindingConditionSyntax) {
+      self = .optionalBinding(node)
+    }
+    public init(_ node: HasSymbolConditionSyntax) {
+      self = .hasSymbol(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(ExprSyntax.self) {
+        self = .expression(node)
+        return
+      }
+      if let node = syntaxNode.as(AvailabilityConditionSyntax.self) {
+        self = .availability(node)
+        return
+      }
+      if let node = syntaxNode.as(UnavailabilityConditionSyntax.self) {
+        self = .unavailability(node)
+        return
+      }
+      if let node = syntaxNode.as(MatchingPatternConditionSyntax.self) {
+        self = .matchingPattern(node)
+        return
+      }
+      if let node = syntaxNode.as(OptionalBindingConditionSyntax.self) {
+        self = .optionalBinding(node)
+        return
+      }
+      if let node = syntaxNode.as(HasSymbolConditionSyntax.self) {
+        self = .hasSymbol(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ConditionElementSyntax` if possible. Returns
@@ -17198,7 +17720,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeCondition: UnexpectedNodesSyntax? = nil,
-    condition: Syntax,
+    condition: Condition,
     _ unexpectedBetweenConditionAndTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingComma: TokenSyntax?,
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
@@ -17237,10 +17759,10 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
     return ConditionElementSyntax(newData)
   }
 
-  public var condition: Syntax {
+  public var condition: Condition {
     get {
       let childData = data.child(at: 1, parent: Syntax(self))
-      return Syntax(childData!)
+      return Condition(childData!)
     }
     set(value) {
       self = withCondition(value)
@@ -17251,7 +17773,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `condition` to replace the node's
   ///                   current `condition`, if present.
   public func withCondition(
-    _ newChild: Syntax?) -> ConditionElementSyntax {
+    _ newChild: Condition?) -> ConditionElementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return ConditionElementSyntax(newData)
@@ -18767,6 +19289,35 @@ extension HasSymbolConditionSyntax: CustomReflectable {
 // MARK: - SwitchCaseSyntax
 
 public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum Label: SyntaxChildChoices {
+    case `default`(SwitchDefaultLabelSyntax)
+    case `case`(SwitchCaseLabelSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .default(let node): return node._syntaxNode
+      case .case(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: SwitchDefaultLabelSyntax) {
+      self = .default(node)
+    }
+    public init(_ node: SwitchCaseLabelSyntax) {
+      self = .case(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(SwitchDefaultLabelSyntax.self) {
+        self = .default(node)
+        return
+      }
+      if let node = syntaxNode.as(SwitchCaseLabelSyntax.self) {
+        self = .case(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SwitchCaseSyntax` if possible. Returns
@@ -18788,7 +19339,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeUnknownAttr: UnexpectedNodesSyntax? = nil,
     unknownAttr: AttributeSyntax?,
     _ unexpectedBetweenUnknownAttrAndLabel: UnexpectedNodesSyntax? = nil,
-    label: Syntax,
+    label: Label,
     _ unexpectedBetweenLabelAndStatements: UnexpectedNodesSyntax? = nil,
     statements: CodeBlockItemListSyntax,
     _ unexpectedAfterStatements: UnexpectedNodesSyntax? = nil
@@ -18871,10 +19422,10 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
     return SwitchCaseSyntax(newData)
   }
 
-  public var label: Syntax {
+  public var label: Label {
     get {
       let childData = data.child(at: 3, parent: Syntax(self))
-      return Syntax(childData!)
+      return Label(childData!)
     }
     set(value) {
       self = withLabel(value)
@@ -18885,7 +19436,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
   public func withLabel(
-    _ newChild: Syntax?) -> SwitchCaseSyntax {
+    _ newChild: Label?) -> SwitchCaseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return SwitchCaseSyntax(newData)
@@ -20312,6 +20863,44 @@ extension GenericWhereClauseSyntax: CustomReflectable {
 // MARK: - GenericRequirementSyntax
 
 public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum Body: SyntaxChildChoices {
+    case `sameTypeRequirement`(SameTypeRequirementSyntax)
+    case `conformanceRequirement`(ConformanceRequirementSyntax)
+    case `layoutRequirement`(LayoutRequirementSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .sameTypeRequirement(let node): return node._syntaxNode
+      case .conformanceRequirement(let node): return node._syntaxNode
+      case .layoutRequirement(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: SameTypeRequirementSyntax) {
+      self = .sameTypeRequirement(node)
+    }
+    public init(_ node: ConformanceRequirementSyntax) {
+      self = .conformanceRequirement(node)
+    }
+    public init(_ node: LayoutRequirementSyntax) {
+      self = .layoutRequirement(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(SameTypeRequirementSyntax.self) {
+        self = .sameTypeRequirement(node)
+        return
+      }
+      if let node = syntaxNode.as(ConformanceRequirementSyntax.self) {
+        self = .conformanceRequirement(node)
+        return
+      }
+      if let node = syntaxNode.as(LayoutRequirementSyntax.self) {
+        self = .layoutRequirement(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `GenericRequirementSyntax` if possible. Returns
@@ -20331,7 +20920,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeBody: UnexpectedNodesSyntax? = nil,
-    body: Syntax,
+    body: Body,
     _ unexpectedBetweenBodyAndTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingComma: TokenSyntax?,
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
@@ -20370,10 +20959,10 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     return GenericRequirementSyntax(newData)
   }
 
-  public var body: Syntax {
+  public var body: Body {
     get {
       let childData = data.child(at: 1, parent: Syntax(self))
-      return Syntax(childData!)
+      return Body(childData!)
     }
     set(value) {
       self = withBody(value)
@@ -20384,7 +20973,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
   public func withBody(
-    _ newChild: Syntax?) -> GenericRequirementSyntax {
+    _ newChild: Body?) -> GenericRequirementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return GenericRequirementSyntax(newData)
@@ -24059,6 +24648,47 @@ extension TuplePatternElementSyntax: CustomReflectable {
 /// or `message: "This has been deprecated"`.
 /// 
 public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum Entry: SyntaxChildChoices {
+    case `star`(TokenSyntax)
+    case `identifierRestriction`(TokenSyntax)
+    case `availabilityVersionRestriction`(AvailabilityVersionRestrictionSyntax)
+    case `availabilityLabeledArgument`(AvailabilityLabeledArgumentSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .star(let node): return node._syntaxNode
+      case .identifierRestriction(let node): return node._syntaxNode
+      case .availabilityVersionRestriction(let node): return node._syntaxNode
+      case .availabilityLabeledArgument(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: AvailabilityVersionRestrictionSyntax) {
+      self = .availabilityVersionRestriction(node)
+    }
+    public init(_ node: AvailabilityLabeledArgumentSyntax) {
+      self = .availabilityLabeledArgument(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let tok = syntaxNode.as(TokenSyntax.self) {
+        switch tok.rawTokenKind {
+        case .spacedBinaryOperator: self = .star(tok)
+        case .identifier: self = .identifierRestriction(tok)
+        default: return nil
+        }
+        return
+      }
+      if let node = syntaxNode.as(AvailabilityVersionRestrictionSyntax.self) {
+        self = .availabilityVersionRestriction(node)
+        return
+      }
+      if let node = syntaxNode.as(AvailabilityLabeledArgumentSyntax.self) {
+        self = .availabilityLabeledArgument(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AvailabilityArgumentSyntax` if possible. Returns
@@ -24078,7 +24708,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeEntry: UnexpectedNodesSyntax? = nil,
-    entry: Syntax,
+    entry: Entry,
     _ unexpectedBetweenEntryAndTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingComma: TokenSyntax?,
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
@@ -24118,10 +24748,10 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   }
 
   /// The actual argument
-  public var entry: Syntax {
+  public var entry: Entry {
     get {
       let childData = data.child(at: 1, parent: Syntax(self))
-      return Syntax(childData!)
+      return Entry(childData!)
     }
     set(value) {
       self = withEntry(value)
@@ -24132,7 +24762,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `entry` to replace the node's
   ///                   current `entry`, if present.
   public func withEntry(
-    _ newChild: Syntax?) -> AvailabilityArgumentSyntax {
+    _ newChild: Entry?) -> AvailabilityArgumentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return AvailabilityArgumentSyntax(newData)
@@ -24242,6 +24872,35 @@ extension AvailabilityArgumentSyntax: CustomReflectable {
 /// a value, e.g. `message: "This has been deprecated"`.
 /// 
 public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum Value: SyntaxChildChoices {
+    case `string`(TokenSyntax)
+    case `version`(VersionTupleSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .string(let node): return node._syntaxNode
+      case .version(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: VersionTupleSyntax) {
+      self = .version(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let tok = syntaxNode.as(TokenSyntax.self) {
+        switch tok.rawTokenKind {
+        case .stringLiteral: self = .string(tok)
+        default: return nil
+        }
+        return
+      }
+      if let node = syntaxNode.as(VersionTupleSyntax.self) {
+        self = .version(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AvailabilityLabeledArgumentSyntax` if possible. Returns
@@ -24265,7 +24924,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
     _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil,
-    value: Syntax,
+    value: Value,
     _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
@@ -24389,10 +25048,10 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   }
 
   /// The value of this labeled argument
-  public var value: Syntax {
+  public var value: Value {
     get {
       let childData = data.child(at: 5, parent: Syntax(self))
-      return Syntax(childData!)
+      return Value(childData!)
     }
     set(value) {
       self = withValue(value)
@@ -24403,7 +25062,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   /// - param newChild: The new `value` to replace the node's
   ///                   current `value`, if present.
   public func withValue(
-    _ newChild: Syntax?) -> AvailabilityLabeledArgumentSyntax {
+    _ newChild: Value?) -> AvailabilityLabeledArgumentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return AvailabilityLabeledArgumentSyntax(newData)
@@ -24656,6 +25315,29 @@ extension AvailabilityVersionRestrictionSyntax: CustomReflectable {
 /// and patch part may be omitted.
 /// 
 public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum MajorMinor: SyntaxChildChoices {
+    case `major`(TokenSyntax)
+    case `majorMinor`(TokenSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .major(let node): return node._syntaxNode
+      case .majorMinor(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let tok = syntaxNode.as(TokenSyntax.self) {
+        switch tok.rawTokenKind {
+        case .integerLiteral: self = .major(tok)
+        case .floatingLiteral: self = .majorMinor(tok)
+        default: return nil
+        }
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `VersionTupleSyntax` if possible. Returns
@@ -24675,7 +25357,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeMajorMinor: UnexpectedNodesSyntax? = nil,
-    majorMinor: Syntax,
+    majorMinor: MajorMinor,
     _ unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodesSyntax? = nil,
     patchPeriod: TokenSyntax?,
     _ unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodesSyntax? = nil,
@@ -24725,10 +25407,10 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   /// floating literal in which the decimal part is interpreted
   /// as the minor version.
   /// 
-  public var majorMinor: Syntax {
+  public var majorMinor: MajorMinor {
     get {
       let childData = data.child(at: 1, parent: Syntax(self))
-      return Syntax(childData!)
+      return MajorMinor(childData!)
     }
     set(value) {
       self = withMajorMinor(value)
@@ -24739,7 +25421,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `majorMinor` to replace the node's
   ///                   current `majorMinor`, if present.
   public func withMajorMinor(
-    _ newChild: Syntax?) -> VersionTupleSyntax {
+    _ newChild: MajorMinor?) -> VersionTupleSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return VersionTupleSyntax(newData)

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -2956,6 +2956,35 @@ extension ReturnStmtSyntax: CustomReflectable {
 // MARK: - YieldStmtSyntax
 
 public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+  public enum Yields: SyntaxChildChoices {
+    case `yieldList`(YieldListSyntax)
+    case `simpleYield`(ExprSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .yieldList(let node): return node._syntaxNode
+      case .simpleYield(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: YieldListSyntax) {
+      self = .yieldList(node)
+    }
+    public init<Node: ExprSyntaxProtocol>(_ node: Node) {
+      self = .simpleYield(ExprSyntax(node))
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(YieldListSyntax.self) {
+        self = .yieldList(node)
+        return
+      }
+      if let node = syntaxNode.as(ExprSyntax.self) {
+        self = .simpleYield(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `YieldStmtSyntax` if possible. Returns
@@ -2977,7 +3006,7 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeYieldKeyword: UnexpectedNodesSyntax? = nil,
     yieldKeyword: TokenSyntax,
     _ unexpectedBetweenYieldKeywordAndYields: UnexpectedNodesSyntax? = nil,
-    yields: Syntax,
+    yields: Yields,
     _ unexpectedAfterYields: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
@@ -3055,10 +3084,10 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return YieldStmtSyntax(newData)
   }
 
-  public var yields: Syntax {
+  public var yields: Yields {
     get {
       let childData = data.child(at: 3, parent: Syntax(self))
-      return Syntax(childData!)
+      return Yields(childData!)
     }
     set(value) {
       self = withYields(value)
@@ -3069,7 +3098,7 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `yields` to replace the node's
   ///                   current `yields`, if present.
   public func withYields(
-    _ newChild: Syntax?) -> YieldStmtSyntax {
+    _ newChild: Yields?) -> YieldStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return YieldStmtSyntax(newData)
@@ -3720,6 +3749,35 @@ extension ThrowStmtSyntax: CustomReflectable {
 // MARK: - IfStmtSyntax
 
 public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+  public enum ElseBody: SyntaxChildChoices {
+    case `ifStmt`(IfStmtSyntax)
+    case `codeBlock`(CodeBlockSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .ifStmt(let node): return node._syntaxNode
+      case .codeBlock(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: IfStmtSyntax) {
+      self = .ifStmt(node)
+    }
+    public init(_ node: CodeBlockSyntax) {
+      self = .codeBlock(node)
+    }
+    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+      if let node = syntaxNode.as(IfStmtSyntax.self) {
+        self = .ifStmt(node)
+        return
+      }
+      if let node = syntaxNode.as(CodeBlockSyntax.self) {
+        self = .codeBlock(node)
+        return
+      }
+      return nil
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `IfStmtSyntax` if possible. Returns
@@ -3747,7 +3805,7 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenBodyAndElseKeyword: UnexpectedNodesSyntax? = nil,
     elseKeyword: TokenSyntax?,
     _ unexpectedBetweenElseKeywordAndElseBody: UnexpectedNodesSyntax? = nil,
-    elseBody: Syntax?,
+    elseBody: ElseBody?,
     _ unexpectedAfterElseBody: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
@@ -3973,11 +4031,11 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return IfStmtSyntax(newData)
   }
 
-  public var elseBody: Syntax? {
+  public var elseBody: ElseBody? {
     get {
       let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
-      return Syntax(childData!)
+      return ElseBody(childData!)
     }
     set(value) {
       self = withElseBody(value)
@@ -3988,7 +4046,7 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `elseBody` to replace the node's
   ///                   current `elseBody`, if present.
   public func withElseBody(
-    _ newChild: Syntax?) -> IfStmtSyntax {
+    _ newChild: ElseBody?) -> IfStmtSyntax {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 9)
     return IfStmtSyntax(newData)

--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/DictionaryExprConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/DictionaryExprConvenienceInitializers.swift
@@ -23,7 +23,7 @@ extension DictionaryExpr {
     let elementList = contentBuilder()
     self.init(
       leftSquare: leftSquare,
-      content: elementList.isEmpty ? Syntax(Token.colon.withTrailingTrivia([])) : Syntax(elementList),
+      content: elementList.isEmpty ? .colon(Token.colon.withTrailingTrivia([])) : .elements(elementList),
       rightSquare: rightSquare
     )
   }

--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/IfStmtConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/IfStmtConvenienceInitializers.swift
@@ -28,7 +28,7 @@ public extension IfStmt {
       conditions: conditions,
       body: CodeBlockSyntax(statements: body()),
       elseKeyword: generatedElseBody == nil ? nil : Token.else.withLeadingTrivia(.space).withTrailingTrivia([]),
-      elseBody: generatedElseBody.map { CodeBlock(statements: $0) }
+      elseBody: generatedElseBody.map { .codeBlock(CodeBlock(statements: $0)) }
     )
   }
 }

--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/StringLiteralExprConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/StringLiteralExprConvenienceInitializers.swift
@@ -36,7 +36,7 @@ extension StringLiteralExpr {
   ) {
     let contentToken = Token.stringSegment(content)
     let segment = StringSegment(content: contentToken)
-    let segments = StringLiteralSegments([segment])
+    let segments = StringLiteralSegments([.stringSegment(segment)])
 
     var openDelimiter = openDelimiter
     var closeDelimiter = closeDelimiter

--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/VariableDeclConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/VariableDeclConvenienceInitializers.swift
@@ -55,7 +55,7 @@ extension VariableDecl {
       PatternBinding(
         pattern: name,
         typeAnnotation: type,
-        accessor: CodeBlock(statements: accessor())
+        accessor: .getter(CodeBlock(statements: accessor()))
       )
     }
   }

--- a/Sources/SwiftSyntaxBuilder/ResultBuilderExtensions.swift
+++ b/Sources/SwiftSyntaxBuilder/ResultBuilderExtensions.swift
@@ -15,41 +15,41 @@ import SwiftSyntax
 
 extension CodeBlockItemListBuilder {
   public static func buildExpression<ExprType: ExprSyntaxProtocol>(_ expression: ExprType) -> Component {
-    return buildExpression(CodeBlockItemSyntax(item: expression))
+    return buildExpression(CodeBlockItemSyntax(item: .expr(ExprSyntax(expression))))
   }
 
   public static func buildExpression<StmtType: StmtSyntaxProtocol>(_ expression: StmtType) -> Component {
-    return buildExpression(CodeBlockItemSyntax(item: expression))
+    return buildExpression(CodeBlockItemSyntax(item: .stmt(StmtSyntax(expression))))
   }
 
   public static func buildExpression<DeclType: DeclSyntaxProtocol>(_ expression: DeclType) -> Component {
-    return buildExpression(CodeBlockItemSyntax(item: expression))
+    return buildExpression(CodeBlockItemSyntax(item: .decl(DeclSyntax(expression))))
   }
 }
 
 extension ConditionElementListBuilder {
   public static func buildExpression<ExprType: ExprSyntaxProtocol>(_ expression: ExprType) -> Component {
-    return buildExpression(ConditionElementSyntax(condition: expression))
+    return buildExpression(ConditionElementSyntax(condition: .expression(ExprSyntax(expression))))
   }
 
   public static func buildExpression(_ expression: AvailabilityConditionSyntax) -> Component {
-    return buildExpression(ConditionElementSyntax(condition: expression))
+    return buildExpression(ConditionElementSyntax(condition: .availability(expression)))
   }
 
   public static func buildExpression(_ expression: UnavailabilityConditionSyntax) -> Component {
-    return buildExpression(ConditionElementSyntax(condition: expression))
+    return buildExpression(ConditionElementSyntax(condition: .unavailability(expression)))
   }
 
   public static func buildExpression(_ expression: MatchingPatternConditionSyntax) -> Component {
-    return buildExpression(ConditionElementSyntax(condition: expression))
+    return buildExpression(ConditionElementSyntax(condition: .matchingPattern(expression)))
   }
 
   public static func buildExpression(_ expression: OptionalBindingConditionSyntax) -> Component {
-    return buildExpression(ConditionElementSyntax(condition: expression))
+    return buildExpression(ConditionElementSyntax(condition: .optionalBinding(expression)))
   }
 
   public static func buildExpression(_ expression: HasSymbolConditionSyntax) -> Component {
-    return buildExpression(ConditionElementSyntax(condition: expression))
+    return buildExpression(ConditionElementSyntax(condition: .hasSymbol(expression)))
   }
 }
 

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
@@ -17,150 +17,139 @@ import SwiftSyntax
 
 /// `AccessPath` represents a collection of `AccessPathComponentSyntax`
 extension AccessPath: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: AccessPathComponent...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `AccessorList` represents a collection of `AccessorDeclSyntax`
 extension AccessorList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: AccessorDecl...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `ArrayElementList` represents a collection of `ArrayElementSyntax`
 extension ArrayElementList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: ArrayElement...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `AttributeList` represents a collection of `Syntax`
 extension AttributeList: ExpressibleByArrayLiteral {
-  /// Creates a `AttributeList` with the provided list of elements.
-  /// - Parameters:
-  ///   - elements: A list of `SyntaxProtocol`
-  public init (_ elements: [SyntaxProtocol]) {
-    self = AttributeListSyntax(elements.map { 
-      Syntax(fromProtocol: $0) 
-    })
-  }
-  public init (arrayLiteral elements: SyntaxProtocol...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `AvailabilitySpecList` represents a collection of `AvailabilityArgumentSyntax`
 extension AvailabilitySpecList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: AvailabilityArgument...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `BackDeployVersionList` represents a collection of `BackDeployVersionArgumentSyntax`
 extension BackDeployVersionList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: BackDeployVersionArgument...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `CaseItemList` represents a collection of `CaseItemSyntax`
 extension CaseItemList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: CaseItem...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `CatchClauseList` represents a collection of `CatchClauseSyntax`
 extension CatchClauseList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: CatchClause...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `CatchItemList` represents a collection of `CatchItemSyntax`
 extension CatchItemList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: CatchItem...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `ClosureCaptureItemList` represents a collection of `ClosureCaptureItemSyntax`
 extension ClosureCaptureItemList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: ClosureCaptureItem...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `ClosureParamList` represents a collection of `ClosureParamSyntax`
 extension ClosureParamList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: ClosureParam...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `CodeBlockItemList` represents a collection of `CodeBlockItemSyntax`
 extension CodeBlockItemList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: CodeBlockItem...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `CompositionTypeElementList` represents a collection of `CompositionTypeElementSyntax`
 extension CompositionTypeElementList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: CompositionTypeElement...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `ConditionElementList` represents a collection of `ConditionElementSyntax`
 extension ConditionElementList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: ConditionElement...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `DeclNameArgumentList` represents a collection of `DeclNameArgumentSyntax`
 extension DeclNameArgumentList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: DeclNameArgument...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `DesignatedTypeList` represents a collection of `DesignatedTypeElementSyntax`
 extension DesignatedTypeList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: DesignatedTypeElement...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `DictionaryElementList` represents a collection of `DictionaryElementSyntax`
 extension DictionaryElementList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: DictionaryElement...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `DifferentiabilityParamList` represents a collection of `DifferentiabilityParamSyntax`
 extension DifferentiabilityParamList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: DifferentiabilityParam...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// A collection of 0 or more `EnumCaseElement`s.
 extension EnumCaseElementList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: EnumCaseElement...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// A list of expressions connected by operators. This list is containedby a `SequenceExprSyntax`.
 extension ExprList: ExpressibleByArrayLiteral {
-  /// Creates a `ExprList` with the provided list of elements.
-  /// - Parameters:
-  ///   - elements: A list of `ExprSyntaxProtocol`
   public init (_ elements: [ExprSyntaxProtocol]) {
     self = ExprListSyntax(elements.map { 
       ExprSyntax(fromProtocol: $0) 
@@ -173,209 +162,174 @@ extension ExprList: ExpressibleByArrayLiteral {
 
 /// `FunctionParameterList` represents a collection of `FunctionParameterSyntax`
 extension FunctionParameterList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: FunctionParameter...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `GenericArgumentList` represents a collection of `GenericArgumentSyntax`
 extension GenericArgumentList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: GenericArgument...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `GenericParameterList` represents a collection of `GenericParameterSyntax`
 extension GenericParameterList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: GenericParameter...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `GenericRequirementList` represents a collection of `GenericRequirementSyntax`
 extension GenericRequirementList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: GenericRequirement...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `IfConfigClauseList` represents a collection of `IfConfigClauseSyntax`
 extension IfConfigClauseList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: IfConfigClause...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `InheritedTypeList` represents a collection of `InheritedTypeSyntax`
 extension InheritedTypeList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: InheritedType...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `KeyPathComponentList` represents a collection of `KeyPathComponentSyntax`
 extension KeyPathComponentList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: KeyPathComponent...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `MemberDeclList` represents a collection of `MemberDeclListItemSyntax`
 extension MemberDeclList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: MemberDeclListItem...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `ModifierList` represents a collection of `DeclModifierSyntax`
 extension ModifierList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: DeclModifier...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `MultipleTrailingClosureElementList` represents a collection of `MultipleTrailingClosureElementSyntax`
 extension MultipleTrailingClosureElementList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: MultipleTrailingClosureElement...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `NonEmptyTokenList` represents a collection of `TokenSyntax`
 extension NonEmptyTokenList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: Token...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `ObjCSelector` represents a collection of `ObjCSelectorPieceSyntax`
 extension ObjCSelector: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: ObjCSelectorPiece...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `ObjcName` represents a collection of `ObjcNamePieceSyntax`
 extension ObjcName: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: ObjcNamePiece...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `PatternBindingList` represents a collection of `PatternBindingSyntax`
 extension PatternBindingList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: PatternBinding...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `PrecedenceGroupAttributeList` represents a collection of `Syntax`
 extension PrecedenceGroupAttributeList: ExpressibleByArrayLiteral {
-  /// Creates a `PrecedenceGroupAttributeList` with the provided list of elements.
-  /// - Parameters:
-  ///   - elements: A list of `SyntaxProtocol`
-  public init (_ elements: [SyntaxProtocol]) {
-    self = PrecedenceGroupAttributeListSyntax(elements.map { 
-      Syntax(fromProtocol: $0) 
-    })
-  }
-  public init (arrayLiteral elements: SyntaxProtocol...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `PrecedenceGroupNameList` represents a collection of `PrecedenceGroupNameElementSyntax`
 extension PrecedenceGroupNameList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: PrecedenceGroupNameElement...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `PrimaryAssociatedTypeList` represents a collection of `PrimaryAssociatedTypeSyntax`
 extension PrimaryAssociatedTypeList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: PrimaryAssociatedType...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// A collection of arguments for the `@_specialize` attribute
 extension SpecializeAttributeSpecList: ExpressibleByArrayLiteral {
-  /// Creates a `SpecializeAttributeSpecList` with the provided list of elements.
-  /// - Parameters:
-  ///   - elements: A list of `SyntaxProtocol`
-  public init (_ elements: [SyntaxProtocol]) {
-    self = SpecializeAttributeSpecListSyntax(elements.map { 
-      Syntax(fromProtocol: $0) 
-    })
-  }
-  public init (arrayLiteral elements: SyntaxProtocol...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `StringLiteralSegments` represents a collection of `Syntax`
 extension StringLiteralSegments: ExpressibleByArrayLiteral {
-  /// Creates a `StringLiteralSegments` with the provided list of elements.
-  /// - Parameters:
-  ///   - elements: A list of `SyntaxProtocol`
-  public init (_ elements: [SyntaxProtocol]) {
-    self = StringLiteralSegmentsSyntax(elements.map { 
-      Syntax(fromProtocol: $0) 
-    })
-  }
-  public init (arrayLiteral elements: SyntaxProtocol...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `SwitchCaseList` represents a collection of `Syntax`
 extension SwitchCaseList: ExpressibleByArrayLiteral {
-  /// Creates a `SwitchCaseList` with the provided list of elements.
-  /// - Parameters:
-  ///   - elements: A list of `SyntaxProtocol`
-  public init (_ elements: [SyntaxProtocol]) {
-    self = SwitchCaseListSyntax(elements.map { 
-      Syntax(fromProtocol: $0) 
-    })
-  }
-  public init (arrayLiteral elements: SyntaxProtocol...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `TokenList` represents a collection of `TokenSyntax`
 extension TokenList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: Token...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `TupleExprElementList` represents a collection of `TupleExprElementSyntax`
 extension TupleExprElementList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: TupleExprElement...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `TuplePatternElementList` represents a collection of `TuplePatternElementSyntax`
 extension TuplePatternElementList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: TuplePatternElement...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// `TupleTypeElementList` represents a collection of `TupleTypeElementSyntax`
 extension TupleTypeElementList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: TupleTypeElement...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }
 
 /// A collection of syntax nodes that occurred in the source code butcould not be used to form a valid syntax tree.
 extension UnexpectedNodes: ExpressibleByArrayLiteral {
-  /// Creates a `UnexpectedNodes` with the provided list of elements.
-  /// - Parameters:
-  ///   - elements: A list of `SyntaxProtocol`
   public init (_ elements: [SyntaxProtocol]) {
     self = UnexpectedNodesSyntax(elements.map { 
       Syntax(fromProtocol: $0) 
@@ -388,7 +342,7 @@ extension UnexpectedNodes: ExpressibleByArrayLiteral {
 
 /// `YieldExprList` represents a collection of `YieldExprListElementSyntax`
 extension YieldExprList: ExpressibleByArrayLiteral {
-  public init (arrayLiteral elements: YieldExprListElement...) {
+  public init (arrayLiteral elements: Element...) {
     self.init (elements)
   }
 }

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -370,11 +370,11 @@ extension Attribute {
   ///   - rightParen: If the attribute takes arguments, the closing parenthesis.
   ///   - unexpectedBetweenRightParenAndTokenList: 
   ///   - tokenList: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAtSignToken: UnexpectedNodes? = nil, atSignToken: Token = Token.`atSign`, unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodes? = nil, attributeName: Token, unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgument: UnexpectedNodes? = nil, argument: SyntaxProtocol? = nil, unexpectedBetweenArgumentAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTokenList: UnexpectedNodes? = nil, tokenList: TokenList? = nil) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAtSignToken: UnexpectedNodes? = nil, atSignToken: Token = Token.`atSign`, unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodes? = nil, attributeName: Token, unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgument: UnexpectedNodes? = nil, argument: Argument? = nil, unexpectedBetweenArgumentAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTokenList: UnexpectedNodes? = nil, tokenList: TokenList? = nil) {
     assert(atSignToken.text == "@")
     assert(leftParen == nil || leftParen!.text == "(")
     assert(rightParen == nil || rightParen!.text == ")")
-    self = AttributeSyntax(unexpectedBeforeAtSignToken, atSignToken: atSignToken, unexpectedBetweenAtSignTokenAndAttributeName, attributeName: attributeName, unexpectedBetweenAttributeNameAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgument, argument: Syntax(fromProtocol: argument), unexpectedBetweenArgumentAndRightParen, rightParen: rightParen, unexpectedBetweenRightParenAndTokenList, tokenList: tokenList)
+    self = AttributeSyntax(unexpectedBeforeAtSignToken, atSignToken: atSignToken, unexpectedBetweenAtSignTokenAndAttributeName, attributeName: attributeName, unexpectedBetweenAttributeNameAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgument, argument: argument, unexpectedBetweenArgumentAndRightParen, rightParen: rightParen, unexpectedBetweenRightParenAndTokenList, tokenList: tokenList)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -405,9 +405,9 @@ extension AvailabilityArgument {
   ///   - entry: The actual argument
   ///   - unexpectedBetweenEntryAndTrailingComma: 
   ///   - trailingComma: A trailing comma if the argument is followed by anotherargument
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeEntry: UnexpectedNodes? = nil, entry: SyntaxProtocol, unexpectedBetweenEntryAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeEntry: UnexpectedNodes? = nil, entry: Entry, unexpectedBetweenEntryAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
     assert(trailingComma == nil || trailingComma!.text == ",")
-    self = AvailabilityArgumentSyntax(unexpectedBeforeEntry, entry: Syntax(fromProtocol: entry), unexpectedBetweenEntryAndTrailingComma, trailingComma: trailingComma)
+    self = AvailabilityArgumentSyntax(unexpectedBeforeEntry, entry: entry, unexpectedBetweenEntryAndTrailingComma, trailingComma: trailingComma)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -472,17 +472,17 @@ extension AvailabilityLabeledArgument {
   ///   - colon: The colon separating label and value
   ///   - unexpectedBetweenColonAndValue: 
   ///   - value: The value of this labeled argument
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabel: UnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: UnexpectedNodes? = nil, value: SyntaxProtocol) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabel: UnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: UnexpectedNodes? = nil, value: Value) {
     assert(colon.text == ":")
-    self = AvailabilityLabeledArgumentSyntax(unexpectedBeforeLabel, label: label, unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndValue, value: Syntax(fromProtocol: value))
+    self = AvailabilityLabeledArgumentSyntax(unexpectedBeforeLabel, label: label, unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndValue, value: value)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: UnexpectedNodes? = nil, label: String, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: UnexpectedNodes? = nil, value: SyntaxProtocol) {
-    self.init (unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndValue, value: Syntax(fromProtocol: value))
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: UnexpectedNodes? = nil, label: String, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: UnexpectedNodes? = nil, value: Value) {
+    self.init (unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndValue, value: value)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
   }
 }
@@ -878,19 +878,19 @@ extension ClosureSignature {
   ///   - output: 
   ///   - unexpectedBetweenOutputAndInTok: 
   ///   - inTok: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndCapture: UnexpectedNodes? = nil, capture: ClosureCaptureSignature? = nil, unexpectedBetweenCaptureAndInput: UnexpectedNodes? = nil, input: SyntaxProtocol? = nil, unexpectedBetweenInputAndAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: Token? = nil, unexpectedBetweenAsyncKeywordAndThrowsTok: UnexpectedNodes? = nil, throwsTok: Token? = nil, unexpectedBetweenThrowsTokAndOutput: UnexpectedNodes? = nil, output: ReturnClause? = nil, unexpectedBetweenOutputAndInTok: UnexpectedNodes? = nil, inTok: Token = Token.`in`) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndCapture: UnexpectedNodes? = nil, capture: ClosureCaptureSignature? = nil, unexpectedBetweenCaptureAndInput: UnexpectedNodes? = nil, input: Input? = nil, unexpectedBetweenInputAndAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: Token? = nil, unexpectedBetweenAsyncKeywordAndThrowsTok: UnexpectedNodes? = nil, throwsTok: Token? = nil, unexpectedBetweenThrowsTokAndOutput: UnexpectedNodes? = nil, output: ReturnClause? = nil, unexpectedBetweenOutputAndInTok: UnexpectedNodes? = nil, inTok: Token = Token.`in`) {
     assert(asyncKeyword == nil || asyncKeyword!.text == "async")
     assert(throwsTok == nil || throwsTok!.text == "throws")
     assert(inTok.text == "in")
-    self = ClosureSignatureSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndCapture, capture: capture, unexpectedBetweenCaptureAndInput, input: Syntax(fromProtocol: input), unexpectedBetweenInputAndAsyncKeyword, asyncKeyword: asyncKeyword, unexpectedBetweenAsyncKeywordAndThrowsTok, throwsTok: throwsTok, unexpectedBetweenThrowsTokAndOutput, output: output, unexpectedBetweenOutputAndInTok, inTok: inTok)
+    self = ClosureSignatureSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndCapture, capture: capture, unexpectedBetweenCaptureAndInput, input: input, unexpectedBetweenInputAndAsyncKeyword, asyncKeyword: asyncKeyword, unexpectedBetweenAsyncKeywordAndThrowsTok, throwsTok: throwsTok, unexpectedBetweenThrowsTokAndOutput, output: output, unexpectedBetweenOutputAndInTok, inTok: inTok)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndCapture: UnexpectedNodes? = nil, capture: ClosureCaptureSignature? = nil, unexpectedBetweenCaptureAndInput: UnexpectedNodes? = nil, input: SyntaxProtocol? = nil, unexpectedBetweenInputAndAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: String?, unexpectedBetweenAsyncKeywordAndThrowsTok: UnexpectedNodes? = nil, throwsTok: Token? = nil, unexpectedBetweenThrowsTokAndOutput: UnexpectedNodes? = nil, output: ReturnClause? = nil, unexpectedBetweenOutputAndInTok: UnexpectedNodes? = nil, inTok: Token = Token.`in`) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndCapture, capture: capture, unexpectedBetweenCaptureAndInput, input: Syntax(fromProtocol: input), unexpectedBetweenInputAndAsyncKeyword, asyncKeyword: asyncKeyword.map { 
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndCapture: UnexpectedNodes? = nil, capture: ClosureCaptureSignature? = nil, unexpectedBetweenCaptureAndInput: UnexpectedNodes? = nil, input: Input? = nil, unexpectedBetweenInputAndAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: String?, unexpectedBetweenAsyncKeywordAndThrowsTok: UnexpectedNodes? = nil, throwsTok: Token? = nil, unexpectedBetweenThrowsTokAndOutput: UnexpectedNodes? = nil, output: ReturnClause? = nil, unexpectedBetweenOutputAndInTok: UnexpectedNodes? = nil, inTok: Token = Token.`in`) {
+    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndCapture, capture: capture, unexpectedBetweenCaptureAndInput, input: input, unexpectedBetweenInputAndAsyncKeyword, asyncKeyword: asyncKeyword.map { 
       Token.`contextualKeyword`($0) 
     }, unexpectedBetweenAsyncKeywordAndThrowsTok, throwsTok: throwsTok, unexpectedBetweenThrowsTokAndOutput, output: output, unexpectedBetweenOutputAndInTok, inTok: inTok)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
@@ -907,9 +907,9 @@ extension CodeBlockItem {
   ///   - semicolon: If present, the trailing semicolon at the end of the item.
   ///   - unexpectedBetweenSemicolonAndErrorTokens: 
   ///   - errorTokens: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeItem: UnexpectedNodes? = nil, item: SyntaxProtocol, unexpectedBetweenItemAndSemicolon: UnexpectedNodes? = nil, semicolon: Token? = nil, unexpectedBetweenSemicolonAndErrorTokens: UnexpectedNodes? = nil, errorTokens: SyntaxProtocol? = nil) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeItem: UnexpectedNodes? = nil, item: Item, unexpectedBetweenItemAndSemicolon: UnexpectedNodes? = nil, semicolon: Token? = nil, unexpectedBetweenSemicolonAndErrorTokens: UnexpectedNodes? = nil, errorTokens: SyntaxProtocol? = nil) {
     assert(semicolon == nil || semicolon!.text == ";")
-    self = CodeBlockItemSyntax(unexpectedBeforeItem, item: Syntax(fromProtocol: item), unexpectedBetweenItemAndSemicolon, semicolon: semicolon, unexpectedBetweenSemicolonAndErrorTokens, errorTokens: Syntax(fromProtocol: errorTokens))
+    self = CodeBlockItemSyntax(unexpectedBeforeItem, item: item, unexpectedBetweenItemAndSemicolon, semicolon: semicolon, unexpectedBetweenSemicolonAndErrorTokens, errorTokens: Syntax(fromProtocol: errorTokens))
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -976,9 +976,9 @@ extension ConditionElement: HasTrailingComma {
   ///   - condition: 
   ///   - unexpectedBetweenConditionAndTrailingComma: 
   ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeCondition: UnexpectedNodes? = nil, condition: SyntaxProtocol, unexpectedBetweenConditionAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeCondition: UnexpectedNodes? = nil, condition: Condition, unexpectedBetweenConditionAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
     assert(trailingComma == nil || trailingComma!.text == ",")
-    self = ConditionElementSyntax(unexpectedBeforeCondition, condition: Syntax(fromProtocol: condition), unexpectedBetweenConditionAndTrailingComma, trailingComma: trailingComma)
+    self = ConditionElementSyntax(unexpectedBeforeCondition, condition: condition, unexpectedBetweenConditionAndTrailingComma, trailingComma: trailingComma)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -1228,8 +1228,8 @@ extension DeclName {
   ///   - declBaseName: The base name of the protocol's requirement.
   ///   - unexpectedBetweenDeclBaseNameAndDeclNameArguments: 
   ///   - declNameArguments: The argument labels of the protocol's requirement if itis a function requirement.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDeclBaseName: UnexpectedNodes? = nil, declBaseName: SyntaxProtocol, unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodes? = nil, declNameArguments: DeclNameArguments? = nil) {
-    self = DeclNameSyntax(unexpectedBeforeDeclBaseName, declBaseName: Syntax(fromProtocol: declBaseName), unexpectedBetweenDeclBaseNameAndDeclNameArguments, declNameArguments: declNameArguments)
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDeclBaseName: UnexpectedNodes? = nil, declBaseName: DeclBaseName, unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodes? = nil, declNameArguments: DeclNameArguments? = nil) {
+    self = DeclNameSyntax(unexpectedBeforeDeclBaseName, declBaseName: declBaseName, unexpectedBetweenDeclBaseNameAndDeclNameArguments, declNameArguments: declNameArguments)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -1398,10 +1398,10 @@ extension DictionaryExpr {
   ///   - content: 
   ///   - unexpectedBetweenContentAndRightSquare: 
   ///   - rightSquare: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftSquare: UnexpectedNodes? = nil, leftSquare: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareAndContent: UnexpectedNodes? = nil, content: SyntaxProtocol, unexpectedBetweenContentAndRightSquare: UnexpectedNodes? = nil, rightSquare: Token = Token.`rightSquareBracket`) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftSquare: UnexpectedNodes? = nil, leftSquare: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareAndContent: UnexpectedNodes? = nil, content: Content, unexpectedBetweenContentAndRightSquare: UnexpectedNodes? = nil, rightSquare: Token = Token.`rightSquareBracket`) {
     assert(leftSquare.text == "[")
     assert(rightSquare.text == "]")
-    self = DictionaryExprSyntax(unexpectedBeforeLeftSquare, leftSquare: leftSquare, unexpectedBetweenLeftSquareAndContent, content: Syntax(fromProtocol: content), unexpectedBetweenContentAndRightSquare, rightSquare: rightSquare)
+    self = DictionaryExprSyntax(unexpectedBeforeLeftSquare, leftSquare: leftSquare, unexpectedBetweenLeftSquareAndContent, content: content, unexpectedBetweenContentAndRightSquare, rightSquare: rightSquare)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -1438,9 +1438,9 @@ extension DifferentiabilityParam: HasTrailingComma {
   ///   - parameter: 
   ///   - unexpectedBetweenParameterAndTrailingComma: 
   ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeParameter: UnexpectedNodes? = nil, parameter: SyntaxProtocol, unexpectedBetweenParameterAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeParameter: UnexpectedNodes? = nil, parameter: Parameter, unexpectedBetweenParameterAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
     assert(trailingComma == nil || trailingComma!.text == ",")
-    self = DifferentiabilityParamSyntax(unexpectedBeforeParameter, parameter: Syntax(fromProtocol: parameter), unexpectedBetweenParameterAndTrailingComma, trailingComma: trailingComma)
+    self = DifferentiabilityParamSyntax(unexpectedBeforeParameter, parameter: parameter, unexpectedBetweenParameterAndTrailingComma, trailingComma: trailingComma)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -1463,18 +1463,18 @@ extension DifferentiabilityParamsClause {
   ///   - colon: The colon separating "wrt" and the parameter list.
   ///   - unexpectedBetweenColonAndParameters: 
   ///   - parameters: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWrtLabel: UnexpectedNodes? = nil, wrtLabel: Token, unexpectedBetweenWrtLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndParameters: UnexpectedNodes? = nil, parameters: SyntaxProtocol) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWrtLabel: UnexpectedNodes? = nil, wrtLabel: Token, unexpectedBetweenWrtLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndParameters: UnexpectedNodes? = nil, parameters: Parameters) {
     assert(wrtLabel.text == "wrt")
     assert(colon.text == ":")
-    self = DifferentiabilityParamsClauseSyntax(unexpectedBeforeWrtLabel, wrtLabel: wrtLabel, unexpectedBetweenWrtLabelAndColon, colon: colon, unexpectedBetweenColonAndParameters, parameters: Syntax(fromProtocol: parameters))
+    self = DifferentiabilityParamsClauseSyntax(unexpectedBeforeWrtLabel, wrtLabel: wrtLabel, unexpectedBetweenWrtLabelAndColon, colon: colon, unexpectedBetweenColonAndParameters, parameters: parameters)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeWrtLabel: UnexpectedNodes? = nil, wrtLabel: String, unexpectedBetweenWrtLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndParameters: UnexpectedNodes? = nil, parameters: SyntaxProtocol) {
-    self.init (unexpectedBeforeWrtLabel, wrtLabel: Token.`identifier`(wrtLabel), unexpectedBetweenWrtLabelAndColon, colon: colon, unexpectedBetweenColonAndParameters, parameters: Syntax(fromProtocol: parameters))
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeWrtLabel: UnexpectedNodes? = nil, wrtLabel: String, unexpectedBetweenWrtLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndParameters: UnexpectedNodes? = nil, parameters: Parameters) {
+    self.init (unexpectedBeforeWrtLabel, wrtLabel: Token.`identifier`(wrtLabel), unexpectedBetweenWrtLabelAndColon, colon: colon, unexpectedBetweenColonAndParameters, parameters: parameters)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
   }
 }
@@ -1941,8 +1941,8 @@ extension FunctionDeclName {
   ///   - name: The base name of the referenced function.
   ///   - unexpectedBetweenNameAndArguments: 
   ///   - arguments: The argument labels of the referenced function, optionallyspecified.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: SyntaxProtocol, unexpectedBetweenNameAndArguments: UnexpectedNodes? = nil, arguments: DeclNameArguments? = nil) {
-    self = FunctionDeclNameSyntax(unexpectedBeforeName, name: Syntax(fromProtocol: name), unexpectedBetweenNameAndArguments, arguments: arguments)
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: Name, unexpectedBetweenNameAndArguments: UnexpectedNodes? = nil, arguments: DeclNameArguments? = nil) {
+    self = FunctionDeclNameSyntax(unexpectedBeforeName, name: name, unexpectedBetweenNameAndArguments, arguments: arguments)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -2206,9 +2206,9 @@ extension GenericRequirement: HasTrailingComma {
   ///   - body: 
   ///   - unexpectedBetweenBodyAndTrailingComma: 
   ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBody: UnexpectedNodes? = nil, body: SyntaxProtocol, unexpectedBetweenBodyAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBody: UnexpectedNodes? = nil, body: Body, unexpectedBetweenBodyAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
     assert(trailingComma == nil || trailingComma!.text == ",")
-    self = GenericRequirementSyntax(unexpectedBeforeBody, body: Syntax(fromProtocol: body), unexpectedBetweenBodyAndTrailingComma, trailingComma: trailingComma)
+    self = GenericRequirementSyntax(unexpectedBeforeBody, body: body, unexpectedBetweenBodyAndTrailingComma, trailingComma: trailingComma)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -2329,9 +2329,9 @@ extension IfConfigClause {
   ///   - condition: 
   ///   - unexpectedBetweenConditionAndElements: 
   ///   - elements: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundKeyword: UnexpectedNodes? = nil, poundKeyword: Token, unexpectedBetweenPoundKeywordAndCondition: UnexpectedNodes? = nil, condition: ExprSyntaxProtocol? = nil, unexpectedBetweenConditionAndElements: UnexpectedNodes? = nil, elements: SyntaxProtocol? = nil) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundKeyword: UnexpectedNodes? = nil, poundKeyword: Token, unexpectedBetweenPoundKeywordAndCondition: UnexpectedNodes? = nil, condition: ExprSyntaxProtocol? = nil, unexpectedBetweenConditionAndElements: UnexpectedNodes? = nil, elements: Elements? = nil) {
     assert(poundKeyword.text == "#if" || poundKeyword.text == "#elseif" || poundKeyword.text == "#else")
-    self = IfConfigClauseSyntax(unexpectedBeforePoundKeyword, poundKeyword: poundKeyword, unexpectedBetweenPoundKeywordAndCondition, condition: ExprSyntax(fromProtocol: condition), unexpectedBetweenConditionAndElements, elements: Syntax(fromProtocol: elements))
+    self = IfConfigClauseSyntax(unexpectedBeforePoundKeyword, poundKeyword: poundKeyword, unexpectedBetweenPoundKeywordAndCondition, condition: ExprSyntax(fromProtocol: condition), unexpectedBetweenConditionAndElements, elements: elements)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -2365,20 +2365,20 @@ extension IfStmt {
   ///   - elseKeyword: 
   ///   - unexpectedBetweenElseKeywordAndElseBody: 
   ///   - elseBody: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIfKeyword: UnexpectedNodes? = nil, ifKeyword: Token = Token.`if`, unexpectedBetweenIfKeywordAndConditions: UnexpectedNodes? = nil, conditions: ConditionElementList, unexpectedBetweenConditionsAndBody: UnexpectedNodes? = nil, body: CodeBlock, unexpectedBetweenBodyAndElseKeyword: UnexpectedNodes? = nil, elseKeyword: Token? = nil, unexpectedBetweenElseKeywordAndElseBody: UnexpectedNodes? = nil, elseBody: SyntaxProtocol? = nil) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIfKeyword: UnexpectedNodes? = nil, ifKeyword: Token = Token.`if`, unexpectedBetweenIfKeywordAndConditions: UnexpectedNodes? = nil, conditions: ConditionElementList, unexpectedBetweenConditionsAndBody: UnexpectedNodes? = nil, body: CodeBlock, unexpectedBetweenBodyAndElseKeyword: UnexpectedNodes? = nil, elseKeyword: Token? = nil, unexpectedBetweenElseKeywordAndElseBody: UnexpectedNodes? = nil, elseBody: ElseBody? = nil) {
     assert(ifKeyword.text == "if")
     assert(elseKeyword == nil || elseKeyword!.text == "else")
-    self = IfStmtSyntax(unexpectedBeforeIfKeyword, ifKeyword: ifKeyword, unexpectedBetweenIfKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndBody, body: body, unexpectedBetweenBodyAndElseKeyword, elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndElseBody, elseBody: Syntax(fromProtocol: elseBody))
+    self = IfStmtSyntax(unexpectedBeforeIfKeyword, ifKeyword: ifKeyword, unexpectedBetweenIfKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndBody, body: body, unexpectedBetweenBodyAndElseKeyword, elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndElseBody, elseBody: elseBody)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeIfKeyword: UnexpectedNodes? = nil, ifKeyword: Token = Token.`if`, unexpectedBetweenIfKeywordAndConditions: UnexpectedNodes? = nil, conditions: ConditionElementList, unexpectedBetweenConditionsAndBody: UnexpectedNodes? = nil, unexpectedBetweenBodyAndElseKeyword: UnexpectedNodes? = nil, elseKeyword: Token? = nil, unexpectedBetweenElseKeywordAndElseBody: UnexpectedNodes? = nil, elseBody: SyntaxProtocol? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeIfKeyword: UnexpectedNodes? = nil, ifKeyword: Token = Token.`if`, unexpectedBetweenIfKeywordAndConditions: UnexpectedNodes? = nil, conditions: ConditionElementList, unexpectedBetweenConditionsAndBody: UnexpectedNodes? = nil, unexpectedBetweenBodyAndElseKeyword: UnexpectedNodes? = nil, elseKeyword: Token? = nil, unexpectedBetweenElseKeywordAndElseBody: UnexpectedNodes? = nil, elseBody: ElseBody? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
     CodeBlockItemListSyntax([])
   }) {
-    self.init (unexpectedBeforeIfKeyword, ifKeyword: ifKeyword, unexpectedBetweenIfKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndBody, body: CodeBlockSyntax(statements: bodyBuilder()), unexpectedBetweenBodyAndElseKeyword, elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndElseBody, elseBody: Syntax(fromProtocol: elseBody))
+    self.init (unexpectedBeforeIfKeyword, ifKeyword: ifKeyword, unexpectedBetweenIfKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndBody, body: CodeBlockSyntax(statements: bodyBuilder()), unexpectedBetweenBodyAndElseKeyword, elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndElseBody, elseBody: elseBody)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
   }
 }
@@ -2618,9 +2618,9 @@ extension KeyPathComponent {
   ///   - period: 
   ///   - unexpectedBetweenPeriodAndComponent: 
   ///   - component: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePeriod: UnexpectedNodes? = nil, period: Token? = nil, unexpectedBetweenPeriodAndComponent: UnexpectedNodes? = nil, component: SyntaxProtocol) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePeriod: UnexpectedNodes? = nil, period: Token? = nil, unexpectedBetweenPeriodAndComponent: UnexpectedNodes? = nil, component: Component) {
     assert(period == nil || period!.text == "." || period!.text == ".")
-    self = KeyPathComponentSyntax(unexpectedBeforePeriod, period: period, unexpectedBetweenPeriodAndComponent, component: Syntax(fromProtocol: component))
+    self = KeyPathComponentSyntax(unexpectedBeforePeriod, period: period, unexpectedBetweenPeriodAndComponent, component: component)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -3045,9 +3045,9 @@ extension NamedAttributeStringArgument {
   ///   - colon: The colon separating the label and the value
   ///   - unexpectedBetweenColonAndStringOrDeclname: 
   ///   - stringOrDeclname: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeNameTok: UnexpectedNodes? = nil, nameTok: Token, unexpectedBetweenNameTokAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndStringOrDeclname: UnexpectedNodes? = nil, stringOrDeclname: SyntaxProtocol) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeNameTok: UnexpectedNodes? = nil, nameTok: Token, unexpectedBetweenNameTokAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndStringOrDeclname: UnexpectedNodes? = nil, stringOrDeclname: StringOrDeclname) {
     assert(colon.text == ":")
-    self = NamedAttributeStringArgumentSyntax(unexpectedBeforeNameTok, nameTok: nameTok, unexpectedBetweenNameTokAndColon, colon: colon, unexpectedBetweenColonAndStringOrDeclname, stringOrDeclname: Syntax(fromProtocol: stringOrDeclname))
+    self = NamedAttributeStringArgumentSyntax(unexpectedBeforeNameTok, nameTok: nameTok, unexpectedBetweenNameTokAndColon, colon: colon, unexpectedBetweenColonAndStringOrDeclname, stringOrDeclname: stringOrDeclname)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -3223,9 +3223,9 @@ extension OldKeyPathExpr {
   ///   - rootExpr: 
   ///   - unexpectedBetweenRootExprAndExpression: 
   ///   - expression: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBackslash: UnexpectedNodes? = nil, backslash: Token = Token.`backslash`, unexpectedBetweenBackslashAndRootExpr: UnexpectedNodes? = nil, rootExpr: ExprSyntaxProtocol? = nil, unexpectedBetweenRootExprAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBackslash: UnexpectedNodes? = nil, backslash: Token = Token.`backslash`, unexpectedBetweenBackslashAndRootExpr: UnexpectedNodes? = nil, rootExpr: RootExpr? = nil, unexpectedBetweenRootExprAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol) {
     assert(backslash.text == #"\"#)
-    self = OldKeyPathExprSyntax(unexpectedBeforeBackslash, backslash: backslash, unexpectedBetweenBackslashAndRootExpr, rootExpr: ExprSyntax(fromProtocol: rootExpr), unexpectedBetweenRootExprAndExpression, expression: ExprSyntax(fromProtocol: expression))
+    self = OldKeyPathExprSyntax(unexpectedBeforeBackslash, backslash: backslash, unexpectedBetweenBackslashAndRootExpr, rootExpr: rootExpr, unexpectedBetweenRootExprAndExpression, expression: ExprSyntax(fromProtocol: expression))
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -3422,9 +3422,9 @@ extension PatternBinding: HasTrailingComma {
   ///   - accessor: 
   ///   - unexpectedBetweenAccessorAndTrailingComma: 
   ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePattern: UnexpectedNodes? = nil, pattern: PatternSyntaxProtocol, unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodes? = nil, typeAnnotation: TypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodes? = nil, initializer: InitializerClause? = nil, unexpectedBetweenInitializerAndAccessor: UnexpectedNodes? = nil, accessor: SyntaxProtocol? = nil, unexpectedBetweenAccessorAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePattern: UnexpectedNodes? = nil, pattern: PatternSyntaxProtocol, unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodes? = nil, typeAnnotation: TypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodes? = nil, initializer: InitializerClause? = nil, unexpectedBetweenInitializerAndAccessor: UnexpectedNodes? = nil, accessor: Accessor? = nil, unexpectedBetweenAccessorAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
     assert(trailingComma == nil || trailingComma!.text == ",")
-    self = PatternBindingSyntax(unexpectedBeforePattern, pattern: PatternSyntax(fromProtocol: pattern), unexpectedBetweenPatternAndTypeAnnotation, typeAnnotation: typeAnnotation, unexpectedBetweenTypeAnnotationAndInitializer, initializer: initializer, unexpectedBetweenInitializerAndAccessor, accessor: Syntax(fromProtocol: accessor), unexpectedBetweenAccessorAndTrailingComma, trailingComma: trailingComma)
+    self = PatternBindingSyntax(unexpectedBeforePattern, pattern: PatternSyntax(fromProtocol: pattern), unexpectedBetweenPatternAndTypeAnnotation, typeAnnotation: typeAnnotation, unexpectedBetweenTypeAnnotationAndInitializer, initializer: initializer, unexpectedBetweenInitializerAndAccessor, accessor: accessor, unexpectedBetweenAccessorAndTrailingComma, trailingComma: trailingComma)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -4233,9 +4233,9 @@ extension SubscriptDecl {
   ///   - genericWhereClause: 
   ///   - unexpectedBetweenGenericWhereClauseAndAccessor: 
   ///   - accessor: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndSubscriptKeyword: UnexpectedNodes? = nil, subscriptKeyword: Token = Token.`subscript`, unexpectedBetweenSubscriptKeywordAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndIndices: UnexpectedNodes? = nil, indices: ParameterClause, unexpectedBetweenIndicesAndResult: UnexpectedNodes? = nil, result: ReturnClause, unexpectedBetweenResultAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndAccessor: UnexpectedNodes? = nil, accessor: SyntaxProtocol? = nil) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndSubscriptKeyword: UnexpectedNodes? = nil, subscriptKeyword: Token = Token.`subscript`, unexpectedBetweenSubscriptKeywordAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndIndices: UnexpectedNodes? = nil, indices: ParameterClause, unexpectedBetweenIndicesAndResult: UnexpectedNodes? = nil, result: ReturnClause, unexpectedBetweenResultAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndAccessor: UnexpectedNodes? = nil, accessor: Accessor? = nil) {
     assert(subscriptKeyword.text == "subscript")
-    self = SubscriptDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndSubscriptKeyword, subscriptKeyword: subscriptKeyword, unexpectedBetweenSubscriptKeywordAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndIndices, indices: indices, unexpectedBetweenIndicesAndResult, result: result, unexpectedBetweenResultAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndAccessor, accessor: Syntax(fromProtocol: accessor))
+    self = SubscriptDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndSubscriptKeyword, subscriptKeyword: subscriptKeyword, unexpectedBetweenSubscriptKeywordAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndIndices, indices: indices, unexpectedBetweenIndicesAndResult, result: result, unexpectedBetweenResultAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndAccessor, accessor: accessor)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -4323,18 +4323,18 @@ extension SwitchCase {
   ///   - label: 
   ///   - unexpectedBetweenLabelAndStatements: 
   ///   - statements: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeUnknownAttr: UnexpectedNodes? = nil, unknownAttr: Attribute? = nil, unexpectedBetweenUnknownAttrAndLabel: UnexpectedNodes? = nil, label: SyntaxProtocol, unexpectedBetweenLabelAndStatements: UnexpectedNodes? = nil, statements: CodeBlockItemList) {
-    self = SwitchCaseSyntax(unexpectedBeforeUnknownAttr, unknownAttr: unknownAttr, unexpectedBetweenUnknownAttrAndLabel, label: Syntax(fromProtocol: label), unexpectedBetweenLabelAndStatements, statements: statements)
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeUnknownAttr: UnexpectedNodes? = nil, unknownAttr: Attribute? = nil, unexpectedBetweenUnknownAttrAndLabel: UnexpectedNodes? = nil, label: Label, unexpectedBetweenLabelAndStatements: UnexpectedNodes? = nil, statements: CodeBlockItemList) {
+    self = SwitchCaseSyntax(unexpectedBeforeUnknownAttr, unknownAttr: unknownAttr, unexpectedBetweenUnknownAttrAndLabel, label: label, unexpectedBetweenLabelAndStatements, statements: statements)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeUnknownAttr: UnexpectedNodes? = nil, unknownAttr: Attribute? = nil, unexpectedBetweenUnknownAttrAndLabel: UnexpectedNodes? = nil, label: SyntaxProtocol, unexpectedBetweenLabelAndStatements: UnexpectedNodes? = nil, @CodeBlockItemListBuilder statementsBuilder: () -> CodeBlockItemListSyntax = {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeUnknownAttr: UnexpectedNodes? = nil, unknownAttr: Attribute? = nil, unexpectedBetweenUnknownAttrAndLabel: UnexpectedNodes? = nil, label: Label, unexpectedBetweenLabelAndStatements: UnexpectedNodes? = nil, @CodeBlockItemListBuilder statementsBuilder: () -> CodeBlockItemListSyntax = {
     CodeBlockItemListSyntax([])
   }) {
-    self.init (unexpectedBeforeUnknownAttr, unknownAttr: unknownAttr, unexpectedBetweenUnknownAttrAndLabel, label: Syntax(fromProtocol: label), unexpectedBetweenLabelAndStatements, statements: statementsBuilder())
+    self.init (unexpectedBeforeUnknownAttr, unknownAttr: unknownAttr, unexpectedBetweenUnknownAttrAndLabel, label: label, unexpectedBetweenLabelAndStatements, statements: statementsBuilder())
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
   }
 }
@@ -4901,17 +4901,17 @@ extension VersionTuple {
   ///   - patchPeriod: If the version contains a patch number, the periodseparating the minor from the patch number.
   ///   - unexpectedBetweenPatchPeriodAndPatchVersion: 
   ///   - patchVersion: The patch version if specified.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeMajorMinor: UnexpectedNodes? = nil, majorMinor: SyntaxProtocol, unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodes? = nil, patchPeriod: Token? = nil, unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodes? = nil, patchVersion: Token? = nil) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeMajorMinor: UnexpectedNodes? = nil, majorMinor: MajorMinor, unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodes? = nil, patchPeriod: Token? = nil, unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodes? = nil, patchVersion: Token? = nil) {
     assert(patchPeriod == nil || patchPeriod!.text == ".")
-    self = VersionTupleSyntax(unexpectedBeforeMajorMinor, majorMinor: Syntax(fromProtocol: majorMinor), unexpectedBetweenMajorMinorAndPatchPeriod, patchPeriod: patchPeriod, unexpectedBetweenPatchPeriodAndPatchVersion, patchVersion: patchVersion)
+    self = VersionTupleSyntax(unexpectedBeforeMajorMinor, majorMinor: majorMinor, unexpectedBetweenMajorMinorAndPatchPeriod, patchPeriod: patchPeriod, unexpectedBetweenPatchPeriodAndPatchVersion, patchVersion: patchVersion)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeMajorMinor: UnexpectedNodes? = nil, majorMinor: SyntaxProtocol, unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodes? = nil, patchPeriod: Token? = nil, unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodes? = nil, patchVersion: String?) {
-    self.init (unexpectedBeforeMajorMinor, majorMinor: Syntax(fromProtocol: majorMinor), unexpectedBetweenMajorMinorAndPatchPeriod, patchPeriod: patchPeriod, unexpectedBetweenPatchPeriodAndPatchVersion, patchVersion: patchVersion.map { 
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeMajorMinor: UnexpectedNodes? = nil, majorMinor: MajorMinor, unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodes? = nil, patchPeriod: Token? = nil, unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodes? = nil, patchVersion: String?) {
+    self.init (unexpectedBeforeMajorMinor, majorMinor: majorMinor, unexpectedBetweenMajorMinorAndPatchPeriod, patchPeriod: patchPeriod, unexpectedBetweenPatchPeriodAndPatchVersion, patchVersion: patchVersion.map { 
       Token.`integerLiteral`($0) 
     })
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
@@ -5014,9 +5014,9 @@ extension YieldStmt {
   ///   - yieldKeyword: 
   ///   - unexpectedBetweenYieldKeywordAndYields: 
   ///   - yields: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeYieldKeyword: UnexpectedNodes? = nil, yieldKeyword: Token = Token.`yield`, unexpectedBetweenYieldKeywordAndYields: UnexpectedNodes? = nil, yields: SyntaxProtocol) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeYieldKeyword: UnexpectedNodes? = nil, yieldKeyword: Token = Token.`yield`, unexpectedBetweenYieldKeywordAndYields: UnexpectedNodes? = nil, yields: Yields) {
     assert(yieldKeyword.text == "yield")
-    self = YieldStmtSyntax(unexpectedBeforeYieldKeyword, yieldKeyword: yieldKeyword, unexpectedBetweenYieldKeywordAndYields, yields: Syntax(fromProtocol: yields))
+    self = YieldStmtSyntax(unexpectedBeforeYieldKeyword, yieldKeyword: yieldKeyword, unexpectedBetweenYieldKeywordAndYields, yields: yields)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }

--- a/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
@@ -15,7 +15,6 @@
 
 import SwiftSyntax
 
-
 @resultBuilder
 public struct AccessPathBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -23,45 +22,45 @@ public struct AccessPathBuilder {
   public typealias Expression = AccessPathComponent
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [AccessPathComponent]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = AccessPath
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -69,7 +68,7 @@ public struct AccessPathBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -87,7 +86,6 @@ public extension AccessPath {
   }
 }
 
-
 @resultBuilder
 public struct AccessorListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -95,45 +93,45 @@ public struct AccessorListBuilder {
   public typealias Expression = AccessorDecl
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [AccessorDecl]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = AccessorList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -141,7 +139,7 @@ public struct AccessorListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -159,7 +157,6 @@ public extension AccessorList {
   }
 }
 
-
 @resultBuilder
 public struct ArrayElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -167,45 +164,45 @@ public struct ArrayElementListBuilder {
   public typealias Expression = ArrayElement
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [ArrayElement]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ArrayElementList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -213,7 +210,7 @@ public struct ArrayElementListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -234,53 +231,62 @@ public extension ArrayElementList {
   }
 }
 
-
 @resultBuilder
 public struct AttributeListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = SyntaxProtocol
+  public typealias Expression = AttributeList.Element
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [SyntaxProtocol]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = AttributeList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: Attribute) -> Self.Component {
+    return buildExpression(.init (expression))
+  }
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: CustomAttribute) -> Self.Component {
+    return buildExpression(.init (expression))
+  }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -288,7 +294,7 @@ public struct AttributeListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -306,7 +312,6 @@ public extension AttributeList {
   }
 }
 
-
 @resultBuilder
 public struct AvailabilitySpecListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -314,45 +319,45 @@ public struct AvailabilitySpecListBuilder {
   public typealias Expression = AvailabilityArgument
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [AvailabilityArgument]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = AvailabilitySpecList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -360,7 +365,7 @@ public struct AvailabilitySpecListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -378,7 +383,6 @@ public extension AvailabilitySpecList {
   }
 }
 
-
 @resultBuilder
 public struct BackDeployVersionListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -386,45 +390,45 @@ public struct BackDeployVersionListBuilder {
   public typealias Expression = BackDeployVersionArgument
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [BackDeployVersionArgument]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = BackDeployVersionList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -432,7 +436,7 @@ public struct BackDeployVersionListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -450,7 +454,6 @@ public extension BackDeployVersionList {
   }
 }
 
-
 @resultBuilder
 public struct CaseItemListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -458,45 +461,45 @@ public struct CaseItemListBuilder {
   public typealias Expression = CaseItem
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [CaseItem]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = CaseItemList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -504,7 +507,7 @@ public struct CaseItemListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -525,7 +528,6 @@ public extension CaseItemList {
   }
 }
 
-
 @resultBuilder
 public struct CatchClauseListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -533,45 +535,45 @@ public struct CatchClauseListBuilder {
   public typealias Expression = CatchClause
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [CatchClause]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = CatchClauseList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -579,7 +581,7 @@ public struct CatchClauseListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -597,7 +599,6 @@ public extension CatchClauseList {
   }
 }
 
-
 @resultBuilder
 public struct CatchItemListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -605,45 +606,45 @@ public struct CatchItemListBuilder {
   public typealias Expression = CatchItem
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [CatchItem]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = CatchItemList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -651,7 +652,7 @@ public struct CatchItemListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -672,7 +673,6 @@ public extension CatchItemList {
   }
 }
 
-
 @resultBuilder
 public struct ClosureCaptureItemListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -680,45 +680,45 @@ public struct ClosureCaptureItemListBuilder {
   public typealias Expression = ClosureCaptureItem
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [ClosureCaptureItem]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ClosureCaptureItemList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -726,7 +726,7 @@ public struct ClosureCaptureItemListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -747,7 +747,6 @@ public extension ClosureCaptureItemList {
   }
 }
 
-
 @resultBuilder
 public struct ClosureParamListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -755,45 +754,45 @@ public struct ClosureParamListBuilder {
   public typealias Expression = ClosureParam
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [ClosureParam]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ClosureParamList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -801,7 +800,7 @@ public struct ClosureParamListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -822,7 +821,6 @@ public extension ClosureParamList {
   }
 }
 
-
 @resultBuilder
 public struct CodeBlockItemListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -830,45 +828,45 @@ public struct CodeBlockItemListBuilder {
   public typealias Expression = CodeBlockItem
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [CodeBlockItem]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = CodeBlockItemList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -876,7 +874,7 @@ public struct CodeBlockItemListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -894,7 +892,6 @@ public extension CodeBlockItemList {
   }
 }
 
-
 @resultBuilder
 public struct CompositionTypeElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -902,45 +899,45 @@ public struct CompositionTypeElementListBuilder {
   public typealias Expression = CompositionTypeElement
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [CompositionTypeElement]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = CompositionTypeElementList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -948,7 +945,7 @@ public struct CompositionTypeElementListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -966,7 +963,6 @@ public extension CompositionTypeElementList {
   }
 }
 
-
 @resultBuilder
 public struct ConditionElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -974,45 +970,45 @@ public struct ConditionElementListBuilder {
   public typealias Expression = ConditionElement
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [ConditionElement]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ConditionElementList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -1020,7 +1016,7 @@ public struct ConditionElementListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -1041,7 +1037,6 @@ public extension ConditionElementList {
   }
 }
 
-
 @resultBuilder
 public struct DeclNameArgumentListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -1049,45 +1044,45 @@ public struct DeclNameArgumentListBuilder {
   public typealias Expression = DeclNameArgument
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [DeclNameArgument]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = DeclNameArgumentList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -1095,7 +1090,7 @@ public struct DeclNameArgumentListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -1113,7 +1108,6 @@ public extension DeclNameArgumentList {
   }
 }
 
-
 @resultBuilder
 public struct DesignatedTypeListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -1121,45 +1115,45 @@ public struct DesignatedTypeListBuilder {
   public typealias Expression = DesignatedTypeElement
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [DesignatedTypeElement]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = DesignatedTypeList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -1167,7 +1161,7 @@ public struct DesignatedTypeListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -1185,7 +1179,6 @@ public extension DesignatedTypeList {
   }
 }
 
-
 @resultBuilder
 public struct DictionaryElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -1193,45 +1186,45 @@ public struct DictionaryElementListBuilder {
   public typealias Expression = DictionaryElement
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [DictionaryElement]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = DictionaryElementList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -1239,7 +1232,7 @@ public struct DictionaryElementListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -1260,7 +1253,6 @@ public extension DictionaryElementList {
   }
 }
 
-
 @resultBuilder
 public struct DifferentiabilityParamListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -1268,45 +1260,45 @@ public struct DifferentiabilityParamListBuilder {
   public typealias Expression = DifferentiabilityParam
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [DifferentiabilityParam]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = DifferentiabilityParamList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -1314,7 +1306,7 @@ public struct DifferentiabilityParamListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -1335,7 +1327,6 @@ public extension DifferentiabilityParamList {
   }
 }
 
-
 @resultBuilder
 public struct EnumCaseElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -1343,45 +1334,45 @@ public struct EnumCaseElementListBuilder {
   public typealias Expression = EnumCaseElement
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [EnumCaseElement]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = EnumCaseElementList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -1389,7 +1380,7 @@ public struct EnumCaseElementListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -1410,7 +1401,6 @@ public extension EnumCaseElementList {
   }
 }
 
-
 @resultBuilder
 public struct ExprListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -1418,45 +1408,45 @@ public struct ExprListBuilder {
   public typealias Expression = ExprSyntaxProtocol
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [ExprSyntaxProtocol]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ExprList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -1464,7 +1454,7 @@ public struct ExprListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -1482,7 +1472,6 @@ public extension ExprList {
   }
 }
 
-
 @resultBuilder
 public struct FunctionParameterListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -1490,45 +1479,45 @@ public struct FunctionParameterListBuilder {
   public typealias Expression = FunctionParameter
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [FunctionParameter]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = FunctionParameterList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -1536,7 +1525,7 @@ public struct FunctionParameterListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -1557,7 +1546,6 @@ public extension FunctionParameterList {
   }
 }
 
-
 @resultBuilder
 public struct GenericArgumentListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -1565,45 +1553,45 @@ public struct GenericArgumentListBuilder {
   public typealias Expression = GenericArgument
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [GenericArgument]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = GenericArgumentList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -1611,7 +1599,7 @@ public struct GenericArgumentListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -1632,7 +1620,6 @@ public extension GenericArgumentList {
   }
 }
 
-
 @resultBuilder
 public struct GenericParameterListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -1640,45 +1627,45 @@ public struct GenericParameterListBuilder {
   public typealias Expression = GenericParameter
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [GenericParameter]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = GenericParameterList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -1686,7 +1673,7 @@ public struct GenericParameterListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -1707,7 +1694,6 @@ public extension GenericParameterList {
   }
 }
 
-
 @resultBuilder
 public struct GenericRequirementListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -1715,45 +1701,45 @@ public struct GenericRequirementListBuilder {
   public typealias Expression = GenericRequirement
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [GenericRequirement]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = GenericRequirementList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -1761,7 +1747,7 @@ public struct GenericRequirementListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -1782,7 +1768,6 @@ public extension GenericRequirementList {
   }
 }
 
-
 @resultBuilder
 public struct IfConfigClauseListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -1790,45 +1775,45 @@ public struct IfConfigClauseListBuilder {
   public typealias Expression = IfConfigClause
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [IfConfigClause]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = IfConfigClauseList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -1836,7 +1821,7 @@ public struct IfConfigClauseListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -1854,7 +1839,6 @@ public extension IfConfigClauseList {
   }
 }
 
-
 @resultBuilder
 public struct InheritedTypeListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -1862,45 +1846,45 @@ public struct InheritedTypeListBuilder {
   public typealias Expression = InheritedType
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [InheritedType]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = InheritedTypeList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -1908,7 +1892,7 @@ public struct InheritedTypeListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -1929,7 +1913,6 @@ public extension InheritedTypeList {
   }
 }
 
-
 @resultBuilder
 public struct KeyPathComponentListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -1937,45 +1920,45 @@ public struct KeyPathComponentListBuilder {
   public typealias Expression = KeyPathComponent
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [KeyPathComponent]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = KeyPathComponentList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -1983,7 +1966,7 @@ public struct KeyPathComponentListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -2001,7 +1984,6 @@ public extension KeyPathComponentList {
   }
 }
 
-
 @resultBuilder
 public struct MemberDeclListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -2009,45 +1991,45 @@ public struct MemberDeclListBuilder {
   public typealias Expression = MemberDeclListItem
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [MemberDeclListItem]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = MemberDeclList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -2055,7 +2037,7 @@ public struct MemberDeclListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -2073,7 +2055,6 @@ public extension MemberDeclList {
   }
 }
 
-
 @resultBuilder
 public struct ModifierListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -2081,45 +2062,45 @@ public struct ModifierListBuilder {
   public typealias Expression = DeclModifier
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [DeclModifier]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ModifierList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -2127,7 +2108,7 @@ public struct ModifierListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -2145,7 +2126,6 @@ public extension ModifierList {
   }
 }
 
-
 @resultBuilder
 public struct MultipleTrailingClosureElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -2153,45 +2133,45 @@ public struct MultipleTrailingClosureElementListBuilder {
   public typealias Expression = MultipleTrailingClosureElement
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [MultipleTrailingClosureElement]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = MultipleTrailingClosureElementList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -2199,7 +2179,7 @@ public struct MultipleTrailingClosureElementListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -2217,7 +2197,6 @@ public extension MultipleTrailingClosureElementList {
   }
 }
 
-
 @resultBuilder
 public struct NonEmptyTokenListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -2225,45 +2204,45 @@ public struct NonEmptyTokenListBuilder {
   public typealias Expression = Token
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [Token]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = NonEmptyTokenList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -2271,7 +2250,7 @@ public struct NonEmptyTokenListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -2289,7 +2268,6 @@ public extension NonEmptyTokenList {
   }
 }
 
-
 @resultBuilder
 public struct ObjCSelectorBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -2297,45 +2275,45 @@ public struct ObjCSelectorBuilder {
   public typealias Expression = ObjCSelectorPiece
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [ObjCSelectorPiece]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ObjCSelector
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -2343,7 +2321,7 @@ public struct ObjCSelectorBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -2361,7 +2339,6 @@ public extension ObjCSelector {
   }
 }
 
-
 @resultBuilder
 public struct ObjcNameBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -2369,45 +2346,45 @@ public struct ObjcNameBuilder {
   public typealias Expression = ObjcNamePiece
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [ObjcNamePiece]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ObjcName
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -2415,7 +2392,7 @@ public struct ObjcNameBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -2433,7 +2410,6 @@ public extension ObjcName {
   }
 }
 
-
 @resultBuilder
 public struct PatternBindingListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -2441,45 +2417,45 @@ public struct PatternBindingListBuilder {
   public typealias Expression = PatternBinding
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [PatternBinding]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = PatternBindingList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -2487,7 +2463,7 @@ public struct PatternBindingListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -2508,53 +2484,67 @@ public extension PatternBindingList {
   }
 }
 
-
 @resultBuilder
 public struct PrecedenceGroupAttributeListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = SyntaxProtocol
+  public typealias Expression = PrecedenceGroupAttributeList.Element
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [SyntaxProtocol]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = PrecedenceGroupAttributeList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: PrecedenceGroupRelation) -> Self.Component {
+    return buildExpression(.init (expression))
+  }
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: PrecedenceGroupAssignment) -> Self.Component {
+    return buildExpression(.init (expression))
+  }
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: PrecedenceGroupAssociativity) -> Self.Component {
+    return buildExpression(.init (expression))
+  }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -2562,7 +2552,7 @@ public struct PrecedenceGroupAttributeListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -2580,7 +2570,6 @@ public extension PrecedenceGroupAttributeList {
   }
 }
 
-
 @resultBuilder
 public struct PrecedenceGroupNameListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -2588,45 +2577,45 @@ public struct PrecedenceGroupNameListBuilder {
   public typealias Expression = PrecedenceGroupNameElement
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [PrecedenceGroupNameElement]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = PrecedenceGroupNameList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -2634,7 +2623,7 @@ public struct PrecedenceGroupNameListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -2652,7 +2641,6 @@ public extension PrecedenceGroupNameList {
   }
 }
 
-
 @resultBuilder
 public struct PrimaryAssociatedTypeListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -2660,45 +2648,45 @@ public struct PrimaryAssociatedTypeListBuilder {
   public typealias Expression = PrimaryAssociatedType
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [PrimaryAssociatedType]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = PrimaryAssociatedTypeList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -2706,7 +2694,7 @@ public struct PrimaryAssociatedTypeListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -2727,53 +2715,72 @@ public extension PrimaryAssociatedTypeList {
   }
 }
 
-
 @resultBuilder
 public struct SpecializeAttributeSpecListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = SyntaxProtocol
+  public typealias Expression = SpecializeAttributeSpecList.Element
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [SyntaxProtocol]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = SpecializeAttributeSpecList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: LabeledSpecializeEntry) -> Self.Component {
+    return buildExpression(.init (expression))
+  }
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: AvailabilityEntry) -> Self.Component {
+    return buildExpression(.init (expression))
+  }
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: TargetFunctionEntry) -> Self.Component {
+    return buildExpression(.init (expression))
+  }
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: GenericWhereClause) -> Self.Component {
+    return buildExpression(.init (expression))
+  }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -2781,7 +2788,7 @@ public struct SpecializeAttributeSpecListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -2799,53 +2806,62 @@ public extension SpecializeAttributeSpecList {
   }
 }
 
-
 @resultBuilder
 public struct StringLiteralSegmentsBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = SyntaxProtocol
+  public typealias Expression = StringLiteralSegments.Element
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [SyntaxProtocol]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = StringLiteralSegments
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: StringSegment) -> Self.Component {
+    return buildExpression(.init (expression))
+  }
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: ExpressionSegment) -> Self.Component {
+    return buildExpression(.init (expression))
+  }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -2853,7 +2869,7 @@ public struct StringLiteralSegmentsBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -2871,53 +2887,62 @@ public extension StringLiteralSegments {
   }
 }
 
-
 @resultBuilder
 public struct SwitchCaseListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = SyntaxProtocol
+  public typealias Expression = SwitchCaseList.Element
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [SyntaxProtocol]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = SwitchCaseList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: SwitchCase) -> Self.Component {
+    return buildExpression(.init (expression))
+  }
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: IfConfigDecl) -> Self.Component {
+    return buildExpression(.init (expression))
+  }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -2925,7 +2950,7 @@ public struct SwitchCaseListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -2943,7 +2968,6 @@ public extension SwitchCaseList {
   }
 }
 
-
 @resultBuilder
 public struct TokenListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -2951,45 +2975,45 @@ public struct TokenListBuilder {
   public typealias Expression = Token
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [Token]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = TokenList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -2997,7 +3021,7 @@ public struct TokenListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -3015,7 +3039,6 @@ public extension TokenList {
   }
 }
 
-
 @resultBuilder
 public struct TupleExprElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -3023,45 +3046,45 @@ public struct TupleExprElementListBuilder {
   public typealias Expression = TupleExprElement
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [TupleExprElement]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = TupleExprElementList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -3069,7 +3092,7 @@ public struct TupleExprElementListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -3090,7 +3113,6 @@ public extension TupleExprElementList {
   }
 }
 
-
 @resultBuilder
 public struct TuplePatternElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -3098,45 +3120,45 @@ public struct TuplePatternElementListBuilder {
   public typealias Expression = TuplePatternElement
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [TuplePatternElement]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = TuplePatternElementList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -3144,7 +3166,7 @@ public struct TuplePatternElementListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -3165,7 +3187,6 @@ public extension TuplePatternElementList {
   }
 }
 
-
 @resultBuilder
 public struct TupleTypeElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -3173,45 +3194,45 @@ public struct TupleTypeElementListBuilder {
   public typealias Expression = TupleTypeElement
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [TupleTypeElement]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = TupleTypeElementList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -3219,7 +3240,7 @@ public struct TupleTypeElementListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -3240,7 +3261,6 @@ public extension TupleTypeElementList {
   }
 }
 
-
 @resultBuilder
 public struct UnexpectedNodesBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -3248,45 +3268,45 @@ public struct UnexpectedNodesBuilder {
   public typealias Expression = SyntaxProtocol
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [SyntaxProtocol]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = UnexpectedNodes
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -3294,7 +3314,7 @@ public struct UnexpectedNodesBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   
@@ -3312,7 +3332,6 @@ public extension UnexpectedNodes {
   }
 }
 
-
 @resultBuilder
 public struct YieldExprListBuilder {
   /// The type of individual statement expressions in the transformed function,
@@ -3320,45 +3339,45 @@ public struct YieldExprListBuilder {
   public typealias Expression = YieldExprListElement
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [YieldExprListElement]
+  public typealias Component = [Expression]
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = YieldExprList
   /// Required by every result builder to build combined results from
   /// statement blocks.
-  public static func buildBlock(_ components: Component...) -> Component {
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
     return components.flatMap { 
       $0 
     }
   }
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Expression) -> Component {
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: FinalResult) -> Component {
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
   /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Component?) -> Component {
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Component) -> Component {
+  public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Component) -> Component {
+  public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Component]) -> Component {
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
     return components.flatMap { 
       $0 
     }
@@ -3366,7 +3385,7 @@ public struct YieldExprListBuilder {
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
-  public static func buildLimitedAvailability(_ component: Component) -> Component {
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
     return component
   }
   

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -109,14 +109,14 @@ final class ExpressionTests: XCTestCase {
       substructure: Syntax(
         CodeBlockItemListSyntax([
           CodeBlockItemSyntax(
-            item: Syntax(
+            item: .init(
               KeyPathExprSyntax(
               backslash: .backslashToken(),
               root: nil,
               components: KeyPathComponentListSyntax([
                 KeyPathComponentSyntax(
                   period: .periodToken(),
-                  component: Syntax(
+                  component: .init(
                     KeyPathOptionalComponentSyntax(
                       questionOrExclamationMark: .postfixQuestionMarkToken()
                     )
@@ -124,7 +124,7 @@ final class ExpressionTests: XCTestCase {
                 ),
                 KeyPathComponentSyntax(
                   period: .periodToken(),
-                  component: Syntax(
+                  component: .init(
                     KeyPathPropertyComponentSyntax(
                       identifier: .identifier("foo"),
                       declNameArguments: nil,

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -21,7 +21,7 @@ final class StatementTests: XCTestCase {
                 """,
                 substructure: Syntax(IfStmtSyntax(ifKeyword: .ifKeyword(),
                                                   conditions: ConditionElementListSyntax([
-                                                    ConditionElementSyntax(condition: Syntax(OptionalBindingConditionSyntax(
+                                                    ConditionElementSyntax(condition: .init(OptionalBindingConditionSyntax(
                                                       letOrVarKeyword: .letKeyword(),
                                                       pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("baz"))),
                                                       typeAnnotation: nil,
@@ -37,7 +37,7 @@ final class StatementTests: XCTestCase {
                 """,
                 substructure: Syntax(IfStmtSyntax(ifKeyword: .ifKeyword(),
                                                   conditions: ConditionElementListSyntax([
-                                                    ConditionElementSyntax(condition: Syntax(OptionalBindingConditionSyntax(
+                                                    ConditionElementSyntax(condition: .init(OptionalBindingConditionSyntax(
                                                       letOrVarKeyword: .letKeyword(),
                                                       pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .selfKeyword())),
                                                       typeAnnotation: nil,
@@ -371,7 +371,7 @@ final class StatementTests: XCTestCase {
       """,
       substructure: Syntax(YieldStmtSyntax(
         yieldKeyword: .contextualKeyword("yield"),
-        yields: Syntax(InOutExprSyntax(
+        yields: .init(InOutExprSyntax(
           ampersand: .prefixAmpersandToken(),
           expression: ExprSyntax(IdentifierExprSyntax(
             identifier: .identifier("x"),
@@ -400,7 +400,7 @@ final class StatementTests: XCTestCase {
       """,
       substructure: Syntax(YieldStmtSyntax(
         yieldKeyword: .contextualKeyword("yield"),
-        yields: Syntax(InOutExprSyntax(
+        yields: .init(InOutExprSyntax(
           ampersand: .prefixAmpersandToken(),
           expression: ExprSyntax(SubscriptExprSyntax(
             calledExpression: ExprSyntax(IdentifierExprSyntax(identifier: .identifier("native"), declNameArguments: nil)),

--- a/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
+++ b/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
@@ -533,7 +533,7 @@ final class IfconfigExprTests: XCTestCase {
           trailingClosure: nil,
           additionalTrailingClosures: nil
         )),
-        elements: Syntax(CodeBlockItemListSyntax([]))
+        elements: .init(CodeBlockItemListSyntax([]))
       ))
     )
   }

--- a/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
+++ b/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
@@ -186,7 +186,7 @@ final class TrailingClosuresTests: XCTestCase {
           signature: nil,
           statements: CodeBlockItemListSyntax([
             CodeBlockItemSyntax(
-              item: Syntax(EditorPlaceholderExprSyntax(identifier: .identifier("<#T##() -> Void#>"))),
+              item: .init(EditorPlaceholderExprSyntax(identifier: .identifier("<#T##() -> Void#>"))),
               semicolon: nil,
               errorTokens: nil
             )

--- a/Tests/SwiftSyntaxBuilderTest/DoStmtTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/DoStmtTests.swift
@@ -18,7 +18,7 @@ final class DoStmtTests: XCTestCase {
   func testDoStmt() {
     let buildable = DoStmt(
       body: CodeBlock(statementsBuilder: {
-        CodeBlockItem(item: TryExpr(expression: FunctionCallExpr(calledExpression: MemberAccessExpr(base: "a", name: "b"))))
+        TryExpr(expression: FunctionCallExpr(calledExpression: MemberAccessExpr(base: "a", name: "b")))
       }),
       catchClauses: [
         CatchClause(CatchItemList {

--- a/Tests/SwiftSyntaxBuilderTest/ExtensionDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ExtensionDeclTests.swift
@@ -29,7 +29,7 @@ final class ExtensionDeclTests: XCTestCase {
         PatternBinding(pattern: Pattern("`\(keyword)`"),
                        typeAnnotation: TypeAnnotation(type: Type("TokenSyntax")),
                        initializer: nil,
-                       accessor: body)
+                       accessor: .getter(body))
 
       }
     }

--- a/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
@@ -27,9 +27,9 @@ final class FunctionTests: XCTestCase {
     let signature = FunctionSignature(input: input, output: ReturnClause(returnType: Type("Int")))
     
     let buildable = FunctionDecl(leadingTrivia: leadingTrivia, identifier: .identifier("fibonacci"), signature: signature) {
-      CodeBlockItem(item: IfStmt("if n <= 1 { return n }"))
+      IfStmt("if n <= 1 { return n }")
 
-      CodeBlockItem(item: ReturnStmt("return fibonacci(n - 1) + self.fibonacci(n - 2)"))
+      ReturnStmt("return fibonacci(n - 1) + self.fibonacci(n - 2)")
     }
 
     AssertBuildResult(buildable, """

--- a/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
@@ -28,7 +28,7 @@ final class StringLiteralTests: XCTestCase {
       let segment = StringSegment(content: string)
       let builder = StringLiteralExpr(leadingTrivia: leadingTrivia,
                                       openQuote: .stringQuote,
-                                      segments: StringLiteralSegments([segment]),
+                                      segments: StringLiteralSegments([.stringSegment(segment)]),
                                       closeQuote: .stringQuote)
 
       AssertBuildResult(builder, expected, line: line)

--- a/Tests/SwiftSyntaxBuilderTest/StructTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StructTests.swift
@@ -41,9 +41,9 @@ final class StructTests: XCTestCase {
         GenericParameter(name: "D")
       },
       genericWhereClause: GenericWhereClause {
-        GenericRequirement(body: ConformanceRequirement(leftTypeIdentifier: Type("A"), rightTypeIdentifier: SimpleTypeIdentifier("X")))
-        GenericRequirement(body: SameTypeRequirement(
-            leftTypeIdentifier: "A.P", equalityToken: .spacedBinaryOperator("=="), rightTypeIdentifier: "D"))
+        GenericRequirement(body: .conformanceRequirement(ConformanceRequirement(leftTypeIdentifier: Type("A"), rightTypeIdentifier: SimpleTypeIdentifier("X"))))
+        GenericRequirement(body: .sameTypeRequirement(SameTypeRequirement(
+            leftTypeIdentifier: "A.P", equalityToken: .spacedBinaryOperator("=="), rightTypeIdentifier: "D")))
       }
     ) {}
     

--- a/Tests/SwiftSyntaxBuilderTest/TriviaTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/TriviaTests.swift
@@ -61,11 +61,16 @@ final class TriviaTests: XCTestCase {
   func testAttachedListTrivia() {
     let testCases: [UInt: (AttributeList, String)] = [
       #line: (
-        AttributeList([CustomAttribute("Test")]).withLeadingTrivia(.space),
+        AttributeList {
+          CustomAttribute("Test").withLeadingTrivia(.space)
+        },
         " @Test"
       ),
       #line: (
-        AttributeList([CustomAttribute("A").withTrailingTrivia(.space), CustomAttribute("B")]).withTrailingTrivia(.space),
+        AttributeList {
+          CustomAttribute("A").withTrailingTrivia(.space)
+          CustomAttribute("B").withTrailingTrivia(.space)
+        },
         "@A @B "
       ),
     ]

--- a/Tests/SwiftSyntaxParserTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftSyntaxParserTest/AbsolutePositionTests.swift
@@ -80,7 +80,7 @@ public class AbsolutePositionTests: XCTestCase {
     let idx = 2000
     for _ in 0...idx {
       l.append(CodeBlockItemSyntax(
-        item: Syntax(
+        item: .init(
           ReturnStmtSyntax(
             returnKeyword: .returnKeyword(trailingTrivia: .newline),
             expression: nil
@@ -112,7 +112,7 @@ public class AbsolutePositionTests: XCTestCase {
   func createSourceFile(_ count: Int) -> SourceFileSyntax {
     let items : [CodeBlockItemSyntax] =
     [CodeBlockItemSyntax](repeating: CodeBlockItemSyntax(
-      item: Syntax(ReturnStmtSyntax(
+      item: .init(ReturnStmtSyntax(
         returnKeyword: .returnKeyword(
           leadingTrivia: AbsolutePositionTests.leadingTrivia,
           trailingTrivia: AbsolutePositionTests.trailingTrivia
@@ -182,7 +182,7 @@ public class AbsolutePositionTests: XCTestCase {
 
   public func testWithoutSourceFileRoot() {
     let item = CodeBlockItemSyntax(
-      item: Syntax(
+      item: .init(
         ReturnStmtSyntax(
           returnKeyword: .returnKeyword(leadingTrivia: .newline, trailingTrivia: .newline),
           expression: nil)

--- a/Tests/SwiftSyntaxParserTest/SyntaxComparisonTests.swift
+++ b/Tests/SwiftSyntaxParserTest/SyntaxComparisonTests.swift
@@ -212,7 +212,7 @@ public class SyntaxComparisonTests: XCTestCase {
     var items = [CodeBlockItemSyntax]()
     for i in 0..<statementCount {
       let literal = IntegerLiteralExprSyntax(digits: .integerLiteral(String(i)))
-      items.append(CodeBlockItemSyntax(item: Syntax(literal), semicolon: nil, errorTokens: nil))
+      items.append(CodeBlockItemSyntax(item: .init(literal), semicolon: nil, errorTokens: nil))
     }
     let block = CodeBlockItemListSyntax(items)
     return CodeBlockSyntax(

--- a/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
@@ -107,7 +107,7 @@ public class SyntaxCreationTests: XCTestCase {
     let string = StringLiteralExprSyntax(
       openDelimiter: nil,
       openQuote: .stringQuoteToken(),
-      segments: StringLiteralSegmentsSyntax([Syntax(StringSegmentSyntax(content: .stringSegment("Hello, world!")))]),
+      segments: StringLiteralSegmentsSyntax([.stringSegment(StringSegmentSyntax(content: .stringSegment("Hello, world!")))]),
       closeQuote: .stringQuoteToken(),
       closeDelimiter: nil
     )
@@ -131,7 +131,7 @@ public class SyntaxCreationTests: XCTestCase {
     let emptyString = StringLiteralExprSyntax(
       openDelimiter: nil,
       openQuote: .stringQuoteToken(),
-      segments: StringLiteralSegmentsSyntax([Syntax(StringSegmentSyntax(content: .stringSegment(" ")))]),
+      segments: StringLiteralSegmentsSyntax([.stringSegment(StringSegmentSyntax(content: .stringSegment(" ")))]),
       closeQuote: .stringQuoteToken(),
       closeDelimiter: nil
     )
@@ -157,7 +157,7 @@ public class SyntaxCreationTests: XCTestCase {
     let string = StringLiteralExprSyntax(
       openDelimiter: nil,
       openQuote: .stringQuoteToken(),
-      segments: StringLiteralSegmentsSyntax([Syntax(StringSegmentSyntax(content: .stringSegment("Hello, world!")))]),
+      segments: StringLiteralSegmentsSyntax([.stringSegment(StringSegmentSyntax(content: .stringSegment("Hello, world!")))]),
       closeQuote: .stringQuoteToken(),
       closeDelimiter: nil
     )
@@ -199,7 +199,7 @@ public class SyntaxCreationTests: XCTestCase {
     let expr = StringLiteralExprSyntax(
       openDelimiter: nil,
       openQuote: .stringQuoteToken(),
-      segments: StringLiteralSegmentsSyntax([Syntax(StringSegmentSyntax(content: .stringSegment("Hello, world!")))]),
+      segments: StringLiteralSegmentsSyntax([.stringSegment(StringSegmentSyntax(content: .stringSegment("Hello, world!")))]),
       closeQuote: .stringQuoteToken(),
       closeDelimiter: nil
     )
@@ -215,7 +215,7 @@ public class SyntaxCreationTests: XCTestCase {
     let expr = StringLiteralExprSyntax(
       openDelimiter: nil,
       openQuote: .stringQuoteToken(leadingTrivia: [.lineComment("// hello"), .newlines(1)]),
-      segments: StringLiteralSegmentsSyntax([Syntax(StringSegmentSyntax(content: .stringSegment("Hello, world!")))]),
+      segments: StringLiteralSegmentsSyntax([.stringSegment(StringSegmentSyntax(content: .stringSegment("Hello, world!")))]),
       closeQuote: .stringQuoteToken(),
       closeDelimiter: nil
     )


### PR DESCRIPTION
This is based on https://github.com/apple/swift-syntax/pull/765 but rebased on `main` and with all tests passing.

Previously, we relied on runtime checks to make sure only supported node types were used for a child with `node_choices`. If we explicitly model the set of supported nodes as an enum, we get compile-time safety.

rdar://101200491