### PR TITLE
[CMake] Reduce build dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,12 +23,27 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set(CMAKE_MACOSX_RPATH YES)
 
-# Ensure that we do not link the _StringProcessing module.
-add_compile_options(
-  $<$<COMPILE_LANGUAGE:Swift>:-Xfrontend>
-  $<$<COMPILE_LANGUAGE:Swift>:-disable-implicit-string-processing-module-import>)
+# Ensure that we do not link the _StringProcessing module. But we can
+# only pass this flag for new-enough compilers that support it.
+file(WRITE "${CMAKE_BINARY_DIR}/tmp/empty-check-string-processing.swift" "")
+execute_process(
+  COMMAND
+    "${CMAKE_Swift_COMPILER}"
+    -Xfrontend -disable-implicit-string-processing-module-import
+    -c - -o /dev/null
+  INPUT_FILE
+    "${CMAKE_BINARY_DIR}/tmp/empty-check-string-processing.swift"
+  OUTPUT_QUIET ERROR_QUIET
+  RESULT_VARIABLE
+    SWIFT_SUPPORTS_DISABLE_IMPLICIT_STRING_PROCESSING_MODULE_IMPORT)
+if (NOT SWIFT_SUPPORTS_DISABLE_IMPLICIT_STRING_PROCESSING_MODULE_IMPORT)
+  add_compile_options(
+    $<$<COMPILE_LANGUAGE:Swift>:-Xfrontend>
+    $<$<COMPILE_LANGUAGE:Swift>:-disable-implicit-string-processing-module-import>)
+endif()
 
-# Force single-threaded builds to eliminate the Darwin dependency.
+# Force single-threaded-only syntax trees to eliminate the Darwin
+# dependency in the compiler.
 add_compile_definitions(
   $<$<COMPILE_LANGUAGE:Swift>:SWIFT_SYNTAX_ALWAYS_SINGLE_THREADED>
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,15 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set(CMAKE_MACOSX_RPATH YES)
 
+# Ensure that we do not link the _StringProcessing module.
 add_compile_options(
   $<$<COMPILE_LANGUAGE:Swift>:-Xfrontend>
   $<$<COMPILE_LANGUAGE:Swift>:-disable-implicit-string-processing-module-import>)
+
+# Force single-threaded builds to eliminate the Darwin dependency.
+add_compile_definitions(
+  $<$<COMPILE_LANGUAGE:Swift>:SWIFT_SYNTAX_ALWAYS_SINGLE_THREADED>
+)
 
 add_subdirectory(Sources)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set(CMAKE_MACOSX_RPATH YES)
 
+add_compile_options(
+  $<$<COMPILE_LANGUAGE:Swift>:-Xfrontend>
+  $<$<COMPILE_LANGUAGE:Swift>:-disable-implicit-string-processing-module-import>)
+
 add_subdirectory(Sources)
 
 export(EXPORT SwiftSyntaxTargets

--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -11,7 +11,9 @@ add_library(SwiftSyntax STATIC
   BumpPtrAllocator.swift
   CommonAncestor.swift
   IncrementalParseTransition.swift
-  PlatformMutex.swift
+  # PlatformMutex.swift is intentionally excluded because it brings in
+  # platform dependencies we don't want within the CMake build, which is
+  # trying to minimize such dependencies.
   SourceLength.swift
   SourceLocation.swift
   SourcePresence.swift

--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -10,10 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !SWIFT_SYNTAX_ALWAYS_SINGLE_THREADED
 #if canImport(Darwin)
 @_implementationOnly import Darwin
 #elseif canImport(Glibc)
 @_implementationOnly import Glibc
+#endif
 #endif
 
 /// Represent a string.
@@ -222,7 +224,10 @@ private func compareMemory(
   _ s1: UnsafePointer<UInt8>, _ s2: UnsafePointer<UInt8>, _ count: Int
 ) -> Bool {
   assert(count >= 0)
-#if canImport(Darwin)
+#if SWIFT_SYNTAX_ALWAYS_SINGLE_THREADED
+  return UnsafeBufferPointer(start: s1, count: count)
+    .elementsEqual(UnsafeBufferPointer(start: s2, count: count))
+#elseif canImport(Darwin)
   return Darwin.memcmp(s1, s2, count) == 0
 #elseif canImport(Glibc)
   return Glibc.memcmp(s1, s2, count) == 0

--- a/Tests/SwiftParserTest/LinkageTests.swift
+++ b/Tests/SwiftParserTest/LinkageTests.swift
@@ -32,7 +32,7 @@ final class LinkageTest: XCTestCase {
       .library("-lswiftCompatibility56", condition: .mayBeAbsent("Starting in Xcode 14 this library is not always autolinked")),
       .library("-lswiftCompatibilityConcurrency"),
       .library("-lswiftCore"),
-      .library("-lswiftDarwin", condition: .mayBeAbsent("Not present when building inside the compiler"),
+      .library("-lswiftDarwin", condition: .mayBeAbsent("Not present when building inside the compiler")),
       .library("-lswiftSwiftOnoneSupport", condition: .when(configuration: .debug)),
       .library("-lswift_Concurrency"),
       .library("-lswift_StringProcessing", condition: .mayBeAbsent("Starting in Xcode 14 this library is not always autolinked")),

--- a/Tests/SwiftParserTest/LinkageTests.swift
+++ b/Tests/SwiftParserTest/LinkageTests.swift
@@ -32,7 +32,7 @@ final class LinkageTest: XCTestCase {
       .library("-lswiftCompatibility56", condition: .mayBeAbsent("Starting in Xcode 14 this library is not always autolinked")),
       .library("-lswiftCompatibilityConcurrency"),
       .library("-lswiftCore"),
-      .library("-lswiftDarwin"),
+      .library("-lswiftDarwin", condition: .mayBeAbsent("Not present when building inside the compiler"),
       .library("-lswiftSwiftOnoneSupport", condition: .when(configuration: .debug)),
       .library("-lswift_Concurrency"),
       .library("-lswift_StringProcessing", condition: .mayBeAbsent("Starting in Xcode 14 this library is not always autolinked")),


### PR DESCRIPTION
Eliminate build dependencies on both `_StringProcessing` and the platform (`Darwin` / `Glibc`) when building in CMake to be embedded in the compiler. This eliminates a dependency cycle in some build configurations, fixing rdar://101650446