### PR TITLE
Don’t eat closing braces while trying to recover to a declaration start keyword

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -190,7 +190,12 @@ extension Parser {
     let attrs = DeclAttributes(
       attributes: self.parseAttributeList(),
       modifiers: self.parseModifierList())
-    switch self.canRecoverTo(anyIn: DeclarationStart.self) {
+
+    // If we are inside a memberDecl list, we don't want to eat closing braces (which most likely close the outer context)
+    // while recoverying to the declaration start.
+    let recoveryPrecedence = inMemberDeclList ? TokenPrecedence.closingBrace : nil
+    
+    switch self.canRecoverTo(anyIn: DeclarationStart.self, recoveryPrecedence: recoveryPrecedence) {
     case (.importKeyword, let handle)?:
       return RawDeclSyntax(self.parseImportDeclaration(attrs, handle))
     case (.classKeyword, let handle)?:

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -263,13 +263,14 @@ extension Parser {
   /// If so, return the token that we can recover to and a handle that can be
   /// used to consume the unexpected tokens and the token we recovered to.
   func canRecoverTo<Subset: RawTokenKindSubset>(
-    anyIn subset: Subset.Type
+    anyIn subset: Subset.Type,
+    recoveryPrecedence: TokenPrecedence? = nil
   ) -> (Subset, RecoveryConsumptionHandle)? {
     if let (kind, handle) = self.at(anyIn: subset) {
       return (kind, RecoveryConsumptionHandle(unexpectedTokens: 0, tokenConsumptionHandle: handle))
     }
     var lookahead = self.lookahead()
-    return lookahead.canRecoverTo(anyIn: subset)
+    return lookahead.canRecoverTo(anyIn: subset, recoveryPrecedence: recoveryPrecedence)
   }
 
   /// Eat a token that we know we are currently positioned at, based on `canRecoverTo(anyIn:)`.

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxComparison.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxComparison.swift
@@ -45,8 +45,8 @@ extension TreeDifference: CustomDebugStringConvertible {
   public var debugDescription: String {
     let includeTrivia = reason == .trivia
 
-    let expectedConverter = SourceLocationConverter(file: "Baseline.swift", source: baseline.description)
-    let actualConverter = SourceLocationConverter(file: "Actual.swift", source: node.description)
+    let expectedConverter = SourceLocationConverter(file: "Baseline.swift", tree: baseline.root)
+    let actualConverter = SourceLocationConverter(file: "Actual.swift", tree: node.root)
 
     let expectedDesc = baseline.debugDescription(includeTrivia: includeTrivia, converter: expectedConverter)
     let actualDesc = node.debugDescription(includeTrivia: includeTrivia, converter: actualConverter)

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
@@ -62,11 +62,11 @@ private extension TriviaPiece {
     let (label, value) = Mirror(reflecting: self).children.first!
     switch value {
     case let value as String:
-      return FunctionCallExpr(calledExpression: MemberAccessExpr(name: label!)) {
+      return FunctionCallExpr(callee: ".\(label!)") {
         TupleExprElement(expression: StringLiteralExpr(content: value))
       }
     case let value as Int:
-      return FunctionCallExpr(calledExpression: MemberAccessExpr(name: label!)) {
+      return FunctionCallExpr(callee: ".\(label!)") {
         TupleExprElement(expression: IntegerLiteralExpr(value))
       }
     default:
@@ -106,7 +106,7 @@ extension SyntaxProtocol {
   private var debugInitCallExpr: ExprSyntaxProtocol {
     let mirror = Mirror(reflecting: self)
     if self.isCollection {
-      return FunctionCallExpr(calledExpression: IdentifierExpr(String("\(type(of: self))"))) {
+      return FunctionCallExpr(callee: "\(type(of: self))") {
         TupleExprElement(
           expression: ArrayExpr() {
             for child in mirror.children {
@@ -131,7 +131,7 @@ extension SyntaxProtocol {
         tokenInitializerName = String(tokenKindStr[..<tokenKindStr.firstIndex(of: "(")!])
         requiresExplicitText = true
       }
-      return FunctionCallExpr(calledExpression: MemberAccessExpr(name: tokenInitializerName)) {
+      return FunctionCallExpr(callee: ".\(tokenInitializerName)") {
         if requiresExplicitText {
           TupleExprElement(
             expression: StringLiteralExpr(content: token.text)
@@ -160,7 +160,7 @@ extension SyntaxProtocol {
         }
       }
     } else {
-      return FunctionCallExpr(calledExpression: IdentifierExpr(String("\(type(of: self))"))) {
+      return FunctionCallExpr(callee: "\(type(of: self))") {
         for child in mirror.children {
           let label = child.label!
           let value = child.value as! SyntaxProtocol?

--- a/Tests/SwiftParserTest/ParserTests.swift
+++ b/Tests/SwiftParserTest/ParserTests.swift
@@ -160,6 +160,8 @@ public class ParserTests: XCTestCase {
         || fileURL.absoluteString.contains("26773-swift-diagnosticengine-diagnose.swift")
         || fileURL.absoluteString.contains("parser-cutoff.swift")
         || fileURL.absoluteString.contains("26233-swift-iterabledeclcontext-getmembers.swift")
+        || fileURL.absoluteString.contains("26190-swift-iterabledeclcontext-getmembers.swift")
+        || fileURL.absoluteString.contains("26139-swift-abstractclosureexpr-setparams.swift")
       }
     )
   }


### PR DESCRIPTION
Previously, when given 

```swift
class A {
  ^
}
class B {
}
```

recovery to the second `class` (because `^` is unexpected) would also consume the closing `}` nesting `B` inside `A`. That’s unexpected. Recovery of decl keywords inside member decl lists should not consume closing braces.

---

While doing this, also fix a few miscellaneous bugs in the test infrastructure.