### PR TITLE
Make sure that any keyword or identifier inserted by a Fix-It is separated from the previous one by trivia

### DIFF
--- a/Tests/SwiftParserTest/translated/ToplevelLibraryTests.swift
+++ b/Tests/SwiftParserTest/translated/ToplevelLibraryTests.swift
@@ -44,7 +44,9 @@ final class ToplevelLibraryTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected 'in', expression, and body in 'for' statement"),
-      ]
+      ], fixedSource: """
+        for i in <#expression#> {}
+        """
     )
   }
 }


### PR DESCRIPTION
Previously, the now updated test case generated `for iin <#expression#> {}` when applying the Fix-It.