### PR TITLE
Add `--include-trivia` flag to `swift-parser-cli`.

### DIFF
--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -182,6 +182,9 @@ class PrintTree: ParsableCommand {
   @Flag(name: .long, help: "Perform sequence folding with the standard operators")
   var foldSequences: Bool = false
 
+  @Flag(name: .long, help: "Include trivia in the output")
+  var includeTrivia: Bool = false
+
   func run() throws {
     let source = try getContentsOfSourceFile(at: sourceFile)
 
@@ -195,7 +198,7 @@ class PrintTree: ParsableCommand {
         resultTree = Syntax(tree)
       }
 
-      print(resultTree.recursiveDescription)
+      print(resultTree.debugDescription(includeChildren: true, includeTrivia: includeTrivia))
     }
   }
 }


### PR DESCRIPTION
This is something that I've wanted to have during development, especially when manipulating trivia in swift-format.

---

Manually tested example:

```
$ swift-parser-cli print-tree --include-trivia <<'EOF'
heredoc> /*xyz*/ func foo() {  // blah
heredoc>   }
heredoc> EOF

SourceFileSyntax children=2
  0: CodeBlockItemListSyntax children=1
    0: CodeBlockItemSyntax children=1
      0: FunctionDeclSyntax children=4
        0: funcKeyword leadingTrivia=[blockComment("/*xyz*/"), spaces(1)] trailingTrivia=spaces(1)
        1: identifier("foo")
        2: FunctionSignatureSyntax children=1
          0: ParameterClauseSyntax children=3
            0: leftParen
            1: FunctionParameterListSyntax
            2: rightParen trailingTrivia=spaces(1)
        3: CodeBlockSyntax children=3
          0: leftBrace trailingTrivia=[spaces(2), lineComment("// blah")]
          1: CodeBlockItemListSyntax
          2: rightBrace leadingTrivia=[newlines(1), spaces(2)]
  1: eof leadingTrivia=newlines(1)
```