### PR TITLE
Restrict the maximum nesting level in the parser to avoid stack overflows

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -363,8 +363,18 @@ extension Parser {
 
   @_spi(RawSyntax)
   public mutating func parseGenericParameters() -> RawGenericParameterClauseSyntax {
-    assert(self.currentToken.starts(with: "<"))
+    if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
+      return RawGenericParameterClauseSyntax(
+        remainingTokens,
+        leftAngleBracket: missingToken(.leftAngle),
+        genericParameterList: RawGenericParameterListSyntax(elements: [], arena: self.arena),
+        genericWhereClause: nil,
+        rightAngleBracket: missingToken(.rightAngle),
+        arena: self.arena
+      )
+    }
 
+    assert(self.currentToken.starts(with: "<"))
     let langle = self.consumeAnyToken(remapping: .leftAngle)
     var elements = [RawGenericParameterSyntax]()
     do {
@@ -616,6 +626,16 @@ extension Parser {
 extension Parser {
   @_spi(RawSyntax)
   public mutating func parseMemberDeclListItem() -> RawMemberDeclListItemSyntax? {
+    if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
+      let item = RawMemberDeclListItemSyntax(
+        remainingTokens,
+        decl: RawDeclSyntax(RawMissingDeclSyntax(attributes: nil, modifiers: nil, arena: self.arena)),
+        semicolon: nil,
+        arena: self.arena
+      )
+      return item
+    }
+
     let decl: RawDeclSyntax
     if self.at(.poundSourceLocationKeyword) {
       decl = RawDeclSyntax(self.parsePoundSourceLocationDirective())

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -70,6 +70,15 @@ extension Parser {
     addSemicolonIfNeeded: (_ lastElement: Element, _ newItemAtStartOfLine: Bool, _ parser: inout Parser) -> Element? = { _, _, _ in nil },
     syntax: (inout Parser, [Element]) -> RawSyntax?
   ) -> RawIfConfigDeclSyntax {
+    if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
+      return RawIfConfigDeclSyntax(
+        remainingTokens,
+        clauses: RawIfConfigClauseListSyntax(elements: [], arena: self.arena),
+        poundEndif: missingToken(.poundEndifKeyword),
+        arena: self.arena
+      )
+    }
+
     var clauses = [RawIfConfigClauseSyntax]()
     do {
       var firstIteration = true

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1757,6 +1757,16 @@ extension Parser {
   ///     dictionary-literal-items → dictionary-literal-item ','? | dictionary-literal-item ',' dictionary-literal-items
   @_spi(RawSyntax)
   public mutating func parseCollectionLiteral() -> RawExprSyntax {
+    if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
+      return RawExprSyntax(RawArrayExprSyntax(
+        remainingTokens,
+        leftSquare: missingToken(.leftSquareBracket),
+        elements: RawArrayElementListSyntax(elements: [], arena: self.arena),
+        rightSquare: missingToken(.rightSquareBracket),
+        arena: self.arena
+      ))
+    }
+
     let (unexpectedBeforeLSquare, lsquare) = self.expect(.leftSquareBracket)
 
     if let rsquare = self.consume(if: .rightSquareBracket) {
@@ -2177,6 +2187,17 @@ extension Parser {
   ///     tuple-element → expression | identifier ':' expression
   @_spi(RawSyntax)
   public mutating func parseArgumentListElements(pattern: PatternContext) -> [RawTupleExprElementSyntax] {
+    if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
+      return [RawTupleExprElementSyntax(
+        remainingTokens,
+        label: nil,
+        colon: nil,
+        expression: RawExprSyntax(RawMissingExprSyntax(arena: self.arena)),
+        trailingComma: nil,
+        arena: self.arena
+      )]
+    }
+
     guard !self.at(.rightParen) else {
       return []
     }

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -26,11 +26,16 @@ extension Parser {
   }
 
   /// Parse the source code in the given string as Swift source file.
+  /// If `maximumNestingLevel` is set, the parser will stop if a nesting level
+  /// that is greater than this value is reached to avoid overflowing the stack.
+  /// The nesting level is increased whenever a bracketed expression like `(`
+  /// or `{` is stared.
   public static func parse(
     source: UnsafeBufferPointer<UInt8>,
+    maximumNestingLevel: Int? = nil,
     parseTransition: IncrementalParseTransition? = nil
   ) -> SourceFileSyntax {
-    var parser = Parser(source)
+    var parser = Parser(source, maximumNestingLevel: maximumNestingLevel)
     // Extended lifetime is required because `SyntaxArena` in the parser must
     // be alive until `Syntax(raw:)` retains the arena.
     return withExtendedLifetime(parser) {
@@ -122,6 +127,23 @@ public struct Parser: TokenConsumer {
   @_spi(RawSyntax)
   public var currentToken: Lexer.Lexeme
 
+  /// The current nesting level, i.e. the number of tokens that
+  /// `startNestingLevel` minus the number of tokens that `endNestingLevel`
+  /// which have been consumed so far.
+  public var nestingLevel: Int = 0
+
+  /// When this nesting level is exceeded, the parser should stop parsing.
+  public let maximumNestingLevel: Int
+
+  /// A default maximum nesting level that is used if the client didn't
+  /// explicitly specify one. Debug builds of the parser comume a lot more stack
+  /// space and thus have a lower default maximum nesting level.
+  #if DEBUG
+  public static let defaultMaximumNestingLevel = 25
+  #else
+  public static let defaultMaximumNestingLevel = 256
+  #endif
+
   /// Initializes a Parser from the given input buffer.
   ///
   /// The lexer will copy any string data it needs from the resulting buffer
@@ -133,7 +155,9 @@ public struct Parser: TokenConsumer {
   ///            arena is created automatically, and `input` copied into the
   ///            arena. If non-`nil`, `input` must be the registered source
   ///            buffer of `arena` or a slice of the source buffer.
-  public init(_ input: UnsafeBufferPointer<UInt8>, arena: SyntaxArena? = nil) {
+  public init(_ input: UnsafeBufferPointer<UInt8>, maximumNestingLevel: Int? = nil, arena: SyntaxArena? = nil) {
+    self.maximumNestingLevel = maximumNestingLevel ?? Self.defaultMaximumNestingLevel
+
     var sourceBuffer: UnsafeBufferPointer<UInt8>
     if let arena = arena {
       self.arena = arena
@@ -150,6 +174,7 @@ public struct Parser: TokenConsumer {
 
   @_spi(RawSyntax)
   public mutating func missingToken(_ kind: RawTokenKind, text: SyntaxText? = nil) -> RawTokenSyntax {
+    adjustNestingLevel(for: kind)
     return RawTokenSyntax(missing: kind, text: text, arena: self.arena)
   }
 
@@ -158,6 +183,12 @@ public struct Parser: TokenConsumer {
   /// - Returns: The token that was consumed.
   @_spi(RawSyntax)
   public mutating func consumeAnyToken() -> RawTokenSyntax {
+    adjustNestingLevel(for: self.currentToken.tokenKind)
+    return self.consumeAnyTokenWithoutAdjustingNestingLevel()
+  }
+
+  @_spi(RawSyntax)
+  public mutating func consumeAnyTokenWithoutAdjustingNestingLevel() -> RawTokenSyntax {
     let tok = self.currentToken
     self.currentToken = self.lexemes.advance()
     return RawTokenSyntax(
@@ -167,6 +198,17 @@ public struct Parser: TokenConsumer {
       presence: .present,
       arena: arena
     )
+  }
+
+  private mutating func adjustNestingLevel(for tokenKind: RawTokenKind) {
+    switch tokenKind {
+    case .leftAngle, .leftBrace, .leftParen, .leftSquareBracket, .poundIfKeyword:
+      nestingLevel += 1
+    case .rightAngle, .rightBrace, .rightParen, .rightSquareBracket, .poundEndifKeyword:
+      nestingLevel -= 1
+    default:
+      break
+    }
   }
 }
 
@@ -279,7 +321,7 @@ extension Parser {
     if handle.unexpectedTokens > 0 {
       var unexpectedTokens = [RawSyntax]()
       for _ in 0..<handle.unexpectedTokens {
-        unexpectedTokens.append(RawSyntax(self.consumeAnyToken()))
+        unexpectedTokens.append(RawSyntax(self.consumeAnyTokenWithoutAdjustingNestingLevel()))
       }
       unexpectedNodes = RawUnexpectedNodesSyntax(elements: unexpectedTokens, arena: self.arena)
     } else {
@@ -511,6 +553,8 @@ extension Parser {
       presence: .present,
       arena: self.arena
     )
+
+    self.adjustNestingLevel(for: tokenKind)
 
     // ... or a multi-character token with the first N characters being the one
     // that we want to consume as a separate token.

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -179,6 +179,18 @@ extension Parser {
   ///     tuple-pattern-element-list → tuple-pattern-element | tuple-pattern-element ',' tuple-pattern-element-list
   ///     tuple-pattern-element → pattern | identifier ':' pattern
   mutating func parsePatternTupleElements() -> RawTuplePatternElementListSyntax {
+    if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
+      return RawTuplePatternElementListSyntax(elements: [
+        RawTuplePatternElementSyntax(
+          remainingTokens,
+          labelName: nil,
+          labelColon: nil,
+          pattern: RawPatternSyntax(RawMissingPatternSyntax(arena: self.arena)),
+          trailingComma: nil,
+          arena: self.arena
+        )
+      ], arena: self.arena)
+    }
     var elements = [RawTuplePatternElementSyntax]()
     do {
       var keepGoing = true

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -392,6 +392,16 @@ extension Parser {
   ///     element-name → identifier
   @_spi(RawSyntax)
   public mutating func parseTupleTypeBody() -> RawTupleTypeSyntax {
+    if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
+      return RawTupleTypeSyntax(
+        remainingTokens,
+        leftParen: missingToken(.leftParen),
+        elements: RawTupleTypeElementListSyntax(elements: [], arena: self.arena),
+        rightParen: missingToken(.rightParen),
+        arena: self.arena
+      )
+    }
+
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
     var elements = [RawTupleTypeElementSyntax]()
     do {
@@ -501,6 +511,16 @@ extension Parser {
   ///     dictionary-type → '[' type ':' type ']'
   @_spi(RawSyntax)
   public mutating func parseCollectionType() -> RawTypeSyntax {
+    if let remaingingTokens = remainingTokensIfMaximumNestingLevelReached() {
+      return RawTypeSyntax(RawArrayTypeSyntax(
+        remaingingTokens,
+        leftSquareBracket: missingToken(.leftSquareBracket),
+        elementType: RawTypeSyntax(RawMissingTypeSyntax(arena: self.arena)),
+        rightSquareBracket: missingToken(.rightSquareBracket),
+        arena: self.arena
+      ))
+    }
+
     let (unexpectedBeforeLSquare, lsquare) = self.expect(.leftSquareBracket)
     let firstType = self.parseType()
     if let colon = self.consume(if: .colon) {

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -143,6 +143,9 @@ extension DiagnosticMessage where Self == StaticParserError {
   public static var standaloneSemicolonStatement: Self {
     .init("standalone ';' statements are not allowed")
   }
+  public static var maximumNestingLevelOverflow: Self {
+    .init("parsing has exceeded the maximum nesting level")
+  }
   public static var subscriptsCannotHaveNames: Self {
     .init("subscripts cannot have a name")
   }

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -26,6 +26,7 @@ struct RecursiveRawSyntaxFlags: OptionSet {
   /// Whether the tree contained by this layout has any missing or unexpected nodes.
   static let hasError = RecursiveRawSyntaxFlags(rawValue: 1 << 0)
   static let hasSequenceExpr = RecursiveRawSyntaxFlags(rawValue: 1 << 1)
+  static let hasMaximumNestingLevelOverflow = RecursiveRawSyntaxFlags(rawValue: 1 << 2)
 }
 
 /// Node data for RawSyntax tree. Tagged union plus common data.
@@ -633,6 +634,7 @@ extension RawSyntax {
   public static func makeLayout(
     kind: SyntaxKind,
     uninitializedCount count: Int,
+    isMaximumNestingLevelOverflow: Bool = false,
     arena: SyntaxArena,
     initializingWith initializer: (UnsafeMutableBufferPointer<RawSyntax?>) -> Void
   ) -> RawSyntax {
@@ -655,6 +657,9 @@ extension RawSyntax {
     }
     if kind == .sequenceExpr {
       recursiveFlags.insert(.hasSequenceExpr)
+    }
+    if isMaximumNestingLevelOverflow {
+      recursiveFlags.insert(.hasMaximumNestingLevelOverflow)
     }
     return .layout(
       kind: kind,

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -278,6 +278,10 @@ public extension SyntaxProtocol {
     return raw.recursiveFlags.contains(.hasSequenceExpr)
   }
 
+  var hasMaximumNestingLevelOverflow: Bool {
+    return raw.recursiveFlags.contains(.hasMaximumNestingLevelOverflow)
+  }
+
   /// The parent of this syntax node, or `nil` if this node is the root.
   var parent: Syntax? {
     return data.parent.map(Syntax.init(_:))

--- a/Sources/SwiftSyntax/Utils.swift
+++ b/Sources/SwiftSyntax/Utils.swift
@@ -119,3 +119,17 @@ extension UInt8 {
   static var asciiRightAngleBracket: UInt8 { return 62 /* > */ }
   static var asciiPound: UInt8 { return 35 /* # */ }
 }
+
+extension RawUnexpectedNodesSyntax {
+  public init(elements: [RawSyntax], isMaximumNestingLevelOverflow: Bool, arena: __shared SyntaxArena) {
+    let raw = RawSyntax.makeLayout(
+      kind: .unexpectedNodes, uninitializedCount: elements.count, isMaximumNestingLevelOverflow: isMaximumNestingLevelOverflow, arena: arena) { layout in
+      guard var ptr = layout.baseAddress else { return }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
+    }
+    self.init(raw: raw)
+  }
+}

--- a/Tests/SwiftParserTest/ParserTests.swift
+++ b/Tests/SwiftParserTest/ParserTests.swift
@@ -22,7 +22,9 @@ public class ParserTests: XCTestCase {
   func runParseTest(fileURL: URL, checkDiagnostics: Bool) throws {
     let fileContents = try Data(contentsOf: fileURL)
     let parsed = fileContents.withUnsafeBytes({ buffer in
-      Parser.parse(source: buffer.bindMemory(to: UInt8.self))
+      // Release builds are fine with the default maximum nesting level of 256.
+      // Debug builds overflow with any stack size bigger than 25-ish.
+      Parser.parse(source: buffer.bindMemory(to: UInt8.self), maximumNestingLevel: 25)
     })
     AssertDataEqualWithDiff(Data(parsed.syntaxTextBytes), fileContents,
                             additionalInfo: "Failed in file \(fileURL)")
@@ -103,14 +105,7 @@ public class ParserTests: XCTestCase {
       .appendingPathComponent("swift")
       .appendingPathComponent("test")
     runParserTests(
-      name: "Swift tests", path: testDir, checkDiagnostics: false,
-      shouldExclude: { fileURL in
-        false
-
-        // These tests overflow the parser.
-        || fileURL.absoluteString.contains("_overflow")
-        || fileURL.absoluteString.contains("parser-cutoff.swift")
-      }
+      name: "Swift tests", path: testDir, checkDiagnostics: false
     )
   }
 
@@ -127,42 +122,7 @@ public class ParserTests: XCTestCase {
       .appendingPathComponent("swift")
       .appendingPathComponent("validation-test")
     runParserTests(
-      name: "Swift validation tests", path: testDir, checkDiagnostics: false,
-      shouldExclude: { fileURL in
-        false
-
-        // Crashes due to deep recursion in the parser.
-        || fileURL.absoluteString.contains("swift-lexer-leximpl.swift")
-        || fileURL.absoluteString.contains("swift-inflightdiagnostic.swift")
-        || fileURL.absoluteString.contains("swift-lexer-kindofidentifier.swift")
-        || fileURL.absoluteString.contains("swift-lexer-lexidentifier.swift")
-        || fileURL.absoluteString.contains("swift-parser-skipsingle.swift")
-        || fileURL.absoluteString.contains("swift-lexer-kindofidentifier.swift")
-        || fileURL.absoluteString.contains("swift-lexer-lexstringliteral.swift")
-        || fileURL.absoluteString.contains("swift-lexer-lexoperatoridentifier.swift")
-        || fileURL.absoluteString.contains("26089-swift-constraints-constraintsystem-getconstraintlocator.swift")
-        || fileURL.absoluteString.contains("28616-swift-parser-parseexprsequence-swift-diag-bool-bool.swift")
-        || fileURL.absoluteString.contains("26205-swift-lexer-leximpl.swift")
-        || fileURL.absoluteString.contains("28686-swift-typebase-getcanonicaltype.swift")
-        || fileURL.absoluteString.contains(
-          "28591-swift-constraints-constraintsystem-solvesimplified-llvm-smallvectorimpl-swift-co.swift")
-        || fileURL.absoluteString.contains("28678-result-case-not-implemented.swift")
-        || fileURL.absoluteString.contains("28685-unreachable-executed-at-swift-lib-ast-type-cpp-1344.swift")
-        || fileURL.absoluteString.contains(
-          "28651-swift-cleanupillformedexpressionraii-doit-swift-expr-swift-astcontext-cleanupill.swift")
-        || fileURL.absoluteString.contains("28681-swift-typebase-getcanonicaltype.swift")
-        || fileURL.absoluteString.contains(
-          "28684-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift")
-        || fileURL.absoluteString.contains("26659-swift-genericsignature-getcanonicalmanglingsignature.swift")
-        || fileURL.absoluteString.contains("26162-swift-constraints-constraintsystem-getconstraintlocator.swift")
-        || fileURL.absoluteString.contains("26161-swift-patternbindingdecl-setpattern.swift")
-        || fileURL.absoluteString.contains("26101-swift-parser-parsenewdeclattribute.swift")
-        || fileURL.absoluteString.contains("26773-swift-diagnosticengine-diagnose.swift")
-        || fileURL.absoluteString.contains("parser-cutoff.swift")
-        || fileURL.absoluteString.contains("26233-swift-iterabledeclcontext-getmembers.swift")
-        || fileURL.absoluteString.contains("26190-swift-iterabledeclcontext-getmembers.swift")
-        || fileURL.absoluteString.contains("26139-swift-abstractclosureexpr-setparams.swift")
-      }
+      name: "Swift validation tests", path: testDir, checkDiagnostics: false
     )
   }
 }


### PR DESCRIPTION
The basic idea is that we start a new nesting level whenever we consume or synthesize an opening bracket (`<`, `{`, `(`, `[` or `#if`) and reduce it when we read the matching closing bracket. This should be a pretty simple indicator for the current nesting level that doesn’t require custom logins in productions. IMO the benefit here is that this notion of nesting level is easy to describe and explain.

Productions that are known to be able to overflow (I just took the ones that introduce `StructureMarkerRAII` in the C++ parser) can check `remainingTokensIfMaximumNestingLevelReached` and stop parsing if the maximum nesting level has been exceeded.

It turns out that a nesting level of 256 (which is the current maximum nesting level in the C++ parser) is totally fine in Release builds of the parser, but debug builds fail with nesting levels > 30-ish. 

---

Since lookahead cannot really bail out to prevent stack overflow, I rewrote `skipSingle` and `skipUntil` to work iteratively instead of recursively.