### PR TITLE
Eliminate Foundation dependency from SwiftSyntaxBuilder

### DIFF
--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/StringLiteralExprConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/StringLiteralExprConvenienceInitializers.swift
@@ -27,21 +27,21 @@ private func countPounds(_ string: String) -> Int {
     }
 
     if afterQuote {
-      maxPounds = max(maxPounds, consecutivePounds)
+      maxPounds = max(maxPounds, consecutivePounds + 1)
     }
   }
 
   for c in string {
     switch c {
     case #"""#:
-      maxPounds = max(maxPounds, consecutivePounds)
+      maxPounds = max(maxPounds, consecutivePounds + 1)
       afterQuote = true
       afterBackslash = false
       consecutivePounds = 0
 
     case #"\"#:
       if afterQuote {
-        maxPounds = max(maxPounds, consecutivePounds)
+        maxPounds = max(maxPounds, consecutivePounds + 1)
         afterQuote = false
       }
       afterBackslash = true

--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/StringLiteralExprConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/StringLiteralExprConvenienceInitializers.swift
@@ -11,17 +11,57 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
-import Foundation
 
-/// A regular expression matching sequences of `#`s with an adjacent quote or
-/// interpolation. Used to determine the number of `#`s for a raw string literal.
-private let rawStringPotentialEscapesPattern = try! NSRegularExpression(
-  pattern: [
-    #""(#*)"#, // Match potential opening delimiters
-    #"(#*)""#, // Match potential closing delimiters
-    #"\\(#*)"#, // Match potential interpolations
-  ].joined(separator: "|")
-)
+/// Count the number of # signs before/after a `#` or between a `\` and a `(`.
+private func countPounds(_ string: String) -> Int {
+  var afterQuote = false
+  var afterBackslash = false
+
+  var consecutivePounds = 0
+
+  var maxPounds = 0
+
+  func updateForAnyCharacter() {
+    if afterBackslash {
+      maxPounds = max(maxPounds, consecutivePounds + 1)
+    }
+
+    if afterQuote {
+      maxPounds = max(maxPounds, consecutivePounds)
+    }
+  }
+
+  for c in string {
+    switch c {
+    case #"""#:
+      maxPounds = max(maxPounds, consecutivePounds)
+      afterQuote = true
+      afterBackslash = false
+      consecutivePounds = 0
+
+    case #"\"#:
+      if afterQuote {
+        maxPounds = max(maxPounds, consecutivePounds)
+        afterQuote = false
+      }
+      afterBackslash = true
+      consecutivePounds = 0
+
+    case "#":
+      consecutivePounds += 1
+
+    default:
+      updateForAnyCharacter()
+      afterQuote = false
+      afterBackslash = false
+      consecutivePounds = 0
+    }
+  }
+
+  updateForAnyCharacter()
+
+  return maxPounds
+}
 
 extension StringLiteralExpr {
   /// Creates a string literal, optionally specifying quotes and delimiters.
@@ -41,13 +81,7 @@ extension StringLiteralExpr {
     var openDelimiter = openDelimiter
     var closeDelimiter = closeDelimiter
     if openDelimiter == nil, closeDelimiter == nil {
-      // Match potential escapes in the string
-      let matches = rawStringPotentialEscapesPattern.matches(in: content, range: NSRange(content.startIndex..., in: content))
-
-      // Find longest sequence of `#`s by taking the maximum length over all captures
-      let poundCount = matches
-        .compactMap { match in (1..<match.numberOfRanges).map { match.range(at: $0).length + 1 }.max() }
-        .max() ?? 0
+      let poundCount = countPounds(content)
 
       // Use a delimiter that is exactly one longer
       openDelimiter = Token.rawStringDelimiter(String(repeating: "#", count: poundCount))

--- a/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
@@ -35,9 +35,23 @@ final class StringLiteralTests: XCTestCase {
     }
   }
 
+  func testEscapeLiteral() {
+    AssertBuildResult(
+      StringLiteralExpr(content: #""""foobar""#),
+      ##"#""""foobar""#"##
+    )
+  }
+
   func testEscapeBackslash() {
     AssertBuildResult(StringLiteralExpr(content: #"\"#), ##"""
     #"\"#
     """##)
+  }
+
+  func testEscapePounds() {
+    AssertBuildResult(
+      StringLiteralExpr(content: ###""foobar"##foobar"###),
+      #####"###""foobar"##foobar"###"#####
+    )
   }
 }


### PR DESCRIPTION
We can code the "count the #'s needed" operation directly by walking the contents of the string, without using NSRegularExpression. Do so to eliminate the only Foundation dependency in SwiftSyntaxBuilder.

Fixes rdar://101503176.