### PR TITLE
Add SyntaxProtocol.token(at:) to find the token at an absolute position

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -320,6 +320,25 @@ public extension SyntaxProtocol {
     return nil
   }
 
+  /// Find the syntax token at the given absolute position within this
+  /// syntax node or any of its children.
+  func token(at position: AbsolutePosition) -> TokenSyntax? {
+    // If the position isn't within this node at all, return early.
+    guard position >= self.position && position < self.endPosition else {
+      return nil
+    }
+
+    // If we are a token syntax, that's it!
+    if let token = Syntax(self).as(TokenSyntax.self) {
+      return token
+    }
+
+    // Otherwise, it must be one of our children.
+    return children(viewMode: .sourceAccurate).lazy.compactMap { child in
+      child.token(at: position)
+    }.first
+  }
+
   /// The absolute position of the starting point of this node. If the first token
   /// is with leading trivia, the position points to the start of the leading
   /// trivia.

--- a/Tests/SwiftParserTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftParserTest/AbsolutePositionTests.swift
@@ -1,0 +1,37 @@
+
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import SwiftSyntax
+import SwiftParser
+import _SwiftSyntaxTestSupport
+
+public class AbsolutePositionTests: XCTestCase {
+  public func testTokenAt() {
+    let source =
+      """
+      func f(a: Int) { }
+      """
+
+    let parsed = Parser.parse(source: source)
+    for expectedToken in parsed.tokens(viewMode: .sourceAccurate) {
+      let tokenStart = expectedToken.position.utf8Offset
+      let tokenEnd = expectedToken.endPosition.utf8Offset
+      for offset in tokenStart..<tokenEnd {
+        let token = parsed.token(at: AbsolutePosition(utf8Offset: offset))
+        XCTAssertEqual(token, expectedToken)
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
This is useful for finding the token at a particular absolute position.