### PR TITLE
Remove Foundation dependency in SwiftSyntaxBuilder

### DIFF
--- a/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
@@ -35,8 +35,50 @@ final class StringLiteralTests: XCTestCase {
     }
   }
 
+  func testRegular() {
+    AssertBuildResult(
+      StringLiteralExpr(content: "foobar"),
+      """
+      "foobar"
+      """
+    )
+
+    AssertBuildResult(
+      StringLiteralExpr(content: "##foobar"),
+      """
+      "##foobar"
+      """
+    )
+  }
+
+  func testEscapeLiteral() {
+    AssertBuildResult(
+      StringLiteralExpr(content: #""""foobar""#),
+      ##"""
+      #""""foobar""#
+      """##
+    )
+  }
+
+  func testEscapePounds() {
+     AssertBuildResult(
+       StringLiteralExpr(content: ###"#####"foobar"##foobar"#foobar"###),
+       #####"""
+       ###"#####"foobar"##foobar"#foobar"###
+       """#####
+     )
+   }
+
+  func testEscapeInteropolation() {
+    AssertBuildResult(StringLiteralExpr(content: ###"\##(foobar)\#(foobar)"###),
+    ####"""
+    ###"\##(foobar)\#(foobar)"###
+    """####)
+  }
+
   func testEscapeBackslash() {
-    AssertBuildResult(StringLiteralExpr(content: #"\"#), ##"""
+    AssertBuildResult(StringLiteralExpr(content: #"\"#),
+    ##"""
     #"\"#
     """##)
   }


### PR DESCRIPTION
Avoid using a `NSRegularExpression` to count the number of #'s. Walk through the contents of the string and count them directly.

Resolves rdar://101503176.