### PR TITLE
Fix build failure

### DIFF
--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -144,7 +144,7 @@ extension Parser {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return RawCodeBlockItemSyntax(
         remainingTokens,
-        item: RawSyntax(RawMissingExprSyntax(arena: self.arena)),
+        item: .expr(RawExprSyntax(RawMissingExprSyntax(arena: self.arena))),
         semicolon: nil,
         errorTokens: nil,
         arena: self.arena


### PR DESCRIPTION
https://github.com/apple/swift-syntax/pull/1034 and https://github.com/apple/swift-syntax/pull/1034 raced, causing a build failure.