### PR TITLE
Extend macro protocols with information about the macro types.

### DIFF
--- a/Sources/SwiftSyntaxBuilder/gyb_generated/SyntaxExpressibleByStringInterpolationConformances.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/SyntaxExpressibleByStringInterpolationConformances.swift
@@ -332,6 +332,12 @@ extension CatchClauseSyntax: SyntaxExpressibleByStringInterpolation {
 
 extension PoundAssertStmtSyntax: SyntaxExpressibleByStringInterpolation {}
 
+extension GenericParameterClauseSyntax: SyntaxExpressibleByStringInterpolation {
+  public static func parse(from parser: inout Parser) -> Self {
+    return parser.parseGenericParameters().syntax
+  }
+}
+
 extension SimpleTypeIdentifierSyntax: SyntaxExpressibleByStringInterpolation {}
 
 extension MemberTypeIdentifierSyntax: SyntaxExpressibleByStringInterpolation {}

--- a/Sources/_SwiftSyntaxMacros/Macro.swift
+++ b/Sources/_SwiftSyntaxMacros/Macro.swift
@@ -9,9 +9,22 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+import SwiftSyntax
 
 /// Describes a macro.
 public protocol Macro {
   /// The name of this macro.
   static var name: String { get }
+
+  /// The generic signature to use when describing the type of this macro.
+  static var genericSignature: GenericParameterClauseSyntax? { get }
+
+  /// The type signature for this macro.
+  ///
+  /// A function type indicates a function-like macro (such as
+  /// `#colorLiteral(red: r, green: b, blue: b, alpha: a)`) that takes
+  /// arguments, whereas any other type indicates a value-like macro (such
+  /// as `#line`) that does not. This is a syntactic distinction, not a
+  /// semantic one.
+  static var signature: TypeSyntax { get }
 }

--- a/Sources/_SwiftSyntaxMacros/MacroSystem+Builtin.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem+Builtin.swift
@@ -16,6 +16,13 @@ import SwiftSyntaxBuilder
 struct ColumnMacro: ExpressionMacro {
   static var name: String { "column" }
 
+  static var genericSignature: GenericParameterClauseSyntax? =
+     """
+     <T: ExpressibleByIntegerLiteral>
+     """
+
+  static var signature: TypeSyntax = "T"
+
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
   ) -> MacroResult<ExprSyntax> {
@@ -28,6 +35,13 @@ struct ColumnMacro: ExpressionMacro {
 
 struct LineMacro: ExpressionMacro {
   static var name: String { "line" }
+
+  static var genericSignature: GenericParameterClauseSyntax? =
+     """
+     <T: ExpressibleByIntegerLiteral>
+     """
+
+  static var signature: TypeSyntax = "T"
 
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
@@ -53,6 +67,13 @@ extension PatternBindingSyntax {
 
 struct FunctionMacro: ExpressionMacro {
   static var name: String { "function" }
+
+  static var genericSignature: GenericParameterClauseSyntax? =
+     """
+     <T: ExpressibleByStringLiteral>
+     """
+
+  static var signature: TypeSyntax = "T"
 
   /// Form a function name.
   private static func formFunctionName(
@@ -159,6 +180,18 @@ struct FunctionMacro: ExpressionMacro {
 struct ColorLiteralMacro: ExpressionMacro {
   static var name: String { "colorLiteral" }
 
+  static var genericSignature: GenericParameterClauseSyntax? =
+     """
+     <T: ExpressibleByColorLiteral>
+     """
+
+  static var signature: TypeSyntax =
+     """
+     (
+      _colorLiteralRed red: Float, green: Float, blue: Float, alpha: Float
+     ) -> T
+     """
+
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
   ) -> MacroResult<ExprSyntax> {
@@ -172,6 +205,14 @@ struct ColorLiteralMacro: ExpressionMacro {
 
 struct FileLiteralMacro: ExpressionMacro {
   static var name: String { "fileLiteral" }
+
+  static var genericSignature: GenericParameterClauseSyntax? =
+      """
+      <T: ExpressibleByFileReferenceLiteral>
+      """
+
+  static var signature: TypeSyntax =
+      "(fileReferenceLiteralResourceName path: String) -> T"
 
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
@@ -187,6 +228,14 @@ struct FileLiteralMacro: ExpressionMacro {
 struct ImageLiteralMacro: ExpressionMacro {
   static var name: String { "imageLiteral" }
 
+  static var genericSignature: GenericParameterClauseSyntax? =
+      """
+      <T: ExpressibleByImageLiteral>
+      """
+
+  static var signature: TypeSyntax =
+      "(imageLiteralResourceName path: String) -> T"
+
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
   ) -> MacroResult<ExprSyntax> {
@@ -200,6 +249,13 @@ struct ImageLiteralMacro: ExpressionMacro {
 
 struct FilePathMacro: ExpressionMacro {
   static var name: String { "filePath" }
+
+  static var genericSignature: GenericParameterClauseSyntax? =
+     """
+     <T: ExpressibleByStringLiteral>
+     """
+
+  static var signature: TypeSyntax = "T"
 
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
@@ -217,6 +273,13 @@ struct FilePathMacro: ExpressionMacro {
 
 struct FileIDMacro: ExpressionMacro {
   static var name: String { "fileID" }
+
+  static var genericSignature: GenericParameterClauseSyntax? =
+     """
+     <T: ExpressibleByStringLiteral>
+     """
+
+  static var signature: TypeSyntax = "T"
 
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
@@ -240,6 +303,13 @@ struct FileIDMacro: ExpressionMacro {
 
 struct FileMacro: ExpressionMacro {
   static var name: String { "file" }
+
+  static var genericSignature: GenericParameterClauseSyntax? =
+     """
+     <T: ExpressibleByStringLiteral>
+     """
+
+  static var signature: TypeSyntax = "T"
 
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext

--- a/Sources/_SwiftSyntaxMacros/MacroSystem+Examples.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem+Examples.swift
@@ -17,6 +17,10 @@ import SwiftSyntaxBuilder
 struct StringifyMacro: ExpressionMacro {
   static var name: String { "stringify" }
 
+  static var genericSignature: GenericParameterClauseSyntax? = "<T>"
+
+  static var signature: TypeSyntax = "(T) -> (T, String)"
+
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
   ) -> MacroResult<ExprSyntax> {

--- a/Sources/_SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem.swift
@@ -52,6 +52,11 @@ public struct MacroSystem {
 
     macros[macro.name] = macro
   }
+
+  /// Look for a macro with the given name.
+  public func lookup(_ macroName: String) -> Macro.Type? {
+    return macros[macroName]
+  }
 }
 
 /// Syntax rewriter that evaluates any macros encountered along the way.

--- a/gyb_syntax_support/GenericNodes.py
+++ b/gyb_syntax_support/GenericNodes.py
@@ -102,6 +102,7 @@ GENERIC_NODES = [
     # generic-parameter-clause -> '<' generic-parameter-list generic-where-clause? '>'
     Node('GenericParameterClause', name_for_diagnostics='generic parameter clause',
          kind='Syntax',
+         parser_function='parseGenericParameters',
          children=[
              Child('LeftAngleBracket', kind='LeftAngleToken'),
              Child('GenericParameterList', kind='GenericParameterList',


### PR DESCRIPTION
Macros are intended to have typed inputs and outputs, so express those
via a signature and (optional) generic parameter clause to help express
that signature. This puts the entirety of the macro's "declaration" in
the conformance, so it can be queried by the macro system.