### PR TITLE
build: add dependency on Foundation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set(CMAKE_MACOSX_RPATH YES)
 
+find_package(dispatch QUIET)
+find_package(Foundation QUIET)
+
 add_subdirectory(Sources)
 
 export(EXPORT SwiftSyntaxTargets

--- a/Sources/SwiftSyntaxBuilder/CMakeLists.txt
+++ b/Sources/SwiftSyntaxBuilder/CMakeLists.txt
@@ -27,8 +27,12 @@ target_link_libraries(SwiftSyntaxBuilder PUBLIC
   SwiftBasicFormat
   SwiftParser
   SwiftParserDiagnostics
-  SwiftSyntax
-  )
+  SwiftSyntax)
+if(TARGET Foundation AND TARGET dispatch)
+  target_link_libraries(SwiftSyntaxBuilder PRIVATE
+    $<$<NOT:$<PLATFORM_ID:Darwin>>:dispatch>
+    $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
+endif()
 
 set_property(GLOBAL APPEND PROPERTY SWIFTSYNTAX_EXPORTS SwiftSyntaxBuilder)
 


### PR DESCRIPTION
Now that Foundation is required for SwiftSyntax, add the ability to tie together build trees and bootstrap SwiftSyntax.  This is required to repair the Windows build.