### PR TITLE
Remove UserInaccesible from SetterAccess

### DIFF
--- a/gyb_syntax_support/AttributeKinds.py
+++ b/gyb_syntax_support/AttributeKinds.py
@@ -817,7 +817,6 @@ DECL_MODIFIER_KINDS = [
     ContextualDeclAttributeAlias('open', 'AccessControl'),
     DeclAttribute('__setter_access', 'SetterAccess',
                   OnVar,  OnSubscript,
-                  UserInaccessible,
                   DeclModifier,  RejectByParser,
                   NotSerialized,
                   ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,


### PR DESCRIPTION
`__setter_access` is similar to `_custom` in that this name isn't actually used when printing. So even though it's double underscored, it should still be user accessible.