### PR TITLE
Handle object literal's rewriting of the first argument label

### DIFF
--- a/Sources/_SwiftSyntaxMacros/MacroSystem+Builtin.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem+Builtin.swift
@@ -177,6 +177,19 @@ struct FunctionMacro: ExpressionMacro {
   }
 }
 
+/// Replace the label of the first element in the tuple with the given
+/// new label.
+private func replaceFirstLabel(
+  of tuple: TupleExprElementListSyntax, with newLabel: String
+) -> TupleExprElementListSyntax{
+  guard let firstElement = tuple.first else {
+    return tuple
+  }
+
+  return tuple.replacing(
+    childAt: 0, with: firstElement.withLabel(.identifier(newLabel)))
+}
+
 struct ColorLiteralMacro: ExpressionMacro {
   static var name: String { "colorLiteral" }
 
@@ -188,14 +201,17 @@ struct ColorLiteralMacro: ExpressionMacro {
   static var signature: TypeSyntax =
      """
      (
-      _colorLiteralRed red: Float, green: Float, blue: Float, alpha: Float
+      red: Float, green: Float, blue: Float, alpha: Float
      ) -> T
      """
 
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
   ) -> MacroResult<ExprSyntax> {
-    let initSyntax: ExprSyntax = ".init(\(macro.argumentList))"
+    let argList = replaceFirstLabel(
+      of: macro.argumentList, with: "_colorLiteralRed"
+    )
+    let initSyntax: ExprSyntax = ".init(\(argList))"
     if let leadingTrivia = macro.leadingTrivia {
       return MacroResult(initSyntax.withLeadingTrivia(leadingTrivia))
     }
@@ -212,12 +228,15 @@ struct FileLiteralMacro: ExpressionMacro {
       """
 
   static var signature: TypeSyntax =
-      "(fileReferenceLiteralResourceName path: String) -> T"
+      "(resourceName path: String) -> T"
 
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
   ) -> MacroResult<ExprSyntax> {
-    let initSyntax: ExprSyntax = ".init(\(macro.argumentList))"
+    let argList = replaceFirstLabel(
+      of: macro.argumentList, with: "fileReferenceLiteralResourceName"
+    )
+    let initSyntax: ExprSyntax = ".init(\(argList))"
     if let leadingTrivia = macro.leadingTrivia {
       return MacroResult(initSyntax.withLeadingTrivia(leadingTrivia))
     }
@@ -234,12 +253,15 @@ struct ImageLiteralMacro: ExpressionMacro {
       """
 
   static var signature: TypeSyntax =
-      "(imageLiteralResourceName path: String) -> T"
+      "(resourceName path: String) -> T"
 
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
   ) -> MacroResult<ExprSyntax> {
-    let initSyntax: ExprSyntax = ".init(\(macro.argumentList))"
+    let argList = replaceFirstLabel(
+      of: macro.argumentList, with: "imageLiteralResourceName"
+    )
+    let initSyntax: ExprSyntax = ".init(\(argList))"
     if let leadingTrivia = macro.leadingTrivia {
       return MacroResult(initSyntax.withLeadingTrivia(leadingTrivia))
     }

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -39,7 +39,7 @@ final class MacroSystemTests: XCTestCase {
       1
       let a = (2)
       let b = (x + y, #"x + y"#)
-      .init(red: 0.5, green: 0.5, blue: 0.25, alpha: 1.0)
+      .init(_colorLiteralRed: 0.5, green: 0.5, blue: 0.25, alpha: 1.0)
       let c = 9
       """
     )


### PR DESCRIPTION
The macro signature of the object literals is different from the initializer that's used for the rewritten version. Account for this in the macro's definition.