### PR TITLE
Specialize Guarded Pattern Parsing for Cases and Catches

### DIFF
--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -105,6 +105,12 @@ final class StatementTests: XCTestCase {
        }
        """
     )
+
+    AssertParse(
+      """
+      do {}
+      catch where (error as NSError) == NSError() {}
+      """)
   }
 
   func testReturn() {

--- a/Tests/SwiftParserTest/translated/ErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/ErrorsTests.swift
@@ -86,7 +86,6 @@ final class ErrorsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 3: expected expression after '? ... :' in ternary expression
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected expression in 'do' statement"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in pattern"),
       ]
     )
   }


### PR DESCRIPTION
Catch patterns are allowed to forgo their pattern, while cases must have patterns. Since these productions have two different types, split these two distinct productions apart.

Fixes #1040
rdar://101815618