### PR TITLE
s/build-path/scratch-path

### DIFF
--- a/build-script.py
+++ b/build-script.py
@@ -416,7 +416,7 @@ def get_swiftpm_invocation(
     if release:
         swiftpm_call.extend(["--configuration", "release"])
     if build_dir:
-        swiftpm_call.extend(["--build-path", build_dir])
+        swiftpm_call.extend(["--scratch-path", build_dir])
     if multiroot_data_file:
         swiftpm_call.extend(["--multiroot-data-file", multiroot_data_file])
 


### PR DESCRIPTION
SwiftPM retracted support for this option fairly recently. Restore the build.