### PR TITLE
Eliminate SyntaxArena.default

### DIFF
--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -219,7 +219,8 @@ extension RawSyntax {
   /// If the syntax tree did not contain a token and thus no trivia could be attached to it, `nil` is returned.
   /// - Parameters:
   ///   - leadingTrivia: The trivia to attach.
-  func withLeadingTrivia(_ leadingTrivia: Trivia) -> RawSyntax? {
+  ///   - arena: SyntaxArena to the result node data resides.
+  func withLeadingTrivia(_ leadingTrivia: Trivia, arena: SyntaxArena) -> RawSyntax? {
     switch view {
     case .token(let tokenView):
       return .makeMaterializedToken(
@@ -229,7 +230,7 @@ extension RawSyntax {
         arena: arena)
     case .layout(let layoutView):
       for (index, child) in layoutView.children.enumerated() {
-        if let replaced = child?.withLeadingTrivia(leadingTrivia) {
+        if let replaced = child?.withLeadingTrivia(leadingTrivia, arena: arena) {
           return layoutView.replacingChild(at: index, with: replaced, arena: arena)
         }
       }
@@ -241,7 +242,8 @@ extension RawSyntax {
   /// If the syntax tree did not contain a token and thus no trivia could be attached to it, `nil` is returned.
   /// - Parameters:
   ///   - trailingTrivia: The trivia to attach.
-  func withTrailingTrivia(_ trailingTrivia: Trivia) -> RawSyntax? {
+  ///   - arena: SyntaxArena to the result node data resides.
+  func withTrailingTrivia(_ trailingTrivia: Trivia, arena: SyntaxArena) -> RawSyntax? {
     switch view {
     case .token(let tokenView):
       return .makeMaterializedToken(
@@ -251,7 +253,7 @@ extension RawSyntax {
         arena: arena)
     case .layout(let layoutView):
       for (index, child) in layoutView.children.enumerated().reversed() {
-        if let replaced = child?.withTrailingTrivia(trailingTrivia) {
+        if let replaced = child?.withTrailingTrivia(trailingTrivia, arena: arena) {
           return layoutView.replacingChild(at: index, with: replaced, arena: arena)
         }
       }

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -151,7 +151,7 @@ public struct RawSyntaxTokenView {
   /// Returns a `RawSyntax` node with the same source text but with the token
   /// kind changed to `newValue`.
   @_spi(RawSyntax)
-  public func withKind(_ newValue: TokenKind) -> RawSyntax {
+  public func withKind(_ newValue: TokenKind, arena: SyntaxArena) -> RawSyntax {
     switch raw.rawData.payload {
     case .parsedToken(_):
       // The wholeText can't be continuous anymore. Make a materialized token.
@@ -159,16 +159,16 @@ public struct RawSyntaxTokenView {
         kind: newValue,
         leadingTrivia: formLeadingTrivia(),
         trailingTrivia: formTrailingTrivia(),
-        arena: raw.arena)
+        arena: arena)
     case .materializedToken(var payload):
       let decomposed = newValue.decomposeToRaw()
       let rawKind = decomposed.rawKind
-      let text: SyntaxText = (decomposed.string.map({raw.arena.intern($0)}) ??
+      let text: SyntaxText = (decomposed.string.map({arena.intern($0)}) ??
                               decomposed.rawKind.defaultText ??
                               "")
       payload.tokenKind = rawKind
       payload.tokenText = text
-      return RawSyntax(arena: raw.arena, payload: .materializedToken(payload))
+      return RawSyntax(arena: arena, payload: .materializedToken(payload))
     default:
       preconditionFailure("'withTokenKind()' is called on non-token raw syntax")
     }

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -482,13 +482,13 @@ public extension SyntaxProtocol {
   /// Returns a new syntax node with its leading trivia replaced
   /// by the provided trivia.
   func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
-    return Self(Syntax(data.withLeadingTrivia(leadingTrivia)))!
+    return Self(Syntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena())))!
   }
 
   /// Returns a new syntax node with its trailing trivia replaced
   /// by the provided trivia.
   func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
-    return Self(Syntax(data.withTrailingTrivia(trailingTrivia)))!
+    return Self(Syntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena())))!
   }
 
   /// Returns a new syntax node with its leading trivia removed.

--- a/Sources/SwiftSyntax/SyntaxArena.swift
+++ b/Sources/SwiftSyntax/SyntaxArena.swift
@@ -250,12 +250,6 @@ struct SyntaxArenaRef: Equatable {
   }
 }
 
-extension SyntaxArena {
-  // FIXME: This is only for migration. All clients should move to "arena" model.
-  //@available(*, deprecated, message: ".default SyntaxArena is subject to remove soon")
-  public static let `default` = SyntaxArena()
-}
-
 private func _defaultParseTriviaFunction(_ source: SyntaxText, _ position: TriviaPosition) -> [RawTriviaPiece] {
   preconditionFailure("Trivia parsing not supported")
 }

--- a/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -118,9 +118,11 @@ public struct ${node.name}: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.${node.swift_syntax_kind},
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.${node.swift_syntax_kind},
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -135,8 +137,9 @@ public struct ${node.name}: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `${node.name}` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> ${node.name} {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return ${node.name}(newData)
   }
 
@@ -228,13 +231,13 @@ public struct ${node.name}: SyntaxCollection, SyntaxHashable {
   /// Returns a new `${node.name}` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ${node.name} {
-    return ${node.name}(data.withLeadingTrivia(leadingTrivia))
+    return ${node.name}(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `${node.name}` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ${node.name} {
-    return ${node.name}(data.withTrailingTrivia(trailingTrivia))
+    return ${node.name}(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `${node.name}` with its leading trivia removed.

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -322,15 +322,16 @@ struct SyntaxData {
 
   /// Creates a copy of `self` and recursively creates `SyntaxData` nodes up to
   /// the root.
-  /// - parameter newRaw: The new RawSyntax that will back the new `Data`
-  /// - returns: A tuple of both the new root node and the new data with the raw
+  /// - Parameters:
+  ///   - newRaw: The new RawSyntax that will back the new `Data`
+  ///   - arena: SyntaxArena to the result RawSyntax node data resides.
+  /// - Returns: A tuple of both the new root node and the new data with the raw
   ///            layout replaced.
-  func replacingSelf(
-    _ newRaw: RawSyntax) -> SyntaxData {
+  func replacingSelf(_ newRaw: RawSyntax, arena: SyntaxArena) -> SyntaxData {
     // If we have a parent already, then ask our current parent to copy itself
     // recursively up to the root.
     if let parent = parent {
-      let parentData = parent.replacingChild(newRaw, at: indexInParent)
+      let parentData = parent.replacingChild(newRaw, at: indexInParent, arena: arena)
       let newParent = Syntax(parentData)
       return SyntaxData(absoluteRaw.replacingSelf(newRaw, newRootId: parentData.nodeId.rootId), parent: newParent)
     } else {
@@ -346,25 +347,26 @@ struct SyntaxData {
   ///   - child: The raw syntax for the new child to replace.
   ///   - index: The index pointing to where in the raw layout to place this
   ///            child.
+  ///   - arena: SyntaxArena to the result RawSyntax node data resides.
   /// - Returns: The new root node created by this operation, and the new child
   ///            syntax data.
   /// - SeeAlso: replacingSelf(_:)
-  func replacingChild(_ child: RawSyntax?, at index: Int) -> SyntaxData {
-    let newRaw = raw.layoutView!.replacingChild(at: index, with: child, arena: .default)
-    return replacingSelf(newRaw)
+  func replacingChild(_ child: RawSyntax?, at index: Int, arena: SyntaxArena) -> SyntaxData {
+    let newRaw = raw.layoutView!.replacingChild(at: index, with: child, arena: arena)
+    return replacingSelf(newRaw, arena: arena)
   }
 
-  func withLeadingTrivia(_ leadingTrivia: Trivia) -> SyntaxData {
-    if let raw = raw.withLeadingTrivia(leadingTrivia) {
-      return replacingSelf(raw)
+  func withLeadingTrivia(_ leadingTrivia: Trivia, arena: SyntaxArena) -> SyntaxData {
+    if let raw = raw.withLeadingTrivia(leadingTrivia, arena: arena) {
+      return replacingSelf(raw, arena: arena)
     } else {
       return self
     }
   }
 
-  func withTrailingTrivia(_ trailingTrivia: Trivia) -> SyntaxData {
-    if let raw = raw.withTrailingTrivia(trailingTrivia) {
-      return replacingSelf(raw)
+  func withTrailingTrivia(_ trailingTrivia: Trivia, arena: SyntaxArena) -> SyntaxData {
+    if let raw = raw.withTrailingTrivia(trailingTrivia, arena: arena) {
+      return replacingSelf(raw, arena: arena)
     } else {
       return self
     }

--- a/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -32,18 +32,16 @@ public enum SyntaxFactory {
   public static func makeToken(_ kind: TokenKind, presence: SourcePresence,
                                leadingTrivia: Trivia = [],
                                trailingTrivia: Trivia = []) -> TokenSyntax {
-    let raw = RawSyntax.makeMaterializedToken(kind: kind, leadingTrivia: leadingTrivia,
-      trailingTrivia: trailingTrivia, presence: presence, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TokenSyntax(data)
+    TokenSyntax(
+      kind,
+      leadingTrivia: leadingTrivia,
+      trailingTrivia: trailingTrivia,
+      presence: presence)
   }
 
   @available(*, deprecated, message: "Use initializer on UnknownSyntax")
   public static func makeUnknownSyntax(tokens: [TokenSyntax]) -> UnknownSyntax {
-    let raw = RawSyntax.makeLayout(kind: .unknown,
-      from: tokens.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return UnknownSyntax(data)
+    UnknownSyntax(tokens: tokens)
   }
 
 /// MARK: Syntax Node Creation APIs
@@ -78,19 +76,23 @@ public enum SyntaxFactory {
 %       end
 %     end
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.${node.swift_syntax_kind},
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ${node.name}(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.${node.swift_syntax_kind},
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ${node.name}(data)
+    }
   }
 %   elif node.is_syntax_collection():
   @available(*, deprecated, message: "Use initializer on ${node.name}")
   public static func make${node.syntax_kind}(
     _ elements: [${node.collection_element_type}]) -> ${node.name} {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.${node.swift_syntax_kind},
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ${node.name}(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.${node.swift_syntax_kind},
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ${node.name}(data)
+    }
   }
 %   end
 
@@ -98,17 +100,19 @@ public enum SyntaxFactory {
 %   default_presence = 'missing' if node.is_missing() else 'present'
   @available(*, deprecated, message: "Use initializer on ${node.name}")
   public static func makeBlank${node.syntax_kind}(presence: SourcePresence = .${default_presence}) -> ${node.name} {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .${node.swift_syntax_kind},
-      from: [
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .${node.swift_syntax_kind},
+        from: [
 %     for child in node.children:
 %       if child.is_optional:
-      nil,
+        nil,
 %       else:
-      ${make_missing_swift_child(child)},
+        ${make_missing_swift_child(child)},
 %       end
 %     end
-    ], arena: .default))
-    return ${node.name}(data)
+      ], arena: arena))
+      return ${node.name}(data)
+    }
   }
 %   end
 % end

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
@@ -126,7 +126,7 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
 %       else:
     ${child.swift_name}: ${param_type}${comma}
 %       end
-%     end 
+%     end
   ) {
     let layout: [RawSyntax?] = [
 %     for child in node.children:
@@ -137,9 +137,11 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
 %       end
 %     end
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.${node.swift_syntax_kind},
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.${node.swift_syntax_kind},
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 %     for (idx, child) in enumerate(node.children):
@@ -190,13 +192,14 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
   ///            appended to its `${child.swift_name}` collection.
   public func add${child_elt}(_ element: ${child_elt_type}) -> ${node.name} {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[${idx}] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.${child_node.swift_syntax_kind},
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: ${idx})
+    let newData = data.replacingChild(collection, at: ${idx}, arena: arena)
     return ${node.name}(newData)
   }
 %       end
@@ -207,14 +210,14 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `${child.swift_name}` replaced.
   /// - param newChild: The new `${child.swift_name}` to replace the node's
   ///                   current `${child.swift_name}`, if present.
-  public func with${child.name}(
-    _ newChild: ${child_type}?) -> ${node.name} {
+  public func with${child.name}(_ newChild: ${child_type}?) -> ${node.name} {
+    let arena = SyntaxArena()
 %       if child.is_optional:
     let raw = newChild?.raw
 %       else:
     let raw = newChild?.raw ?? ${make_missing_swift_child(child)}
 %       end
-    let newData = data.replacingChild(raw, at: ${idx})
+    let newData = data.replacingChild(raw, at: ${idx}, arena: arena)
     return ${node.name}(newData)
   }
 %     end

--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -274,9 +274,10 @@ open class SyntaxRewriter {
       // Sanity check, ensure the new children are the same length.
       assert(newLayout.count == node.raw.layoutView!.children.count)
 
-      let newRaw = node.raw.layoutView!.replacingLayout(with: Array(newLayout), arena: .default)
+      let arena = SyntaxArena()
+      let newRaw = node.raw.layoutView!.replacingLayout(with: Array(newLayout), arena: arena)
       // 'withExtendedLifetime' to keep 'SyntaxArena's of them alive until here.
-      return withExtendedLifetime(rewrittens) {
+      return withExtendedLifetime((arena, rewrittens)) {
         SyntaxType(Syntax(SyntaxData.forRoot(newRaw)))!
       }
     } else {

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
@@ -54,9 +54,11 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -71,8 +73,9 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `CodeBlockItemListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> CodeBlockItemListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return CodeBlockItemListSyntax(newData)
   }
 
@@ -164,13 +167,13 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `CodeBlockItemListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> CodeBlockItemListSyntax {
-    return CodeBlockItemListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return CodeBlockItemListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `CodeBlockItemListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> CodeBlockItemListSyntax {
-    return CodeBlockItemListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return CodeBlockItemListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `CodeBlockItemListSyntax` with its leading trivia removed.
@@ -305,9 +308,11 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unexpectedNodes,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unexpectedNodes,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -322,8 +327,9 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `UnexpectedNodesSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> UnexpectedNodesSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return UnexpectedNodesSyntax(newData)
   }
 
@@ -415,13 +421,13 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `UnexpectedNodesSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> UnexpectedNodesSyntax {
-    return UnexpectedNodesSyntax(data.withLeadingTrivia(leadingTrivia))
+    return UnexpectedNodesSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `UnexpectedNodesSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> UnexpectedNodesSyntax {
-    return UnexpectedNodesSyntax(data.withTrailingTrivia(trailingTrivia))
+    return UnexpectedNodesSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `UnexpectedNodesSyntax` with its leading trivia removed.
@@ -556,9 +562,11 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -573,8 +581,9 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `TupleExprElementListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> TupleExprElementListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return TupleExprElementListSyntax(newData)
   }
 
@@ -666,13 +675,13 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `TupleExprElementListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> TupleExprElementListSyntax {
-    return TupleExprElementListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return TupleExprElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `TupleExprElementListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> TupleExprElementListSyntax {
-    return TupleExprElementListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return TupleExprElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `TupleExprElementListSyntax` with its leading trivia removed.
@@ -807,9 +816,11 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayElementList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayElementList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -824,8 +835,9 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `ArrayElementListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> ArrayElementListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return ArrayElementListSyntax(newData)
   }
 
@@ -917,13 +929,13 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `ArrayElementListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ArrayElementListSyntax {
-    return ArrayElementListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return ArrayElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ArrayElementListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ArrayElementListSyntax {
-    return ArrayElementListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return ArrayElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ArrayElementListSyntax` with its leading trivia removed.
@@ -1058,9 +1070,11 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryElementList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryElementList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1075,8 +1089,9 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `DictionaryElementListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> DictionaryElementListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return DictionaryElementListSyntax(newData)
   }
 
@@ -1168,13 +1183,13 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `DictionaryElementListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> DictionaryElementListSyntax {
-    return DictionaryElementListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return DictionaryElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `DictionaryElementListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> DictionaryElementListSyntax {
-    return DictionaryElementListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return DictionaryElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `DictionaryElementListSyntax` with its leading trivia removed.
@@ -1343,9 +1358,11 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralSegments,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralSegments,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1360,8 +1377,9 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `StringLiteralSegmentsSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> StringLiteralSegmentsSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return StringLiteralSegmentsSyntax(newData)
   }
 
@@ -1453,13 +1471,13 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `StringLiteralSegmentsSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> StringLiteralSegmentsSyntax {
-    return StringLiteralSegmentsSyntax(data.withLeadingTrivia(leadingTrivia))
+    return StringLiteralSegmentsSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `StringLiteralSegmentsSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> StringLiteralSegmentsSyntax {
-    return StringLiteralSegmentsSyntax(data.withTrailingTrivia(trailingTrivia))
+    return StringLiteralSegmentsSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `StringLiteralSegmentsSyntax` with its leading trivia removed.
@@ -1594,9 +1612,11 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgumentList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgumentList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1611,8 +1631,9 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `DeclNameArgumentListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> DeclNameArgumentListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return DeclNameArgumentListSyntax(newData)
   }
 
@@ -1704,13 +1725,13 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `DeclNameArgumentListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> DeclNameArgumentListSyntax {
-    return DeclNameArgumentListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return DeclNameArgumentListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `DeclNameArgumentListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> DeclNameArgumentListSyntax {
-    return DeclNameArgumentListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return DeclNameArgumentListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `DeclNameArgumentListSyntax` with its leading trivia removed.
@@ -1845,9 +1866,11 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.exprList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.exprList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1862,8 +1885,9 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `ExprListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> ExprListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return ExprListSyntax(newData)
   }
 
@@ -1955,13 +1979,13 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `ExprListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ExprListSyntax {
-    return ExprListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return ExprListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ExprListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ExprListSyntax {
-    return ExprListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return ExprListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ExprListSyntax` with its leading trivia removed.
@@ -2096,9 +2120,11 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItemList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItemList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2113,8 +2139,9 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `ClosureCaptureItemListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> ClosureCaptureItemListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return ClosureCaptureItemListSyntax(newData)
   }
 
@@ -2206,13 +2233,13 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `ClosureCaptureItemListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ClosureCaptureItemListSyntax {
-    return ClosureCaptureItemListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return ClosureCaptureItemListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ClosureCaptureItemListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ClosureCaptureItemListSyntax {
-    return ClosureCaptureItemListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return ClosureCaptureItemListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ClosureCaptureItemListSyntax` with its leading trivia removed.
@@ -2347,9 +2374,11 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParamList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParamList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2364,8 +2393,9 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `ClosureParamListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> ClosureParamListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return ClosureParamListSyntax(newData)
   }
 
@@ -2457,13 +2487,13 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `ClosureParamListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ClosureParamListSyntax {
-    return ClosureParamListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return ClosureParamListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ClosureParamListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ClosureParamListSyntax {
-    return ClosureParamListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return ClosureParamListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ClosureParamListSyntax` with its leading trivia removed.
@@ -2598,9 +2628,11 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElementList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElementList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2615,8 +2647,9 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
   /// - Returns: A new `MultipleTrailingClosureElementListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> MultipleTrailingClosureElementListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return MultipleTrailingClosureElementListSyntax(newData)
   }
 
@@ -2708,13 +2741,13 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
   /// Returns a new `MultipleTrailingClosureElementListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> MultipleTrailingClosureElementListSyntax {
-    return MultipleTrailingClosureElementListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return MultipleTrailingClosureElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `MultipleTrailingClosureElementListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> MultipleTrailingClosureElementListSyntax {
-    return MultipleTrailingClosureElementListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return MultipleTrailingClosureElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `MultipleTrailingClosureElementListSyntax` with its leading trivia removed.
@@ -2849,9 +2882,11 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathComponentList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathComponentList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2866,8 +2901,9 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `KeyPathComponentListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> KeyPathComponentListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return KeyPathComponentListSyntax(newData)
   }
 
@@ -2959,13 +2995,13 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `KeyPathComponentListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> KeyPathComponentListSyntax {
-    return KeyPathComponentListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return KeyPathComponentListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `KeyPathComponentListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> KeyPathComponentListSyntax {
-    return KeyPathComponentListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return KeyPathComponentListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `KeyPathComponentListSyntax` with its leading trivia removed.
@@ -3100,9 +3136,11 @@ public struct ObjcNameSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcName,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcName,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3117,8 +3155,9 @@ public struct ObjcNameSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `ObjcNameSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> ObjcNameSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return ObjcNameSyntax(newData)
   }
 
@@ -3210,13 +3249,13 @@ public struct ObjcNameSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `ObjcNameSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ObjcNameSyntax {
-    return ObjcNameSyntax(data.withLeadingTrivia(leadingTrivia))
+    return ObjcNameSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ObjcNameSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ObjcNameSyntax {
-    return ObjcNameSyntax(data.withTrailingTrivia(trailingTrivia))
+    return ObjcNameSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ObjcNameSyntax` with its leading trivia removed.
@@ -3351,9 +3390,11 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3368,8 +3409,9 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `YieldExprListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> YieldExprListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return YieldExprListSyntax(newData)
   }
 
@@ -3461,13 +3503,13 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `YieldExprListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> YieldExprListSyntax {
-    return YieldExprListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return YieldExprListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `YieldExprListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> YieldExprListSyntax {
-    return YieldExprListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return YieldExprListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `YieldExprListSyntax` with its leading trivia removed.
@@ -3602,9 +3644,11 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionParameterList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionParameterList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3619,8 +3663,9 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `FunctionParameterListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> FunctionParameterListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return FunctionParameterListSyntax(newData)
   }
 
@@ -3712,13 +3757,13 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `FunctionParameterListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> FunctionParameterListSyntax {
-    return FunctionParameterListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return FunctionParameterListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `FunctionParameterListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> FunctionParameterListSyntax {
-    return FunctionParameterListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return FunctionParameterListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `FunctionParameterListSyntax` with its leading trivia removed.
@@ -3853,9 +3898,11 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClauseList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClauseList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3870,8 +3917,9 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `IfConfigClauseListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> IfConfigClauseListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return IfConfigClauseListSyntax(newData)
   }
 
@@ -3963,13 +4011,13 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `IfConfigClauseListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> IfConfigClauseListSyntax {
-    return IfConfigClauseListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return IfConfigClauseListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `IfConfigClauseListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> IfConfigClauseListSyntax {
-    return IfConfigClauseListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return IfConfigClauseListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `IfConfigClauseListSyntax` with its leading trivia removed.
@@ -4104,9 +4152,11 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.inheritedTypeList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.inheritedTypeList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4121,8 +4171,9 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `InheritedTypeListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> InheritedTypeListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return InheritedTypeListSyntax(newData)
   }
 
@@ -4214,13 +4265,13 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `InheritedTypeListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> InheritedTypeListSyntax {
-    return InheritedTypeListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return InheritedTypeListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `InheritedTypeListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> InheritedTypeListSyntax {
-    return InheritedTypeListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return InheritedTypeListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `InheritedTypeListSyntax` with its leading trivia removed.
@@ -4355,9 +4406,11 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4372,8 +4425,9 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `MemberDeclListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> MemberDeclListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return MemberDeclListSyntax(newData)
   }
 
@@ -4465,13 +4519,13 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `MemberDeclListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> MemberDeclListSyntax {
-    return MemberDeclListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return MemberDeclListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `MemberDeclListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> MemberDeclListSyntax {
-    return MemberDeclListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return MemberDeclListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `MemberDeclListSyntax` with its leading trivia removed.
@@ -4606,9 +4660,11 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4623,8 +4679,9 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `ModifierListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> ModifierListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return ModifierListSyntax(newData)
   }
 
@@ -4716,13 +4773,13 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `ModifierListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ModifierListSyntax {
-    return ModifierListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return ModifierListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ModifierListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ModifierListSyntax {
-    return ModifierListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return ModifierListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ModifierListSyntax` with its leading trivia removed.
@@ -4857,9 +4914,11 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessPath,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessPath,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4874,8 +4933,9 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `AccessPathSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> AccessPathSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return AccessPathSyntax(newData)
   }
 
@@ -4967,13 +5027,13 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `AccessPathSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> AccessPathSyntax {
-    return AccessPathSyntax(data.withLeadingTrivia(leadingTrivia))
+    return AccessPathSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `AccessPathSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> AccessPathSyntax {
-    return AccessPathSyntax(data.withTrailingTrivia(trailingTrivia))
+    return AccessPathSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `AccessPathSyntax` with its leading trivia removed.
@@ -5108,9 +5168,11 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -5125,8 +5187,9 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `AccessorListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> AccessorListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return AccessorListSyntax(newData)
   }
 
@@ -5218,13 +5281,13 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `AccessorListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> AccessorListSyntax {
-    return AccessorListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return AccessorListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `AccessorListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> AccessorListSyntax {
-    return AccessorListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return AccessorListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `AccessorListSyntax` with its leading trivia removed.
@@ -5359,9 +5422,11 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.patternBindingList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.patternBindingList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -5376,8 +5441,9 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `PatternBindingListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> PatternBindingListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return PatternBindingListSyntax(newData)
   }
 
@@ -5469,13 +5535,13 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `PatternBindingListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> PatternBindingListSyntax {
-    return PatternBindingListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return PatternBindingListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `PatternBindingListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> PatternBindingListSyntax {
-    return PatternBindingListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return PatternBindingListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `PatternBindingListSyntax` with its leading trivia removed.
@@ -5607,9 +5673,11 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElementList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElementList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -5624,8 +5692,9 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `EnumCaseElementListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> EnumCaseElementListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return EnumCaseElementListSyntax(newData)
   }
 
@@ -5717,13 +5786,13 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `EnumCaseElementListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> EnumCaseElementListSyntax {
-    return EnumCaseElementListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return EnumCaseElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `EnumCaseElementListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> EnumCaseElementListSyntax {
-    return EnumCaseElementListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return EnumCaseElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `EnumCaseElementListSyntax` with its leading trivia removed.
@@ -5858,9 +5927,11 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -5875,8 +5946,9 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `DesignatedTypeListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> DesignatedTypeListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return DesignatedTypeListSyntax(newData)
   }
 
@@ -5968,13 +6040,13 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `DesignatedTypeListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> DesignatedTypeListSyntax {
-    return DesignatedTypeListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return DesignatedTypeListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `DesignatedTypeListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> DesignatedTypeListSyntax {
-    return DesignatedTypeListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return DesignatedTypeListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `DesignatedTypeListSyntax` with its leading trivia removed.
@@ -6153,9 +6225,11 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAttributeList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAttributeList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -6170,8 +6244,9 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
   /// - Returns: A new `PrecedenceGroupAttributeListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> PrecedenceGroupAttributeListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return PrecedenceGroupAttributeListSyntax(newData)
   }
 
@@ -6263,13 +6338,13 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
   /// Returns a new `PrecedenceGroupAttributeListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> PrecedenceGroupAttributeListSyntax {
-    return PrecedenceGroupAttributeListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return PrecedenceGroupAttributeListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `PrecedenceGroupAttributeListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> PrecedenceGroupAttributeListSyntax {
-    return PrecedenceGroupAttributeListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return PrecedenceGroupAttributeListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `PrecedenceGroupAttributeListSyntax` with its leading trivia removed.
@@ -6404,9 +6479,11 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -6421,8 +6498,9 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `PrecedenceGroupNameListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> PrecedenceGroupNameListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return PrecedenceGroupNameListSyntax(newData)
   }
 
@@ -6514,13 +6592,13 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `PrecedenceGroupNameListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> PrecedenceGroupNameListSyntax {
-    return PrecedenceGroupNameListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return PrecedenceGroupNameListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `PrecedenceGroupNameListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> PrecedenceGroupNameListSyntax {
-    return PrecedenceGroupNameListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return PrecedenceGroupNameListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `PrecedenceGroupNameListSyntax` with its leading trivia removed.
@@ -6655,9 +6733,11 @@ public struct TokenListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tokenList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tokenList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -6672,8 +6752,9 @@ public struct TokenListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `TokenListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> TokenListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return TokenListSyntax(newData)
   }
 
@@ -6765,13 +6846,13 @@ public struct TokenListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `TokenListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> TokenListSyntax {
-    return TokenListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return TokenListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `TokenListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> TokenListSyntax {
-    return TokenListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return TokenListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `TokenListSyntax` with its leading trivia removed.
@@ -6906,9 +6987,11 @@ public struct NonEmptyTokenListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.nonEmptyTokenList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.nonEmptyTokenList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -6923,8 +7006,9 @@ public struct NonEmptyTokenListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `NonEmptyTokenListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> NonEmptyTokenListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return NonEmptyTokenListSyntax(newData)
   }
 
@@ -7016,13 +7100,13 @@ public struct NonEmptyTokenListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `NonEmptyTokenListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> NonEmptyTokenListSyntax {
-    return NonEmptyTokenListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return NonEmptyTokenListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `NonEmptyTokenListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> NonEmptyTokenListSyntax {
-    return NonEmptyTokenListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return NonEmptyTokenListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `NonEmptyTokenListSyntax` with its leading trivia removed.
@@ -7201,9 +7285,11 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -7218,8 +7304,9 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `AttributeListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> AttributeListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return AttributeListSyntax(newData)
   }
 
@@ -7311,13 +7398,13 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `AttributeListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> AttributeListSyntax {
-    return AttributeListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return AttributeListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `AttributeListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> AttributeListSyntax {
-    return AttributeListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return AttributeListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `AttributeListSyntax` with its leading trivia removed.
@@ -7505,9 +7592,11 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.specializeAttributeSpecList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.specializeAttributeSpecList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -7522,8 +7611,9 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
   /// - Returns: A new `SpecializeAttributeSpecListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> SpecializeAttributeSpecListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return SpecializeAttributeSpecListSyntax(newData)
   }
 
@@ -7615,13 +7705,13 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
   /// Returns a new `SpecializeAttributeSpecListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> SpecializeAttributeSpecListSyntax {
-    return SpecializeAttributeSpecListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return SpecializeAttributeSpecListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `SpecializeAttributeSpecListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> SpecializeAttributeSpecListSyntax {
-    return SpecializeAttributeSpecListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return SpecializeAttributeSpecListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `SpecializeAttributeSpecListSyntax` with its leading trivia removed.
@@ -7756,9 +7846,11 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.objCSelector,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.objCSelector,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -7773,8 +7865,9 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `ObjCSelectorSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> ObjCSelectorSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return ObjCSelectorSyntax(newData)
   }
 
@@ -7866,13 +7959,13 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `ObjCSelectorSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ObjCSelectorSyntax {
-    return ObjCSelectorSyntax(data.withLeadingTrivia(leadingTrivia))
+    return ObjCSelectorSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ObjCSelectorSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ObjCSelectorSyntax {
-    return ObjCSelectorSyntax(data.withTrailingTrivia(trailingTrivia))
+    return ObjCSelectorSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ObjCSelectorSyntax` with its leading trivia removed.
@@ -8007,9 +8100,11 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -8024,8 +8119,9 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
   /// - Returns: A new `DifferentiabilityParamListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> DifferentiabilityParamListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return DifferentiabilityParamListSyntax(newData)
   }
 
@@ -8117,13 +8213,13 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
   /// Returns a new `DifferentiabilityParamListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> DifferentiabilityParamListSyntax {
-    return DifferentiabilityParamListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return DifferentiabilityParamListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `DifferentiabilityParamListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> DifferentiabilityParamListSyntax {
-    return DifferentiabilityParamListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return DifferentiabilityParamListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `DifferentiabilityParamListSyntax` with its leading trivia removed.
@@ -8258,9 +8354,11 @@ public struct BackDeployVersionListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployVersionList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployVersionList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -8275,8 +8373,9 @@ public struct BackDeployVersionListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `BackDeployVersionListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> BackDeployVersionListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return BackDeployVersionListSyntax(newData)
   }
 
@@ -8368,13 +8467,13 @@ public struct BackDeployVersionListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `BackDeployVersionListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> BackDeployVersionListSyntax {
-    return BackDeployVersionListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return BackDeployVersionListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `BackDeployVersionListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> BackDeployVersionListSyntax {
-    return BackDeployVersionListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return BackDeployVersionListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `BackDeployVersionListSyntax` with its leading trivia removed.
@@ -8543,9 +8642,11 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -8560,8 +8661,9 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `SwitchCaseListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> SwitchCaseListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return SwitchCaseListSyntax(newData)
   }
 
@@ -8653,13 +8755,13 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `SwitchCaseListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> SwitchCaseListSyntax {
-    return SwitchCaseListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return SwitchCaseListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `SwitchCaseListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> SwitchCaseListSyntax {
-    return SwitchCaseListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return SwitchCaseListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `SwitchCaseListSyntax` with its leading trivia removed.
@@ -8794,9 +8896,11 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchClauseList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchClauseList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -8811,8 +8915,9 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `CatchClauseListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> CatchClauseListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return CatchClauseListSyntax(newData)
   }
 
@@ -8904,13 +9009,13 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `CatchClauseListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> CatchClauseListSyntax {
-    return CatchClauseListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return CatchClauseListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `CatchClauseListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> CatchClauseListSyntax {
-    return CatchClauseListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return CatchClauseListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `CatchClauseListSyntax` with its leading trivia removed.
@@ -9045,9 +9150,11 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.caseItemList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.caseItemList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9062,8 +9169,9 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `CaseItemListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> CaseItemListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return CaseItemListSyntax(newData)
   }
 
@@ -9155,13 +9263,13 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `CaseItemListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> CaseItemListSyntax {
-    return CaseItemListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return CaseItemListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `CaseItemListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> CaseItemListSyntax {
-    return CaseItemListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return CaseItemListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `CaseItemListSyntax` with its leading trivia removed.
@@ -9296,9 +9404,11 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchItemList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchItemList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9313,8 +9423,9 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `CatchItemListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> CatchItemListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return CatchItemListSyntax(newData)
   }
 
@@ -9406,13 +9517,13 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `CatchItemListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> CatchItemListSyntax {
-    return CatchItemListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return CatchItemListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `CatchItemListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> CatchItemListSyntax {
-    return CatchItemListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return CatchItemListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `CatchItemListSyntax` with its leading trivia removed.
@@ -9547,9 +9658,11 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.conditionElementList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.conditionElementList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9564,8 +9677,9 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `ConditionElementListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> ConditionElementListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return ConditionElementListSyntax(newData)
   }
 
@@ -9657,13 +9771,13 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `ConditionElementListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ConditionElementListSyntax {
-    return ConditionElementListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return ConditionElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ConditionElementListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ConditionElementListSyntax {
-    return ConditionElementListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return ConditionElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `ConditionElementListSyntax` with its leading trivia removed.
@@ -9798,9 +9912,11 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirementList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirementList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9815,8 +9931,9 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `GenericRequirementListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> GenericRequirementListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return GenericRequirementListSyntax(newData)
   }
 
@@ -9908,13 +10025,13 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `GenericRequirementListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> GenericRequirementListSyntax {
-    return GenericRequirementListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return GenericRequirementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `GenericRequirementListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> GenericRequirementListSyntax {
-    return GenericRequirementListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return GenericRequirementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `GenericRequirementListSyntax` with its leading trivia removed.
@@ -10049,9 +10166,11 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -10066,8 +10185,9 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `GenericParameterListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> GenericParameterListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return GenericParameterListSyntax(newData)
   }
 
@@ -10159,13 +10279,13 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `GenericParameterListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> GenericParameterListSyntax {
-    return GenericParameterListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return GenericParameterListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `GenericParameterListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> GenericParameterListSyntax {
-    return GenericParameterListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return GenericParameterListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `GenericParameterListSyntax` with its leading trivia removed.
@@ -10300,9 +10420,11 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -10317,8 +10439,9 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
   /// - Returns: A new `PrimaryAssociatedTypeListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> PrimaryAssociatedTypeListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return PrimaryAssociatedTypeListSyntax(newData)
   }
 
@@ -10410,13 +10533,13 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
   /// Returns a new `PrimaryAssociatedTypeListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> PrimaryAssociatedTypeListSyntax {
-    return PrimaryAssociatedTypeListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return PrimaryAssociatedTypeListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `PrimaryAssociatedTypeListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> PrimaryAssociatedTypeListSyntax {
-    return PrimaryAssociatedTypeListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return PrimaryAssociatedTypeListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `PrimaryAssociatedTypeListSyntax` with its leading trivia removed.
@@ -10551,9 +10674,11 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElementList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElementList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -10568,8 +10693,9 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
   /// - Returns: A new `CompositionTypeElementListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> CompositionTypeElementListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return CompositionTypeElementListSyntax(newData)
   }
 
@@ -10661,13 +10787,13 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
   /// Returns a new `CompositionTypeElementListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> CompositionTypeElementListSyntax {
-    return CompositionTypeElementListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return CompositionTypeElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `CompositionTypeElementListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> CompositionTypeElementListSyntax {
-    return CompositionTypeElementListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return CompositionTypeElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `CompositionTypeElementListSyntax` with its leading trivia removed.
@@ -10802,9 +10928,11 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElementList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElementList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -10819,8 +10947,9 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `TupleTypeElementListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> TupleTypeElementListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return TupleTypeElementListSyntax(newData)
   }
 
@@ -10912,13 +11041,13 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `TupleTypeElementListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> TupleTypeElementListSyntax {
-    return TupleTypeElementListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return TupleTypeElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `TupleTypeElementListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> TupleTypeElementListSyntax {
-    return TupleTypeElementListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return TupleTypeElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `TupleTypeElementListSyntax` with its leading trivia removed.
@@ -11053,9 +11182,11 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -11070,8 +11201,9 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `GenericArgumentListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> GenericArgumentListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return GenericArgumentListSyntax(newData)
   }
 
@@ -11163,13 +11295,13 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `GenericArgumentListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> GenericArgumentListSyntax {
-    return GenericArgumentListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return GenericArgumentListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `GenericArgumentListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> GenericArgumentListSyntax {
-    return GenericArgumentListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return GenericArgumentListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `GenericArgumentListSyntax` with its leading trivia removed.
@@ -11304,9 +11436,11 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElementList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElementList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -11321,8 +11455,9 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `TuplePatternElementListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> TuplePatternElementListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return TuplePatternElementListSyntax(newData)
   }
 
@@ -11414,13 +11549,13 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `TuplePatternElementListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> TuplePatternElementListSyntax {
-    return TuplePatternElementListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return TuplePatternElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `TuplePatternElementListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> TuplePatternElementListSyntax {
-    return TuplePatternElementListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return TuplePatternElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `TuplePatternElementListSyntax` with its leading trivia removed.
@@ -11555,9 +11690,11 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
   }
 
   public init(_ children: [Element]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilitySpecList,
-      from: children.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilitySpecList,
+        from: children.map { $0.raw }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -11572,8 +11709,9 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Returns: A new `AvailabilitySpecListSyntax` with the new layout underlying it.
   internal func replacingLayout(
     _ layout: [RawSyntax?]) -> AvailabilitySpecListSyntax {
-    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
-    let newData = data.replacingSelf(newRaw)
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
     return AvailabilitySpecListSyntax(newData)
   }
 
@@ -11665,13 +11803,13 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
   /// Returns a new `AvailabilitySpecListSyntax` with its leading trivia replaced
   /// by the provided trivia.
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> AvailabilitySpecListSyntax {
-    return AvailabilitySpecListSyntax(data.withLeadingTrivia(leadingTrivia))
+    return AvailabilitySpecListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `AvailabilitySpecListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> AvailabilitySpecListSyntax {
-    return AvailabilitySpecListSyntax(data.withTrailingTrivia(trailingTrivia))
+    return AvailabilitySpecListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
   }
 
   /// Returns a new `AvailabilitySpecListSyntax` with its leading trivia removed.

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -27,18 +27,16 @@ public enum SyntaxFactory {
   public static func makeToken(_ kind: TokenKind, presence: SourcePresence,
                                leadingTrivia: Trivia = [],
                                trailingTrivia: Trivia = []) -> TokenSyntax {
-    let raw = RawSyntax.makeMaterializedToken(kind: kind, leadingTrivia: leadingTrivia,
-      trailingTrivia: trailingTrivia, presence: presence, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TokenSyntax(data)
+    TokenSyntax(
+      kind,
+      leadingTrivia: leadingTrivia,
+      trailingTrivia: trailingTrivia,
+      presence: presence)
   }
 
   @available(*, deprecated, message: "Use initializer on UnknownSyntax")
   public static func makeUnknownSyntax(tokens: [TokenSyntax]) -> UnknownSyntax {
-    let raw = RawSyntax.makeLayout(kind: .unknown,
-      from: tokens.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return UnknownSyntax(data)
+    UnknownSyntax(tokens: tokens)
   }
 
 /// MARK: Syntax Node Creation APIs
@@ -51,50 +49,62 @@ public enum SyntaxFactory {
 
   @available(*, deprecated, message: "Use initializer on UnknownDeclSyntax")
   public static func makeBlankUnknownDecl(presence: SourcePresence = .present) -> UnknownDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unknownDecl,
-      from: [
-    ], arena: .default))
-    return UnknownDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unknownDecl,
+        from: [
+      ], arena: arena))
+      return UnknownDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on UnknownExprSyntax")
   public static func makeBlankUnknownExpr(presence: SourcePresence = .present) -> UnknownExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unknownExpr,
-      from: [
-    ], arena: .default))
-    return UnknownExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unknownExpr,
+        from: [
+      ], arena: arena))
+      return UnknownExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on UnknownStmtSyntax")
   public static func makeBlankUnknownStmt(presence: SourcePresence = .present) -> UnknownStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unknownStmt,
-      from: [
-    ], arena: .default))
-    return UnknownStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unknownStmt,
+        from: [
+      ], arena: arena))
+      return UnknownStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on UnknownTypeSyntax")
   public static func makeBlankUnknownType(presence: SourcePresence = .present) -> UnknownTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unknownType,
-      from: [
-    ], arena: .default))
-    return UnknownTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unknownType,
+        from: [
+      ], arena: arena))
+      return UnknownTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on UnknownPatternSyntax")
   public static func makeBlankUnknownPattern(presence: SourcePresence = .present) -> UnknownPatternSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unknownPattern,
-      from: [
-    ], arena: .default))
-    return UnknownPatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unknownPattern,
+        from: [
+      ], arena: arena))
+      return UnknownPatternSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MissingSyntax")
   public static func makeBlankMissing(presence: SourcePresence = .missing) -> MissingSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missing,
-      from: [
-    ], arena: .default))
-    return MissingSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missing,
+        from: [
+      ], arena: arena))
+      return MissingSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on MissingDeclSyntax")
   public static func makeMissingDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedAfterModifiers: UnexpectedNodesSyntax? = nil) -> MissingDeclSyntax {
@@ -105,55 +115,67 @@ public enum SyntaxFactory {
       modifiers?.raw,
       unexpectedAfterModifiers?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return MissingDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MissingDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MissingDeclSyntax")
   public static func makeBlankMissingDecl(presence: SourcePresence = .missing) -> MissingDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missingDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return MissingDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missingDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return MissingDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MissingExprSyntax")
   public static func makeBlankMissingExpr(presence: SourcePresence = .missing) -> MissingExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missingExpr,
-      from: [
-    ], arena: .default))
-    return MissingExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missingExpr,
+        from: [
+      ], arena: arena))
+      return MissingExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MissingStmtSyntax")
   public static func makeBlankMissingStmt(presence: SourcePresence = .missing) -> MissingStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missingStmt,
-      from: [
-    ], arena: .default))
-    return MissingStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missingStmt,
+        from: [
+      ], arena: arena))
+      return MissingStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MissingTypeSyntax")
   public static func makeBlankMissingType(presence: SourcePresence = .missing) -> MissingTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missingType,
-      from: [
-    ], arena: .default))
-    return MissingTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missingType,
+        from: [
+      ], arena: arena))
+      return MissingTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MissingPatternSyntax")
   public static func makeBlankMissingPattern(presence: SourcePresence = .missing) -> MissingPatternSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missingPattern,
-      from: [
-    ], arena: .default))
-    return MissingPatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missingPattern,
+        from: [
+      ], arena: arena))
+      return MissingPatternSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on CodeBlockItemSyntax")
   public static func makeCodeBlockItem(_ unexpectedBeforeItem: UnexpectedNodesSyntax? = nil, item: Syntax, _ unexpectedBetweenItemAndSemicolon: UnexpectedNodesSyntax? = nil, semicolon: TokenSyntax?, _ unexpectedBetweenSemicolonAndErrorTokens: UnexpectedNodesSyntax? = nil, errorTokens: Syntax?, _ unexpectedAfterErrorTokens: UnexpectedNodesSyntax? = nil) -> CodeBlockItemSyntax {
@@ -166,41 +188,49 @@ public enum SyntaxFactory {
       errorTokens?.raw,
       unexpectedAfterErrorTokens?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItem,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return CodeBlockItemSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItem,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return CodeBlockItemSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on CodeBlockItemSyntax")
   public static func makeBlankCodeBlockItem(presence: SourcePresence = .present) -> CodeBlockItemSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .codeBlockItem,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return CodeBlockItemSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .codeBlockItem,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return CodeBlockItemSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on CodeBlockItemListSyntax")
   public static func makeCodeBlockItemList(
     _ elements: [CodeBlockItemSyntax]) -> CodeBlockItemListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return CodeBlockItemListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return CodeBlockItemListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on CodeBlockItemListSyntax")
   public static func makeBlankCodeBlockItemList(presence: SourcePresence = .present) -> CodeBlockItemListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .codeBlockItemList,
-      from: [
-    ], arena: .default))
-    return CodeBlockItemListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .codeBlockItemList,
+        from: [
+      ], arena: arena))
+      return CodeBlockItemListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on CodeBlockSyntax")
   public static func makeCodeBlock(_ unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndStatements: UnexpectedNodesSyntax? = nil, statements: CodeBlockItemListSyntax, _ unexpectedBetweenStatementsAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax, _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil) -> CodeBlockSyntax {
@@ -213,41 +243,49 @@ public enum SyntaxFactory {
       rightBrace.raw,
       unexpectedAfterRightBrace?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlock,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return CodeBlockSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlock,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return CodeBlockSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on CodeBlockSyntax")
   public static func makeBlankCodeBlock(presence: SourcePresence = .present) -> CodeBlockSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .codeBlock,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default),
-      nil,
-    ], arena: .default))
-    return CodeBlockSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .codeBlock,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena),
+        nil,
+      ], arena: arena))
+      return CodeBlockSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on UnexpectedNodesSyntax")
   public static func makeUnexpectedNodes(
     _ elements: [Syntax]) -> UnexpectedNodesSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unexpectedNodes,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return UnexpectedNodesSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unexpectedNodes,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return UnexpectedNodesSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on UnexpectedNodesSyntax")
   public static func makeBlankUnexpectedNodes(presence: SourcePresence = .present) -> UnexpectedNodesSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unexpectedNodes,
-      from: [
-    ], arena: .default))
-    return UnexpectedNodesSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unexpectedNodes,
+        from: [
+      ], arena: arena))
+      return UnexpectedNodesSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on InOutExprSyntax")
   public static func makeInOutExpr(_ unexpectedBeforeAmpersand: UnexpectedNodesSyntax? = nil, ampersand: TokenSyntax, _ unexpectedBetweenAmpersandAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> InOutExprSyntax {
@@ -258,23 +296,27 @@ public enum SyntaxFactory {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.inOutExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return InOutExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.inOutExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return InOutExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on InOutExprSyntax")
   public static func makeBlankInOutExpr(presence: SourcePresence = .present) -> InOutExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .inOutExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.prefixAmpersand, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-    ], arena: .default))
-    return InOutExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .inOutExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.prefixAmpersand, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return InOutExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PoundColumnExprSyntax")
   public static func makePoundColumnExpr(_ unexpectedBeforePoundColumn: UnexpectedNodesSyntax? = nil, poundColumn: TokenSyntax, _ unexpectedAfterPoundColumn: UnexpectedNodesSyntax? = nil) -> PoundColumnExprSyntax {
@@ -283,85 +325,105 @@ public enum SyntaxFactory {
       poundColumn.raw,
       unexpectedAfterPoundColumn?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundColumnExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PoundColumnExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundColumnExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PoundColumnExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PoundColumnExprSyntax")
   public static func makeBlankPoundColumnExpr(presence: SourcePresence = .present) -> PoundColumnExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundColumnExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundColumnKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return PoundColumnExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundColumnExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundColumnKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return PoundColumnExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TupleExprElementListSyntax")
   public static func makeTupleExprElementList(
     _ elements: [TupleExprElementSyntax]) -> TupleExprElementListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TupleExprElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TupleExprElementListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TupleExprElementListSyntax")
   public static func makeBlankTupleExprElementList(presence: SourcePresence = .present) -> TupleExprElementListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tupleExprElementList,
-      from: [
-    ], arena: .default))
-    return TupleExprElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tupleExprElementList,
+        from: [
+      ], arena: arena))
+      return TupleExprElementListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ArrayElementListSyntax")
   public static func makeArrayElementList(
     _ elements: [ArrayElementSyntax]) -> ArrayElementListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayElementList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ArrayElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayElementList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ArrayElementListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ArrayElementListSyntax")
   public static func makeBlankArrayElementList(presence: SourcePresence = .present) -> ArrayElementListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .arrayElementList,
-      from: [
-    ], arena: .default))
-    return ArrayElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .arrayElementList,
+        from: [
+      ], arena: arena))
+      return ArrayElementListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DictionaryElementListSyntax")
   public static func makeDictionaryElementList(
     _ elements: [DictionaryElementSyntax]) -> DictionaryElementListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryElementList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DictionaryElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryElementList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DictionaryElementListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DictionaryElementListSyntax")
   public static func makeBlankDictionaryElementList(presence: SourcePresence = .present) -> DictionaryElementListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .dictionaryElementList,
-      from: [
-    ], arena: .default))
-    return DictionaryElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .dictionaryElementList,
+        from: [
+      ], arena: arena))
+      return DictionaryElementListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on StringLiteralSegmentsSyntax")
   public static func makeStringLiteralSegments(
     _ elements: [Syntax]) -> StringLiteralSegmentsSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralSegments,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return StringLiteralSegmentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralSegments,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return StringLiteralSegmentsSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on StringLiteralSegmentsSyntax")
   public static func makeBlankStringLiteralSegments(presence: SourcePresence = .present) -> StringLiteralSegmentsSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .stringLiteralSegments,
-      from: [
-    ], arena: .default))
-    return StringLiteralSegmentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .stringLiteralSegments,
+        from: [
+      ], arena: arena))
+      return StringLiteralSegmentsSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TryExprSyntax")
   public static func makeTryExpr(_ unexpectedBeforeTryKeyword: UnexpectedNodesSyntax? = nil, tryKeyword: TokenSyntax, _ unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil, questionOrExclamationMark: TokenSyntax?, _ unexpectedBetweenQuestionOrExclamationMarkAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> TryExprSyntax {
@@ -374,25 +436,29 @@ public enum SyntaxFactory {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tryExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TryExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tryExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TryExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TryExprSyntax")
   public static func makeBlankTryExpr(presence: SourcePresence = .present) -> TryExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tryExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.tryKeyword, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-    ], arena: .default))
-    return TryExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tryExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.tryKeyword, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return TryExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AwaitExprSyntax")
   public static func makeAwaitExpr(_ unexpectedBeforeAwaitKeyword: UnexpectedNodesSyntax? = nil, awaitKeyword: TokenSyntax, _ unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> AwaitExprSyntax {
@@ -403,23 +469,27 @@ public enum SyntaxFactory {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.awaitExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AwaitExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.awaitExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AwaitExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AwaitExprSyntax")
   public static func makeBlankAwaitExpr(presence: SourcePresence = .present) -> AwaitExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .awaitExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-    ], arena: .default))
-    return AwaitExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .awaitExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return AwaitExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on MoveExprSyntax")
   public static func makeMoveExpr(_ unexpectedBeforeMoveKeyword: UnexpectedNodesSyntax? = nil, moveKeyword: TokenSyntax, _ unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> MoveExprSyntax {
@@ -430,23 +500,27 @@ public enum SyntaxFactory {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.moveExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return MoveExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.moveExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MoveExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MoveExprSyntax")
   public static func makeBlankMoveExpr(presence: SourcePresence = .present) -> MoveExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .moveExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-    ], arena: .default))
-    return MoveExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .moveExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return MoveExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DeclNameArgumentSyntax")
   public static func makeDeclNameArgument(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil) -> DeclNameArgumentSyntax {
@@ -457,39 +531,47 @@ public enum SyntaxFactory {
       colon.raw,
       unexpectedAfterColon?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgument,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DeclNameArgumentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgument,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DeclNameArgumentSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DeclNameArgumentSyntax")
   public static func makeBlankDeclNameArgument(presence: SourcePresence = .present) -> DeclNameArgumentSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .declNameArgument,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-    ], arena: .default))
-    return DeclNameArgumentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .declNameArgument,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+      ], arena: arena))
+      return DeclNameArgumentSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DeclNameArgumentListSyntax")
   public static func makeDeclNameArgumentList(
     _ elements: [DeclNameArgumentSyntax]) -> DeclNameArgumentListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgumentList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DeclNameArgumentListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgumentList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DeclNameArgumentListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DeclNameArgumentListSyntax")
   public static func makeBlankDeclNameArgumentList(presence: SourcePresence = .present) -> DeclNameArgumentListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .declNameArgumentList,
-      from: [
-    ], arena: .default))
-    return DeclNameArgumentListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .declNameArgumentList,
+        from: [
+      ], arena: arena))
+      return DeclNameArgumentListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DeclNameArgumentsSyntax")
   public static func makeDeclNameArguments(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil, arguments: DeclNameArgumentListSyntax, _ unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> DeclNameArgumentsSyntax {
@@ -502,25 +584,29 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArguments,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DeclNameArgumentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArguments,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DeclNameArgumentsSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DeclNameArgumentsSyntax")
   public static func makeBlankDeclNameArguments(presence: SourcePresence = .present) -> DeclNameArgumentsSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .declNameArguments,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.declNameArgumentList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return DeclNameArgumentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .declNameArguments,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.declNameArgumentList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return DeclNameArgumentsSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on IdentifierExprSyntax")
   public static func makeIdentifierExpr(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?, _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil) -> IdentifierExprSyntax {
@@ -531,23 +617,27 @@ public enum SyntaxFactory {
       declNameArguments?.raw,
       unexpectedAfterDeclNameArguments?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.identifierExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return IdentifierExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.identifierExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return IdentifierExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on IdentifierExprSyntax")
   public static func makeBlankIdentifierExpr(presence: SourcePresence = .present) -> IdentifierExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .identifierExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return IdentifierExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .identifierExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return IdentifierExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on SuperRefExprSyntax")
   public static func makeSuperRefExpr(_ unexpectedBeforeSuperKeyword: UnexpectedNodesSyntax? = nil, superKeyword: TokenSyntax, _ unexpectedAfterSuperKeyword: UnexpectedNodesSyntax? = nil) -> SuperRefExprSyntax {
@@ -556,21 +646,25 @@ public enum SyntaxFactory {
       superKeyword.raw,
       unexpectedAfterSuperKeyword?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.superRefExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return SuperRefExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.superRefExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return SuperRefExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on SuperRefExprSyntax")
   public static func makeBlankSuperRefExpr(presence: SourcePresence = .present) -> SuperRefExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .superRefExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.superKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return SuperRefExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .superRefExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.superKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return SuperRefExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on NilLiteralExprSyntax")
   public static func makeNilLiteralExpr(_ unexpectedBeforeNilKeyword: UnexpectedNodesSyntax? = nil, nilKeyword: TokenSyntax, _ unexpectedAfterNilKeyword: UnexpectedNodesSyntax? = nil) -> NilLiteralExprSyntax {
@@ -579,21 +673,25 @@ public enum SyntaxFactory {
       nilKeyword.raw,
       unexpectedAfterNilKeyword?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.nilLiteralExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return NilLiteralExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.nilLiteralExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return NilLiteralExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on NilLiteralExprSyntax")
   public static func makeBlankNilLiteralExpr(presence: SourcePresence = .present) -> NilLiteralExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .nilLiteralExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.nilKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return NilLiteralExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .nilLiteralExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.nilKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return NilLiteralExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DiscardAssignmentExprSyntax")
   public static func makeDiscardAssignmentExpr(_ unexpectedBeforeWildcard: UnexpectedNodesSyntax? = nil, wildcard: TokenSyntax, _ unexpectedAfterWildcard: UnexpectedNodesSyntax? = nil) -> DiscardAssignmentExprSyntax {
@@ -602,21 +700,25 @@ public enum SyntaxFactory {
       wildcard.raw,
       unexpectedAfterWildcard?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.discardAssignmentExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DiscardAssignmentExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.discardAssignmentExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DiscardAssignmentExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DiscardAssignmentExprSyntax")
   public static func makeBlankDiscardAssignmentExpr(presence: SourcePresence = .present) -> DiscardAssignmentExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .discardAssignmentExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.wildcardKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return DiscardAssignmentExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .discardAssignmentExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.wildcardKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return DiscardAssignmentExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AssignmentExprSyntax")
   public static func makeAssignmentExpr(_ unexpectedBeforeAssignToken: UnexpectedNodesSyntax? = nil, assignToken: TokenSyntax, _ unexpectedAfterAssignToken: UnexpectedNodesSyntax? = nil) -> AssignmentExprSyntax {
@@ -625,21 +727,25 @@ public enum SyntaxFactory {
       assignToken.raw,
       unexpectedAfterAssignToken?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.assignmentExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AssignmentExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.assignmentExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AssignmentExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AssignmentExprSyntax")
   public static func makeBlankAssignmentExpr(presence: SourcePresence = .present) -> AssignmentExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .assignmentExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: .default),
-      nil,
-    ], arena: .default))
-    return AssignmentExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .assignmentExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: arena),
+        nil,
+      ], arena: arena))
+      return AssignmentExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on SequenceExprSyntax")
   public static func makeSequenceExpr(_ unexpectedBeforeElements: UnexpectedNodesSyntax? = nil, elements: ExprListSyntax, _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil) -> SequenceExprSyntax {
@@ -648,37 +754,45 @@ public enum SyntaxFactory {
       elements.raw,
       unexpectedAfterElements?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.sequenceExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return SequenceExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.sequenceExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return SequenceExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on SequenceExprSyntax")
   public static func makeBlankSequenceExpr(presence: SourcePresence = .present) -> SequenceExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .sequenceExpr,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.exprList, arena: .default),
-      nil,
-    ], arena: .default))
-    return SequenceExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .sequenceExpr,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.exprList, arena: arena),
+        nil,
+      ], arena: arena))
+      return SequenceExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ExprListSyntax")
   public static func makeExprList(
     _ elements: [ExprSyntax]) -> ExprListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.exprList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ExprListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.exprList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ExprListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ExprListSyntax")
   public static func makeBlankExprList(presence: SourcePresence = .present) -> ExprListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .exprList,
-      from: [
-    ], arena: .default))
-    return ExprListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .exprList,
+        from: [
+      ], arena: arena))
+      return ExprListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PoundLineExprSyntax")
   public static func makePoundLineExpr(_ unexpectedBeforePoundLine: UnexpectedNodesSyntax? = nil, poundLine: TokenSyntax, _ unexpectedAfterPoundLine: UnexpectedNodesSyntax? = nil) -> PoundLineExprSyntax {
@@ -687,21 +801,25 @@ public enum SyntaxFactory {
       poundLine.raw,
       unexpectedAfterPoundLine?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundLineExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PoundLineExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundLineExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PoundLineExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PoundLineExprSyntax")
   public static func makeBlankPoundLineExpr(presence: SourcePresence = .present) -> PoundLineExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundLineExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundLineKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return PoundLineExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundLineExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundLineKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return PoundLineExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PoundFileExprSyntax")
   public static func makePoundFileExpr(_ unexpectedBeforePoundFile: UnexpectedNodesSyntax? = nil, poundFile: TokenSyntax, _ unexpectedAfterPoundFile: UnexpectedNodesSyntax? = nil) -> PoundFileExprSyntax {
@@ -710,21 +828,25 @@ public enum SyntaxFactory {
       poundFile.raw,
       unexpectedAfterPoundFile?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFileExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PoundFileExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFileExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PoundFileExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PoundFileExprSyntax")
   public static func makeBlankPoundFileExpr(presence: SourcePresence = .present) -> PoundFileExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundFileExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundFileKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return PoundFileExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundFileExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundFileKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return PoundFileExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PoundFileIDExprSyntax")
   public static func makePoundFileIDExpr(_ unexpectedBeforePoundFileID: UnexpectedNodesSyntax? = nil, poundFileID: TokenSyntax, _ unexpectedAfterPoundFileID: UnexpectedNodesSyntax? = nil) -> PoundFileIDExprSyntax {
@@ -733,21 +855,25 @@ public enum SyntaxFactory {
       poundFileID.raw,
       unexpectedAfterPoundFileID?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFileIDExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PoundFileIDExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFileIDExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PoundFileIDExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PoundFileIDExprSyntax")
   public static func makeBlankPoundFileIDExpr(presence: SourcePresence = .present) -> PoundFileIDExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundFileIDExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundFileIDKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return PoundFileIDExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundFileIDExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundFileIDKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return PoundFileIDExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PoundFilePathExprSyntax")
   public static func makePoundFilePathExpr(_ unexpectedBeforePoundFilePath: UnexpectedNodesSyntax? = nil, poundFilePath: TokenSyntax, _ unexpectedAfterPoundFilePath: UnexpectedNodesSyntax? = nil) -> PoundFilePathExprSyntax {
@@ -756,21 +882,25 @@ public enum SyntaxFactory {
       poundFilePath.raw,
       unexpectedAfterPoundFilePath?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFilePathExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PoundFilePathExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFilePathExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PoundFilePathExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PoundFilePathExprSyntax")
   public static func makeBlankPoundFilePathExpr(presence: SourcePresence = .present) -> PoundFilePathExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundFilePathExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundFilePathKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return PoundFilePathExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundFilePathExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundFilePathKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return PoundFilePathExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PoundFunctionExprSyntax")
   public static func makePoundFunctionExpr(_ unexpectedBeforePoundFunction: UnexpectedNodesSyntax? = nil, poundFunction: TokenSyntax, _ unexpectedAfterPoundFunction: UnexpectedNodesSyntax? = nil) -> PoundFunctionExprSyntax {
@@ -779,21 +909,25 @@ public enum SyntaxFactory {
       poundFunction.raw,
       unexpectedAfterPoundFunction?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFunctionExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PoundFunctionExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFunctionExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PoundFunctionExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PoundFunctionExprSyntax")
   public static func makeBlankPoundFunctionExpr(presence: SourcePresence = .present) -> PoundFunctionExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundFunctionExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundFunctionKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return PoundFunctionExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundFunctionExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundFunctionKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return PoundFunctionExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PoundDsohandleExprSyntax")
   public static func makePoundDsohandleExpr(_ unexpectedBeforePoundDsohandle: UnexpectedNodesSyntax? = nil, poundDsohandle: TokenSyntax, _ unexpectedAfterPoundDsohandle: UnexpectedNodesSyntax? = nil) -> PoundDsohandleExprSyntax {
@@ -802,21 +936,25 @@ public enum SyntaxFactory {
       poundDsohandle.raw,
       unexpectedAfterPoundDsohandle?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundDsohandleExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PoundDsohandleExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundDsohandleExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PoundDsohandleExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PoundDsohandleExprSyntax")
   public static func makeBlankPoundDsohandleExpr(presence: SourcePresence = .present) -> PoundDsohandleExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundDsohandleExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundDsohandleKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return PoundDsohandleExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundDsohandleExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundDsohandleKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return PoundDsohandleExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on SymbolicReferenceExprSyntax")
   public static func makeSymbolicReferenceExpr(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericArgumentClause: UnexpectedNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax?, _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil) -> SymbolicReferenceExprSyntax {
@@ -827,23 +965,27 @@ public enum SyntaxFactory {
       genericArgumentClause?.raw,
       unexpectedAfterGenericArgumentClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.symbolicReferenceExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return SymbolicReferenceExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.symbolicReferenceExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return SymbolicReferenceExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on SymbolicReferenceExprSyntax")
   public static func makeBlankSymbolicReferenceExpr(presence: SourcePresence = .present) -> SymbolicReferenceExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .symbolicReferenceExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return SymbolicReferenceExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .symbolicReferenceExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return SymbolicReferenceExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PrefixOperatorExprSyntax")
   public static func makePrefixOperatorExpr(_ unexpectedBeforeOperatorToken: UnexpectedNodesSyntax? = nil, operatorToken: TokenSyntax?, _ unexpectedBetweenOperatorTokenAndPostfixExpression: UnexpectedNodesSyntax? = nil, postfixExpression: ExprSyntax, _ unexpectedAfterPostfixExpression: UnexpectedNodesSyntax? = nil) -> PrefixOperatorExprSyntax {
@@ -854,23 +996,27 @@ public enum SyntaxFactory {
       postfixExpression.raw,
       unexpectedAfterPostfixExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.prefixOperatorExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PrefixOperatorExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.prefixOperatorExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PrefixOperatorExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PrefixOperatorExprSyntax")
   public static func makeBlankPrefixOperatorExpr(presence: SourcePresence = .present) -> PrefixOperatorExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .prefixOperatorExpr,
-      from: [
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-    ], arena: .default))
-    return PrefixOperatorExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .prefixOperatorExpr,
+        from: [
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return PrefixOperatorExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on BinaryOperatorExprSyntax")
   public static func makeBinaryOperatorExpr(_ unexpectedBeforeOperatorToken: UnexpectedNodesSyntax? = nil, operatorToken: TokenSyntax, _ unexpectedAfterOperatorToken: UnexpectedNodesSyntax? = nil) -> BinaryOperatorExprSyntax {
@@ -879,21 +1025,25 @@ public enum SyntaxFactory {
       operatorToken.raw,
       unexpectedAfterOperatorToken?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.binaryOperatorExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return BinaryOperatorExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.binaryOperatorExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return BinaryOperatorExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on BinaryOperatorExprSyntax")
   public static func makeBlankBinaryOperatorExpr(presence: SourcePresence = .present) -> BinaryOperatorExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .binaryOperatorExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
-      nil,
-    ], arena: .default))
-    return BinaryOperatorExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .binaryOperatorExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena),
+        nil,
+      ], arena: arena))
+      return BinaryOperatorExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ArrowExprSyntax")
   public static func makeArrowExpr(_ unexpectedBeforeAsyncKeyword: UnexpectedNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ unexpectedBetweenAsyncKeywordAndThrowsToken: UnexpectedNodesSyntax? = nil, throwsToken: TokenSyntax?, _ unexpectedBetweenThrowsTokenAndArrowToken: UnexpectedNodesSyntax? = nil, arrowToken: TokenSyntax, _ unexpectedAfterArrowToken: UnexpectedNodesSyntax? = nil) -> ArrowExprSyntax {
@@ -906,25 +1056,29 @@ public enum SyntaxFactory {
       arrowToken.raw,
       unexpectedAfterArrowToken?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrowExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ArrowExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrowExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ArrowExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ArrowExprSyntax")
   public static func makeBlankArrowExpr(presence: SourcePresence = .present) -> ArrowExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .arrowExpr,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: .default),
-      nil,
-    ], arena: .default))
-    return ArrowExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .arrowExpr,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: arena),
+        nil,
+      ], arena: arena))
+      return ArrowExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on InfixOperatorExprSyntax")
   public static func makeInfixOperatorExpr(_ unexpectedBeforeLeftOperand: UnexpectedNodesSyntax? = nil, leftOperand: ExprSyntax, _ unexpectedBetweenLeftOperandAndOperatorOperand: UnexpectedNodesSyntax? = nil, operatorOperand: ExprSyntax, _ unexpectedBetweenOperatorOperandAndRightOperand: UnexpectedNodesSyntax? = nil, rightOperand: ExprSyntax, _ unexpectedAfterRightOperand: UnexpectedNodesSyntax? = nil) -> InfixOperatorExprSyntax {
@@ -937,25 +1091,29 @@ public enum SyntaxFactory {
       rightOperand.raw,
       unexpectedAfterRightOperand?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.infixOperatorExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return InfixOperatorExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.infixOperatorExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return InfixOperatorExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on InfixOperatorExprSyntax")
   public static func makeBlankInfixOperatorExpr(presence: SourcePresence = .present) -> InfixOperatorExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .infixOperatorExpr,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-    ], arena: .default))
-    return InfixOperatorExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .infixOperatorExpr,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return InfixOperatorExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on FloatLiteralExprSyntax")
   public static func makeFloatLiteralExpr(_ unexpectedBeforeFloatingDigits: UnexpectedNodesSyntax? = nil, floatingDigits: TokenSyntax, _ unexpectedAfterFloatingDigits: UnexpectedNodesSyntax? = nil) -> FloatLiteralExprSyntax {
@@ -964,21 +1122,25 @@ public enum SyntaxFactory {
       floatingDigits.raw,
       unexpectedAfterFloatingDigits?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.floatLiteralExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return FloatLiteralExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.floatLiteralExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return FloatLiteralExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on FloatLiteralExprSyntax")
   public static func makeBlankFloatLiteralExpr(presence: SourcePresence = .present) -> FloatLiteralExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .floatLiteralExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.floatingLiteral(""), arena: .default),
-      nil,
-    ], arena: .default))
-    return FloatLiteralExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .floatLiteralExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.floatingLiteral(""), arena: arena),
+        nil,
+      ], arena: arena))
+      return FloatLiteralExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TupleExprSyntax")
   public static func makeTupleExpr(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil, elementList: TupleExprElementListSyntax, _ unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> TupleExprSyntax {
@@ -991,25 +1153,29 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TupleExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TupleExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TupleExprSyntax")
   public static func makeBlankTupleExpr(presence: SourcePresence = .present) -> TupleExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tupleExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return TupleExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tupleExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return TupleExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ArrayExprSyntax")
   public static func makeArrayExpr(_ unexpectedBeforeLeftSquare: UnexpectedNodesSyntax? = nil, leftSquare: TokenSyntax, _ unexpectedBetweenLeftSquareAndElements: UnexpectedNodesSyntax? = nil, elements: ArrayElementListSyntax, _ unexpectedBetweenElementsAndRightSquare: UnexpectedNodesSyntax? = nil, rightSquare: TokenSyntax, _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil) -> ArrayExprSyntax {
@@ -1022,25 +1188,29 @@ public enum SyntaxFactory {
       rightSquare.raw,
       unexpectedAfterRightSquare?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ArrayExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ArrayExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ArrayExprSyntax")
   public static func makeBlankArrayExpr(presence: SourcePresence = .present) -> ArrayExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .arrayExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.arrayElementList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default),
-      nil,
-    ], arena: .default))
-    return ArrayExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .arrayExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.arrayElementList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena),
+        nil,
+      ], arena: arena))
+      return ArrayExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DictionaryExprSyntax")
   public static func makeDictionaryExpr(_ unexpectedBeforeLeftSquare: UnexpectedNodesSyntax? = nil, leftSquare: TokenSyntax, _ unexpectedBetweenLeftSquareAndContent: UnexpectedNodesSyntax? = nil, content: Syntax, _ unexpectedBetweenContentAndRightSquare: UnexpectedNodesSyntax? = nil, rightSquare: TokenSyntax, _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil) -> DictionaryExprSyntax {
@@ -1053,25 +1223,29 @@ public enum SyntaxFactory {
       rightSquare.raw,
       unexpectedAfterRightSquare?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DictionaryExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DictionaryExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DictionaryExprSyntax")
   public static func makeBlankDictionaryExpr(presence: SourcePresence = .present) -> DictionaryExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .dictionaryExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default),
-      nil,
-    ], arena: .default))
-    return DictionaryExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .dictionaryExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena),
+        nil,
+      ], arena: arena))
+      return DictionaryExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TupleExprElementSyntax")
   public static func makeTupleExprElement(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax?, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> TupleExprElementSyntax {
@@ -1086,27 +1260,31 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TupleExprElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TupleExprElementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TupleExprElementSyntax")
   public static func makeBlankTupleExprElement(presence: SourcePresence = .present) -> TupleExprElementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tupleExprElement,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return TupleExprElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tupleExprElement,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return TupleExprElementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ArrayElementSyntax")
   public static func makeArrayElement(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> ArrayElementSyntax {
@@ -1117,23 +1295,27 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ArrayElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayElement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ArrayElementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ArrayElementSyntax")
   public static func makeBlankArrayElement(presence: SourcePresence = .present) -> ArrayElementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .arrayElement,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return ArrayElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .arrayElement,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return ArrayElementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DictionaryElementSyntax")
   public static func makeDictionaryElement(_ unexpectedBeforeKeyExpression: UnexpectedNodesSyntax? = nil, keyExpression: ExprSyntax, _ unexpectedBetweenKeyExpressionAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValueExpression: UnexpectedNodesSyntax? = nil, valueExpression: ExprSyntax, _ unexpectedBetweenValueExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> DictionaryElementSyntax {
@@ -1148,27 +1330,31 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DictionaryElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryElement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DictionaryElementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DictionaryElementSyntax")
   public static func makeBlankDictionaryElement(presence: SourcePresence = .present) -> DictionaryElementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .dictionaryElement,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return DictionaryElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .dictionaryElement,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return DictionaryElementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on IntegerLiteralExprSyntax")
   public static func makeIntegerLiteralExpr(_ unexpectedBeforeDigits: UnexpectedNodesSyntax? = nil, digits: TokenSyntax, _ unexpectedAfterDigits: UnexpectedNodesSyntax? = nil) -> IntegerLiteralExprSyntax {
@@ -1177,21 +1363,25 @@ public enum SyntaxFactory {
       digits.raw,
       unexpectedAfterDigits?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.integerLiteralExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return IntegerLiteralExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.integerLiteralExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return IntegerLiteralExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on IntegerLiteralExprSyntax")
   public static func makeBlankIntegerLiteralExpr(presence: SourcePresence = .present) -> IntegerLiteralExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .integerLiteralExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default),
-      nil,
-    ], arena: .default))
-    return IntegerLiteralExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .integerLiteralExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: arena),
+        nil,
+      ], arena: arena))
+      return IntegerLiteralExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on BooleanLiteralExprSyntax")
   public static func makeBooleanLiteralExpr(_ unexpectedBeforeBooleanLiteral: UnexpectedNodesSyntax? = nil, booleanLiteral: TokenSyntax, _ unexpectedAfterBooleanLiteral: UnexpectedNodesSyntax? = nil) -> BooleanLiteralExprSyntax {
@@ -1200,21 +1390,25 @@ public enum SyntaxFactory {
       booleanLiteral.raw,
       unexpectedAfterBooleanLiteral?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.booleanLiteralExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return BooleanLiteralExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.booleanLiteralExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return BooleanLiteralExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on BooleanLiteralExprSyntax")
   public static func makeBlankBooleanLiteralExpr(presence: SourcePresence = .present) -> BooleanLiteralExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .booleanLiteralExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.trueKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return BooleanLiteralExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .booleanLiteralExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.trueKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return BooleanLiteralExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on UnresolvedTernaryExprSyntax")
   public static func makeUnresolvedTernaryExpr(_ unexpectedBeforeQuestionMark: UnexpectedNodesSyntax? = nil, questionMark: TokenSyntax, _ unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? = nil, firstChoice: ExprSyntax, _ unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? = nil, colonMark: TokenSyntax, _ unexpectedAfterColonMark: UnexpectedNodesSyntax? = nil) -> UnresolvedTernaryExprSyntax {
@@ -1227,25 +1421,29 @@ public enum SyntaxFactory {
       colonMark.raw,
       unexpectedAfterColonMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedTernaryExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return UnresolvedTernaryExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedTernaryExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return UnresolvedTernaryExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on UnresolvedTernaryExprSyntax")
   public static func makeBlankUnresolvedTernaryExpr(presence: SourcePresence = .present) -> UnresolvedTernaryExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unresolvedTernaryExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.infixQuestionMark, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-    ], arena: .default))
-    return UnresolvedTernaryExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unresolvedTernaryExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.infixQuestionMark, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+      ], arena: arena))
+      return UnresolvedTernaryExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TernaryExprSyntax")
   public static func makeTernaryExpr(_ unexpectedBeforeConditionExpression: UnexpectedNodesSyntax? = nil, conditionExpression: ExprSyntax, _ unexpectedBetweenConditionExpressionAndQuestionMark: UnexpectedNodesSyntax? = nil, questionMark: TokenSyntax, _ unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? = nil, firstChoice: ExprSyntax, _ unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? = nil, colonMark: TokenSyntax, _ unexpectedBetweenColonMarkAndSecondChoice: UnexpectedNodesSyntax? = nil, secondChoice: ExprSyntax, _ unexpectedAfterSecondChoice: UnexpectedNodesSyntax? = nil) -> TernaryExprSyntax {
@@ -1262,29 +1460,33 @@ public enum SyntaxFactory {
       secondChoice.raw,
       unexpectedAfterSecondChoice?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.ternaryExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TernaryExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.ternaryExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TernaryExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TernaryExprSyntax")
   public static func makeBlankTernaryExpr(presence: SourcePresence = .present) -> TernaryExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .ternaryExpr,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.infixQuestionMark, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-    ], arena: .default))
-    return TernaryExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .ternaryExpr,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.infixQuestionMark, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return TernaryExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on MemberAccessExprSyntax")
   public static func makeMemberAccessExpr(_ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil, base: ExprSyntax?, _ unexpectedBetweenBaseAndDot: UnexpectedNodesSyntax? = nil, dot: TokenSyntax, _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?, _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil) -> MemberAccessExprSyntax {
@@ -1299,27 +1501,31 @@ public enum SyntaxFactory {
       declNameArguments?.raw,
       unexpectedAfterDeclNameArguments?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberAccessExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return MemberAccessExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberAccessExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MemberAccessExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MemberAccessExprSyntax")
   public static func makeBlankMemberAccessExpr(presence: SourcePresence = .present) -> MemberAccessExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .memberAccessExpr,
-      from: [
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return MemberAccessExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .memberAccessExpr,
+        from: [
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.period, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return MemberAccessExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on UnresolvedIsExprSyntax")
   public static func makeUnresolvedIsExpr(_ unexpectedBeforeIsTok: UnexpectedNodesSyntax? = nil, isTok: TokenSyntax, _ unexpectedAfterIsTok: UnexpectedNodesSyntax? = nil) -> UnresolvedIsExprSyntax {
@@ -1328,21 +1534,25 @@ public enum SyntaxFactory {
       isTok.raw,
       unexpectedAfterIsTok?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedIsExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return UnresolvedIsExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedIsExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return UnresolvedIsExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on UnresolvedIsExprSyntax")
   public static func makeBlankUnresolvedIsExpr(presence: SourcePresence = .present) -> UnresolvedIsExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unresolvedIsExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return UnresolvedIsExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unresolvedIsExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return UnresolvedIsExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on IsExprSyntax")
   public static func makeIsExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndIsTok: UnexpectedNodesSyntax? = nil, isTok: TokenSyntax, _ unexpectedBetweenIsTokAndTypeName: UnexpectedNodesSyntax? = nil, typeName: TypeSyntax, _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil) -> IsExprSyntax {
@@ -1355,25 +1565,29 @@ public enum SyntaxFactory {
       typeName.raw,
       unexpectedAfterTypeName?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.isExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return IsExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.isExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return IsExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on IsExprSyntax")
   public static func makeBlankIsExpr(presence: SourcePresence = .present) -> IsExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .isExpr,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-    ], arena: .default))
-    return IsExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .isExpr,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+      ], arena: arena))
+      return IsExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on UnresolvedAsExprSyntax")
   public static func makeUnresolvedAsExpr(_ unexpectedBeforeAsTok: UnexpectedNodesSyntax? = nil, asTok: TokenSyntax, _ unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil, questionOrExclamationMark: TokenSyntax?, _ unexpectedAfterQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil) -> UnresolvedAsExprSyntax {
@@ -1384,23 +1598,27 @@ public enum SyntaxFactory {
       questionOrExclamationMark?.raw,
       unexpectedAfterQuestionOrExclamationMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedAsExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return UnresolvedAsExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedAsExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return UnresolvedAsExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on UnresolvedAsExprSyntax")
   public static func makeBlankUnresolvedAsExpr(presence: SourcePresence = .present) -> UnresolvedAsExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unresolvedAsExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return UnresolvedAsExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unresolvedAsExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return UnresolvedAsExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AsExprSyntax")
   public static func makeAsExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndAsTok: UnexpectedNodesSyntax? = nil, asTok: TokenSyntax, _ unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil, questionOrExclamationMark: TokenSyntax?, _ unexpectedBetweenQuestionOrExclamationMarkAndTypeName: UnexpectedNodesSyntax? = nil, typeName: TypeSyntax, _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil) -> AsExprSyntax {
@@ -1415,27 +1633,31 @@ public enum SyntaxFactory {
       typeName.raw,
       unexpectedAfterTypeName?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.asExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AsExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.asExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AsExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AsExprSyntax")
   public static func makeBlankAsExpr(presence: SourcePresence = .present) -> AsExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .asExpr,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-    ], arena: .default))
-    return AsExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .asExpr,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+      ], arena: arena))
+      return AsExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TypeExprSyntax")
   public static func makeTypeExpr(_ unexpectedBeforeType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedAfterType: UnexpectedNodesSyntax? = nil) -> TypeExprSyntax {
@@ -1444,21 +1666,25 @@ public enum SyntaxFactory {
       type.raw,
       unexpectedAfterType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TypeExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TypeExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TypeExprSyntax")
   public static func makeBlankTypeExpr(presence: SourcePresence = .present) -> TypeExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .typeExpr,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-    ], arena: .default))
-    return TypeExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .typeExpr,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+      ], arena: arena))
+      return TypeExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ClosureCaptureItemSyntax")
   public static func makeClosureCaptureItem(_ unexpectedBeforeSpecifier: UnexpectedNodesSyntax? = nil, specifier: TokenListSyntax?, _ unexpectedBetweenSpecifierAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax?, _ unexpectedBetweenNameAndAssignToken: UnexpectedNodesSyntax? = nil, assignToken: TokenSyntax?, _ unexpectedBetweenAssignTokenAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> ClosureCaptureItemSyntax {
@@ -1475,45 +1701,53 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItem,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ClosureCaptureItemSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItem,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ClosureCaptureItemSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ClosureCaptureItemSyntax")
   public static func makeBlankClosureCaptureItem(presence: SourcePresence = .present) -> ClosureCaptureItemSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .closureCaptureItem,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return ClosureCaptureItemSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .closureCaptureItem,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return ClosureCaptureItemSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ClosureCaptureItemListSyntax")
   public static func makeClosureCaptureItemList(
     _ elements: [ClosureCaptureItemSyntax]) -> ClosureCaptureItemListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItemList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ClosureCaptureItemListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItemList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ClosureCaptureItemListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ClosureCaptureItemListSyntax")
   public static func makeBlankClosureCaptureItemList(presence: SourcePresence = .present) -> ClosureCaptureItemListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .closureCaptureItemList,
-      from: [
-    ], arena: .default))
-    return ClosureCaptureItemListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .closureCaptureItemList,
+        from: [
+      ], arena: arena))
+      return ClosureCaptureItemListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ClosureCaptureSignatureSyntax")
   public static func makeClosureCaptureSignature(_ unexpectedBeforeLeftSquare: UnexpectedNodesSyntax? = nil, leftSquare: TokenSyntax, _ unexpectedBetweenLeftSquareAndItems: UnexpectedNodesSyntax? = nil, items: ClosureCaptureItemListSyntax?, _ unexpectedBetweenItemsAndRightSquare: UnexpectedNodesSyntax? = nil, rightSquare: TokenSyntax, _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil) -> ClosureCaptureSignatureSyntax {
@@ -1526,25 +1760,29 @@ public enum SyntaxFactory {
       rightSquare.raw,
       unexpectedAfterRightSquare?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureSignature,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ClosureCaptureSignatureSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureSignature,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ClosureCaptureSignatureSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ClosureCaptureSignatureSyntax")
   public static func makeBlankClosureCaptureSignature(presence: SourcePresence = .present) -> ClosureCaptureSignatureSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .closureCaptureSignature,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default),
-      nil,
-    ], arena: .default))
-    return ClosureCaptureSignatureSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .closureCaptureSignature,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena),
+        nil,
+      ], arena: arena))
+      return ClosureCaptureSignatureSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ClosureParamSyntax")
   public static func makeClosureParam(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> ClosureParamSyntax {
@@ -1555,39 +1793,47 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParam,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ClosureParamSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParam,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ClosureParamSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ClosureParamSyntax")
   public static func makeBlankClosureParam(presence: SourcePresence = .present) -> ClosureParamSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .closureParam,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return ClosureParamSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .closureParam,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return ClosureParamSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ClosureParamListSyntax")
   public static func makeClosureParamList(
     _ elements: [ClosureParamSyntax]) -> ClosureParamListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParamList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ClosureParamListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParamList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ClosureParamListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ClosureParamListSyntax")
   public static func makeBlankClosureParamList(presence: SourcePresence = .present) -> ClosureParamListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .closureParamList,
-      from: [
-    ], arena: .default))
-    return ClosureParamListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .closureParamList,
+        from: [
+      ], arena: arena))
+      return ClosureParamListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ClosureSignatureSyntax")
   public static func makeClosureSignature(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndCapture: UnexpectedNodesSyntax? = nil, capture: ClosureCaptureSignatureSyntax?, _ unexpectedBetweenCaptureAndInput: UnexpectedNodesSyntax? = nil, input: Syntax?, _ unexpectedBetweenInputAndAsyncKeyword: UnexpectedNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ unexpectedBetweenAsyncKeywordAndThrowsTok: UnexpectedNodesSyntax? = nil, throwsTok: TokenSyntax?, _ unexpectedBetweenThrowsTokAndOutput: UnexpectedNodesSyntax? = nil, output: ReturnClauseSyntax?, _ unexpectedBetweenOutputAndInTok: UnexpectedNodesSyntax? = nil, inTok: TokenSyntax, _ unexpectedAfterInTok: UnexpectedNodesSyntax? = nil) -> ClosureSignatureSyntax {
@@ -1608,33 +1854,37 @@ public enum SyntaxFactory {
       inTok.raw,
       unexpectedAfterInTok?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureSignature,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ClosureSignatureSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureSignature,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ClosureSignatureSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ClosureSignatureSyntax")
   public static func makeBlankClosureSignature(presence: SourcePresence = .present) -> ClosureSignatureSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .closureSignature,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.inKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return ClosureSignatureSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .closureSignature,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.inKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return ClosureSignatureSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ClosureExprSyntax")
   public static func makeClosureExpr(_ unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndSignature: UnexpectedNodesSyntax? = nil, signature: ClosureSignatureSyntax?, _ unexpectedBetweenSignatureAndStatements: UnexpectedNodesSyntax? = nil, statements: CodeBlockItemListSyntax, _ unexpectedBetweenStatementsAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax, _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil) -> ClosureExprSyntax {
@@ -1649,27 +1899,31 @@ public enum SyntaxFactory {
       rightBrace.raw,
       unexpectedAfterRightBrace?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ClosureExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ClosureExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ClosureExprSyntax")
   public static func makeBlankClosureExpr(presence: SourcePresence = .present) -> ClosureExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .closureExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default),
-      nil,
-    ], arena: .default))
-    return ClosureExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .closureExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena),
+        nil,
+      ], arena: arena))
+      return ClosureExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on UnresolvedPatternExprSyntax")
   public static func makeUnresolvedPatternExpr(_ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedAfterPattern: UnexpectedNodesSyntax? = nil) -> UnresolvedPatternExprSyntax {
@@ -1678,21 +1932,25 @@ public enum SyntaxFactory {
       pattern.raw,
       unexpectedAfterPattern?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedPatternExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return UnresolvedPatternExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedPatternExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return UnresolvedPatternExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on UnresolvedPatternExprSyntax")
   public static func makeBlankUnresolvedPatternExpr(presence: SourcePresence = .present) -> UnresolvedPatternExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unresolvedPatternExpr,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default),
-      nil,
-    ], arena: .default))
-    return UnresolvedPatternExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unresolvedPatternExpr,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena),
+        nil,
+      ], arena: arena))
+      return UnresolvedPatternExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on MultipleTrailingClosureElementSyntax")
   public static func makeMultipleTrailingClosureElement(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndClosure: UnexpectedNodesSyntax? = nil, closure: ClosureExprSyntax, _ unexpectedAfterClosure: UnexpectedNodesSyntax? = nil) -> MultipleTrailingClosureElementSyntax {
@@ -1705,41 +1963,49 @@ public enum SyntaxFactory {
       closure.raw,
       unexpectedAfterClosure?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return MultipleTrailingClosureElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MultipleTrailingClosureElementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MultipleTrailingClosureElementSyntax")
   public static func makeBlankMultipleTrailingClosureElement(presence: SourcePresence = .present) -> MultipleTrailingClosureElementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .multipleTrailingClosureElement,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.closureExpr, arena: .default),
-      nil,
-    ], arena: .default))
-    return MultipleTrailingClosureElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .multipleTrailingClosureElement,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.closureExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return MultipleTrailingClosureElementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on MultipleTrailingClosureElementListSyntax")
   public static func makeMultipleTrailingClosureElementList(
     _ elements: [MultipleTrailingClosureElementSyntax]) -> MultipleTrailingClosureElementListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElementList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return MultipleTrailingClosureElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElementList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MultipleTrailingClosureElementListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MultipleTrailingClosureElementListSyntax")
   public static func makeBlankMultipleTrailingClosureElementList(presence: SourcePresence = .present) -> MultipleTrailingClosureElementListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .multipleTrailingClosureElementList,
-      from: [
-    ], arena: .default))
-    return MultipleTrailingClosureElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .multipleTrailingClosureElementList,
+        from: [
+      ], arena: arena))
+      return MultipleTrailingClosureElementListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on FunctionCallExprSyntax")
   public static func makeFunctionCallExpr(_ unexpectedBeforeCalledExpression: UnexpectedNodesSyntax? = nil, calledExpression: ExprSyntax, _ unexpectedBetweenCalledExpressionAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax?, _ unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? = nil, argumentList: TupleExprElementListSyntax, _ unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax?, _ unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodesSyntax? = nil, trailingClosure: ClosureExprSyntax?, _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil, additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?, _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil) -> FunctionCallExprSyntax {
@@ -1758,31 +2024,35 @@ public enum SyntaxFactory {
       additionalTrailingClosures?.raw,
       unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionCallExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return FunctionCallExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionCallExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return FunctionCallExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on FunctionCallExprSyntax")
   public static func makeBlankFunctionCallExpr(presence: SourcePresence = .present) -> FunctionCallExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .functionCallExpr,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return FunctionCallExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .functionCallExpr,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return FunctionCallExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on SubscriptExprSyntax")
   public static func makeSubscriptExpr(_ unexpectedBeforeCalledExpression: UnexpectedNodesSyntax? = nil, calledExpression: ExprSyntax, _ unexpectedBetweenCalledExpressionAndLeftBracket: UnexpectedNodesSyntax? = nil, leftBracket: TokenSyntax, _ unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodesSyntax? = nil, argumentList: TupleExprElementListSyntax, _ unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodesSyntax? = nil, rightBracket: TokenSyntax, _ unexpectedBetweenRightBracketAndTrailingClosure: UnexpectedNodesSyntax? = nil, trailingClosure: ClosureExprSyntax?, _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil, additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?, _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil) -> SubscriptExprSyntax {
@@ -1801,31 +2071,35 @@ public enum SyntaxFactory {
       additionalTrailingClosures?.raw,
       unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.subscriptExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return SubscriptExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.subscriptExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return SubscriptExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on SubscriptExprSyntax")
   public static func makeBlankSubscriptExpr(presence: SourcePresence = .present) -> SubscriptExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .subscriptExpr,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return SubscriptExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .subscriptExpr,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return SubscriptExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on OptionalChainingExprSyntax")
   public static func makeOptionalChainingExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndQuestionMark: UnexpectedNodesSyntax? = nil, questionMark: TokenSyntax, _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil) -> OptionalChainingExprSyntax {
@@ -1836,23 +2110,27 @@ public enum SyntaxFactory {
       questionMark.raw,
       unexpectedAfterQuestionMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalChainingExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return OptionalChainingExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalChainingExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return OptionalChainingExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on OptionalChainingExprSyntax")
   public static func makeBlankOptionalChainingExpr(presence: SourcePresence = .present) -> OptionalChainingExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .optionalChainingExpr,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: .default),
-      nil,
-    ], arena: .default))
-    return OptionalChainingExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .optionalChainingExpr,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: arena),
+        nil,
+      ], arena: arena))
+      return OptionalChainingExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ForcedValueExprSyntax")
   public static func makeForcedValueExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndExclamationMark: UnexpectedNodesSyntax? = nil, exclamationMark: TokenSyntax, _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil) -> ForcedValueExprSyntax {
@@ -1863,23 +2141,27 @@ public enum SyntaxFactory {
       exclamationMark.raw,
       unexpectedAfterExclamationMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.forcedValueExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ForcedValueExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.forcedValueExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ForcedValueExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ForcedValueExprSyntax")
   public static func makeBlankForcedValueExpr(presence: SourcePresence = .present) -> ForcedValueExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .forcedValueExpr,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.exclamationMark, arena: .default),
-      nil,
-    ], arena: .default))
-    return ForcedValueExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .forcedValueExpr,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.exclamationMark, arena: arena),
+        nil,
+      ], arena: arena))
+      return ForcedValueExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PostfixUnaryExprSyntax")
   public static func makePostfixUnaryExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndOperatorToken: UnexpectedNodesSyntax? = nil, operatorToken: TokenSyntax, _ unexpectedAfterOperatorToken: UnexpectedNodesSyntax? = nil) -> PostfixUnaryExprSyntax {
@@ -1890,23 +2172,27 @@ public enum SyntaxFactory {
       operatorToken.raw,
       unexpectedAfterOperatorToken?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.postfixUnaryExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PostfixUnaryExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.postfixUnaryExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PostfixUnaryExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PostfixUnaryExprSyntax")
   public static func makeBlankPostfixUnaryExpr(presence: SourcePresence = .present) -> PostfixUnaryExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .postfixUnaryExpr,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.postfixOperator(""), arena: .default),
-      nil,
-    ], arena: .default))
-    return PostfixUnaryExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .postfixUnaryExpr,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.postfixOperator(""), arena: arena),
+        nil,
+      ], arena: arena))
+      return PostfixUnaryExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on SpecializeExprSyntax")
   public static func makeSpecializeExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndGenericArgumentClause: UnexpectedNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax, _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil) -> SpecializeExprSyntax {
@@ -1917,23 +2203,27 @@ public enum SyntaxFactory {
       genericArgumentClause.raw,
       unexpectedAfterGenericArgumentClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.specializeExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return SpecializeExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.specializeExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return SpecializeExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on SpecializeExprSyntax")
   public static func makeBlankSpecializeExpr(presence: SourcePresence = .present) -> SpecializeExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .specializeExpr,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericArgumentClause, arena: .default),
-      nil,
-    ], arena: .default))
-    return SpecializeExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .specializeExpr,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericArgumentClause, arena: arena),
+        nil,
+      ], arena: arena))
+      return SpecializeExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on StringSegmentSyntax")
   public static func makeStringSegment(_ unexpectedBeforeContent: UnexpectedNodesSyntax? = nil, content: TokenSyntax, _ unexpectedAfterContent: UnexpectedNodesSyntax? = nil) -> StringSegmentSyntax {
@@ -1942,21 +2232,25 @@ public enum SyntaxFactory {
       content.raw,
       unexpectedAfterContent?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringSegment,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return StringSegmentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringSegment,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return StringSegmentSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on StringSegmentSyntax")
   public static func makeBlankStringSegment(presence: SourcePresence = .present) -> StringSegmentSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .stringSegment,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.stringSegment(""), arena: .default),
-      nil,
-    ], arena: .default))
-    return StringSegmentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .stringSegment,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.stringSegment(""), arena: arena),
+        nil,
+      ], arena: arena))
+      return StringSegmentSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ExpressionSegmentSyntax")
   public static func makeExpressionSegment(_ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil, backslash: TokenSyntax, _ unexpectedBetweenBackslashAndDelimiter: UnexpectedNodesSyntax? = nil, delimiter: TokenSyntax?, _ unexpectedBetweenDelimiterAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndExpressions: UnexpectedNodesSyntax? = nil, expressions: TupleExprElementListSyntax, _ unexpectedBetweenExpressionsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> ExpressionSegmentSyntax {
@@ -1973,29 +2267,33 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionSegment,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ExpressionSegmentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionSegment,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ExpressionSegmentSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ExpressionSegmentSyntax")
   public static func makeBlankExpressionSegment(presence: SourcePresence = .present) -> ExpressionSegmentSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .expressionSegment,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.stringInterpolationAnchor, arena: .default),
-      nil,
-    ], arena: .default))
-    return ExpressionSegmentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .expressionSegment,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.stringInterpolationAnchor, arena: arena),
+        nil,
+      ], arena: arena))
+      return ExpressionSegmentSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on StringLiteralExprSyntax")
   public static func makeStringLiteralExpr(_ unexpectedBeforeOpenDelimiter: UnexpectedNodesSyntax? = nil, openDelimiter: TokenSyntax?, _ unexpectedBetweenOpenDelimiterAndOpenQuote: UnexpectedNodesSyntax? = nil, openQuote: TokenSyntax, _ unexpectedBetweenOpenQuoteAndSegments: UnexpectedNodesSyntax? = nil, segments: StringLiteralSegmentsSyntax, _ unexpectedBetweenSegmentsAndCloseQuote: UnexpectedNodesSyntax? = nil, closeQuote: TokenSyntax, _ unexpectedBetweenCloseQuoteAndCloseDelimiter: UnexpectedNodesSyntax? = nil, closeDelimiter: TokenSyntax?, _ unexpectedAfterCloseDelimiter: UnexpectedNodesSyntax? = nil) -> StringLiteralExprSyntax {
@@ -2012,29 +2310,33 @@ public enum SyntaxFactory {
       closeDelimiter?.raw,
       unexpectedAfterCloseDelimiter?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return StringLiteralExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return StringLiteralExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on StringLiteralExprSyntax")
   public static func makeBlankStringLiteralExpr(presence: SourcePresence = .present) -> StringLiteralExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .stringLiteralExpr,
-      from: [
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.stringQuote, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralSegments, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.stringQuote, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return StringLiteralExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .stringLiteralExpr,
+        from: [
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.stringQuote, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralSegments, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.stringQuote, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return StringLiteralExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on RegexLiteralExprSyntax")
   public static func makeRegexLiteralExpr(_ unexpectedBeforeRegex: UnexpectedNodesSyntax? = nil, regex: TokenSyntax, _ unexpectedAfterRegex: UnexpectedNodesSyntax? = nil) -> RegexLiteralExprSyntax {
@@ -2043,21 +2345,25 @@ public enum SyntaxFactory {
       regex.raw,
       unexpectedAfterRegex?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.regexLiteralExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return RegexLiteralExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.regexLiteralExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return RegexLiteralExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on RegexLiteralExprSyntax")
   public static func makeBlankRegexLiteralExpr(presence: SourcePresence = .present) -> RegexLiteralExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .regexLiteralExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.regexLiteral(""), arena: .default),
-      nil,
-    ], arena: .default))
-    return RegexLiteralExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .regexLiteralExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.regexLiteral(""), arena: arena),
+        nil,
+      ], arena: arena))
+      return RegexLiteralExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on KeyPathExprSyntax")
   public static func makeKeyPathExpr(_ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil, backslash: TokenSyntax, _ unexpectedBetweenBackslashAndRoot: UnexpectedNodesSyntax? = nil, root: TypeSyntax?, _ unexpectedBetweenRootAndComponents: UnexpectedNodesSyntax? = nil, components: KeyPathComponentListSyntax, _ unexpectedAfterComponents: UnexpectedNodesSyntax? = nil) -> KeyPathExprSyntax {
@@ -2070,41 +2376,49 @@ public enum SyntaxFactory {
       components.raw,
       unexpectedAfterComponents?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return KeyPathExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return KeyPathExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on KeyPathExprSyntax")
   public static func makeBlankKeyPathExpr(presence: SourcePresence = .present) -> KeyPathExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .keyPathExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.keyPathComponentList, arena: .default),
-      nil,
-    ], arena: .default))
-    return KeyPathExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .keyPathExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.keyPathComponentList, arena: arena),
+        nil,
+      ], arena: arena))
+      return KeyPathExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on KeyPathComponentListSyntax")
   public static func makeKeyPathComponentList(
     _ elements: [KeyPathComponentSyntax]) -> KeyPathComponentListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathComponentList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return KeyPathComponentListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathComponentList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return KeyPathComponentListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on KeyPathComponentListSyntax")
   public static func makeBlankKeyPathComponentList(presence: SourcePresence = .present) -> KeyPathComponentListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .keyPathComponentList,
-      from: [
-    ], arena: .default))
-    return KeyPathComponentListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .keyPathComponentList,
+        from: [
+      ], arena: arena))
+      return KeyPathComponentListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on KeyPathComponentSyntax")
   public static func makeKeyPathComponent(_ unexpectedBeforePeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax?, _ unexpectedBetweenPeriodAndComponent: UnexpectedNodesSyntax? = nil, component: Syntax, _ unexpectedAfterComponent: UnexpectedNodesSyntax? = nil) -> KeyPathComponentSyntax {
@@ -2115,23 +2429,27 @@ public enum SyntaxFactory {
       component.raw,
       unexpectedAfterComponent?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathComponent,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return KeyPathComponentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathComponent,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return KeyPathComponentSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on KeyPathComponentSyntax")
   public static func makeBlankKeyPathComponent(presence: SourcePresence = .present) -> KeyPathComponentSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .keyPathComponent,
-      from: [
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
-      nil,
-    ], arena: .default))
-    return KeyPathComponentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .keyPathComponent,
+        from: [
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena),
+        nil,
+      ], arena: arena))
+      return KeyPathComponentSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on KeyPathPropertyComponentSyntax")
   public static func makeKeyPathPropertyComponent(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?, _ unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause: UnexpectedNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax?, _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil) -> KeyPathPropertyComponentSyntax {
@@ -2144,25 +2462,29 @@ public enum SyntaxFactory {
       genericArgumentClause?.raw,
       unexpectedAfterGenericArgumentClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathPropertyComponent,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return KeyPathPropertyComponentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathPropertyComponent,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return KeyPathPropertyComponentSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on KeyPathPropertyComponentSyntax")
   public static func makeBlankKeyPathPropertyComponent(presence: SourcePresence = .present) -> KeyPathPropertyComponentSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .keyPathPropertyComponent,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return KeyPathPropertyComponentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .keyPathPropertyComponent,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return KeyPathPropertyComponentSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on KeyPathSubscriptComponentSyntax")
   public static func makeKeyPathSubscriptComponent(_ unexpectedBeforeLeftBracket: UnexpectedNodesSyntax? = nil, leftBracket: TokenSyntax, _ unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodesSyntax? = nil, argumentList: TupleExprElementListSyntax, _ unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodesSyntax? = nil, rightBracket: TokenSyntax, _ unexpectedAfterRightBracket: UnexpectedNodesSyntax? = nil) -> KeyPathSubscriptComponentSyntax {
@@ -2175,25 +2497,29 @@ public enum SyntaxFactory {
       rightBracket.raw,
       unexpectedAfterRightBracket?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathSubscriptComponent,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return KeyPathSubscriptComponentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathSubscriptComponent,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return KeyPathSubscriptComponentSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on KeyPathSubscriptComponentSyntax")
   public static func makeBlankKeyPathSubscriptComponent(presence: SourcePresence = .present) -> KeyPathSubscriptComponentSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .keyPathSubscriptComponent,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default),
-      nil,
-    ], arena: .default))
-    return KeyPathSubscriptComponentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .keyPathSubscriptComponent,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena),
+        nil,
+      ], arena: arena))
+      return KeyPathSubscriptComponentSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on KeyPathOptionalComponentSyntax")
   public static func makeKeyPathOptionalComponent(_ unexpectedBeforeQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil, questionOrExclamationMark: TokenSyntax, _ unexpectedAfterQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil) -> KeyPathOptionalComponentSyntax {
@@ -2202,21 +2528,25 @@ public enum SyntaxFactory {
       questionOrExclamationMark.raw,
       unexpectedAfterQuestionOrExclamationMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathOptionalComponent,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return KeyPathOptionalComponentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathOptionalComponent,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return KeyPathOptionalComponentSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on KeyPathOptionalComponentSyntax")
   public static func makeBlankKeyPathOptionalComponent(presence: SourcePresence = .present) -> KeyPathOptionalComponentSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .keyPathOptionalComponent,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: .default),
-      nil,
-    ], arena: .default))
-    return KeyPathOptionalComponentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .keyPathOptionalComponent,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: arena),
+        nil,
+      ], arena: arena))
+      return KeyPathOptionalComponentSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on OldKeyPathExprSyntax")
   public static func makeOldKeyPathExpr(_ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil, backslash: TokenSyntax, _ unexpectedBetweenBackslashAndRootExpr: UnexpectedNodesSyntax? = nil, rootExpr: ExprSyntax?, _ unexpectedBetweenRootExprAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> OldKeyPathExprSyntax {
@@ -2229,25 +2559,29 @@ public enum SyntaxFactory {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.oldKeyPathExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return OldKeyPathExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.oldKeyPathExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return OldKeyPathExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on OldKeyPathExprSyntax")
   public static func makeBlankOldKeyPathExpr(presence: SourcePresence = .present) -> OldKeyPathExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .oldKeyPathExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-    ], arena: .default))
-    return OldKeyPathExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .oldKeyPathExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return OldKeyPathExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on KeyPathBaseExprSyntax")
   public static func makeKeyPathBaseExpr(_ unexpectedBeforePeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax, _ unexpectedAfterPeriod: UnexpectedNodesSyntax? = nil) -> KeyPathBaseExprSyntax {
@@ -2256,21 +2590,25 @@ public enum SyntaxFactory {
       period.raw,
       unexpectedAfterPeriod?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathBaseExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return KeyPathBaseExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathBaseExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return KeyPathBaseExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on KeyPathBaseExprSyntax")
   public static func makeBlankKeyPathBaseExpr(presence: SourcePresence = .present) -> KeyPathBaseExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .keyPathBaseExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default),
-      nil,
-    ], arena: .default))
-    return KeyPathBaseExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .keyPathBaseExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.period, arena: arena),
+        nil,
+      ], arena: arena))
+      return KeyPathBaseExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ObjcNamePieceSyntax")
   public static func makeObjcNamePiece(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndDot: UnexpectedNodesSyntax? = nil, dot: TokenSyntax?, _ unexpectedAfterDot: UnexpectedNodesSyntax? = nil) -> ObjcNamePieceSyntax {
@@ -2281,39 +2619,47 @@ public enum SyntaxFactory {
       dot?.raw,
       unexpectedAfterDot?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcNamePiece,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ObjcNamePieceSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcNamePiece,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ObjcNamePieceSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ObjcNamePieceSyntax")
   public static func makeBlankObjcNamePiece(presence: SourcePresence = .present) -> ObjcNamePieceSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .objcNamePiece,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return ObjcNamePieceSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .objcNamePiece,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return ObjcNamePieceSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ObjcNameSyntax")
   public static func makeObjcName(
     _ elements: [ObjcNamePieceSyntax]) -> ObjcNameSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcName,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ObjcNameSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcName,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ObjcNameSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ObjcNameSyntax")
   public static func makeBlankObjcName(presence: SourcePresence = .present) -> ObjcNameSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .objcName,
-      from: [
-    ], arena: .default))
-    return ObjcNameSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .objcName,
+        from: [
+      ], arena: arena))
+      return ObjcNameSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ObjcKeyPathExprSyntax")
   public static func makeObjcKeyPathExpr(_ unexpectedBeforeKeyPath: UnexpectedNodesSyntax? = nil, keyPath: TokenSyntax, _ unexpectedBetweenKeyPathAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndName: UnexpectedNodesSyntax? = nil, name: ObjcNameSyntax, _ unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> ObjcKeyPathExprSyntax {
@@ -2328,27 +2674,31 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcKeyPathExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ObjcKeyPathExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcKeyPathExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ObjcKeyPathExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ObjcKeyPathExprSyntax")
   public static func makeBlankObjcKeyPathExpr(presence: SourcePresence = .present) -> ObjcKeyPathExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .objcKeyPathExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundKeyPathKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.objcName, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return ObjcKeyPathExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .objcKeyPathExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundKeyPathKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.objcName, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return ObjcKeyPathExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ObjcSelectorExprSyntax")
   public static func makeObjcSelectorExpr(_ unexpectedBeforePoundSelector: UnexpectedNodesSyntax? = nil, poundSelector: TokenSyntax, _ unexpectedBetweenPoundSelectorAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndKind: UnexpectedNodesSyntax? = nil, kind: TokenSyntax?, _ unexpectedBetweenKindAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndName: UnexpectedNodesSyntax? = nil, name: ExprSyntax, _ unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> ObjcSelectorExprSyntax {
@@ -2367,31 +2717,35 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcSelectorExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ObjcSelectorExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcSelectorExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ObjcSelectorExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ObjcSelectorExprSyntax")
   public static func makeBlankObjcSelectorExpr(presence: SourcePresence = .present) -> ObjcSelectorExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .objcSelectorExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundSelectorKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return ObjcSelectorExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .objcSelectorExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundSelectorKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return ObjcSelectorExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on MacroExpansionExprSyntax")
   public static func makeMacroExpansionExpr(_ unexpectedBeforePoundToken: UnexpectedNodesSyntax? = nil, poundToken: TokenSyntax, _ unexpectedBetweenPoundTokenAndMacro: UnexpectedNodesSyntax? = nil, macro: TokenSyntax, _ unexpectedBetweenMacroAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax?, _ unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? = nil, argumentList: TupleExprElementListSyntax, _ unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax?, _ unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodesSyntax? = nil, trailingClosure: ClosureExprSyntax?, _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil, additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?, _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil) -> MacroExpansionExprSyntax {
@@ -2412,33 +2766,37 @@ public enum SyntaxFactory {
       additionalTrailingClosures?.raw,
       unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.macroExpansionExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return MacroExpansionExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.macroExpansionExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MacroExpansionExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MacroExpansionExprSyntax")
   public static func makeBlankMacroExpansionExpr(presence: SourcePresence = .present) -> MacroExpansionExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .macroExpansionExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.pound, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return MacroExpansionExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .macroExpansionExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.pound, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return MacroExpansionExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PostfixIfConfigExprSyntax")
   public static func makePostfixIfConfigExpr(_ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil, base: ExprSyntax?, _ unexpectedBetweenBaseAndConfig: UnexpectedNodesSyntax? = nil, config: IfConfigDeclSyntax, _ unexpectedAfterConfig: UnexpectedNodesSyntax? = nil) -> PostfixIfConfigExprSyntax {
@@ -2449,23 +2807,27 @@ public enum SyntaxFactory {
       config.raw,
       unexpectedAfterConfig?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.postfixIfConfigExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PostfixIfConfigExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.postfixIfConfigExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PostfixIfConfigExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PostfixIfConfigExprSyntax")
   public static func makeBlankPostfixIfConfigExpr(presence: SourcePresence = .present) -> PostfixIfConfigExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .postfixIfConfigExpr,
-      from: [
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifConfigDecl, arena: .default),
-      nil,
-    ], arena: .default))
-    return PostfixIfConfigExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .postfixIfConfigExpr,
+        from: [
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifConfigDecl, arena: arena),
+        nil,
+      ], arena: arena))
+      return PostfixIfConfigExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on EditorPlaceholderExprSyntax")
   public static func makeEditorPlaceholderExpr(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedAfterIdentifier: UnexpectedNodesSyntax? = nil) -> EditorPlaceholderExprSyntax {
@@ -2474,21 +2836,25 @@ public enum SyntaxFactory {
       identifier.raw,
       unexpectedAfterIdentifier?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.editorPlaceholderExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return EditorPlaceholderExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.editorPlaceholderExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return EditorPlaceholderExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on EditorPlaceholderExprSyntax")
   public static func makeBlankEditorPlaceholderExpr(presence: SourcePresence = .present) -> EditorPlaceholderExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .editorPlaceholderExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-    ], arena: .default))
-    return EditorPlaceholderExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .editorPlaceholderExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+      ], arena: arena))
+      return EditorPlaceholderExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ObjectLiteralExprSyntax")
   public static func makeObjectLiteralExpr(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil, arguments: TupleExprElementListSyntax, _ unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> ObjectLiteralExprSyntax {
@@ -2503,43 +2869,51 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.objectLiteralExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ObjectLiteralExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.objectLiteralExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ObjectLiteralExprSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ObjectLiteralExprSyntax")
   public static func makeBlankObjectLiteralExpr(presence: SourcePresence = .present) -> ObjectLiteralExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .objectLiteralExpr,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundColorLiteralKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return ObjectLiteralExprSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .objectLiteralExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundColorLiteralKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return ObjectLiteralExprSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on YieldExprListSyntax")
   public static func makeYieldExprList(
     _ elements: [YieldExprListElementSyntax]) -> YieldExprListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return YieldExprListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return YieldExprListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on YieldExprListSyntax")
   public static func makeBlankYieldExprList(presence: SourcePresence = .present) -> YieldExprListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .yieldExprList,
-      from: [
-    ], arena: .default))
-    return YieldExprListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .yieldExprList,
+        from: [
+      ], arena: arena))
+      return YieldExprListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on YieldExprListElementSyntax")
   public static func makeYieldExprListElement(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedAfterComma: UnexpectedNodesSyntax? = nil) -> YieldExprListElementSyntax {
@@ -2550,23 +2924,27 @@ public enum SyntaxFactory {
       comma?.raw,
       unexpectedAfterComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprListElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return YieldExprListElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprListElement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return YieldExprListElementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on YieldExprListElementSyntax")
   public static func makeBlankYieldExprListElement(presence: SourcePresence = .present) -> YieldExprListElementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .yieldExprListElement,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return YieldExprListElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .yieldExprListElement,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return YieldExprListElementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TypeInitializerClauseSyntax")
   public static func makeTypeInitializerClause(_ unexpectedBeforeEqual: UnexpectedNodesSyntax? = nil, equal: TokenSyntax, _ unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? = nil, value: TypeSyntax, _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil) -> TypeInitializerClauseSyntax {
@@ -2577,23 +2955,27 @@ public enum SyntaxFactory {
       value.raw,
       unexpectedAfterValue?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeInitializerClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TypeInitializerClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeInitializerClause,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TypeInitializerClauseSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TypeInitializerClauseSyntax")
   public static func makeBlankTypeInitializerClause(presence: SourcePresence = .present) -> TypeInitializerClauseSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .typeInitializerClause,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-    ], arena: .default))
-    return TypeInitializerClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .typeInitializerClause,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+      ], arena: arena))
+      return TypeInitializerClauseSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TypealiasDeclSyntax")
   public static func makeTypealiasDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndTypealiasKeyword: UnexpectedNodesSyntax? = nil, typealiasKeyword: TokenSyntax, _ unexpectedBetweenTypealiasKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndInitializer: UnexpectedNodesSyntax? = nil, initializer: TypeInitializerClauseSyntax, _ unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil) -> TypealiasDeclSyntax {
@@ -2614,33 +2996,37 @@ public enum SyntaxFactory {
       genericWhereClause?.raw,
       unexpectedAfterGenericWhereClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.typealiasDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TypealiasDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.typealiasDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TypealiasDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TypealiasDeclSyntax")
   public static func makeBlankTypealiasDecl(presence: SourcePresence = .present) -> TypealiasDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .typealiasDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.typealiasKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.typeInitializerClause, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return TypealiasDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .typealiasDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.typealiasKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.typeInitializerClause, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return TypealiasDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AssociatedtypeDeclSyntax")
   public static func makeAssociatedtypeDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndAssociatedtypeKeyword: UnexpectedNodesSyntax? = nil, associatedtypeKeyword: TokenSyntax, _ unexpectedBetweenAssociatedtypeKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndInitializer: UnexpectedNodesSyntax? = nil, initializer: TypeInitializerClauseSyntax?, _ unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil) -> AssociatedtypeDeclSyntax {
@@ -2661,49 +3047,57 @@ public enum SyntaxFactory {
       genericWhereClause?.raw,
       unexpectedAfterGenericWhereClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.associatedtypeDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AssociatedtypeDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.associatedtypeDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AssociatedtypeDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AssociatedtypeDeclSyntax")
   public static func makeBlankAssociatedtypeDecl(presence: SourcePresence = .present) -> AssociatedtypeDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .associatedtypeDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.associatedtypeKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return AssociatedtypeDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .associatedtypeDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.associatedtypeKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return AssociatedtypeDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on FunctionParameterListSyntax")
   public static func makeFunctionParameterList(
     _ elements: [FunctionParameterSyntax]) -> FunctionParameterListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionParameterList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return FunctionParameterListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionParameterList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return FunctionParameterListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on FunctionParameterListSyntax")
   public static func makeBlankFunctionParameterList(presence: SourcePresence = .present) -> FunctionParameterListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .functionParameterList,
-      from: [
-    ], arena: .default))
-    return FunctionParameterListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .functionParameterList,
+        from: [
+      ], arena: arena))
+      return FunctionParameterListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ParameterClauseSyntax")
   public static func makeParameterClause(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndParameterList: UnexpectedNodesSyntax? = nil, parameterList: FunctionParameterListSyntax, _ unexpectedBetweenParameterListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> ParameterClauseSyntax {
@@ -2716,25 +3110,29 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.parameterClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ParameterClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.parameterClause,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ParameterClauseSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ParameterClauseSyntax")
   public static func makeBlankParameterClause(presence: SourcePresence = .present) -> ParameterClauseSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .parameterClause,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionParameterList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return ParameterClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .parameterClause,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionParameterList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return ParameterClauseSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ReturnClauseSyntax")
   public static func makeReturnClause(_ unexpectedBeforeArrow: UnexpectedNodesSyntax? = nil, arrow: TokenSyntax, _ unexpectedBetweenArrowAndReturnType: UnexpectedNodesSyntax? = nil, returnType: TypeSyntax, _ unexpectedAfterReturnType: UnexpectedNodesSyntax? = nil) -> ReturnClauseSyntax {
@@ -2745,23 +3143,27 @@ public enum SyntaxFactory {
       returnType.raw,
       unexpectedAfterReturnType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.returnClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ReturnClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.returnClause,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ReturnClauseSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ReturnClauseSyntax")
   public static func makeBlankReturnClause(presence: SourcePresence = .present) -> ReturnClauseSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .returnClause,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-    ], arena: .default))
-    return ReturnClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .returnClause,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+      ], arena: arena))
+      return ReturnClauseSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on FunctionSignatureSyntax")
   public static func makeFunctionSignature(_ unexpectedBeforeInput: UnexpectedNodesSyntax? = nil, input: ParameterClauseSyntax, _ unexpectedBetweenInputAndAsyncOrReasyncKeyword: UnexpectedNodesSyntax? = nil, asyncOrReasyncKeyword: TokenSyntax?, _ unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodesSyntax? = nil, throwsOrRethrowsKeyword: TokenSyntax?, _ unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: UnexpectedNodesSyntax? = nil, output: ReturnClauseSyntax?, _ unexpectedAfterOutput: UnexpectedNodesSyntax? = nil) -> FunctionSignatureSyntax {
@@ -2776,27 +3178,31 @@ public enum SyntaxFactory {
       output?.raw,
       unexpectedAfterOutput?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionSignature,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return FunctionSignatureSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionSignature,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return FunctionSignatureSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on FunctionSignatureSyntax")
   public static func makeBlankFunctionSignature(presence: SourcePresence = .present) -> FunctionSignatureSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .functionSignature,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.parameterClause, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return FunctionSignatureSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .functionSignature,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.parameterClause, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return FunctionSignatureSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on IfConfigClauseSyntax")
   public static func makeIfConfigClause(_ unexpectedBeforePoundKeyword: UnexpectedNodesSyntax? = nil, poundKeyword: TokenSyntax, _ unexpectedBetweenPoundKeywordAndCondition: UnexpectedNodesSyntax? = nil, condition: ExprSyntax?, _ unexpectedBetweenConditionAndElements: UnexpectedNodesSyntax? = nil, elements: Syntax?, _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil) -> IfConfigClauseSyntax {
@@ -2809,41 +3215,49 @@ public enum SyntaxFactory {
       elements?.raw,
       unexpectedAfterElements?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return IfConfigClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClause,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return IfConfigClauseSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on IfConfigClauseSyntax")
   public static func makeBlankIfConfigClause(presence: SourcePresence = .present) -> IfConfigClauseSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .ifConfigClause,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundIfKeyword, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return IfConfigClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .ifConfigClause,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundIfKeyword, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return IfConfigClauseSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on IfConfigClauseListSyntax")
   public static func makeIfConfigClauseList(
     _ elements: [IfConfigClauseSyntax]) -> IfConfigClauseListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClauseList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return IfConfigClauseListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClauseList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return IfConfigClauseListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on IfConfigClauseListSyntax")
   public static func makeBlankIfConfigClauseList(presence: SourcePresence = .present) -> IfConfigClauseListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .ifConfigClauseList,
-      from: [
-    ], arena: .default))
-    return IfConfigClauseListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .ifConfigClauseList,
+        from: [
+      ], arena: arena))
+      return IfConfigClauseListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on IfConfigDeclSyntax")
   public static func makeIfConfigDecl(_ unexpectedBeforeClauses: UnexpectedNodesSyntax? = nil, clauses: IfConfigClauseListSyntax, _ unexpectedBetweenClausesAndPoundEndif: UnexpectedNodesSyntax? = nil, poundEndif: TokenSyntax, _ unexpectedAfterPoundEndif: UnexpectedNodesSyntax? = nil) -> IfConfigDeclSyntax {
@@ -2854,23 +3268,27 @@ public enum SyntaxFactory {
       poundEndif.raw,
       unexpectedAfterPoundEndif?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return IfConfigDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return IfConfigDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on IfConfigDeclSyntax")
   public static func makeBlankIfConfigDecl(presence: SourcePresence = .present) -> IfConfigDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .ifConfigDecl,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifConfigClauseList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundEndifKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return IfConfigDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .ifConfigDecl,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifConfigClauseList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundEndifKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return IfConfigDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PoundErrorDeclSyntax")
   public static func makePoundErrorDecl(_ unexpectedBeforePoundError: UnexpectedNodesSyntax? = nil, poundError: TokenSyntax, _ unexpectedBetweenPoundErrorAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndMessage: UnexpectedNodesSyntax? = nil, message: StringLiteralExprSyntax, _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> PoundErrorDeclSyntax {
@@ -2885,27 +3303,31 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundErrorDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PoundErrorDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundErrorDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PoundErrorDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PoundErrorDeclSyntax")
   public static func makeBlankPoundErrorDecl(presence: SourcePresence = .present) -> PoundErrorDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundErrorDecl,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundErrorKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return PoundErrorDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundErrorDecl,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundErrorKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return PoundErrorDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PoundWarningDeclSyntax")
   public static func makePoundWarningDecl(_ unexpectedBeforePoundWarning: UnexpectedNodesSyntax? = nil, poundWarning: TokenSyntax, _ unexpectedBetweenPoundWarningAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndMessage: UnexpectedNodesSyntax? = nil, message: StringLiteralExprSyntax, _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> PoundWarningDeclSyntax {
@@ -2920,27 +3342,31 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundWarningDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PoundWarningDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundWarningDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PoundWarningDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PoundWarningDeclSyntax")
   public static func makeBlankPoundWarningDecl(presence: SourcePresence = .present) -> PoundWarningDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundWarningDecl,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundWarningKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return PoundWarningDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundWarningDecl,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundWarningKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return PoundWarningDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PoundSourceLocationSyntax")
   public static func makePoundSourceLocation(_ unexpectedBeforePoundSourceLocation: UnexpectedNodesSyntax? = nil, poundSourceLocation: TokenSyntax, _ unexpectedBetweenPoundSourceLocationAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndArgs: UnexpectedNodesSyntax? = nil, args: PoundSourceLocationArgsSyntax?, _ unexpectedBetweenArgsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> PoundSourceLocationSyntax {
@@ -2955,27 +3381,31 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundSourceLocation,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PoundSourceLocationSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundSourceLocation,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PoundSourceLocationSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PoundSourceLocationSyntax")
   public static func makeBlankPoundSourceLocation(presence: SourcePresence = .present) -> PoundSourceLocationSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundSourceLocation,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundSourceLocationKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return PoundSourceLocationSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundSourceLocation,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundSourceLocationKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return PoundSourceLocationSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PoundSourceLocationArgsSyntax")
   public static func makePoundSourceLocationArgs(_ unexpectedBeforeFileArgLabel: UnexpectedNodesSyntax? = nil, fileArgLabel: TokenSyntax, _ unexpectedBetweenFileArgLabelAndFileArgColon: UnexpectedNodesSyntax? = nil, fileArgColon: TokenSyntax, _ unexpectedBetweenFileArgColonAndFileName: UnexpectedNodesSyntax? = nil, fileName: TokenSyntax, _ unexpectedBetweenFileNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndLineArgLabel: UnexpectedNodesSyntax? = nil, lineArgLabel: TokenSyntax, _ unexpectedBetweenLineArgLabelAndLineArgColon: UnexpectedNodesSyntax? = nil, lineArgColon: TokenSyntax, _ unexpectedBetweenLineArgColonAndLineNumber: UnexpectedNodesSyntax? = nil, lineNumber: TokenSyntax, _ unexpectedAfterLineNumber: UnexpectedNodesSyntax? = nil) -> PoundSourceLocationArgsSyntax {
@@ -2996,33 +3426,37 @@ public enum SyntaxFactory {
       lineNumber.raw,
       unexpectedAfterLineNumber?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundSourceLocationArgs,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PoundSourceLocationArgsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundSourceLocationArgs,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PoundSourceLocationArgsSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PoundSourceLocationArgsSyntax")
   public static func makeBlankPoundSourceLocationArgs(presence: SourcePresence = .present) -> PoundSourceLocationArgsSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundSourceLocationArgs,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default),
-      nil,
-    ], arena: .default))
-    return PoundSourceLocationArgsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundSourceLocationArgs,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: arena),
+        nil,
+      ], arena: arena))
+      return PoundSourceLocationArgsSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DeclModifierDetailSyntax")
   public static func makeDeclModifierDetail(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndDetail: UnexpectedNodesSyntax? = nil, detail: TokenSyntax, _ unexpectedBetweenDetailAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> DeclModifierDetailSyntax {
@@ -3035,25 +3469,29 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.declModifierDetail,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DeclModifierDetailSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declModifierDetail,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DeclModifierDetailSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DeclModifierDetailSyntax")
   public static func makeBlankDeclModifierDetail(presence: SourcePresence = .present) -> DeclModifierDetailSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .declModifierDetail,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return DeclModifierDetailSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .declModifierDetail,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return DeclModifierDetailSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DeclModifierSyntax")
   public static func makeDeclModifier(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndDetail: UnexpectedNodesSyntax? = nil, detail: DeclModifierDetailSyntax?, _ unexpectedAfterDetail: UnexpectedNodesSyntax? = nil) -> DeclModifierSyntax {
@@ -3064,23 +3502,27 @@ public enum SyntaxFactory {
       detail?.raw,
       unexpectedAfterDetail?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.declModifier,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DeclModifierSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declModifier,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DeclModifierSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DeclModifierSyntax")
   public static func makeBlankDeclModifier(presence: SourcePresence = .present) -> DeclModifierSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .declModifier,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return DeclModifierSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .declModifier,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return DeclModifierSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on InheritedTypeSyntax")
   public static func makeInheritedType(_ unexpectedBeforeTypeName: UnexpectedNodesSyntax? = nil, typeName: TypeSyntax, _ unexpectedBetweenTypeNameAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> InheritedTypeSyntax {
@@ -3091,39 +3533,47 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.inheritedType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return InheritedTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.inheritedType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return InheritedTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on InheritedTypeSyntax")
   public static func makeBlankInheritedType(presence: SourcePresence = .present) -> InheritedTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .inheritedType,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return InheritedTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .inheritedType,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return InheritedTypeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on InheritedTypeListSyntax")
   public static func makeInheritedTypeList(
     _ elements: [InheritedTypeSyntax]) -> InheritedTypeListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.inheritedTypeList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return InheritedTypeListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.inheritedTypeList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return InheritedTypeListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on InheritedTypeListSyntax")
   public static func makeBlankInheritedTypeList(presence: SourcePresence = .present) -> InheritedTypeListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .inheritedTypeList,
-      from: [
-    ], arena: .default))
-    return InheritedTypeListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .inheritedTypeList,
+        from: [
+      ], arena: arena))
+      return InheritedTypeListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TypeInheritanceClauseSyntax")
   public static func makeTypeInheritanceClause(_ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndInheritedTypeCollection: UnexpectedNodesSyntax? = nil, inheritedTypeCollection: InheritedTypeListSyntax, _ unexpectedAfterInheritedTypeCollection: UnexpectedNodesSyntax? = nil) -> TypeInheritanceClauseSyntax {
@@ -3134,23 +3584,27 @@ public enum SyntaxFactory {
       inheritedTypeCollection.raw,
       unexpectedAfterInheritedTypeCollection?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeInheritanceClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TypeInheritanceClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeInheritanceClause,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TypeInheritanceClauseSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TypeInheritanceClauseSyntax")
   public static func makeBlankTypeInheritanceClause(presence: SourcePresence = .present) -> TypeInheritanceClauseSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .typeInheritanceClause,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.inheritedTypeList, arena: .default),
-      nil,
-    ], arena: .default))
-    return TypeInheritanceClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .typeInheritanceClause,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.inheritedTypeList, arena: arena),
+        nil,
+      ], arena: arena))
+      return TypeInheritanceClauseSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ClassDeclSyntax")
   public static func makeClassDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndClassKeyword: UnexpectedNodesSyntax? = nil, classKeyword: TokenSyntax, _ unexpectedBetweenClassKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax, _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil) -> ClassDeclSyntax {
@@ -3173,35 +3627,39 @@ public enum SyntaxFactory {
       members.raw,
       unexpectedAfterMembers?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.classDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ClassDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.classDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ClassDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ClassDeclSyntax")
   public static func makeBlankClassDecl(presence: SourcePresence = .present) -> ClassDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .classDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.classKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default),
-      nil,
-    ], arena: .default))
-    return ClassDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .classDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.classKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena),
+        nil,
+      ], arena: arena))
+      return ClassDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ActorDeclSyntax")
   public static func makeActorDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndActorKeyword: UnexpectedNodesSyntax? = nil, actorKeyword: TokenSyntax, _ unexpectedBetweenActorKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax, _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil) -> ActorDeclSyntax {
@@ -3224,35 +3682,39 @@ public enum SyntaxFactory {
       members.raw,
       unexpectedAfterMembers?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.actorDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ActorDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.actorDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ActorDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ActorDeclSyntax")
   public static func makeBlankActorDecl(presence: SourcePresence = .present) -> ActorDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .actorDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default),
-      nil,
-    ], arena: .default))
-    return ActorDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .actorDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena),
+        nil,
+      ], arena: arena))
+      return ActorDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on StructDeclSyntax")
   public static func makeStructDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndStructKeyword: UnexpectedNodesSyntax? = nil, structKeyword: TokenSyntax, _ unexpectedBetweenStructKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax, _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil) -> StructDeclSyntax {
@@ -3275,35 +3737,39 @@ public enum SyntaxFactory {
       members.raw,
       unexpectedAfterMembers?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.structDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return StructDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.structDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return StructDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on StructDeclSyntax")
   public static func makeBlankStructDecl(presence: SourcePresence = .present) -> StructDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .structDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.structKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default),
-      nil,
-    ], arena: .default))
-    return StructDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .structDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.structKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena),
+        nil,
+      ], arena: arena))
+      return StructDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ProtocolDeclSyntax")
   public static func makeProtocolDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndProtocolKeyword: UnexpectedNodesSyntax? = nil, protocolKeyword: TokenSyntax, _ unexpectedBetweenProtocolKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause: UnexpectedNodesSyntax? = nil, primaryAssociatedTypeClause: PrimaryAssociatedTypeClauseSyntax?, _ unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax, _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil) -> ProtocolDeclSyntax {
@@ -3326,35 +3792,39 @@ public enum SyntaxFactory {
       members.raw,
       unexpectedAfterMembers?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.protocolDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ProtocolDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.protocolDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ProtocolDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ProtocolDeclSyntax")
   public static func makeBlankProtocolDecl(presence: SourcePresence = .present) -> ProtocolDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .protocolDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.protocolKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default),
-      nil,
-    ], arena: .default))
-    return ProtocolDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .protocolDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.protocolKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena),
+        nil,
+      ], arena: arena))
+      return ProtocolDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ExtensionDeclSyntax")
   public static func makeExtensionDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndExtensionKeyword: UnexpectedNodesSyntax? = nil, extensionKeyword: TokenSyntax, _ unexpectedBetweenExtensionKeywordAndExtendedType: UnexpectedNodesSyntax? = nil, extendedType: TypeSyntax, _ unexpectedBetweenExtendedTypeAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax, _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil) -> ExtensionDeclSyntax {
@@ -3375,33 +3845,37 @@ public enum SyntaxFactory {
       members.raw,
       unexpectedAfterMembers?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.extensionDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ExtensionDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.extensionDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ExtensionDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ExtensionDeclSyntax")
   public static func makeBlankExtensionDecl(presence: SourcePresence = .present) -> ExtensionDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .extensionDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.extensionKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default),
-      nil,
-    ], arena: .default))
-    return ExtensionDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .extensionDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.extensionKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena),
+        nil,
+      ], arena: arena))
+      return ExtensionDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on MemberDeclBlockSyntax")
   public static func makeMemberDeclBlock(_ unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclListSyntax, _ unexpectedBetweenMembersAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax, _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil) -> MemberDeclBlockSyntax {
@@ -3414,41 +3888,49 @@ public enum SyntaxFactory {
       rightBrace.raw,
       unexpectedAfterRightBrace?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclBlock,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return MemberDeclBlockSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclBlock,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MemberDeclBlockSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MemberDeclBlockSyntax")
   public static func makeBlankMemberDeclBlock(presence: SourcePresence = .present) -> MemberDeclBlockSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .memberDeclBlock,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default),
-      nil,
-    ], arena: .default))
-    return MemberDeclBlockSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .memberDeclBlock,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena),
+        nil,
+      ], arena: arena))
+      return MemberDeclBlockSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on MemberDeclListSyntax")
   public static func makeMemberDeclList(
     _ elements: [MemberDeclListItemSyntax]) -> MemberDeclListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return MemberDeclListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MemberDeclListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MemberDeclListSyntax")
   public static func makeBlankMemberDeclList(presence: SourcePresence = .present) -> MemberDeclListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .memberDeclList,
-      from: [
-    ], arena: .default))
-    return MemberDeclListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .memberDeclList,
+        from: [
+      ], arena: arena))
+      return MemberDeclListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on MemberDeclListItemSyntax")
   public static func makeMemberDeclListItem(_ unexpectedBeforeDecl: UnexpectedNodesSyntax? = nil, decl: DeclSyntax, _ unexpectedBetweenDeclAndSemicolon: UnexpectedNodesSyntax? = nil, semicolon: TokenSyntax?, _ unexpectedAfterSemicolon: UnexpectedNodesSyntax? = nil) -> MemberDeclListItemSyntax {
@@ -3459,23 +3941,27 @@ public enum SyntaxFactory {
       semicolon?.raw,
       unexpectedAfterSemicolon?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclListItem,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return MemberDeclListItemSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclListItem,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MemberDeclListItemSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MemberDeclListItemSyntax")
   public static func makeBlankMemberDeclListItem(presence: SourcePresence = .present) -> MemberDeclListItemSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .memberDeclListItem,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingDecl, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return MemberDeclListItemSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .memberDeclListItem,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingDecl, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return MemberDeclListItemSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on SourceFileSyntax")
   public static func makeSourceFile(_ unexpectedBeforeStatements: UnexpectedNodesSyntax? = nil, statements: CodeBlockItemListSyntax, _ unexpectedBetweenStatementsAndEOFToken: UnexpectedNodesSyntax? = nil, eofToken: TokenSyntax, _ unexpectedAfterEOFToken: UnexpectedNodesSyntax? = nil) -> SourceFileSyntax {
@@ -3486,23 +3972,27 @@ public enum SyntaxFactory {
       eofToken.raw,
       unexpectedAfterEOFToken?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.sourceFile,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return SourceFileSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.sourceFile,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return SourceFileSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on SourceFileSyntax")
   public static func makeBlankSourceFile(presence: SourcePresence = .present) -> SourceFileSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .sourceFile,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
-      nil,
-    ], arena: .default))
-    return SourceFileSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .sourceFile,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena),
+        nil,
+      ], arena: arena))
+      return SourceFileSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on InitializerClauseSyntax")
   public static func makeInitializerClause(_ unexpectedBeforeEqual: UnexpectedNodesSyntax? = nil, equal: TokenSyntax, _ unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? = nil, value: ExprSyntax, _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil) -> InitializerClauseSyntax {
@@ -3513,23 +4003,27 @@ public enum SyntaxFactory {
       value.raw,
       unexpectedAfterValue?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.initializerClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return InitializerClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.initializerClause,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return InitializerClauseSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on InitializerClauseSyntax")
   public static func makeBlankInitializerClause(presence: SourcePresence = .present) -> InitializerClauseSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .initializerClause,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-    ], arena: .default))
-    return InitializerClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .initializerClause,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return InitializerClauseSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on FunctionParameterSyntax")
   public static func makeFunctionParameter(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndFirstName: UnexpectedNodesSyntax? = nil, firstName: TokenSyntax?, _ unexpectedBetweenFirstNameAndSecondName: UnexpectedNodesSyntax? = nil, secondName: TokenSyntax?, _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax?, _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil, ellipsis: TokenSyntax?, _ unexpectedBetweenEllipsisAndDefaultArgument: UnexpectedNodesSyntax? = nil, defaultArgument: InitializerClauseSyntax?, _ unexpectedBetweenDefaultArgumentAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> FunctionParameterSyntax {
@@ -3554,53 +4048,61 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionParameter,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return FunctionParameterSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionParameter,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return FunctionParameterSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on FunctionParameterSyntax")
   public static func makeBlankFunctionParameter(presence: SourcePresence = .present) -> FunctionParameterSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .functionParameter,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return FunctionParameterSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .functionParameter,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return FunctionParameterSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ModifierListSyntax")
   public static func makeModifierList(
     _ elements: [DeclModifierSyntax]) -> ModifierListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ModifierListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ModifierListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ModifierListSyntax")
   public static func makeBlankModifierList(presence: SourcePresence = .present) -> ModifierListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .modifierList,
-      from: [
-    ], arena: .default))
-    return ModifierListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .modifierList,
+        from: [
+      ], arena: arena))
+      return ModifierListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on FunctionDeclSyntax")
   public static func makeFunctionDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndFuncKeyword: UnexpectedNodesSyntax? = nil, funcKeyword: TokenSyntax, _ unexpectedBetweenFuncKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? = nil, signature: FunctionSignatureSyntax, _ unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax?, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> FunctionDeclSyntax {
@@ -3623,35 +4125,39 @@ public enum SyntaxFactory {
       body?.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return FunctionDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return FunctionDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on FunctionDeclSyntax")
   public static func makeBlankFunctionDecl(presence: SourcePresence = .present) -> FunctionDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .functionDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.funcKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionSignature, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return FunctionDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .functionDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.funcKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionSignature, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return FunctionDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on InitializerDeclSyntax")
   public static func makeInitializerDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndInitKeyword: UnexpectedNodesSyntax? = nil, initKeyword: TokenSyntax, _ unexpectedBetweenInitKeywordAndOptionalMark: UnexpectedNodesSyntax? = nil, optionalMark: TokenSyntax?, _ unexpectedBetweenOptionalMarkAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? = nil, signature: FunctionSignatureSyntax, _ unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax?, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> InitializerDeclSyntax {
@@ -3674,35 +4180,39 @@ public enum SyntaxFactory {
       body?.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.initializerDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return InitializerDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.initializerDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return InitializerDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on InitializerDeclSyntax")
   public static func makeBlankInitializerDecl(presence: SourcePresence = .present) -> InitializerDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .initializerDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.initKeyword, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionSignature, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return InitializerDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .initializerDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.initKeyword, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionSignature, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return InitializerDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DeinitializerDeclSyntax")
   public static func makeDeinitializerDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndDeinitKeyword: UnexpectedNodesSyntax? = nil, deinitKeyword: TokenSyntax, _ unexpectedBetweenDeinitKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax?, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> DeinitializerDeclSyntax {
@@ -3717,27 +4227,31 @@ public enum SyntaxFactory {
       body?.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.deinitializerDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DeinitializerDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.deinitializerDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DeinitializerDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DeinitializerDeclSyntax")
   public static func makeBlankDeinitializerDecl(presence: SourcePresence = .present) -> DeinitializerDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .deinitializerDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.deinitKeyword, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return DeinitializerDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .deinitializerDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.deinitKeyword, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return DeinitializerDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on SubscriptDeclSyntax")
   public static func makeSubscriptDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndSubscriptKeyword: UnexpectedNodesSyntax? = nil, subscriptKeyword: TokenSyntax, _ unexpectedBetweenSubscriptKeywordAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndIndices: UnexpectedNodesSyntax? = nil, indices: ParameterClauseSyntax, _ unexpectedBetweenIndicesAndResult: UnexpectedNodesSyntax? = nil, result: ReturnClauseSyntax, _ unexpectedBetweenResultAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndAccessor: UnexpectedNodesSyntax? = nil, accessor: Syntax?, _ unexpectedAfterAccessor: UnexpectedNodesSyntax? = nil) -> SubscriptDeclSyntax {
@@ -3760,35 +4274,39 @@ public enum SyntaxFactory {
       accessor?.raw,
       unexpectedAfterAccessor?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.subscriptDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return SubscriptDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.subscriptDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return SubscriptDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on SubscriptDeclSyntax")
   public static func makeBlankSubscriptDecl(presence: SourcePresence = .present) -> SubscriptDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .subscriptDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.subscriptKeyword, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.parameterClause, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.returnClause, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return SubscriptDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .subscriptDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.subscriptKeyword, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.parameterClause, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.returnClause, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return SubscriptDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AccessLevelModifierSyntax")
   public static func makeAccessLevelModifier(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndModifier: UnexpectedNodesSyntax? = nil, modifier: DeclModifierDetailSyntax?, _ unexpectedAfterModifier: UnexpectedNodesSyntax? = nil) -> AccessLevelModifierSyntax {
@@ -3799,23 +4317,27 @@ public enum SyntaxFactory {
       modifier?.raw,
       unexpectedAfterModifier?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessLevelModifier,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AccessLevelModifierSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessLevelModifier,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AccessLevelModifierSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AccessLevelModifierSyntax")
   public static func makeBlankAccessLevelModifier(presence: SourcePresence = .present) -> AccessLevelModifierSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .accessLevelModifier,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return AccessLevelModifierSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .accessLevelModifier,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return AccessLevelModifierSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AccessPathComponentSyntax")
   public static func makeAccessPathComponent(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndTrailingDot: UnexpectedNodesSyntax? = nil, trailingDot: TokenSyntax?, _ unexpectedAfterTrailingDot: UnexpectedNodesSyntax? = nil) -> AccessPathComponentSyntax {
@@ -3826,39 +4348,47 @@ public enum SyntaxFactory {
       trailingDot?.raw,
       unexpectedAfterTrailingDot?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessPathComponent,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AccessPathComponentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessPathComponent,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AccessPathComponentSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AccessPathComponentSyntax")
   public static func makeBlankAccessPathComponent(presence: SourcePresence = .present) -> AccessPathComponentSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .accessPathComponent,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return AccessPathComponentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .accessPathComponent,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return AccessPathComponentSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AccessPathSyntax")
   public static func makeAccessPath(
     _ elements: [AccessPathComponentSyntax]) -> AccessPathSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessPath,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AccessPathSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessPath,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AccessPathSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AccessPathSyntax")
   public static func makeBlankAccessPath(presence: SourcePresence = .present) -> AccessPathSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .accessPath,
-      from: [
-    ], arena: .default))
-    return AccessPathSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .accessPath,
+        from: [
+      ], arena: arena))
+      return AccessPathSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ImportDeclSyntax")
   public static func makeImportDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndImportTok: UnexpectedNodesSyntax? = nil, importTok: TokenSyntax, _ unexpectedBetweenImportTokAndImportKind: UnexpectedNodesSyntax? = nil, importKind: TokenSyntax?, _ unexpectedBetweenImportKindAndPath: UnexpectedNodesSyntax? = nil, path: AccessPathSyntax, _ unexpectedAfterPath: UnexpectedNodesSyntax? = nil) -> ImportDeclSyntax {
@@ -3875,29 +4405,33 @@ public enum SyntaxFactory {
       path.raw,
       unexpectedAfterPath?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.importDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ImportDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.importDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ImportDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ImportDeclSyntax")
   public static func makeBlankImportDecl(presence: SourcePresence = .present) -> ImportDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .importDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.importKeyword, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.accessPath, arena: .default),
-      nil,
-    ], arena: .default))
-    return ImportDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .importDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.importKeyword, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.accessPath, arena: arena),
+        nil,
+      ], arena: arena))
+      return ImportDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AccessorParameterSyntax")
   public static func makeAccessorParameter(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> AccessorParameterSyntax {
@@ -3910,25 +4444,29 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorParameter,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AccessorParameterSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorParameter,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AccessorParameterSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AccessorParameterSyntax")
   public static func makeBlankAccessorParameter(presence: SourcePresence = .present) -> AccessorParameterSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .accessorParameter,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return AccessorParameterSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .accessorParameter,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return AccessorParameterSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AccessorDeclSyntax")
   public static func makeAccessorDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifier: UnexpectedNodesSyntax? = nil, modifier: DeclModifierSyntax?, _ unexpectedBetweenModifierAndAccessorKind: UnexpectedNodesSyntax? = nil, accessorKind: TokenSyntax, _ unexpectedBetweenAccessorKindAndParameter: UnexpectedNodesSyntax? = nil, parameter: AccessorParameterSyntax?, _ unexpectedBetweenParameterAndAsyncKeyword: UnexpectedNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ unexpectedBetweenAsyncKeywordAndThrowsKeyword: UnexpectedNodesSyntax? = nil, throwsKeyword: TokenSyntax?, _ unexpectedBetweenThrowsKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax?, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> AccessorDeclSyntax {
@@ -3949,49 +4487,57 @@ public enum SyntaxFactory {
       body?.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AccessorDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AccessorDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AccessorDeclSyntax")
   public static func makeBlankAccessorDecl(presence: SourcePresence = .present) -> AccessorDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .accessorDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return AccessorDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .accessorDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return AccessorDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AccessorListSyntax")
   public static func makeAccessorList(
     _ elements: [AccessorDeclSyntax]) -> AccessorListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AccessorListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AccessorListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AccessorListSyntax")
   public static func makeBlankAccessorList(presence: SourcePresence = .present) -> AccessorListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .accessorList,
-      from: [
-    ], arena: .default))
-    return AccessorListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .accessorList,
+        from: [
+      ], arena: arena))
+      return AccessorListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AccessorBlockSyntax")
   public static func makeAccessorBlock(_ unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndAccessors: UnexpectedNodesSyntax? = nil, accessors: AccessorListSyntax, _ unexpectedBetweenAccessorsAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax, _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil) -> AccessorBlockSyntax {
@@ -4004,25 +4550,29 @@ public enum SyntaxFactory {
       rightBrace.raw,
       unexpectedAfterRightBrace?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorBlock,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AccessorBlockSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorBlock,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AccessorBlockSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AccessorBlockSyntax")
   public static func makeBlankAccessorBlock(presence: SourcePresence = .present) -> AccessorBlockSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .accessorBlock,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.accessorList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default),
-      nil,
-    ], arena: .default))
-    return AccessorBlockSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .accessorBlock,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.accessorList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena),
+        nil,
+      ], arena: arena))
+      return AccessorBlockSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PatternBindingSyntax")
   public static func makePatternBinding(_ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil, initializer: InitializerClauseSyntax?, _ unexpectedBetweenInitializerAndAccessor: UnexpectedNodesSyntax? = nil, accessor: Syntax?, _ unexpectedBetweenAccessorAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> PatternBindingSyntax {
@@ -4039,45 +4589,53 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.patternBinding,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PatternBindingSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.patternBinding,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PatternBindingSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PatternBindingSyntax")
   public static func makeBlankPatternBinding(presence: SourcePresence = .present) -> PatternBindingSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .patternBinding,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return PatternBindingSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .patternBinding,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return PatternBindingSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PatternBindingListSyntax")
   public static func makePatternBindingList(
     _ elements: [PatternBindingSyntax]) -> PatternBindingListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.patternBindingList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PatternBindingListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.patternBindingList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PatternBindingListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PatternBindingListSyntax")
   public static func makeBlankPatternBindingList(presence: SourcePresence = .present) -> PatternBindingListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .patternBindingList,
-      from: [
-    ], arena: .default))
-    return PatternBindingListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .patternBindingList,
+        from: [
+      ], arena: arena))
+      return PatternBindingListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on VariableDeclSyntax")
   public static func makeVariableDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndLetOrVarKeyword: UnexpectedNodesSyntax? = nil, letOrVarKeyword: TokenSyntax, _ unexpectedBetweenLetOrVarKeywordAndBindings: UnexpectedNodesSyntax? = nil, bindings: PatternBindingListSyntax, _ unexpectedAfterBindings: UnexpectedNodesSyntax? = nil) -> VariableDeclSyntax {
@@ -4092,27 +4650,31 @@ public enum SyntaxFactory {
       bindings.raw,
       unexpectedAfterBindings?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.variableDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return VariableDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.variableDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return VariableDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on VariableDeclSyntax")
   public static func makeBlankVariableDecl(presence: SourcePresence = .present) -> VariableDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .variableDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.patternBindingList, arena: .default),
-      nil,
-    ], arena: .default))
-    return VariableDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .variableDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.patternBindingList, arena: arena),
+        nil,
+      ], arena: arena))
+      return VariableDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on EnumCaseElementSyntax")
   public static func makeEnumCaseElement(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndAssociatedValue: UnexpectedNodesSyntax? = nil, associatedValue: ParameterClauseSyntax?, _ unexpectedBetweenAssociatedValueAndRawValue: UnexpectedNodesSyntax? = nil, rawValue: InitializerClauseSyntax?, _ unexpectedBetweenRawValueAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> EnumCaseElementSyntax {
@@ -4127,43 +4689,51 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return EnumCaseElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return EnumCaseElementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on EnumCaseElementSyntax")
   public static func makeBlankEnumCaseElement(presence: SourcePresence = .present) -> EnumCaseElementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .enumCaseElement,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return EnumCaseElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .enumCaseElement,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return EnumCaseElementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on EnumCaseElementListSyntax")
   public static func makeEnumCaseElementList(
     _ elements: [EnumCaseElementSyntax]) -> EnumCaseElementListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElementList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return EnumCaseElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElementList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return EnumCaseElementListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on EnumCaseElementListSyntax")
   public static func makeBlankEnumCaseElementList(presence: SourcePresence = .present) -> EnumCaseElementListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .enumCaseElementList,
-      from: [
-    ], arena: .default))
-    return EnumCaseElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .enumCaseElementList,
+        from: [
+      ], arena: arena))
+      return EnumCaseElementListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on EnumCaseDeclSyntax")
   public static func makeEnumCaseDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndCaseKeyword: UnexpectedNodesSyntax? = nil, caseKeyword: TokenSyntax, _ unexpectedBetweenCaseKeywordAndElements: UnexpectedNodesSyntax? = nil, elements: EnumCaseElementListSyntax, _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil) -> EnumCaseDeclSyntax {
@@ -4178,27 +4748,31 @@ public enum SyntaxFactory {
       elements.raw,
       unexpectedAfterElements?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return EnumCaseDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return EnumCaseDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on EnumCaseDeclSyntax")
   public static func makeBlankEnumCaseDecl(presence: SourcePresence = .present) -> EnumCaseDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .enumCaseDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.enumCaseElementList, arena: .default),
-      nil,
-    ], arena: .default))
-    return EnumCaseDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .enumCaseDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.enumCaseElementList, arena: arena),
+        nil,
+      ], arena: arena))
+      return EnumCaseDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on EnumDeclSyntax")
   public static func makeEnumDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndEnumKeyword: UnexpectedNodesSyntax? = nil, enumKeyword: TokenSyntax, _ unexpectedBetweenEnumKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameters: UnexpectedNodesSyntax? = nil, genericParameters: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParametersAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax, _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil) -> EnumDeclSyntax {
@@ -4221,35 +4795,39 @@ public enum SyntaxFactory {
       members.raw,
       unexpectedAfterMembers?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return EnumDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return EnumDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on EnumDeclSyntax")
   public static func makeBlankEnumDecl(presence: SourcePresence = .present) -> EnumDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .enumDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.enumKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default),
-      nil,
-    ], arena: .default))
-    return EnumDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .enumDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.enumKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena),
+        nil,
+      ], arena: arena))
+      return EnumDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on OperatorDeclSyntax")
   public static func makeOperatorDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndOperatorKeyword: UnexpectedNodesSyntax? = nil, operatorKeyword: TokenSyntax, _ unexpectedBetweenOperatorKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes: UnexpectedNodesSyntax? = nil, operatorPrecedenceAndTypes: OperatorPrecedenceAndTypesSyntax?, _ unexpectedAfterOperatorPrecedenceAndTypes: UnexpectedNodesSyntax? = nil) -> OperatorDeclSyntax {
@@ -4266,45 +4844,53 @@ public enum SyntaxFactory {
       operatorPrecedenceAndTypes?.raw,
       unexpectedAfterOperatorPrecedenceAndTypes?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return OperatorDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return OperatorDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on OperatorDeclSyntax")
   public static func makeBlankOperatorDecl(presence: SourcePresence = .present) -> OperatorDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .operatorDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.operatorKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.unspacedBinaryOperator(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return OperatorDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .operatorDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.operatorKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.unspacedBinaryOperator(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return OperatorDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DesignatedTypeListSyntax")
   public static func makeDesignatedTypeList(
     _ elements: [DesignatedTypeElementSyntax]) -> DesignatedTypeListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DesignatedTypeListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DesignatedTypeListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DesignatedTypeListSyntax")
   public static func makeBlankDesignatedTypeList(presence: SourcePresence = .present) -> DesignatedTypeListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .designatedTypeList,
-      from: [
-    ], arena: .default))
-    return DesignatedTypeListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .designatedTypeList,
+        from: [
+      ], arena: arena))
+      return DesignatedTypeListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DesignatedTypeElementSyntax")
   public static func makeDesignatedTypeElement(_ unexpectedBeforeLeadingComma: UnexpectedNodesSyntax? = nil, leadingComma: TokenSyntax, _ unexpectedBetweenLeadingCommaAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedAfterName: UnexpectedNodesSyntax? = nil) -> DesignatedTypeElementSyntax {
@@ -4315,23 +4901,27 @@ public enum SyntaxFactory {
       name.raw,
       unexpectedAfterName?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DesignatedTypeElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeElement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DesignatedTypeElementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DesignatedTypeElementSyntax")
   public static func makeBlankDesignatedTypeElement(presence: SourcePresence = .present) -> DesignatedTypeElementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .designatedTypeElement,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-    ], arena: .default))
-    return DesignatedTypeElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .designatedTypeElement,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+      ], arena: arena))
+      return DesignatedTypeElementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on OperatorPrecedenceAndTypesSyntax")
   public static func makeOperatorPrecedenceAndTypes(_ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndPrecedenceGroup: UnexpectedNodesSyntax? = nil, precedenceGroup: TokenSyntax, _ unexpectedBetweenPrecedenceGroupAndDesignatedTypes: UnexpectedNodesSyntax? = nil, designatedTypes: DesignatedTypeListSyntax, _ unexpectedAfterDesignatedTypes: UnexpectedNodesSyntax? = nil) -> OperatorPrecedenceAndTypesSyntax {
@@ -4344,25 +4934,29 @@ public enum SyntaxFactory {
       designatedTypes.raw,
       unexpectedAfterDesignatedTypes?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorPrecedenceAndTypes,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return OperatorPrecedenceAndTypesSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorPrecedenceAndTypes,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return OperatorPrecedenceAndTypesSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on OperatorPrecedenceAndTypesSyntax")
   public static func makeBlankOperatorPrecedenceAndTypes(presence: SourcePresence = .present) -> OperatorPrecedenceAndTypesSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .operatorPrecedenceAndTypes,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.designatedTypeList, arena: .default),
-      nil,
-    ], arena: .default))
-    return OperatorPrecedenceAndTypesSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .operatorPrecedenceAndTypes,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.designatedTypeList, arena: arena),
+        nil,
+      ], arena: arena))
+      return OperatorPrecedenceAndTypesSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupDeclSyntax")
   public static func makePrecedenceGroupDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndPrecedencegroupKeyword: UnexpectedNodesSyntax? = nil, precedencegroupKeyword: TokenSyntax, _ unexpectedBetweenPrecedencegroupKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndGroupAttributes: UnexpectedNodesSyntax? = nil, groupAttributes: PrecedenceGroupAttributeListSyntax, _ unexpectedBetweenGroupAttributesAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax, _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil) -> PrecedenceGroupDeclSyntax {
@@ -4383,49 +4977,57 @@ public enum SyntaxFactory {
       rightBrace.raw,
       unexpectedAfterRightBrace?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PrecedenceGroupDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PrecedenceGroupDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupDeclSyntax")
   public static func makeBlankPrecedenceGroupDecl(presence: SourcePresence = .present) -> PrecedenceGroupDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .precedenceGroupDecl,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.precedencegroupKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.precedenceGroupAttributeList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default),
-      nil,
-    ], arena: .default))
-    return PrecedenceGroupDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .precedenceGroupDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.precedencegroupKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.precedenceGroupAttributeList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena),
+        nil,
+      ], arena: arena))
+      return PrecedenceGroupDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupAttributeListSyntax")
   public static func makePrecedenceGroupAttributeList(
     _ elements: [Syntax]) -> PrecedenceGroupAttributeListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAttributeList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PrecedenceGroupAttributeListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAttributeList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PrecedenceGroupAttributeListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupAttributeListSyntax")
   public static func makeBlankPrecedenceGroupAttributeList(presence: SourcePresence = .present) -> PrecedenceGroupAttributeListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .precedenceGroupAttributeList,
-      from: [
-    ], arena: .default))
-    return PrecedenceGroupAttributeListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .precedenceGroupAttributeList,
+        from: [
+      ], arena: arena))
+      return PrecedenceGroupAttributeListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupRelationSyntax")
   public static func makePrecedenceGroupRelation(_ unexpectedBeforeHigherThanOrLowerThan: UnexpectedNodesSyntax? = nil, higherThanOrLowerThan: TokenSyntax, _ unexpectedBetweenHigherThanOrLowerThanAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndOtherNames: UnexpectedNodesSyntax? = nil, otherNames: PrecedenceGroupNameListSyntax, _ unexpectedAfterOtherNames: UnexpectedNodesSyntax? = nil) -> PrecedenceGroupRelationSyntax {
@@ -4438,41 +5040,49 @@ public enum SyntaxFactory {
       otherNames.raw,
       unexpectedAfterOtherNames?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupRelation,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PrecedenceGroupRelationSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupRelation,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PrecedenceGroupRelationSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupRelationSyntax")
   public static func makeBlankPrecedenceGroupRelation(presence: SourcePresence = .present) -> PrecedenceGroupRelationSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .precedenceGroupRelation,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.precedenceGroupNameList, arena: .default),
-      nil,
-    ], arena: .default))
-    return PrecedenceGroupRelationSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .precedenceGroupRelation,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.precedenceGroupNameList, arena: arena),
+        nil,
+      ], arena: arena))
+      return PrecedenceGroupRelationSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupNameListSyntax")
   public static func makePrecedenceGroupNameList(
     _ elements: [PrecedenceGroupNameElementSyntax]) -> PrecedenceGroupNameListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PrecedenceGroupNameListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PrecedenceGroupNameListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupNameListSyntax")
   public static func makeBlankPrecedenceGroupNameList(presence: SourcePresence = .present) -> PrecedenceGroupNameListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .precedenceGroupNameList,
-      from: [
-    ], arena: .default))
-    return PrecedenceGroupNameListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .precedenceGroupNameList,
+        from: [
+      ], arena: arena))
+      return PrecedenceGroupNameListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupNameElementSyntax")
   public static func makePrecedenceGroupNameElement(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> PrecedenceGroupNameElementSyntax {
@@ -4483,23 +5093,27 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PrecedenceGroupNameElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameElement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PrecedenceGroupNameElementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupNameElementSyntax")
   public static func makeBlankPrecedenceGroupNameElement(presence: SourcePresence = .present) -> PrecedenceGroupNameElementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .precedenceGroupNameElement,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return PrecedenceGroupNameElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .precedenceGroupNameElement,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return PrecedenceGroupNameElementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupAssignmentSyntax")
   public static func makePrecedenceGroupAssignment(_ unexpectedBeforeAssignmentKeyword: UnexpectedNodesSyntax? = nil, assignmentKeyword: TokenSyntax, _ unexpectedBetweenAssignmentKeywordAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndFlag: UnexpectedNodesSyntax? = nil, flag: TokenSyntax, _ unexpectedAfterFlag: UnexpectedNodesSyntax? = nil) -> PrecedenceGroupAssignmentSyntax {
@@ -4512,25 +5126,29 @@ public enum SyntaxFactory {
       flag.raw,
       unexpectedAfterFlag?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAssignment,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PrecedenceGroupAssignmentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAssignment,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PrecedenceGroupAssignmentSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupAssignmentSyntax")
   public static func makeBlankPrecedenceGroupAssignment(presence: SourcePresence = .present) -> PrecedenceGroupAssignmentSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .precedenceGroupAssignment,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.trueKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return PrecedenceGroupAssignmentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .precedenceGroupAssignment,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.trueKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return PrecedenceGroupAssignmentSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupAssociativitySyntax")
   public static func makePrecedenceGroupAssociativity(_ unexpectedBeforeAssociativityKeyword: UnexpectedNodesSyntax? = nil, associativityKeyword: TokenSyntax, _ unexpectedBetweenAssociativityKeywordAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil, value: TokenSyntax, _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil) -> PrecedenceGroupAssociativitySyntax {
@@ -4543,25 +5161,29 @@ public enum SyntaxFactory {
       value.raw,
       unexpectedAfterValue?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAssociativity,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PrecedenceGroupAssociativitySyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAssociativity,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PrecedenceGroupAssociativitySyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupAssociativitySyntax")
   public static func makeBlankPrecedenceGroupAssociativity(presence: SourcePresence = .present) -> PrecedenceGroupAssociativitySyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .precedenceGroupAssociativity,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-    ], arena: .default))
-    return PrecedenceGroupAssociativitySyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .precedenceGroupAssociativity,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+      ], arena: arena))
+      return PrecedenceGroupAssociativitySyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on MacroExpansionDeclSyntax")
   public static func makeMacroExpansionDecl(_ unexpectedBeforePoundToken: UnexpectedNodesSyntax? = nil, poundToken: TokenSyntax, _ unexpectedBetweenPoundTokenAndMacro: UnexpectedNodesSyntax? = nil, macro: TokenSyntax, _ unexpectedBetweenMacroAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax?, _ unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? = nil, argumentList: TupleExprElementListSyntax, _ unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax?, _ unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodesSyntax? = nil, trailingClosure: ClosureExprSyntax?, _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil, additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?, _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil) -> MacroExpansionDeclSyntax {
@@ -4582,65 +5204,77 @@ public enum SyntaxFactory {
       additionalTrailingClosures?.raw,
       unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.macroExpansionDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return MacroExpansionDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.macroExpansionDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MacroExpansionDeclSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MacroExpansionDeclSyntax")
   public static func makeBlankMacroExpansionDecl(presence: SourcePresence = .present) -> MacroExpansionDeclSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .macroExpansionDecl,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.pound, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return MacroExpansionDeclSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .macroExpansionDecl,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.pound, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return MacroExpansionDeclSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TokenListSyntax")
   public static func makeTokenList(
     _ elements: [TokenSyntax]) -> TokenListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tokenList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TokenListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tokenList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TokenListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TokenListSyntax")
   public static func makeBlankTokenList(presence: SourcePresence = .present) -> TokenListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tokenList,
-      from: [
-    ], arena: .default))
-    return TokenListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tokenList,
+        from: [
+      ], arena: arena))
+      return TokenListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on NonEmptyTokenListSyntax")
   public static func makeNonEmptyTokenList(
     _ elements: [TokenSyntax]) -> NonEmptyTokenListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.nonEmptyTokenList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return NonEmptyTokenListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.nonEmptyTokenList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return NonEmptyTokenListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on NonEmptyTokenListSyntax")
   public static func makeBlankNonEmptyTokenList(presence: SourcePresence = .present) -> NonEmptyTokenListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .nonEmptyTokenList,
-      from: [
-    ], arena: .default))
-    return NonEmptyTokenListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .nonEmptyTokenList,
+        from: [
+      ], arena: arena))
+      return NonEmptyTokenListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on CustomAttributeSyntax")
   public static func makeCustomAttribute(_ unexpectedBeforeAtSignToken: UnexpectedNodesSyntax? = nil, atSignToken: TokenSyntax, _ unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodesSyntax? = nil, attributeName: TypeSyntax, _ unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax?, _ unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? = nil, argumentList: TupleExprElementListSyntax?, _ unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax?, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> CustomAttributeSyntax {
@@ -4657,29 +5291,33 @@ public enum SyntaxFactory {
       rightParen?.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.customAttribute,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return CustomAttributeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.customAttribute,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return CustomAttributeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on CustomAttributeSyntax")
   public static func makeBlankCustomAttribute(presence: SourcePresence = .present) -> CustomAttributeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .customAttribute,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.atSign, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return CustomAttributeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .customAttribute,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.atSign, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return CustomAttributeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AttributeSyntax")
   public static func makeAttribute(_ unexpectedBeforeAtSignToken: UnexpectedNodesSyntax? = nil, atSignToken: TokenSyntax, _ unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodesSyntax? = nil, attributeName: TokenSyntax, _ unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax?, _ unexpectedBetweenLeftParenAndArgument: UnexpectedNodesSyntax? = nil, argument: Syntax?, _ unexpectedBetweenArgumentAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax?, _ unexpectedBetweenRightParenAndTokenList: UnexpectedNodesSyntax? = nil, tokenList: TokenListSyntax?, _ unexpectedAfterTokenList: UnexpectedNodesSyntax? = nil) -> AttributeSyntax {
@@ -4698,63 +5336,75 @@ public enum SyntaxFactory {
       tokenList?.raw,
       unexpectedAfterTokenList?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.attribute,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AttributeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.attribute,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AttributeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AttributeSyntax")
   public static func makeBlankAttribute(presence: SourcePresence = .present) -> AttributeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .attribute,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.atSign, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return AttributeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .attribute,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.atSign, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return AttributeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AttributeListSyntax")
   public static func makeAttributeList(
     _ elements: [Syntax]) -> AttributeListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AttributeListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AttributeListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AttributeListSyntax")
   public static func makeBlankAttributeList(presence: SourcePresence = .present) -> AttributeListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .attributeList,
-      from: [
-    ], arena: .default))
-    return AttributeListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .attributeList,
+        from: [
+      ], arena: arena))
+      return AttributeListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on SpecializeAttributeSpecListSyntax")
   public static func makeSpecializeAttributeSpecList(
     _ elements: [Syntax]) -> SpecializeAttributeSpecListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.specializeAttributeSpecList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return SpecializeAttributeSpecListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.specializeAttributeSpecList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return SpecializeAttributeSpecListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on SpecializeAttributeSpecListSyntax")
   public static func makeBlankSpecializeAttributeSpecList(presence: SourcePresence = .present) -> SpecializeAttributeSpecListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .specializeAttributeSpecList,
-      from: [
-    ], arena: .default))
-    return SpecializeAttributeSpecListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .specializeAttributeSpecList,
+        from: [
+      ], arena: arena))
+      return SpecializeAttributeSpecListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AvailabilityEntrySyntax")
   public static func makeAvailabilityEntry(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndAvailabilityList: UnexpectedNodesSyntax? = nil, availabilityList: AvailabilitySpecListSyntax, _ unexpectedBetweenAvailabilityListAndSemicolon: UnexpectedNodesSyntax? = nil, semicolon: TokenSyntax, _ unexpectedAfterSemicolon: UnexpectedNodesSyntax? = nil) -> AvailabilityEntrySyntax {
@@ -4769,27 +5419,31 @@ public enum SyntaxFactory {
       semicolon.raw,
       unexpectedAfterSemicolon?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityEntry,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AvailabilityEntrySyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityEntry,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AvailabilityEntrySyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AvailabilityEntrySyntax")
   public static func makeBlankAvailabilityEntry(presence: SourcePresence = .present) -> AvailabilityEntrySyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .availabilityEntry,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.semicolon, arena: .default),
-      nil,
-    ], arena: .default))
-    return AvailabilityEntrySyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .availabilityEntry,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.semicolon, arena: arena),
+        nil,
+      ], arena: arena))
+      return AvailabilityEntrySyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on LabeledSpecializeEntrySyntax")
   public static func makeLabeledSpecializeEntry(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil, value: TokenSyntax, _ unexpectedBetweenValueAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> LabeledSpecializeEntrySyntax {
@@ -4804,27 +5458,31 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.labeledSpecializeEntry,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return LabeledSpecializeEntrySyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.labeledSpecializeEntry,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return LabeledSpecializeEntrySyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on LabeledSpecializeEntrySyntax")
   public static func makeBlankLabeledSpecializeEntry(presence: SourcePresence = .present) -> LabeledSpecializeEntrySyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .labeledSpecializeEntry,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return LabeledSpecializeEntrySyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .labeledSpecializeEntry,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return LabeledSpecializeEntrySyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TargetFunctionEntrySyntax")
   public static func makeTargetFunctionEntry(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndDeclname: UnexpectedNodesSyntax? = nil, declname: DeclNameSyntax, _ unexpectedBetweenDeclnameAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> TargetFunctionEntrySyntax {
@@ -4839,27 +5497,31 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.targetFunctionEntry,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TargetFunctionEntrySyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.targetFunctionEntry,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TargetFunctionEntrySyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TargetFunctionEntrySyntax")
   public static func makeBlankTargetFunctionEntry(presence: SourcePresence = .present) -> TargetFunctionEntrySyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .targetFunctionEntry,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.declName, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return TargetFunctionEntrySyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .targetFunctionEntry,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.declName, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return TargetFunctionEntrySyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on NamedAttributeStringArgumentSyntax")
   public static func makeNamedAttributeStringArgument(_ unexpectedBeforeNameTok: UnexpectedNodesSyntax? = nil, nameTok: TokenSyntax, _ unexpectedBetweenNameTokAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndStringOrDeclname: UnexpectedNodesSyntax? = nil, stringOrDeclname: Syntax, _ unexpectedAfterStringOrDeclname: UnexpectedNodesSyntax? = nil) -> NamedAttributeStringArgumentSyntax {
@@ -4872,25 +5534,29 @@ public enum SyntaxFactory {
       stringOrDeclname.raw,
       unexpectedAfterStringOrDeclname?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.namedAttributeStringArgument,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return NamedAttributeStringArgumentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.namedAttributeStringArgument,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return NamedAttributeStringArgumentSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on NamedAttributeStringArgumentSyntax")
   public static func makeBlankNamedAttributeStringArgument(presence: SourcePresence = .present) -> NamedAttributeStringArgumentSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .namedAttributeStringArgument,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
-      nil,
-    ], arena: .default))
-    return NamedAttributeStringArgumentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .namedAttributeStringArgument,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena),
+        nil,
+      ], arena: arena))
+      return NamedAttributeStringArgumentSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DeclNameSyntax")
   public static func makeDeclName(_ unexpectedBeforeDeclBaseName: UnexpectedNodesSyntax? = nil, declBaseName: TokenSyntax, _ unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?, _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil) -> DeclNameSyntax {
@@ -4901,23 +5567,27 @@ public enum SyntaxFactory {
       declNameArguments?.raw,
       unexpectedAfterDeclNameArguments?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.declName,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DeclNameSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declName,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DeclNameSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DeclNameSyntax")
   public static func makeBlankDeclName(presence: SourcePresence = .present) -> DeclNameSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .declName,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return DeclNameSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .declName,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return DeclNameSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ImplementsAttributeArgumentsSyntax")
   public static func makeImplementsAttributeArguments(_ unexpectedBeforeType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedBetweenTypeAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndDeclBaseName: UnexpectedNodesSyntax? = nil, declBaseName: TokenSyntax, _ unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?, _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil) -> ImplementsAttributeArgumentsSyntax {
@@ -4932,27 +5602,31 @@ public enum SyntaxFactory {
       declNameArguments?.raw,
       unexpectedAfterDeclNameArguments?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.implementsAttributeArguments,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ImplementsAttributeArgumentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.implementsAttributeArguments,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ImplementsAttributeArgumentsSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ImplementsAttributeArgumentsSyntax")
   public static func makeBlankImplementsAttributeArguments(presence: SourcePresence = .present) -> ImplementsAttributeArgumentsSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .implementsAttributeArguments,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return ImplementsAttributeArgumentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .implementsAttributeArguments,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return ImplementsAttributeArgumentsSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ObjCSelectorPieceSyntax")
   public static func makeObjCSelectorPiece(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax?, _ unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil) -> ObjCSelectorPieceSyntax {
@@ -4963,39 +5637,47 @@ public enum SyntaxFactory {
       colon?.raw,
       unexpectedAfterColon?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.objCSelectorPiece,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ObjCSelectorPieceSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.objCSelectorPiece,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ObjCSelectorPieceSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ObjCSelectorPieceSyntax")
   public static func makeBlankObjCSelectorPiece(presence: SourcePresence = .present) -> ObjCSelectorPieceSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .objCSelectorPiece,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return ObjCSelectorPieceSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .objCSelectorPiece,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return ObjCSelectorPieceSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ObjCSelectorSyntax")
   public static func makeObjCSelector(
     _ elements: [ObjCSelectorPieceSyntax]) -> ObjCSelectorSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.objCSelector,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ObjCSelectorSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.objCSelector,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ObjCSelectorSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ObjCSelectorSyntax")
   public static func makeBlankObjCSelector(presence: SourcePresence = .present) -> ObjCSelectorSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .objCSelector,
-      from: [
-    ], arena: .default))
-    return ObjCSelectorSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .objCSelector,
+        from: [
+      ], arena: arena))
+      return ObjCSelectorSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DifferentiableAttributeArgumentsSyntax")
   public static func makeDifferentiableAttributeArguments(_ unexpectedBeforeDiffKind: UnexpectedNodesSyntax? = nil, diffKind: TokenSyntax?, _ unexpectedBetweenDiffKindAndDiffKindComma: UnexpectedNodesSyntax? = nil, diffKindComma: TokenSyntax?, _ unexpectedBetweenDiffKindCommaAndDiffParams: UnexpectedNodesSyntax? = nil, diffParams: DifferentiabilityParamsClauseSyntax?, _ unexpectedBetweenDiffParamsAndDiffParamsComma: UnexpectedNodesSyntax? = nil, diffParamsComma: TokenSyntax?, _ unexpectedBetweenDiffParamsCommaAndWhereClause: UnexpectedNodesSyntax? = nil, whereClause: GenericWhereClauseSyntax?, _ unexpectedAfterWhereClause: UnexpectedNodesSyntax? = nil) -> DifferentiableAttributeArgumentsSyntax {
@@ -5012,29 +5694,33 @@ public enum SyntaxFactory {
       whereClause?.raw,
       unexpectedAfterWhereClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiableAttributeArguments,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DifferentiableAttributeArgumentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiableAttributeArguments,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DifferentiableAttributeArgumentsSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DifferentiableAttributeArgumentsSyntax")
   public static func makeBlankDifferentiableAttributeArguments(presence: SourcePresence = .present) -> DifferentiableAttributeArgumentsSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .differentiableAttributeArguments,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return DifferentiableAttributeArgumentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .differentiableAttributeArguments,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return DifferentiableAttributeArgumentsSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DifferentiabilityParamsClauseSyntax")
   public static func makeDifferentiabilityParamsClause(_ unexpectedBeforeWrtLabel: UnexpectedNodesSyntax? = nil, wrtLabel: TokenSyntax, _ unexpectedBetweenWrtLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndParameters: UnexpectedNodesSyntax? = nil, parameters: Syntax, _ unexpectedAfterParameters: UnexpectedNodesSyntax? = nil) -> DifferentiabilityParamsClauseSyntax {
@@ -5047,25 +5733,29 @@ public enum SyntaxFactory {
       parameters.raw,
       unexpectedAfterParameters?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamsClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DifferentiabilityParamsClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamsClause,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DifferentiabilityParamsClauseSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DifferentiabilityParamsClauseSyntax")
   public static func makeBlankDifferentiabilityParamsClause(presence: SourcePresence = .present) -> DifferentiabilityParamsClauseSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .differentiabilityParamsClause,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
-      nil,
-    ], arena: .default))
-    return DifferentiabilityParamsClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .differentiabilityParamsClause,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena),
+        nil,
+      ], arena: arena))
+      return DifferentiabilityParamsClauseSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DifferentiabilityParamsSyntax")
   public static func makeDifferentiabilityParams(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndDiffParams: UnexpectedNodesSyntax? = nil, diffParams: DifferentiabilityParamListSyntax, _ unexpectedBetweenDiffParamsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> DifferentiabilityParamsSyntax {
@@ -5078,41 +5768,49 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParams,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DifferentiabilityParamsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParams,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DifferentiabilityParamsSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DifferentiabilityParamsSyntax")
   public static func makeBlankDifferentiabilityParams(presence: SourcePresence = .present) -> DifferentiabilityParamsSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .differentiabilityParams,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.differentiabilityParamList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return DifferentiabilityParamsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .differentiabilityParams,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.differentiabilityParamList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return DifferentiabilityParamsSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DifferentiabilityParamListSyntax")
   public static func makeDifferentiabilityParamList(
     _ elements: [DifferentiabilityParamSyntax]) -> DifferentiabilityParamListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DifferentiabilityParamListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DifferentiabilityParamListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DifferentiabilityParamListSyntax")
   public static func makeBlankDifferentiabilityParamList(presence: SourcePresence = .present) -> DifferentiabilityParamListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .differentiabilityParamList,
-      from: [
-    ], arena: .default))
-    return DifferentiabilityParamListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .differentiabilityParamList,
+        from: [
+      ], arena: arena))
+      return DifferentiabilityParamListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DifferentiabilityParamSyntax")
   public static func makeDifferentiabilityParam(_ unexpectedBeforeParameter: UnexpectedNodesSyntax? = nil, parameter: TokenSyntax, _ unexpectedBetweenParameterAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> DifferentiabilityParamSyntax {
@@ -5123,23 +5821,27 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParam,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DifferentiabilityParamSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParam,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DifferentiabilityParamSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DifferentiabilityParamSyntax")
   public static func makeBlankDifferentiabilityParam(presence: SourcePresence = .present) -> DifferentiabilityParamSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .differentiabilityParam,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.selfKeyword, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return DifferentiabilityParamSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .differentiabilityParam,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.selfKeyword, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return DifferentiabilityParamSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DerivativeRegistrationAttributeArgumentsSyntax")
   public static func makeDerivativeRegistrationAttributeArguments(_ unexpectedBeforeOfLabel: UnexpectedNodesSyntax? = nil, ofLabel: TokenSyntax, _ unexpectedBetweenOfLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndOriginalDeclName: UnexpectedNodesSyntax? = nil, originalDeclName: QualifiedDeclNameSyntax, _ unexpectedBetweenOriginalDeclNameAndPeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax?, _ unexpectedBetweenPeriodAndAccessorKind: UnexpectedNodesSyntax? = nil, accessorKind: TokenSyntax?, _ unexpectedBetweenAccessorKindAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndDiffParams: UnexpectedNodesSyntax? = nil, diffParams: DifferentiabilityParamsClauseSyntax?, _ unexpectedAfterDiffParams: UnexpectedNodesSyntax? = nil) -> DerivativeRegistrationAttributeArgumentsSyntax {
@@ -5160,33 +5862,37 @@ public enum SyntaxFactory {
       diffParams?.raw,
       unexpectedAfterDiffParams?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.derivativeRegistrationAttributeArguments,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DerivativeRegistrationAttributeArgumentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.derivativeRegistrationAttributeArguments,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DerivativeRegistrationAttributeArgumentsSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DerivativeRegistrationAttributeArgumentsSyntax")
   public static func makeBlankDerivativeRegistrationAttributeArguments(presence: SourcePresence = .present) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .derivativeRegistrationAttributeArguments,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.qualifiedDeclName, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return DerivativeRegistrationAttributeArgumentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .derivativeRegistrationAttributeArguments,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.qualifiedDeclName, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return DerivativeRegistrationAttributeArgumentsSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on QualifiedDeclNameSyntax")
   public static func makeQualifiedDeclName(_ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax?, _ unexpectedBetweenBaseTypeAndDot: UnexpectedNodesSyntax? = nil, dot: TokenSyntax?, _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? = nil, arguments: DeclNameArgumentsSyntax?, _ unexpectedAfterArguments: UnexpectedNodesSyntax? = nil) -> QualifiedDeclNameSyntax {
@@ -5201,27 +5907,31 @@ public enum SyntaxFactory {
       arguments?.raw,
       unexpectedAfterArguments?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.qualifiedDeclName,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return QualifiedDeclNameSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.qualifiedDeclName,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return QualifiedDeclNameSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on QualifiedDeclNameSyntax")
   public static func makeBlankQualifiedDeclName(presence: SourcePresence = .present) -> QualifiedDeclNameSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .qualifiedDeclName,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return QualifiedDeclNameSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .qualifiedDeclName,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return QualifiedDeclNameSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on FunctionDeclNameSyntax")
   public static func makeFunctionDeclName(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? = nil, arguments: DeclNameArgumentsSyntax?, _ unexpectedAfterArguments: UnexpectedNodesSyntax? = nil) -> FunctionDeclNameSyntax {
@@ -5232,23 +5942,27 @@ public enum SyntaxFactory {
       arguments?.raw,
       unexpectedAfterArguments?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionDeclName,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return FunctionDeclNameSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionDeclName,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return FunctionDeclNameSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on FunctionDeclNameSyntax")
   public static func makeBlankFunctionDeclName(presence: SourcePresence = .present) -> FunctionDeclNameSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .functionDeclName,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return FunctionDeclNameSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .functionDeclName,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return FunctionDeclNameSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on BackDeployAttributeSpecListSyntax")
   public static func makeBackDeployAttributeSpecList(_ unexpectedBeforeBeforeLabel: UnexpectedNodesSyntax? = nil, beforeLabel: TokenSyntax, _ unexpectedBetweenBeforeLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndVersionList: UnexpectedNodesSyntax? = nil, versionList: BackDeployVersionListSyntax, _ unexpectedAfterVersionList: UnexpectedNodesSyntax? = nil) -> BackDeployAttributeSpecListSyntax {
@@ -5261,41 +5975,49 @@ public enum SyntaxFactory {
       versionList.raw,
       unexpectedAfterVersionList?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployAttributeSpecList,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return BackDeployAttributeSpecListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployAttributeSpecList,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return BackDeployAttributeSpecListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on BackDeployAttributeSpecListSyntax")
   public static func makeBlankBackDeployAttributeSpecList(presence: SourcePresence = .present) -> BackDeployAttributeSpecListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .backDeployAttributeSpecList,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.backDeployVersionList, arena: .default),
-      nil,
-    ], arena: .default))
-    return BackDeployAttributeSpecListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .backDeployAttributeSpecList,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.backDeployVersionList, arena: arena),
+        nil,
+      ], arena: arena))
+      return BackDeployAttributeSpecListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on BackDeployVersionListSyntax")
   public static func makeBackDeployVersionList(
     _ elements: [BackDeployVersionArgumentSyntax]) -> BackDeployVersionListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployVersionList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return BackDeployVersionListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployVersionList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return BackDeployVersionListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on BackDeployVersionListSyntax")
   public static func makeBlankBackDeployVersionList(presence: SourcePresence = .present) -> BackDeployVersionListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .backDeployVersionList,
-      from: [
-    ], arena: .default))
-    return BackDeployVersionListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .backDeployVersionList,
+        from: [
+      ], arena: arena))
+      return BackDeployVersionListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on BackDeployVersionArgumentSyntax")
   public static func makeBackDeployVersionArgument(_ unexpectedBeforeAvailabilityVersionRestriction: UnexpectedNodesSyntax? = nil, availabilityVersionRestriction: AvailabilityVersionRestrictionSyntax, _ unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> BackDeployVersionArgumentSyntax {
@@ -5306,23 +6028,27 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployVersionArgument,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return BackDeployVersionArgumentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployVersionArgument,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return BackDeployVersionArgumentSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on BackDeployVersionArgumentSyntax")
   public static func makeBlankBackDeployVersionArgument(presence: SourcePresence = .present) -> BackDeployVersionArgumentSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .backDeployVersionArgument,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilityVersionRestriction, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return BackDeployVersionArgumentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .backDeployVersionArgument,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilityVersionRestriction, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return BackDeployVersionArgumentSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on OpaqueReturnTypeOfAttributeArgumentsSyntax")
   public static func makeOpaqueReturnTypeOfAttributeArguments(_ unexpectedBeforeMangledName: UnexpectedNodesSyntax? = nil, mangledName: TokenSyntax, _ unexpectedBetweenMangledNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndOrdinal: UnexpectedNodesSyntax? = nil, ordinal: TokenSyntax, _ unexpectedAfterOrdinal: UnexpectedNodesSyntax? = nil) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
@@ -5335,25 +6061,29 @@ public enum SyntaxFactory {
       ordinal.raw,
       unexpectedAfterOrdinal?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.opaqueReturnTypeOfAttributeArguments,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return OpaqueReturnTypeOfAttributeArgumentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.opaqueReturnTypeOfAttributeArguments,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return OpaqueReturnTypeOfAttributeArgumentsSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on OpaqueReturnTypeOfAttributeArgumentsSyntax")
   public static func makeBlankOpaqueReturnTypeOfAttributeArguments(presence: SourcePresence = .present) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .opaqueReturnTypeOfAttributeArguments,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default),
-      nil,
-    ], arena: .default))
-    return OpaqueReturnTypeOfAttributeArgumentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .opaqueReturnTypeOfAttributeArguments,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: arena),
+        nil,
+      ], arena: arena))
+      return OpaqueReturnTypeOfAttributeArgumentsSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ConventionAttributeArgumentsSyntax")
   public static func makeConventionAttributeArguments(_ unexpectedBeforeConventionLabel: UnexpectedNodesSyntax? = nil, conventionLabel: TokenSyntax, _ unexpectedBetweenConventionLabelAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndCTypeLabel: UnexpectedNodesSyntax? = nil, cTypeLabel: TokenSyntax?, _ unexpectedBetweenCTypeLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndCTypeString: UnexpectedNodesSyntax? = nil, cTypeString: TokenSyntax?, _ unexpectedAfterCTypeString: UnexpectedNodesSyntax? = nil) -> ConventionAttributeArgumentsSyntax {
@@ -5370,29 +6100,33 @@ public enum SyntaxFactory {
       cTypeString?.raw,
       unexpectedAfterCTypeString?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionAttributeArguments,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ConventionAttributeArgumentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionAttributeArguments,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ConventionAttributeArgumentsSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ConventionAttributeArgumentsSyntax")
   public static func makeBlankConventionAttributeArguments(presence: SourcePresence = .present) -> ConventionAttributeArgumentsSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .conventionAttributeArguments,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return ConventionAttributeArgumentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .conventionAttributeArguments,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return ConventionAttributeArgumentsSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ConventionWitnessMethodAttributeArgumentsSyntax")
   public static func makeConventionWitnessMethodAttributeArguments(_ unexpectedBeforeWitnessMethodLabel: UnexpectedNodesSyntax? = nil, witnessMethodLabel: TokenSyntax, _ unexpectedBetweenWitnessMethodLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndProtocolName: UnexpectedNodesSyntax? = nil, protocolName: TokenSyntax, _ unexpectedAfterProtocolName: UnexpectedNodesSyntax? = nil) -> ConventionWitnessMethodAttributeArgumentsSyntax {
@@ -5405,25 +6139,29 @@ public enum SyntaxFactory {
       protocolName.raw,
       unexpectedAfterProtocolName?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionWitnessMethodAttributeArguments,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ConventionWitnessMethodAttributeArgumentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionWitnessMethodAttributeArguments,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ConventionWitnessMethodAttributeArgumentsSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ConventionWitnessMethodAttributeArgumentsSyntax")
   public static func makeBlankConventionWitnessMethodAttributeArguments(presence: SourcePresence = .present) -> ConventionWitnessMethodAttributeArgumentsSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .conventionWitnessMethodAttributeArguments,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-    ], arena: .default))
-    return ConventionWitnessMethodAttributeArgumentsSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .conventionWitnessMethodAttributeArguments,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+      ], arena: arena))
+      return ConventionWitnessMethodAttributeArgumentsSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on LabeledStmtSyntax")
   public static func makeLabeledStmt(_ unexpectedBeforeLabelName: UnexpectedNodesSyntax? = nil, labelName: TokenSyntax, _ unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? = nil, labelColon: TokenSyntax, _ unexpectedBetweenLabelColonAndStatement: UnexpectedNodesSyntax? = nil, statement: StmtSyntax, _ unexpectedAfterStatement: UnexpectedNodesSyntax? = nil) -> LabeledStmtSyntax {
@@ -5436,25 +6174,29 @@ public enum SyntaxFactory {
       statement.raw,
       unexpectedAfterStatement?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.labeledStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return LabeledStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.labeledStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return LabeledStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on LabeledStmtSyntax")
   public static func makeBlankLabeledStmt(presence: SourcePresence = .present) -> LabeledStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .labeledStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingStmt, arena: .default),
-      nil,
-    ], arena: .default))
-    return LabeledStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .labeledStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingStmt, arena: arena),
+        nil,
+      ], arena: arena))
+      return LabeledStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ContinueStmtSyntax")
   public static func makeContinueStmt(_ unexpectedBeforeContinueKeyword: UnexpectedNodesSyntax? = nil, continueKeyword: TokenSyntax, _ unexpectedBetweenContinueKeywordAndLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax?, _ unexpectedAfterLabel: UnexpectedNodesSyntax? = nil) -> ContinueStmtSyntax {
@@ -5465,23 +6207,27 @@ public enum SyntaxFactory {
       label?.raw,
       unexpectedAfterLabel?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.continueStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ContinueStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.continueStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ContinueStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ContinueStmtSyntax")
   public static func makeBlankContinueStmt(presence: SourcePresence = .present) -> ContinueStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .continueStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.continueKeyword, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return ContinueStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .continueStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.continueKeyword, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return ContinueStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on WhileStmtSyntax")
   public static func makeWhileStmt(_ unexpectedBeforeWhileKeyword: UnexpectedNodesSyntax? = nil, whileKeyword: TokenSyntax, _ unexpectedBetweenWhileKeywordAndConditions: UnexpectedNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ unexpectedBetweenConditionsAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> WhileStmtSyntax {
@@ -5494,25 +6240,29 @@ public enum SyntaxFactory {
       body.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.whileStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return WhileStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.whileStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return WhileStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on WhileStmtSyntax")
   public static func makeBlankWhileStmt(presence: SourcePresence = .present) -> WhileStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .whileStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.whileKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default),
-      nil,
-    ], arena: .default))
-    return WhileStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .whileStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.whileKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena),
+        nil,
+      ], arena: arena))
+      return WhileStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DeferStmtSyntax")
   public static func makeDeferStmt(_ unexpectedBeforeDeferKeyword: UnexpectedNodesSyntax? = nil, deferKeyword: TokenSyntax, _ unexpectedBetweenDeferKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> DeferStmtSyntax {
@@ -5523,23 +6273,27 @@ public enum SyntaxFactory {
       body.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.deferStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DeferStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.deferStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DeferStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DeferStmtSyntax")
   public static func makeBlankDeferStmt(presence: SourcePresence = .present) -> DeferStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .deferStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.deferKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default),
-      nil,
-    ], arena: .default))
-    return DeferStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .deferStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.deferKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena),
+        nil,
+      ], arena: arena))
+      return DeferStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ExpressionStmtSyntax")
   public static func makeExpressionStmt(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> ExpressionStmtSyntax {
@@ -5548,37 +6302,45 @@ public enum SyntaxFactory {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ExpressionStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ExpressionStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ExpressionStmtSyntax")
   public static func makeBlankExpressionStmt(presence: SourcePresence = .present) -> ExpressionStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .expressionStmt,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-    ], arena: .default))
-    return ExpressionStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .expressionStmt,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return ExpressionStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on SwitchCaseListSyntax")
   public static func makeSwitchCaseList(
     _ elements: [Syntax]) -> SwitchCaseListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return SwitchCaseListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return SwitchCaseListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on SwitchCaseListSyntax")
   public static func makeBlankSwitchCaseList(presence: SourcePresence = .present) -> SwitchCaseListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .switchCaseList,
-      from: [
-    ], arena: .default))
-    return SwitchCaseListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .switchCaseList,
+        from: [
+      ], arena: arena))
+      return SwitchCaseListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on RepeatWhileStmtSyntax")
   public static func makeRepeatWhileStmt(_ unexpectedBeforeRepeatKeyword: UnexpectedNodesSyntax? = nil, repeatKeyword: TokenSyntax, _ unexpectedBetweenRepeatKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedBetweenBodyAndWhileKeyword: UnexpectedNodesSyntax? = nil, whileKeyword: TokenSyntax, _ unexpectedBetweenWhileKeywordAndCondition: UnexpectedNodesSyntax? = nil, condition: ExprSyntax, _ unexpectedAfterCondition: UnexpectedNodesSyntax? = nil) -> RepeatWhileStmtSyntax {
@@ -5593,27 +6355,31 @@ public enum SyntaxFactory {
       condition.raw,
       unexpectedAfterCondition?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.repeatWhileStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return RepeatWhileStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.repeatWhileStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return RepeatWhileStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on RepeatWhileStmtSyntax")
   public static func makeBlankRepeatWhileStmt(presence: SourcePresence = .present) -> RepeatWhileStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .repeatWhileStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.repeatKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.whileKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-    ], arena: .default))
-    return RepeatWhileStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .repeatWhileStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.repeatKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.whileKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return RepeatWhileStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on GuardStmtSyntax")
   public static func makeGuardStmt(_ unexpectedBeforeGuardKeyword: UnexpectedNodesSyntax? = nil, guardKeyword: TokenSyntax, _ unexpectedBetweenGuardKeywordAndConditions: UnexpectedNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ unexpectedBetweenConditionsAndElseKeyword: UnexpectedNodesSyntax? = nil, elseKeyword: TokenSyntax, _ unexpectedBetweenElseKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> GuardStmtSyntax {
@@ -5628,27 +6394,31 @@ public enum SyntaxFactory {
       body.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.guardStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return GuardStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.guardStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return GuardStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on GuardStmtSyntax")
   public static func makeBlankGuardStmt(presence: SourcePresence = .present) -> GuardStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .guardStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.guardKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.elseKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default),
-      nil,
-    ], arena: .default))
-    return GuardStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .guardStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.guardKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.elseKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena),
+        nil,
+      ], arena: arena))
+      return GuardStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on WhereClauseSyntax")
   public static func makeWhereClause(_ unexpectedBeforeWhereKeyword: UnexpectedNodesSyntax? = nil, whereKeyword: TokenSyntax, _ unexpectedBetweenWhereKeywordAndGuardResult: UnexpectedNodesSyntax? = nil, guardResult: ExprSyntax, _ unexpectedAfterGuardResult: UnexpectedNodesSyntax? = nil) -> WhereClauseSyntax {
@@ -5659,23 +6429,27 @@ public enum SyntaxFactory {
       guardResult.raw,
       unexpectedAfterGuardResult?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.whereClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return WhereClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.whereClause,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return WhereClauseSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on WhereClauseSyntax")
   public static func makeBlankWhereClause(presence: SourcePresence = .present) -> WhereClauseSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .whereClause,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.whereKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-    ], arena: .default))
-    return WhereClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .whereClause,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.whereKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return WhereClauseSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ForInStmtSyntax")
   public static func makeForInStmt(_ unexpectedBeforeForKeyword: UnexpectedNodesSyntax? = nil, forKeyword: TokenSyntax, _ unexpectedBetweenForKeywordAndTryKeyword: UnexpectedNodesSyntax? = nil, tryKeyword: TokenSyntax?, _ unexpectedBetweenTryKeywordAndAwaitKeyword: UnexpectedNodesSyntax? = nil, awaitKeyword: TokenSyntax?, _ unexpectedBetweenAwaitKeywordAndCaseKeyword: UnexpectedNodesSyntax? = nil, caseKeyword: TokenSyntax?, _ unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ unexpectedBetweenTypeAnnotationAndInKeyword: UnexpectedNodesSyntax? = nil, inKeyword: TokenSyntax, _ unexpectedBetweenInKeywordAndSequenceExpr: UnexpectedNodesSyntax? = nil, sequenceExpr: ExprSyntax, _ unexpectedBetweenSequenceExprAndWhereClause: UnexpectedNodesSyntax? = nil, whereClause: WhereClauseSyntax?, _ unexpectedBetweenWhereClauseAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> ForInStmtSyntax {
@@ -5702,39 +6476,43 @@ public enum SyntaxFactory {
       body.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.forInStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ForInStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.forInStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ForInStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ForInStmtSyntax")
   public static func makeBlankForInStmt(presence: SourcePresence = .present) -> ForInStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .forInStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.forKeyword, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.inKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default),
-      nil,
-    ], arena: .default))
-    return ForInStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .forInStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.forKeyword, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.inKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena),
+        nil,
+      ], arena: arena))
+      return ForInStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on SwitchStmtSyntax")
   public static func makeSwitchStmt(_ unexpectedBeforeSwitchKeyword: UnexpectedNodesSyntax? = nil, switchKeyword: TokenSyntax, _ unexpectedBetweenSwitchKeywordAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndCases: UnexpectedNodesSyntax? = nil, cases: SwitchCaseListSyntax, _ unexpectedBetweenCasesAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax, _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil) -> SwitchStmtSyntax {
@@ -5751,45 +6529,53 @@ public enum SyntaxFactory {
       rightBrace.raw,
       unexpectedAfterRightBrace?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return SwitchStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return SwitchStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on SwitchStmtSyntax")
   public static func makeBlankSwitchStmt(presence: SourcePresence = .present) -> SwitchStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .switchStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.switchKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.switchCaseList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default),
-      nil,
-    ], arena: .default))
-    return SwitchStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .switchStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.switchKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.switchCaseList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena),
+        nil,
+      ], arena: arena))
+      return SwitchStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on CatchClauseListSyntax")
   public static func makeCatchClauseList(
     _ elements: [CatchClauseSyntax]) -> CatchClauseListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchClauseList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return CatchClauseListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchClauseList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return CatchClauseListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on CatchClauseListSyntax")
   public static func makeBlankCatchClauseList(presence: SourcePresence = .present) -> CatchClauseListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .catchClauseList,
-      from: [
-    ], arena: .default))
-    return CatchClauseListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .catchClauseList,
+        from: [
+      ], arena: arena))
+      return CatchClauseListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DoStmtSyntax")
   public static func makeDoStmt(_ unexpectedBeforeDoKeyword: UnexpectedNodesSyntax? = nil, doKeyword: TokenSyntax, _ unexpectedBetweenDoKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedBetweenBodyAndCatchClauses: UnexpectedNodesSyntax? = nil, catchClauses: CatchClauseListSyntax?, _ unexpectedAfterCatchClauses: UnexpectedNodesSyntax? = nil) -> DoStmtSyntax {
@@ -5802,25 +6588,29 @@ public enum SyntaxFactory {
       catchClauses?.raw,
       unexpectedAfterCatchClauses?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.doStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DoStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.doStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DoStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DoStmtSyntax")
   public static func makeBlankDoStmt(presence: SourcePresence = .present) -> DoStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .doStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.doKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return DoStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .doStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.doKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return DoStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ReturnStmtSyntax")
   public static func makeReturnStmt(_ unexpectedBeforeReturnKeyword: UnexpectedNodesSyntax? = nil, returnKeyword: TokenSyntax, _ unexpectedBetweenReturnKeywordAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax?, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> ReturnStmtSyntax {
@@ -5831,23 +6621,27 @@ public enum SyntaxFactory {
       expression?.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.returnStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ReturnStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.returnStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ReturnStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ReturnStmtSyntax")
   public static func makeBlankReturnStmt(presence: SourcePresence = .present) -> ReturnStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .returnStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.returnKeyword, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return ReturnStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .returnStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.returnKeyword, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return ReturnStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on YieldStmtSyntax")
   public static func makeYieldStmt(_ unexpectedBeforeYieldKeyword: UnexpectedNodesSyntax? = nil, yieldKeyword: TokenSyntax, _ unexpectedBetweenYieldKeywordAndYields: UnexpectedNodesSyntax? = nil, yields: Syntax, _ unexpectedAfterYields: UnexpectedNodesSyntax? = nil) -> YieldStmtSyntax {
@@ -5858,23 +6652,27 @@ public enum SyntaxFactory {
       yields.raw,
       unexpectedAfterYields?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return YieldStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return YieldStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on YieldStmtSyntax")
   public static func makeBlankYieldStmt(presence: SourcePresence = .present) -> YieldStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .yieldStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.yield, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
-      nil,
-    ], arena: .default))
-    return YieldStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .yieldStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.yield, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena),
+        nil,
+      ], arena: arena))
+      return YieldStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on YieldListSyntax")
   public static func makeYieldList(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil, elementList: YieldExprListSyntax, _ unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> YieldListSyntax {
@@ -5887,25 +6685,29 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldList,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return YieldListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldList,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return YieldListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on YieldListSyntax")
   public static func makeBlankYieldList(presence: SourcePresence = .present) -> YieldListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .yieldList,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.yieldExprList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return YieldListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .yieldList,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.yieldExprList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return YieldListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on FallthroughStmtSyntax")
   public static func makeFallthroughStmt(_ unexpectedBeforeFallthroughKeyword: UnexpectedNodesSyntax? = nil, fallthroughKeyword: TokenSyntax, _ unexpectedAfterFallthroughKeyword: UnexpectedNodesSyntax? = nil) -> FallthroughStmtSyntax {
@@ -5914,21 +6716,25 @@ public enum SyntaxFactory {
       fallthroughKeyword.raw,
       unexpectedAfterFallthroughKeyword?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.fallthroughStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return FallthroughStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.fallthroughStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return FallthroughStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on FallthroughStmtSyntax")
   public static func makeBlankFallthroughStmt(presence: SourcePresence = .present) -> FallthroughStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .fallthroughStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.fallthroughKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return FallthroughStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .fallthroughStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.fallthroughKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return FallthroughStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on BreakStmtSyntax")
   public static func makeBreakStmt(_ unexpectedBeforeBreakKeyword: UnexpectedNodesSyntax? = nil, breakKeyword: TokenSyntax, _ unexpectedBetweenBreakKeywordAndLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax?, _ unexpectedAfterLabel: UnexpectedNodesSyntax? = nil) -> BreakStmtSyntax {
@@ -5939,55 +6745,67 @@ public enum SyntaxFactory {
       label?.raw,
       unexpectedAfterLabel?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.breakStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return BreakStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.breakStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return BreakStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on BreakStmtSyntax")
   public static func makeBlankBreakStmt(presence: SourcePresence = .present) -> BreakStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .breakStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.breakKeyword, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return BreakStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .breakStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.breakKeyword, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return BreakStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on CaseItemListSyntax")
   public static func makeCaseItemList(
     _ elements: [CaseItemSyntax]) -> CaseItemListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.caseItemList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return CaseItemListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.caseItemList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return CaseItemListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on CaseItemListSyntax")
   public static func makeBlankCaseItemList(presence: SourcePresence = .present) -> CaseItemListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .caseItemList,
-      from: [
-    ], arena: .default))
-    return CaseItemListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .caseItemList,
+        from: [
+      ], arena: arena))
+      return CaseItemListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on CatchItemListSyntax")
   public static func makeCatchItemList(
     _ elements: [CatchItemSyntax]) -> CatchItemListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchItemList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return CatchItemListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchItemList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return CatchItemListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on CatchItemListSyntax")
   public static func makeBlankCatchItemList(presence: SourcePresence = .present) -> CatchItemListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .catchItemList,
-      from: [
-    ], arena: .default))
-    return CatchItemListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .catchItemList,
+        from: [
+      ], arena: arena))
+      return CatchItemListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ConditionElementSyntax")
   public static func makeConditionElement(_ unexpectedBeforeCondition: UnexpectedNodesSyntax? = nil, condition: Syntax, _ unexpectedBetweenConditionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> ConditionElementSyntax {
@@ -5998,23 +6816,27 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.conditionElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ConditionElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.conditionElement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ConditionElementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ConditionElementSyntax")
   public static func makeBlankConditionElement(presence: SourcePresence = .present) -> ConditionElementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .conditionElement,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return ConditionElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .conditionElement,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return ConditionElementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AvailabilityConditionSyntax")
   public static func makeAvailabilityCondition(_ unexpectedBeforePoundAvailableKeyword: UnexpectedNodesSyntax? = nil, poundAvailableKeyword: TokenSyntax, _ unexpectedBetweenPoundAvailableKeywordAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? = nil, availabilitySpec: AvailabilitySpecListSyntax, _ unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> AvailabilityConditionSyntax {
@@ -6029,27 +6851,31 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityCondition,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AvailabilityConditionSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityCondition,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AvailabilityConditionSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AvailabilityConditionSyntax")
   public static func makeBlankAvailabilityCondition(presence: SourcePresence = .present) -> AvailabilityConditionSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .availabilityCondition,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundAvailableKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return AvailabilityConditionSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .availabilityCondition,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundAvailableKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return AvailabilityConditionSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on MatchingPatternConditionSyntax")
   public static func makeMatchingPatternCondition(_ unexpectedBeforeCaseKeyword: UnexpectedNodesSyntax? = nil, caseKeyword: TokenSyntax, _ unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil, initializer: InitializerClauseSyntax, _ unexpectedAfterInitializer: UnexpectedNodesSyntax? = nil) -> MatchingPatternConditionSyntax {
@@ -6064,27 +6890,31 @@ public enum SyntaxFactory {
       initializer.raw,
       unexpectedAfterInitializer?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.matchingPatternCondition,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return MatchingPatternConditionSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.matchingPatternCondition,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MatchingPatternConditionSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MatchingPatternConditionSyntax")
   public static func makeBlankMatchingPatternCondition(presence: SourcePresence = .present) -> MatchingPatternConditionSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .matchingPatternCondition,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.initializerClause, arena: .default),
-      nil,
-    ], arena: .default))
-    return MatchingPatternConditionSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .matchingPatternCondition,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.initializerClause, arena: arena),
+        nil,
+      ], arena: arena))
+      return MatchingPatternConditionSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on OptionalBindingConditionSyntax")
   public static func makeOptionalBindingCondition(_ unexpectedBeforeLetOrVarKeyword: UnexpectedNodesSyntax? = nil, letOrVarKeyword: TokenSyntax, _ unexpectedBetweenLetOrVarKeywordAndPattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil, initializer: InitializerClauseSyntax?, _ unexpectedAfterInitializer: UnexpectedNodesSyntax? = nil) -> OptionalBindingConditionSyntax {
@@ -6099,27 +6929,31 @@ public enum SyntaxFactory {
       initializer?.raw,
       unexpectedAfterInitializer?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalBindingCondition,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return OptionalBindingConditionSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalBindingCondition,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return OptionalBindingConditionSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on OptionalBindingConditionSyntax")
   public static func makeBlankOptionalBindingCondition(presence: SourcePresence = .present) -> OptionalBindingConditionSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .optionalBindingCondition,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return OptionalBindingConditionSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .optionalBindingCondition,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return OptionalBindingConditionSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on UnavailabilityConditionSyntax")
   public static func makeUnavailabilityCondition(_ unexpectedBeforePoundUnavailableKeyword: UnexpectedNodesSyntax? = nil, poundUnavailableKeyword: TokenSyntax, _ unexpectedBetweenPoundUnavailableKeywordAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? = nil, availabilitySpec: AvailabilitySpecListSyntax, _ unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> UnavailabilityConditionSyntax {
@@ -6134,27 +6968,31 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unavailabilityCondition,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return UnavailabilityConditionSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unavailabilityCondition,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return UnavailabilityConditionSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on UnavailabilityConditionSyntax")
   public static func makeBlankUnavailabilityCondition(presence: SourcePresence = .present) -> UnavailabilityConditionSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unavailabilityCondition,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundUnavailableKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return UnavailabilityConditionSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unavailabilityCondition,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundUnavailableKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return UnavailabilityConditionSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on HasSymbolConditionSyntax")
   public static func makeHasSymbolCondition(_ unexpectedBeforeHasSymbolKeyword: UnexpectedNodesSyntax? = nil, hasSymbolKeyword: TokenSyntax, _ unexpectedBetweenHasSymbolKeywordAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> HasSymbolConditionSyntax {
@@ -6169,43 +7007,51 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.hasSymbolCondition,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return HasSymbolConditionSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.hasSymbolCondition,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return HasSymbolConditionSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on HasSymbolConditionSyntax")
   public static func makeBlankHasSymbolCondition(presence: SourcePresence = .present) -> HasSymbolConditionSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .hasSymbolCondition,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return HasSymbolConditionSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .hasSymbolCondition,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return HasSymbolConditionSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ConditionElementListSyntax")
   public static func makeConditionElementList(
     _ elements: [ConditionElementSyntax]) -> ConditionElementListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.conditionElementList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ConditionElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.conditionElementList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ConditionElementListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ConditionElementListSyntax")
   public static func makeBlankConditionElementList(presence: SourcePresence = .present) -> ConditionElementListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .conditionElementList,
-      from: [
-    ], arena: .default))
-    return ConditionElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .conditionElementList,
+        from: [
+      ], arena: arena))
+      return ConditionElementListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DeclarationStmtSyntax")
   public static func makeDeclarationStmt(_ unexpectedBeforeDeclaration: UnexpectedNodesSyntax? = nil, declaration: DeclSyntax, _ unexpectedAfterDeclaration: UnexpectedNodesSyntax? = nil) -> DeclarationStmtSyntax {
@@ -6214,21 +7060,25 @@ public enum SyntaxFactory {
       declaration.raw,
       unexpectedAfterDeclaration?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.declarationStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DeclarationStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declarationStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DeclarationStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DeclarationStmtSyntax")
   public static func makeBlankDeclarationStmt(presence: SourcePresence = .present) -> DeclarationStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .declarationStmt,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingDecl, arena: .default),
-      nil,
-    ], arena: .default))
-    return DeclarationStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .declarationStmt,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingDecl, arena: arena),
+        nil,
+      ], arena: arena))
+      return DeclarationStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ThrowStmtSyntax")
   public static func makeThrowStmt(_ unexpectedBeforeThrowKeyword: UnexpectedNodesSyntax? = nil, throwKeyword: TokenSyntax, _ unexpectedBetweenThrowKeywordAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> ThrowStmtSyntax {
@@ -6239,23 +7089,27 @@ public enum SyntaxFactory {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.throwStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ThrowStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.throwStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ThrowStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ThrowStmtSyntax")
   public static func makeBlankThrowStmt(presence: SourcePresence = .present) -> ThrowStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .throwStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.throwKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-    ], arena: .default))
-    return ThrowStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .throwStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.throwKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return ThrowStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on IfStmtSyntax")
   public static func makeIfStmt(_ unexpectedBeforeIfKeyword: UnexpectedNodesSyntax? = nil, ifKeyword: TokenSyntax, _ unexpectedBetweenIfKeywordAndConditions: UnexpectedNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ unexpectedBetweenConditionsAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedBetweenBodyAndElseKeyword: UnexpectedNodesSyntax? = nil, elseKeyword: TokenSyntax?, _ unexpectedBetweenElseKeywordAndElseBody: UnexpectedNodesSyntax? = nil, elseBody: Syntax?, _ unexpectedAfterElseBody: UnexpectedNodesSyntax? = nil) -> IfStmtSyntax {
@@ -6272,29 +7126,33 @@ public enum SyntaxFactory {
       elseBody?.raw,
       unexpectedAfterElseBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return IfStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return IfStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on IfStmtSyntax")
   public static func makeBlankIfStmt(presence: SourcePresence = .present) -> IfStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .ifStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.ifKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return IfStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .ifStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.ifKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return IfStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on SwitchCaseSyntax")
   public static func makeSwitchCase(_ unexpectedBeforeUnknownAttr: UnexpectedNodesSyntax? = nil, unknownAttr: AttributeSyntax?, _ unexpectedBetweenUnknownAttrAndLabel: UnexpectedNodesSyntax? = nil, label: Syntax, _ unexpectedBetweenLabelAndStatements: UnexpectedNodesSyntax? = nil, statements: CodeBlockItemListSyntax, _ unexpectedAfterStatements: UnexpectedNodesSyntax? = nil) -> SwitchCaseSyntax {
@@ -6307,25 +7165,29 @@ public enum SyntaxFactory {
       statements.raw,
       unexpectedAfterStatements?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCase,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return SwitchCaseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCase,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return SwitchCaseSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on SwitchCaseSyntax")
   public static func makeBlankSwitchCase(presence: SourcePresence = .present) -> SwitchCaseSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .switchCase,
-      from: [
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default),
-      nil,
-    ], arena: .default))
-    return SwitchCaseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .switchCase,
+        from: [
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: arena),
+        nil,
+      ], arena: arena))
+      return SwitchCaseSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on SwitchDefaultLabelSyntax")
   public static func makeSwitchDefaultLabel(_ unexpectedBeforeDefaultKeyword: UnexpectedNodesSyntax? = nil, defaultKeyword: TokenSyntax, _ unexpectedBetweenDefaultKeywordAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil) -> SwitchDefaultLabelSyntax {
@@ -6336,23 +7198,27 @@ public enum SyntaxFactory {
       colon.raw,
       unexpectedAfterColon?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchDefaultLabel,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return SwitchDefaultLabelSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchDefaultLabel,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return SwitchDefaultLabelSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on SwitchDefaultLabelSyntax")
   public static func makeBlankSwitchDefaultLabel(presence: SourcePresence = .present) -> SwitchDefaultLabelSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .switchDefaultLabel,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.defaultKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-    ], arena: .default))
-    return SwitchDefaultLabelSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .switchDefaultLabel,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.defaultKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+      ], arena: arena))
+      return SwitchDefaultLabelSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on CaseItemSyntax")
   public static func makeCaseItem(_ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? = nil, whereClause: WhereClauseSyntax?, _ unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> CaseItemSyntax {
@@ -6365,25 +7231,29 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.caseItem,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return CaseItemSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.caseItem,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return CaseItemSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on CaseItemSyntax")
   public static func makeBlankCaseItem(presence: SourcePresence = .present) -> CaseItemSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .caseItem,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return CaseItemSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .caseItem,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return CaseItemSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on CatchItemSyntax")
   public static func makeCatchItem(_ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax?, _ unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? = nil, whereClause: WhereClauseSyntax?, _ unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> CatchItemSyntax {
@@ -6396,25 +7266,29 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchItem,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return CatchItemSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchItem,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return CatchItemSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on CatchItemSyntax")
   public static func makeBlankCatchItem(presence: SourcePresence = .present) -> CatchItemSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .catchItem,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return CatchItemSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .catchItem,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return CatchItemSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on SwitchCaseLabelSyntax")
   public static func makeSwitchCaseLabel(_ unexpectedBeforeCaseKeyword: UnexpectedNodesSyntax? = nil, caseKeyword: TokenSyntax, _ unexpectedBetweenCaseKeywordAndCaseItems: UnexpectedNodesSyntax? = nil, caseItems: CaseItemListSyntax, _ unexpectedBetweenCaseItemsAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil) -> SwitchCaseLabelSyntax {
@@ -6427,25 +7301,29 @@ public enum SyntaxFactory {
       colon.raw,
       unexpectedAfterColon?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseLabel,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return SwitchCaseLabelSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseLabel,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return SwitchCaseLabelSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on SwitchCaseLabelSyntax")
   public static func makeBlankSwitchCaseLabel(presence: SourcePresence = .present) -> SwitchCaseLabelSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .switchCaseLabel,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.caseItemList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-    ], arena: .default))
-    return SwitchCaseLabelSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .switchCaseLabel,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.caseItemList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+      ], arena: arena))
+      return SwitchCaseLabelSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on CatchClauseSyntax")
   public static func makeCatchClause(_ unexpectedBeforeCatchKeyword: UnexpectedNodesSyntax? = nil, catchKeyword: TokenSyntax, _ unexpectedBetweenCatchKeywordAndCatchItems: UnexpectedNodesSyntax? = nil, catchItems: CatchItemListSyntax?, _ unexpectedBetweenCatchItemsAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> CatchClauseSyntax {
@@ -6458,25 +7336,29 @@ public enum SyntaxFactory {
       body.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return CatchClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchClause,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return CatchClauseSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on CatchClauseSyntax")
   public static func makeBlankCatchClause(presence: SourcePresence = .present) -> CatchClauseSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .catchClause,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.catchKeyword, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default),
-      nil,
-    ], arena: .default))
-    return CatchClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .catchClause,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.catchKeyword, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena),
+        nil,
+      ], arena: arena))
+      return CatchClauseSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PoundAssertStmtSyntax")
   public static func makePoundAssertStmt(_ unexpectedBeforePoundAssert: UnexpectedNodesSyntax? = nil, poundAssert: TokenSyntax, _ unexpectedBetweenPoundAssertAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndCondition: UnexpectedNodesSyntax? = nil, condition: ExprSyntax, _ unexpectedBetweenConditionAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndMessage: UnexpectedNodesSyntax? = nil, message: TokenSyntax?, _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> PoundAssertStmtSyntax {
@@ -6495,31 +7377,35 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundAssertStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PoundAssertStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundAssertStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PoundAssertStmtSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PoundAssertStmtSyntax")
   public static func makeBlankPoundAssertStmt(presence: SourcePresence = .present) -> PoundAssertStmtSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundAssertStmt,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.poundAssertKeyword, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return PoundAssertStmtSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .poundAssertStmt,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.poundAssertKeyword, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return PoundAssertStmtSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on GenericWhereClauseSyntax")
   public static func makeGenericWhereClause(_ unexpectedBeforeWhereKeyword: UnexpectedNodesSyntax? = nil, whereKeyword: TokenSyntax, _ unexpectedBetweenWhereKeywordAndRequirementList: UnexpectedNodesSyntax? = nil, requirementList: GenericRequirementListSyntax, _ unexpectedAfterRequirementList: UnexpectedNodesSyntax? = nil) -> GenericWhereClauseSyntax {
@@ -6530,39 +7416,47 @@ public enum SyntaxFactory {
       requirementList.raw,
       unexpectedAfterRequirementList?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericWhereClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return GenericWhereClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericWhereClause,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return GenericWhereClauseSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on GenericWhereClauseSyntax")
   public static func makeBlankGenericWhereClause(presence: SourcePresence = .present) -> GenericWhereClauseSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericWhereClause,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.whereKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericRequirementList, arena: .default),
-      nil,
-    ], arena: .default))
-    return GenericWhereClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericWhereClause,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.whereKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericRequirementList, arena: arena),
+        nil,
+      ], arena: arena))
+      return GenericWhereClauseSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on GenericRequirementListSyntax")
   public static func makeGenericRequirementList(
     _ elements: [GenericRequirementSyntax]) -> GenericRequirementListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirementList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return GenericRequirementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirementList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return GenericRequirementListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on GenericRequirementListSyntax")
   public static func makeBlankGenericRequirementList(presence: SourcePresence = .present) -> GenericRequirementListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericRequirementList,
-      from: [
-    ], arena: .default))
-    return GenericRequirementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericRequirementList,
+        from: [
+      ], arena: arena))
+      return GenericRequirementListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on GenericRequirementSyntax")
   public static func makeGenericRequirement(_ unexpectedBeforeBody: UnexpectedNodesSyntax? = nil, body: Syntax, _ unexpectedBetweenBodyAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> GenericRequirementSyntax {
@@ -6573,23 +7467,27 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return GenericRequirementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return GenericRequirementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on GenericRequirementSyntax")
   public static func makeBlankGenericRequirement(presence: SourcePresence = .present) -> GenericRequirementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericRequirement,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return GenericRequirementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericRequirement,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return GenericRequirementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on SameTypeRequirementSyntax")
   public static func makeSameTypeRequirement(_ unexpectedBeforeLeftTypeIdentifier: UnexpectedNodesSyntax? = nil, leftTypeIdentifier: TypeSyntax, _ unexpectedBetweenLeftTypeIdentifierAndEqualityToken: UnexpectedNodesSyntax? = nil, equalityToken: TokenSyntax, _ unexpectedBetweenEqualityTokenAndRightTypeIdentifier: UnexpectedNodesSyntax? = nil, rightTypeIdentifier: TypeSyntax, _ unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? = nil) -> SameTypeRequirementSyntax {
@@ -6602,25 +7500,29 @@ public enum SyntaxFactory {
       rightTypeIdentifier.raw,
       unexpectedAfterRightTypeIdentifier?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.sameTypeRequirement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return SameTypeRequirementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.sameTypeRequirement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return SameTypeRequirementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on SameTypeRequirementSyntax")
   public static func makeBlankSameTypeRequirement(presence: SourcePresence = .present) -> SameTypeRequirementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .sameTypeRequirement,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.spacedBinaryOperator(""), arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-    ], arena: .default))
-    return SameTypeRequirementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .sameTypeRequirement,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.spacedBinaryOperator(""), arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+      ], arena: arena))
+      return SameTypeRequirementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on LayoutRequirementSyntax")
   public static func makeLayoutRequirement(_ unexpectedBeforeTypeIdentifier: UnexpectedNodesSyntax? = nil, typeIdentifier: TypeSyntax, _ unexpectedBetweenTypeIdentifierAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndLayoutConstraint: UnexpectedNodesSyntax? = nil, layoutConstraint: TokenSyntax, _ unexpectedBetweenLayoutConstraintAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax?, _ unexpectedBetweenLeftParenAndSize: UnexpectedNodesSyntax? = nil, size: TokenSyntax?, _ unexpectedBetweenSizeAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndAlignment: UnexpectedNodesSyntax? = nil, alignment: TokenSyntax?, _ unexpectedBetweenAlignmentAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax?, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> LayoutRequirementSyntax {
@@ -6643,51 +7545,59 @@ public enum SyntaxFactory {
       rightParen?.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.layoutRequirement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return LayoutRequirementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.layoutRequirement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return LayoutRequirementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on LayoutRequirementSyntax")
   public static func makeBlankLayoutRequirement(presence: SourcePresence = .present) -> LayoutRequirementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .layoutRequirement,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return LayoutRequirementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .layoutRequirement,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return LayoutRequirementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on GenericParameterListSyntax")
   public static func makeGenericParameterList(
     _ elements: [GenericParameterSyntax]) -> GenericParameterListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return GenericParameterListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return GenericParameterListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on GenericParameterListSyntax")
   public static func makeBlankGenericParameterList(presence: SourcePresence = .present) -> GenericParameterListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericParameterList,
-      from: [
-    ], arena: .default))
-    return GenericParameterListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericParameterList,
+        from: [
+      ], arena: arena))
+      return GenericParameterListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on GenericParameterSyntax")
   public static func makeGenericParameter(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndEllipsis: UnexpectedNodesSyntax? = nil, ellipsis: TokenSyntax?, _ unexpectedBetweenEllipsisAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndInheritedType: UnexpectedNodesSyntax? = nil, inheritedType: TypeSyntax?, _ unexpectedBetweenInheritedTypeAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> GenericParameterSyntax {
@@ -6706,47 +7616,55 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameter,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return GenericParameterSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameter,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return GenericParameterSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on GenericParameterSyntax")
   public static func makeBlankGenericParameter(presence: SourcePresence = .present) -> GenericParameterSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericParameter,
-      from: [
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return GenericParameterSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericParameter,
+        from: [
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return GenericParameterSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PrimaryAssociatedTypeListSyntax")
   public static func makePrimaryAssociatedTypeList(
     _ elements: [PrimaryAssociatedTypeSyntax]) -> PrimaryAssociatedTypeListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PrimaryAssociatedTypeListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PrimaryAssociatedTypeListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PrimaryAssociatedTypeListSyntax")
   public static func makeBlankPrimaryAssociatedTypeList(presence: SourcePresence = .present) -> PrimaryAssociatedTypeListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .primaryAssociatedTypeList,
-      from: [
-    ], arena: .default))
-    return PrimaryAssociatedTypeListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .primaryAssociatedTypeList,
+        from: [
+      ], arena: arena))
+      return PrimaryAssociatedTypeListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PrimaryAssociatedTypeSyntax")
   public static func makePrimaryAssociatedType(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> PrimaryAssociatedTypeSyntax {
@@ -6757,23 +7675,27 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PrimaryAssociatedTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PrimaryAssociatedTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PrimaryAssociatedTypeSyntax")
   public static func makeBlankPrimaryAssociatedType(presence: SourcePresence = .present) -> PrimaryAssociatedTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .primaryAssociatedType,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return PrimaryAssociatedTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .primaryAssociatedType,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return PrimaryAssociatedTypeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on GenericParameterClauseSyntax")
   public static func makeGenericParameterClause(_ unexpectedBeforeLeftAngleBracket: UnexpectedNodesSyntax? = nil, leftAngleBracket: TokenSyntax, _ unexpectedBetweenLeftAngleBracketAndGenericParameterList: UnexpectedNodesSyntax? = nil, genericParameterList: GenericParameterListSyntax, _ unexpectedBetweenGenericParameterListAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndRightAngleBracket: UnexpectedNodesSyntax? = nil, rightAngleBracket: TokenSyntax, _ unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? = nil) -> GenericParameterClauseSyntax {
@@ -6788,27 +7710,31 @@ public enum SyntaxFactory {
       rightAngleBracket.raw,
       unexpectedAfterRightAngleBracket?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return GenericParameterClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterClause,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return GenericParameterClauseSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on GenericParameterClauseSyntax")
   public static func makeBlankGenericParameterClause(presence: SourcePresence = .present) -> GenericParameterClauseSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericParameterClause,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericParameterList, arena: .default),
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: .default),
-      nil,
-    ], arena: .default))
-    return GenericParameterClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericParameterClause,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericParameterList, arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: arena),
+        nil,
+      ], arena: arena))
+      return GenericParameterClauseSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ConformanceRequirementSyntax")
   public static func makeConformanceRequirement(_ unexpectedBeforeLeftTypeIdentifier: UnexpectedNodesSyntax? = nil, leftTypeIdentifier: TypeSyntax, _ unexpectedBetweenLeftTypeIdentifierAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndRightTypeIdentifier: UnexpectedNodesSyntax? = nil, rightTypeIdentifier: TypeSyntax, _ unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? = nil) -> ConformanceRequirementSyntax {
@@ -6821,25 +7747,29 @@ public enum SyntaxFactory {
       rightTypeIdentifier.raw,
       unexpectedAfterRightTypeIdentifier?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.conformanceRequirement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ConformanceRequirementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.conformanceRequirement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ConformanceRequirementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ConformanceRequirementSyntax")
   public static func makeBlankConformanceRequirement(presence: SourcePresence = .present) -> ConformanceRequirementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .conformanceRequirement,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-    ], arena: .default))
-    return ConformanceRequirementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .conformanceRequirement,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+      ], arena: arena))
+      return ConformanceRequirementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PrimaryAssociatedTypeClauseSyntax")
   public static func makePrimaryAssociatedTypeClause(_ unexpectedBeforeLeftAngleBracket: UnexpectedNodesSyntax? = nil, leftAngleBracket: TokenSyntax, _ unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList: UnexpectedNodesSyntax? = nil, primaryAssociatedTypeList: PrimaryAssociatedTypeListSyntax, _ unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket: UnexpectedNodesSyntax? = nil, rightAngleBracket: TokenSyntax, _ unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? = nil) -> PrimaryAssociatedTypeClauseSyntax {
@@ -6852,25 +7782,29 @@ public enum SyntaxFactory {
       rightAngleBracket.raw,
       unexpectedAfterRightAngleBracket?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PrimaryAssociatedTypeClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeClause,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PrimaryAssociatedTypeClauseSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PrimaryAssociatedTypeClauseSyntax")
   public static func makeBlankPrimaryAssociatedTypeClause(presence: SourcePresence = .present) -> PrimaryAssociatedTypeClauseSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .primaryAssociatedTypeClause,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.primaryAssociatedTypeList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: .default),
-      nil,
-    ], arena: .default))
-    return PrimaryAssociatedTypeClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .primaryAssociatedTypeClause,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.primaryAssociatedTypeList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: arena),
+        nil,
+      ], arena: arena))
+      return PrimaryAssociatedTypeClauseSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on SimpleTypeIdentifierSyntax")
   public static func makeSimpleTypeIdentifier(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax?, _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil) -> SimpleTypeIdentifierSyntax {
@@ -6881,23 +7815,27 @@ public enum SyntaxFactory {
       genericArgumentClause?.raw,
       unexpectedAfterGenericArgumentClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.simpleTypeIdentifier,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return SimpleTypeIdentifierSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.simpleTypeIdentifier,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return SimpleTypeIdentifierSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on SimpleTypeIdentifierSyntax")
   public static func makeBlankSimpleTypeIdentifier(presence: SourcePresence = .present) -> SimpleTypeIdentifierSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .simpleTypeIdentifier,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return SimpleTypeIdentifierSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .simpleTypeIdentifier,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return SimpleTypeIdentifierSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on MemberTypeIdentifierSyntax")
   public static func makeMemberTypeIdentifier(_ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax, _ unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax, _ unexpectedBetweenPeriodAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax?, _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil) -> MemberTypeIdentifierSyntax {
@@ -6912,27 +7850,31 @@ public enum SyntaxFactory {
       genericArgumentClause?.raw,
       unexpectedAfterGenericArgumentClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberTypeIdentifier,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return MemberTypeIdentifierSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberTypeIdentifier,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MemberTypeIdentifierSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MemberTypeIdentifierSyntax")
   public static func makeBlankMemberTypeIdentifier(presence: SourcePresence = .present) -> MemberTypeIdentifierSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .memberTypeIdentifier,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return MemberTypeIdentifierSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .memberTypeIdentifier,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.period, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return MemberTypeIdentifierSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ClassRestrictionTypeSyntax")
   public static func makeClassRestrictionType(_ unexpectedBeforeClassKeyword: UnexpectedNodesSyntax? = nil, classKeyword: TokenSyntax, _ unexpectedAfterClassKeyword: UnexpectedNodesSyntax? = nil) -> ClassRestrictionTypeSyntax {
@@ -6941,21 +7883,25 @@ public enum SyntaxFactory {
       classKeyword.raw,
       unexpectedAfterClassKeyword?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.classRestrictionType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ClassRestrictionTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.classRestrictionType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ClassRestrictionTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ClassRestrictionTypeSyntax")
   public static func makeBlankClassRestrictionType(presence: SourcePresence = .present) -> ClassRestrictionTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .classRestrictionType,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.classKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return ClassRestrictionTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .classRestrictionType,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.classKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return ClassRestrictionTypeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ArrayTypeSyntax")
   public static func makeArrayType(_ unexpectedBeforeLeftSquareBracket: UnexpectedNodesSyntax? = nil, leftSquareBracket: TokenSyntax, _ unexpectedBetweenLeftSquareBracketAndElementType: UnexpectedNodesSyntax? = nil, elementType: TypeSyntax, _ unexpectedBetweenElementTypeAndRightSquareBracket: UnexpectedNodesSyntax? = nil, rightSquareBracket: TokenSyntax, _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil) -> ArrayTypeSyntax {
@@ -6968,25 +7914,29 @@ public enum SyntaxFactory {
       rightSquareBracket.raw,
       unexpectedAfterRightSquareBracket?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ArrayTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ArrayTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ArrayTypeSyntax")
   public static func makeBlankArrayType(presence: SourcePresence = .present) -> ArrayTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .arrayType,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default),
-      nil,
-    ], arena: .default))
-    return ArrayTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .arrayType,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena),
+        nil,
+      ], arena: arena))
+      return ArrayTypeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on DictionaryTypeSyntax")
   public static func makeDictionaryType(_ unexpectedBeforeLeftSquareBracket: UnexpectedNodesSyntax? = nil, leftSquareBracket: TokenSyntax, _ unexpectedBetweenLeftSquareBracketAndKeyType: UnexpectedNodesSyntax? = nil, keyType: TypeSyntax, _ unexpectedBetweenKeyTypeAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValueType: UnexpectedNodesSyntax? = nil, valueType: TypeSyntax, _ unexpectedBetweenValueTypeAndRightSquareBracket: UnexpectedNodesSyntax? = nil, rightSquareBracket: TokenSyntax, _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil) -> DictionaryTypeSyntax {
@@ -7003,29 +7953,33 @@ public enum SyntaxFactory {
       rightSquareBracket.raw,
       unexpectedAfterRightSquareBracket?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return DictionaryTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return DictionaryTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on DictionaryTypeSyntax")
   public static func makeBlankDictionaryType(presence: SourcePresence = .present) -> DictionaryTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .dictionaryType,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default),
-      nil,
-    ], arena: .default))
-    return DictionaryTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .dictionaryType,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena),
+        nil,
+      ], arena: arena))
+      return DictionaryTypeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on MetatypeTypeSyntax")
   public static func makeMetatypeType(_ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax, _ unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax, _ unexpectedBetweenPeriodAndTypeOrProtocol: UnexpectedNodesSyntax? = nil, typeOrProtocol: TokenSyntax, _ unexpectedAfterTypeOrProtocol: UnexpectedNodesSyntax? = nil) -> MetatypeTypeSyntax {
@@ -7038,25 +7992,29 @@ public enum SyntaxFactory {
       typeOrProtocol.raw,
       unexpectedAfterTypeOrProtocol?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.metatypeType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return MetatypeTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.metatypeType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MetatypeTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on MetatypeTypeSyntax")
   public static func makeBlankMetatypeType(presence: SourcePresence = .present) -> MetatypeTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .metatypeType,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-    ], arena: .default))
-    return MetatypeTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .metatypeType,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.period, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+      ], arena: arena))
+      return MetatypeTypeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on OptionalTypeSyntax")
   public static func makeOptionalType(_ unexpectedBeforeWrappedType: UnexpectedNodesSyntax? = nil, wrappedType: TypeSyntax, _ unexpectedBetweenWrappedTypeAndQuestionMark: UnexpectedNodesSyntax? = nil, questionMark: TokenSyntax, _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil) -> OptionalTypeSyntax {
@@ -7067,23 +8025,27 @@ public enum SyntaxFactory {
       questionMark.raw,
       unexpectedAfterQuestionMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return OptionalTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return OptionalTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on OptionalTypeSyntax")
   public static func makeBlankOptionalType(presence: SourcePresence = .present) -> OptionalTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .optionalType,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: .default),
-      nil,
-    ], arena: .default))
-    return OptionalTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .optionalType,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: arena),
+        nil,
+      ], arena: arena))
+      return OptionalTypeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ConstrainedSugarTypeSyntax")
   public static func makeConstrainedSugarType(_ unexpectedBeforeSomeOrAnySpecifier: UnexpectedNodesSyntax? = nil, someOrAnySpecifier: TokenSyntax, _ unexpectedBetweenSomeOrAnySpecifierAndBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax, _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil) -> ConstrainedSugarTypeSyntax {
@@ -7094,23 +8056,27 @@ public enum SyntaxFactory {
       baseType.raw,
       unexpectedAfterBaseType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.constrainedSugarType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ConstrainedSugarTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.constrainedSugarType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ConstrainedSugarTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ConstrainedSugarTypeSyntax")
   public static func makeBlankConstrainedSugarType(presence: SourcePresence = .present) -> ConstrainedSugarTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .constrainedSugarType,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-    ], arena: .default))
-    return ConstrainedSugarTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .constrainedSugarType,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+      ], arena: arena))
+      return ConstrainedSugarTypeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ImplicitlyUnwrappedOptionalTypeSyntax")
   public static func makeImplicitlyUnwrappedOptionalType(_ unexpectedBeforeWrappedType: UnexpectedNodesSyntax? = nil, wrappedType: TypeSyntax, _ unexpectedBetweenWrappedTypeAndExclamationMark: UnexpectedNodesSyntax? = nil, exclamationMark: TokenSyntax, _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil) -> ImplicitlyUnwrappedOptionalTypeSyntax {
@@ -7121,23 +8087,27 @@ public enum SyntaxFactory {
       exclamationMark.raw,
       unexpectedAfterExclamationMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.implicitlyUnwrappedOptionalType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ImplicitlyUnwrappedOptionalTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.implicitlyUnwrappedOptionalType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ImplicitlyUnwrappedOptionalTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ImplicitlyUnwrappedOptionalTypeSyntax")
   public static func makeBlankImplicitlyUnwrappedOptionalType(presence: SourcePresence = .present) -> ImplicitlyUnwrappedOptionalTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .implicitlyUnwrappedOptionalType,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.exclamationMark, arena: .default),
-      nil,
-    ], arena: .default))
-    return ImplicitlyUnwrappedOptionalTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .implicitlyUnwrappedOptionalType,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.exclamationMark, arena: arena),
+        nil,
+      ], arena: arena))
+      return ImplicitlyUnwrappedOptionalTypeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on CompositionTypeElementSyntax")
   public static func makeCompositionTypeElement(_ unexpectedBeforeType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedBetweenTypeAndAmpersand: UnexpectedNodesSyntax? = nil, ampersand: TokenSyntax?, _ unexpectedAfterAmpersand: UnexpectedNodesSyntax? = nil) -> CompositionTypeElementSyntax {
@@ -7148,39 +8118,47 @@ public enum SyntaxFactory {
       ampersand?.raw,
       unexpectedAfterAmpersand?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return CompositionTypeElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return CompositionTypeElementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on CompositionTypeElementSyntax")
   public static func makeBlankCompositionTypeElement(presence: SourcePresence = .present) -> CompositionTypeElementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .compositionTypeElement,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return CompositionTypeElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .compositionTypeElement,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return CompositionTypeElementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on CompositionTypeElementListSyntax")
   public static func makeCompositionTypeElementList(
     _ elements: [CompositionTypeElementSyntax]) -> CompositionTypeElementListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElementList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return CompositionTypeElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElementList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return CompositionTypeElementListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on CompositionTypeElementListSyntax")
   public static func makeBlankCompositionTypeElementList(presence: SourcePresence = .present) -> CompositionTypeElementListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .compositionTypeElementList,
-      from: [
-    ], arena: .default))
-    return CompositionTypeElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .compositionTypeElementList,
+        from: [
+      ], arena: arena))
+      return CompositionTypeElementListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on CompositionTypeSyntax")
   public static func makeCompositionType(_ unexpectedBeforeElements: UnexpectedNodesSyntax? = nil, elements: CompositionTypeElementListSyntax, _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil) -> CompositionTypeSyntax {
@@ -7189,21 +8167,25 @@ public enum SyntaxFactory {
       elements.raw,
       unexpectedAfterElements?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return CompositionTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return CompositionTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on CompositionTypeSyntax")
   public static func makeBlankCompositionType(presence: SourcePresence = .present) -> CompositionTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .compositionType,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.compositionTypeElementList, arena: .default),
-      nil,
-    ], arena: .default))
-    return CompositionTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .compositionType,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.compositionTypeElementList, arena: arena),
+        nil,
+      ], arena: arena))
+      return CompositionTypeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on PackExpansionTypeSyntax")
   public static func makePackExpansionType(_ unexpectedBeforePatternType: UnexpectedNodesSyntax? = nil, patternType: TypeSyntax, _ unexpectedBetweenPatternTypeAndEllipsis: UnexpectedNodesSyntax? = nil, ellipsis: TokenSyntax, _ unexpectedAfterEllipsis: UnexpectedNodesSyntax? = nil) -> PackExpansionTypeSyntax {
@@ -7214,23 +8196,27 @@ public enum SyntaxFactory {
       ellipsis.raw,
       unexpectedAfterEllipsis?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.packExpansionType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return PackExpansionTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.packExpansionType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PackExpansionTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on PackExpansionTypeSyntax")
   public static func makeBlankPackExpansionType(presence: SourcePresence = .present) -> PackExpansionTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .packExpansionType,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.ellipsis, arena: .default),
-      nil,
-    ], arena: .default))
-    return PackExpansionTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .packExpansionType,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.ellipsis, arena: arena),
+        nil,
+      ], arena: arena))
+      return PackExpansionTypeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TupleTypeElementSyntax")
   public static func makeTupleTypeElement(_ unexpectedBeforeInOut: UnexpectedNodesSyntax? = nil, inOut: TokenSyntax?, _ unexpectedBetweenInOutAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax?, _ unexpectedBetweenNameAndSecondName: UnexpectedNodesSyntax? = nil, secondName: TokenSyntax?, _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil, ellipsis: TokenSyntax?, _ unexpectedBetweenEllipsisAndInitializer: UnexpectedNodesSyntax? = nil, initializer: InitializerClauseSyntax?, _ unexpectedBetweenInitializerAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> TupleTypeElementSyntax {
@@ -7253,51 +8239,59 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TupleTypeElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TupleTypeElementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TupleTypeElementSyntax")
   public static func makeBlankTupleTypeElement(presence: SourcePresence = .present) -> TupleTypeElementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tupleTypeElement,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return TupleTypeElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tupleTypeElement,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return TupleTypeElementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TupleTypeElementListSyntax")
   public static func makeTupleTypeElementList(
     _ elements: [TupleTypeElementSyntax]) -> TupleTypeElementListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElementList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TupleTypeElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElementList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TupleTypeElementListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TupleTypeElementListSyntax")
   public static func makeBlankTupleTypeElementList(presence: SourcePresence = .present) -> TupleTypeElementListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tupleTypeElementList,
-      from: [
-    ], arena: .default))
-    return TupleTypeElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tupleTypeElementList,
+        from: [
+      ], arena: arena))
+      return TupleTypeElementListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TupleTypeSyntax")
   public static func makeTupleType(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? = nil, elements: TupleTypeElementListSyntax, _ unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> TupleTypeSyntax {
@@ -7310,25 +8304,29 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TupleTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TupleTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TupleTypeSyntax")
   public static func makeBlankTupleType(presence: SourcePresence = .present) -> TupleTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tupleType,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleTypeElementList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return TupleTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tupleType,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleTypeElementList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return TupleTypeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on FunctionTypeSyntax")
   public static func makeFunctionType(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil, arguments: TupleTypeElementListSyntax, _ unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedBetweenRightParenAndAsyncKeyword: UnexpectedNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodesSyntax? = nil, throwsOrRethrowsKeyword: TokenSyntax?, _ unexpectedBetweenThrowsOrRethrowsKeywordAndArrow: UnexpectedNodesSyntax? = nil, arrow: TokenSyntax, _ unexpectedBetweenArrowAndReturnType: UnexpectedNodesSyntax? = nil, returnType: TypeSyntax, _ unexpectedAfterReturnType: UnexpectedNodesSyntax? = nil) -> FunctionTypeSyntax {
@@ -7349,33 +8347,37 @@ public enum SyntaxFactory {
       returnType.raw,
       unexpectedAfterReturnType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return FunctionTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return FunctionTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on FunctionTypeSyntax")
   public static func makeBlankFunctionType(presence: SourcePresence = .present) -> FunctionTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .functionType,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleTypeElementList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-    ], arena: .default))
-    return FunctionTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .functionType,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleTypeElementList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+      ], arena: arena))
+      return FunctionTypeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AttributedTypeSyntax")
   public static func makeAttributedType(_ unexpectedBeforeSpecifier: UnexpectedNodesSyntax? = nil, specifier: TokenSyntax?, _ unexpectedBetweenSpecifierAndAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax, _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil) -> AttributedTypeSyntax {
@@ -7388,41 +8390,49 @@ public enum SyntaxFactory {
       baseType.raw,
       unexpectedAfterBaseType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.attributedType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AttributedTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.attributedType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AttributedTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AttributedTypeSyntax")
   public static func makeBlankAttributedType(presence: SourcePresence = .present) -> AttributedTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .attributedType,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-    ], arena: .default))
-    return AttributedTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .attributedType,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+      ], arena: arena))
+      return AttributedTypeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on GenericArgumentListSyntax")
   public static func makeGenericArgumentList(
     _ elements: [GenericArgumentSyntax]) -> GenericArgumentListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return GenericArgumentListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return GenericArgumentListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on GenericArgumentListSyntax")
   public static func makeBlankGenericArgumentList(presence: SourcePresence = .present) -> GenericArgumentListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericArgumentList,
-      from: [
-    ], arena: .default))
-    return GenericArgumentListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericArgumentList,
+        from: [
+      ], arena: arena))
+      return GenericArgumentListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on GenericArgumentSyntax")
   public static func makeGenericArgument(_ unexpectedBeforeArgumentType: UnexpectedNodesSyntax? = nil, argumentType: TypeSyntax, _ unexpectedBetweenArgumentTypeAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> GenericArgumentSyntax {
@@ -7433,23 +8443,27 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgument,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return GenericArgumentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgument,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return GenericArgumentSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on GenericArgumentSyntax")
   public static func makeBlankGenericArgument(presence: SourcePresence = .present) -> GenericArgumentSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericArgument,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return GenericArgumentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericArgument,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return GenericArgumentSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on GenericArgumentClauseSyntax")
   public static func makeGenericArgumentClause(_ unexpectedBeforeLeftAngleBracket: UnexpectedNodesSyntax? = nil, leftAngleBracket: TokenSyntax, _ unexpectedBetweenLeftAngleBracketAndArguments: UnexpectedNodesSyntax? = nil, arguments: GenericArgumentListSyntax, _ unexpectedBetweenArgumentsAndRightAngleBracket: UnexpectedNodesSyntax? = nil, rightAngleBracket: TokenSyntax, _ unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? = nil) -> GenericArgumentClauseSyntax {
@@ -7462,25 +8476,29 @@ public enum SyntaxFactory {
       rightAngleBracket.raw,
       unexpectedAfterRightAngleBracket?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return GenericArgumentClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentClause,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return GenericArgumentClauseSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on GenericArgumentClauseSyntax")
   public static func makeBlankGenericArgumentClause(presence: SourcePresence = .present) -> GenericArgumentClauseSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericArgumentClause,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericArgumentList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: .default),
-      nil,
-    ], arena: .default))
-    return GenericArgumentClauseSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .genericArgumentClause,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericArgumentList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: arena),
+        nil,
+      ], arena: arena))
+      return GenericArgumentClauseSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on NamedOpaqueReturnTypeSyntax")
   public static func makeNamedOpaqueReturnType(_ unexpectedBeforeGenericParameters: UnexpectedNodesSyntax? = nil, genericParameters: GenericParameterClauseSyntax, _ unexpectedBetweenGenericParametersAndBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax, _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil) -> NamedOpaqueReturnTypeSyntax {
@@ -7491,23 +8509,27 @@ public enum SyntaxFactory {
       baseType.raw,
       unexpectedAfterBaseType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.namedOpaqueReturnType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return NamedOpaqueReturnTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.namedOpaqueReturnType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return NamedOpaqueReturnTypeSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on NamedOpaqueReturnTypeSyntax")
   public static func makeBlankNamedOpaqueReturnType(presence: SourcePresence = .present) -> NamedOpaqueReturnTypeSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .namedOpaqueReturnType,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericParameterClause, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-    ], arena: .default))
-    return NamedOpaqueReturnTypeSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .namedOpaqueReturnType,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericParameterClause, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+      ], arena: arena))
+      return NamedOpaqueReturnTypeSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TypeAnnotationSyntax")
   public static func makeTypeAnnotation(_ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedAfterType: UnexpectedNodesSyntax? = nil) -> TypeAnnotationSyntax {
@@ -7518,23 +8540,27 @@ public enum SyntaxFactory {
       type.raw,
       unexpectedAfterType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeAnnotation,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TypeAnnotationSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeAnnotation,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TypeAnnotationSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TypeAnnotationSyntax")
   public static func makeBlankTypeAnnotation(presence: SourcePresence = .present) -> TypeAnnotationSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .typeAnnotation,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-    ], arena: .default))
-    return TypeAnnotationSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .typeAnnotation,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+      ], arena: arena))
+      return TypeAnnotationSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on EnumCasePatternSyntax")
   public static func makeEnumCasePattern(_ unexpectedBeforeType: UnexpectedNodesSyntax? = nil, type: TypeSyntax?, _ unexpectedBetweenTypeAndPeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax, _ unexpectedBetweenPeriodAndCaseName: UnexpectedNodesSyntax? = nil, caseName: TokenSyntax, _ unexpectedBetweenCaseNameAndAssociatedTuple: UnexpectedNodesSyntax? = nil, associatedTuple: TuplePatternSyntax?, _ unexpectedAfterAssociatedTuple: UnexpectedNodesSyntax? = nil) -> EnumCasePatternSyntax {
@@ -7549,27 +8575,31 @@ public enum SyntaxFactory {
       associatedTuple?.raw,
       unexpectedAfterAssociatedTuple?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCasePattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return EnumCasePatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCasePattern,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return EnumCasePatternSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on EnumCasePatternSyntax")
   public static func makeBlankEnumCasePattern(presence: SourcePresence = .present) -> EnumCasePatternSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .enumCasePattern,
-      from: [
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return EnumCasePatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .enumCasePattern,
+        from: [
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.period, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return EnumCasePatternSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on IsTypePatternSyntax")
   public static func makeIsTypePattern(_ unexpectedBeforeIsKeyword: UnexpectedNodesSyntax? = nil, isKeyword: TokenSyntax, _ unexpectedBetweenIsKeywordAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedAfterType: UnexpectedNodesSyntax? = nil) -> IsTypePatternSyntax {
@@ -7580,23 +8610,27 @@ public enum SyntaxFactory {
       type.raw,
       unexpectedAfterType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.isTypePattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return IsTypePatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.isTypePattern,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return IsTypePatternSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on IsTypePatternSyntax")
   public static func makeBlankIsTypePattern(presence: SourcePresence = .present) -> IsTypePatternSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .isTypePattern,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-    ], arena: .default))
-    return IsTypePatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .isTypePattern,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+      ], arena: arena))
+      return IsTypePatternSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on OptionalPatternSyntax")
   public static func makeOptionalPattern(_ unexpectedBeforeSubPattern: UnexpectedNodesSyntax? = nil, subPattern: PatternSyntax, _ unexpectedBetweenSubPatternAndQuestionMark: UnexpectedNodesSyntax? = nil, questionMark: TokenSyntax, _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil) -> OptionalPatternSyntax {
@@ -7607,23 +8641,27 @@ public enum SyntaxFactory {
       questionMark.raw,
       unexpectedAfterQuestionMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalPattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return OptionalPatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalPattern,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return OptionalPatternSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on OptionalPatternSyntax")
   public static func makeBlankOptionalPattern(presence: SourcePresence = .present) -> OptionalPatternSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .optionalPattern,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: .default),
-      nil,
-    ], arena: .default))
-    return OptionalPatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .optionalPattern,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: arena),
+        nil,
+      ], arena: arena))
+      return OptionalPatternSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on IdentifierPatternSyntax")
   public static func makeIdentifierPattern(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedAfterIdentifier: UnexpectedNodesSyntax? = nil) -> IdentifierPatternSyntax {
@@ -7632,21 +8670,25 @@ public enum SyntaxFactory {
       identifier.raw,
       unexpectedAfterIdentifier?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.identifierPattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return IdentifierPatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.identifierPattern,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return IdentifierPatternSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on IdentifierPatternSyntax")
   public static func makeBlankIdentifierPattern(presence: SourcePresence = .present) -> IdentifierPatternSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .identifierPattern,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.selfKeyword, arena: .default),
-      nil,
-    ], arena: .default))
-    return IdentifierPatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .identifierPattern,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.selfKeyword, arena: arena),
+        nil,
+      ], arena: arena))
+      return IdentifierPatternSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AsTypePatternSyntax")
   public static func makeAsTypePattern(_ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndAsKeyword: UnexpectedNodesSyntax? = nil, asKeyword: TokenSyntax, _ unexpectedBetweenAsKeywordAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedAfterType: UnexpectedNodesSyntax? = nil) -> AsTypePatternSyntax {
@@ -7659,25 +8701,29 @@ public enum SyntaxFactory {
       type.raw,
       unexpectedAfterType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.asTypePattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AsTypePatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.asTypePattern,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AsTypePatternSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AsTypePatternSyntax")
   public static func makeBlankAsTypePattern(presence: SourcePresence = .present) -> AsTypePatternSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .asTypePattern,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
-      nil,
-    ], arena: .default))
-    return AsTypePatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .asTypePattern,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+      ], arena: arena))
+      return AsTypePatternSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TuplePatternSyntax")
   public static func makeTuplePattern(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? = nil, elements: TuplePatternElementListSyntax, _ unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> TuplePatternSyntax {
@@ -7690,25 +8736,29 @@ public enum SyntaxFactory {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TuplePatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePattern,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TuplePatternSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TuplePatternSyntax")
   public static func makeBlankTuplePattern(presence: SourcePresence = .present) -> TuplePatternSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tuplePattern,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.tuplePatternElementList, arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
-      nil,
-    ], arena: .default))
-    return TuplePatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tuplePattern,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.tuplePatternElementList, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
+        nil,
+      ], arena: arena))
+      return TuplePatternSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on WildcardPatternSyntax")
   public static func makeWildcardPattern(_ unexpectedBeforeWildcard: UnexpectedNodesSyntax? = nil, wildcard: TokenSyntax, _ unexpectedBetweenWildcardAndTypeAnnotation: UnexpectedNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ unexpectedAfterTypeAnnotation: UnexpectedNodesSyntax? = nil) -> WildcardPatternSyntax {
@@ -7719,23 +8769,27 @@ public enum SyntaxFactory {
       typeAnnotation?.raw,
       unexpectedAfterTypeAnnotation?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.wildcardPattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return WildcardPatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.wildcardPattern,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return WildcardPatternSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on WildcardPatternSyntax")
   public static func makeBlankWildcardPattern(presence: SourcePresence = .present) -> WildcardPatternSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .wildcardPattern,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.wildcardKeyword, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return WildcardPatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .wildcardPattern,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.wildcardKeyword, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return WildcardPatternSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TuplePatternElementSyntax")
   public static func makeTuplePatternElement(_ unexpectedBeforeLabelName: UnexpectedNodesSyntax? = nil, labelName: TokenSyntax?, _ unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? = nil, labelColon: TokenSyntax?, _ unexpectedBetweenLabelColonAndPattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> TuplePatternElementSyntax {
@@ -7750,27 +8804,31 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TuplePatternElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElement,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TuplePatternElementSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TuplePatternElementSyntax")
   public static func makeBlankTuplePatternElement(presence: SourcePresence = .present) -> TuplePatternElementSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tuplePatternElement,
-      from: [
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return TuplePatternElementSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tuplePatternElement,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return TuplePatternElementSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ExpressionPatternSyntax")
   public static func makeExpressionPattern(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> ExpressionPatternSyntax {
@@ -7779,37 +8837,45 @@ public enum SyntaxFactory {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionPattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ExpressionPatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionPattern,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ExpressionPatternSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ExpressionPatternSyntax")
   public static func makeBlankExpressionPattern(presence: SourcePresence = .present) -> ExpressionPatternSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .expressionPattern,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
-      nil,
-    ], arena: .default))
-    return ExpressionPatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .expressionPattern,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return ExpressionPatternSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on TuplePatternElementListSyntax")
   public static func makeTuplePatternElementList(
     _ elements: [TuplePatternElementSyntax]) -> TuplePatternElementListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElementList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return TuplePatternElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElementList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return TuplePatternElementListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on TuplePatternElementListSyntax")
   public static func makeBlankTuplePatternElementList(presence: SourcePresence = .present) -> TuplePatternElementListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tuplePatternElementList,
-      from: [
-    ], arena: .default))
-    return TuplePatternElementListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .tuplePatternElementList,
+        from: [
+      ], arena: arena))
+      return TuplePatternElementListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on ValueBindingPatternSyntax")
   public static func makeValueBindingPattern(_ unexpectedBeforeLetOrVarKeyword: UnexpectedNodesSyntax? = nil, letOrVarKeyword: TokenSyntax, _ unexpectedBetweenLetOrVarKeywordAndValuePattern: UnexpectedNodesSyntax? = nil, valuePattern: PatternSyntax, _ unexpectedAfterValuePattern: UnexpectedNodesSyntax? = nil) -> ValueBindingPatternSyntax {
@@ -7820,39 +8886,47 @@ public enum SyntaxFactory {
       valuePattern.raw,
       unexpectedAfterValuePattern?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.valueBindingPattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return ValueBindingPatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.valueBindingPattern,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ValueBindingPatternSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on ValueBindingPatternSyntax")
   public static func makeBlankValueBindingPattern(presence: SourcePresence = .present) -> ValueBindingPatternSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .valueBindingPattern,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default),
-      nil,
-    ], arena: .default))
-    return ValueBindingPatternSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .valueBindingPattern,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena),
+        nil,
+      ], arena: arena))
+      return ValueBindingPatternSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AvailabilitySpecListSyntax")
   public static func makeAvailabilitySpecList(
     _ elements: [AvailabilityArgumentSyntax]) -> AvailabilitySpecListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilitySpecList,
-      from: elements.map { $0.raw }, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AvailabilitySpecListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilitySpecList,
+        from: elements.map { $0.raw }, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AvailabilitySpecListSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AvailabilitySpecListSyntax")
   public static func makeBlankAvailabilitySpecList(presence: SourcePresence = .present) -> AvailabilitySpecListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .availabilitySpecList,
-      from: [
-    ], arena: .default))
-    return AvailabilitySpecListSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .availabilitySpecList,
+        from: [
+      ], arena: arena))
+      return AvailabilitySpecListSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AvailabilityArgumentSyntax")
   public static func makeAvailabilityArgument(_ unexpectedBeforeEntry: UnexpectedNodesSyntax? = nil, entry: Syntax, _ unexpectedBetweenEntryAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> AvailabilityArgumentSyntax {
@@ -7863,23 +8937,27 @@ public enum SyntaxFactory {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityArgument,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AvailabilityArgumentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityArgument,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AvailabilityArgumentSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AvailabilityArgumentSyntax")
   public static func makeBlankAvailabilityArgument(presence: SourcePresence = .present) -> AvailabilityArgumentSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .availabilityArgument,
-      from: [
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return AvailabilityArgumentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .availabilityArgument,
+        from: [
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return AvailabilityArgumentSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AvailabilityLabeledArgumentSyntax")
   public static func makeAvailabilityLabeledArgument(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil, value: Syntax, _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil) -> AvailabilityLabeledArgumentSyntax {
@@ -7892,25 +8970,29 @@ public enum SyntaxFactory {
       value.raw,
       unexpectedAfterValue?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityLabeledArgument,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AvailabilityLabeledArgumentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityLabeledArgument,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AvailabilityLabeledArgumentSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AvailabilityLabeledArgumentSyntax")
   public static func makeBlankAvailabilityLabeledArgument(presence: SourcePresence = .present) -> AvailabilityLabeledArgumentSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .availabilityLabeledArgument,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
-      nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
-      nil,
-    ], arena: .default))
-    return AvailabilityLabeledArgumentSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .availabilityLabeledArgument,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena),
+        nil,
+      ], arena: arena))
+      return AvailabilityLabeledArgumentSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on AvailabilityVersionRestrictionSyntax")
   public static func makeAvailabilityVersionRestriction(_ unexpectedBeforePlatform: UnexpectedNodesSyntax? = nil, platform: TokenSyntax, _ unexpectedBetweenPlatformAndVersion: UnexpectedNodesSyntax? = nil, version: VersionTupleSyntax?, _ unexpectedAfterVersion: UnexpectedNodesSyntax? = nil) -> AvailabilityVersionRestrictionSyntax {
@@ -7921,23 +9003,27 @@ public enum SyntaxFactory {
       version?.raw,
       unexpectedAfterVersion?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityVersionRestriction,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return AvailabilityVersionRestrictionSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityVersionRestriction,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return AvailabilityVersionRestrictionSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on AvailabilityVersionRestrictionSyntax")
   public static func makeBlankAvailabilityVersionRestriction(presence: SourcePresence = .present) -> AvailabilityVersionRestrictionSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .availabilityVersionRestriction,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return AvailabilityVersionRestrictionSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .availabilityVersionRestriction,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return AvailabilityVersionRestrictionSyntax(data)
+    }
   }
   @available(*, deprecated, message: "Use initializer on VersionTupleSyntax")
   public static func makeVersionTuple(_ unexpectedBeforeMajorMinor: UnexpectedNodesSyntax? = nil, majorMinor: TokenSyntax, _ unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodesSyntax? = nil, patchPeriod: TokenSyntax?, _ unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodesSyntax? = nil, patchVersion: TokenSyntax?, _ unexpectedAfterPatchVersion: UnexpectedNodesSyntax? = nil) -> VersionTupleSyntax {
@@ -7950,25 +9036,29 @@ public enum SyntaxFactory {
       patchVersion?.raw,
       unexpectedAfterPatchVersion?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.versionTuple,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
-    return VersionTupleSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.versionTuple,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return VersionTupleSyntax(data)
+    }
   }
 
   @available(*, deprecated, message: "Use initializer on VersionTupleSyntax")
   public static func makeBlankVersionTuple(presence: SourcePresence = .present) -> VersionTupleSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .versionTuple,
-      from: [
-      nil,
-      RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default),
-      nil,
-      nil,
-      nil,
-      nil,
-      nil,
-    ], arena: .default))
-    return VersionTupleSyntax(data)
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .versionTuple,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return VersionTupleSyntax(data)
+    }
   }
 
 /// MARK: Token Creation APIs

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -6137,9 +6137,10 @@ open class SyntaxRewriter {
       // Sanity check, ensure the new children are the same length.
       assert(newLayout.count == node.raw.layoutView!.children.count)
 
-      let newRaw = node.raw.layoutView!.replacingLayout(with: Array(newLayout), arena: .default)
+      let arena = SyntaxArena()
+      let newRaw = node.raw.layoutView!.replacingLayout(with: Array(newLayout), arena: arena)
       // 'withExtendedLifetime' to keep 'SyntaxArena's of them alive until here.
-      return withExtendedLifetime(rewrittens) {
+      return withExtendedLifetime((arena, rewrittens)) {
         SyntaxType(Syntax(SyntaxData.forRoot(newRaw)))!
       }
     } else {

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -37,9 +37,11 @@ public struct UnknownDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ) {
     let layout: [RawSyntax?] = [
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unknownDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unknownDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -97,9 +99,11 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       modifiers?.raw,
       unexpectedAfterModifiers?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -117,10 +121,10 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> MissingDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> MissingDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return MissingDeclSyntax(newData)
   }
 
@@ -143,23 +147,24 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> MissingDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return MissingDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> MissingDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> MissingDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return MissingDeclSyntax(newData)
   }
 
@@ -177,10 +182,10 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> MissingDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> MissingDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return MissingDeclSyntax(newData)
   }
 
@@ -203,23 +208,24 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> MissingDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return MissingDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> MissingDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> MissingDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return MissingDeclSyntax(newData)
   }
 
@@ -237,10 +243,10 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterModifiers` replaced.
   /// - param newChild: The new `unexpectedAfterModifiers` to replace the node's
   ///                   current `unexpectedAfterModifiers`, if present.
-  public func withUnexpectedAfterModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> MissingDeclSyntax {
+  public func withUnexpectedAfterModifiers(_ newChild: UnexpectedNodesSyntax?) -> MissingDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return MissingDeclSyntax(newData)
   }
 
@@ -338,9 +344,11 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       genericWhereClause?.raw,
       unexpectedAfterGenericWhereClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.typealiasDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.typealiasDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -358,10 +366,10 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -384,23 +392,24 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> TypealiasDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> TypealiasDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> TypealiasDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -418,10 +427,10 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -444,23 +453,24 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> TypealiasDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> TypealiasDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> TypealiasDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -478,10 +488,10 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndTypealiasKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndTypealiasKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndTypealiasKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndTypealiasKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndTypealiasKeyword(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -498,10 +508,10 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typealiasKeyword` replaced.
   /// - param newChild: The new `typealiasKeyword` to replace the node's
   ///                   current `typealiasKeyword`, if present.
-  public func withTypealiasKeyword(
-    _ newChild: TokenSyntax?) -> TypealiasDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.typealiasKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withTypealiasKeyword(_ newChild: TokenSyntax?) -> TypealiasDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.typealiasKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -519,10 +529,10 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTypealiasKeywordAndIdentifier` replaced.
   /// - param newChild: The new `unexpectedBetweenTypealiasKeywordAndIdentifier` to replace the node's
   ///                   current `unexpectedBetweenTypealiasKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenTypealiasKeywordAndIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+  public func withUnexpectedBetweenTypealiasKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -539,10 +549,10 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> TypealiasDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> TypealiasDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -560,10 +570,10 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndGenericParameterClause` replaced.
   /// - param newChild: The new `unexpectedBetweenIdentifierAndGenericParameterClause` to replace the node's
   ///                   current `unexpectedBetweenIdentifierAndGenericParameterClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(
-    _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -581,10 +591,10 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericParameterClause` replaced.
   /// - param newChild: The new `genericParameterClause` to replace the node's
   ///                   current `genericParameterClause`, if present.
-  public func withGenericParameterClause(
-    _ newChild: GenericParameterClauseSyntax?) -> TypealiasDeclSyntax {
+  public func withGenericParameterClause(_ newChild: GenericParameterClauseSyntax?) -> TypealiasDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -602,10 +612,10 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterClauseAndInitializer` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericParameterClauseAndInitializer` to replace the node's
   ///                   current `unexpectedBetweenGenericParameterClauseAndInitializer`, if present.
-  public func withUnexpectedBetweenGenericParameterClauseAndInitializer(
-    _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+  public func withUnexpectedBetweenGenericParameterClauseAndInitializer(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -622,10 +632,10 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `initializer` replaced.
   /// - param newChild: The new `initializer` to replace the node's
   ///                   current `initializer`, if present.
-  public func withInitializer(
-    _ newChild: TypeInitializerClauseSyntax?) -> TypealiasDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.typeInitializerClause, arena: .default)
-    let newData = data.replacingChild(raw, at: 11)
+  public func withInitializer(_ newChild: TypeInitializerClauseSyntax?) -> TypealiasDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.typeInitializerClause, arena: arena)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -643,10 +653,10 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInitializerAndGenericWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenInitializerAndGenericWhereClause` to replace the node's
   ///                   current `unexpectedBetweenInitializerAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInitializerAndGenericWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+  public func withUnexpectedBetweenInitializerAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -664,10 +674,10 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericWhereClause` replaced.
   /// - param newChild: The new `genericWhereClause` to replace the node's
   ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(
-    _ newChild: GenericWhereClauseSyntax?) -> TypealiasDeclSyntax {
+  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> TypealiasDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -685,10 +695,10 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterGenericWhereClause` replaced.
   /// - param newChild: The new `unexpectedAfterGenericWhereClause` to replace the node's
   ///                   current `unexpectedAfterGenericWhereClause`, if present.
-  public func withUnexpectedAfterGenericWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+  public func withUnexpectedAfterGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -826,9 +836,11 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       genericWhereClause?.raw,
       unexpectedAfterGenericWhereClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.associatedtypeDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.associatedtypeDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -846,10 +858,10 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -872,23 +884,24 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> AssociatedtypeDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> AssociatedtypeDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> AssociatedtypeDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -906,10 +919,10 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -932,23 +945,24 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> AssociatedtypeDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> AssociatedtypeDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> AssociatedtypeDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -966,10 +980,10 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndAssociatedtypeKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndAssociatedtypeKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndAssociatedtypeKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndAssociatedtypeKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndAssociatedtypeKeyword(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -986,10 +1000,10 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `associatedtypeKeyword` replaced.
   /// - param newChild: The new `associatedtypeKeyword` to replace the node's
   ///                   current `associatedtypeKeyword`, if present.
-  public func withAssociatedtypeKeyword(
-    _ newChild: TokenSyntax?) -> AssociatedtypeDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.associatedtypeKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withAssociatedtypeKeyword(_ newChild: TokenSyntax?) -> AssociatedtypeDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.associatedtypeKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -1007,10 +1021,10 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAssociatedtypeKeywordAndIdentifier` replaced.
   /// - param newChild: The new `unexpectedBetweenAssociatedtypeKeywordAndIdentifier` to replace the node's
   ///                   current `unexpectedBetweenAssociatedtypeKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenAssociatedtypeKeywordAndIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+  public func withUnexpectedBetweenAssociatedtypeKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -1027,10 +1041,10 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> AssociatedtypeDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> AssociatedtypeDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -1048,10 +1062,10 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndInheritanceClause` replaced.
   /// - param newChild: The new `unexpectedBetweenIdentifierAndInheritanceClause` to replace the node's
   ///                   current `unexpectedBetweenIdentifierAndInheritanceClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndInheritanceClause(
-    _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+  public func withUnexpectedBetweenIdentifierAndInheritanceClause(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -1069,10 +1083,10 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `inheritanceClause` replaced.
   /// - param newChild: The new `inheritanceClause` to replace the node's
   ///                   current `inheritanceClause`, if present.
-  public func withInheritanceClause(
-    _ newChild: TypeInheritanceClauseSyntax?) -> AssociatedtypeDeclSyntax {
+  public func withInheritanceClause(_ newChild: TypeInheritanceClauseSyntax?) -> AssociatedtypeDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -1090,10 +1104,10 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInheritanceClauseAndInitializer` replaced.
   /// - param newChild: The new `unexpectedBetweenInheritanceClauseAndInitializer` to replace the node's
   ///                   current `unexpectedBetweenInheritanceClauseAndInitializer`, if present.
-  public func withUnexpectedBetweenInheritanceClauseAndInitializer(
-    _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+  public func withUnexpectedBetweenInheritanceClauseAndInitializer(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -1111,10 +1125,10 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `initializer` replaced.
   /// - param newChild: The new `initializer` to replace the node's
   ///                   current `initializer`, if present.
-  public func withInitializer(
-    _ newChild: TypeInitializerClauseSyntax?) -> AssociatedtypeDeclSyntax {
+  public func withInitializer(_ newChild: TypeInitializerClauseSyntax?) -> AssociatedtypeDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -1132,10 +1146,10 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInitializerAndGenericWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenInitializerAndGenericWhereClause` to replace the node's
   ///                   current `unexpectedBetweenInitializerAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInitializerAndGenericWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+  public func withUnexpectedBetweenInitializerAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -1153,10 +1167,10 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericWhereClause` replaced.
   /// - param newChild: The new `genericWhereClause` to replace the node's
   ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(
-    _ newChild: GenericWhereClauseSyntax?) -> AssociatedtypeDeclSyntax {
+  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> AssociatedtypeDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -1174,10 +1188,10 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterGenericWhereClause` replaced.
   /// - param newChild: The new `unexpectedAfterGenericWhereClause` to replace the node's
   ///                   current `unexpectedAfterGenericWhereClause`, if present.
-  public func withUnexpectedAfterGenericWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+  public func withUnexpectedAfterGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -1295,9 +1309,11 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       poundEndif.raw,
       unexpectedAfterPoundEndif?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1315,10 +1331,10 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeClauses` replaced.
   /// - param newChild: The new `unexpectedBeforeClauses` to replace the node's
   ///                   current `unexpectedBeforeClauses`, if present.
-  public func withUnexpectedBeforeClauses(
-    _ newChild: UnexpectedNodesSyntax?) -> IfConfigDeclSyntax {
+  public func withUnexpectedBeforeClauses(_ newChild: UnexpectedNodesSyntax?) -> IfConfigDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return IfConfigDeclSyntax(newData)
   }
 
@@ -1340,23 +1356,24 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `clauses` collection.
   public func addClause(_ element: IfConfigClauseSyntax) -> IfConfigDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClauseList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return IfConfigDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `clauses` replaced.
   /// - param newChild: The new `clauses` to replace the node's
   ///                   current `clauses`, if present.
-  public func withClauses(
-    _ newChild: IfConfigClauseListSyntax?) -> IfConfigDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifConfigClauseList, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withClauses(_ newChild: IfConfigClauseListSyntax?) -> IfConfigDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifConfigClauseList, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return IfConfigDeclSyntax(newData)
   }
 
@@ -1374,10 +1391,10 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenClausesAndPoundEndif` replaced.
   /// - param newChild: The new `unexpectedBetweenClausesAndPoundEndif` to replace the node's
   ///                   current `unexpectedBetweenClausesAndPoundEndif`, if present.
-  public func withUnexpectedBetweenClausesAndPoundEndif(
-    _ newChild: UnexpectedNodesSyntax?) -> IfConfigDeclSyntax {
+  public func withUnexpectedBetweenClausesAndPoundEndif(_ newChild: UnexpectedNodesSyntax?) -> IfConfigDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return IfConfigDeclSyntax(newData)
   }
 
@@ -1394,10 +1411,10 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundEndif` replaced.
   /// - param newChild: The new `poundEndif` to replace the node's
   ///                   current `poundEndif`, if present.
-  public func withPoundEndif(
-    _ newChild: TokenSyntax?) -> IfConfigDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundEndifKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withPoundEndif(_ newChild: TokenSyntax?) -> IfConfigDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundEndifKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return IfConfigDeclSyntax(newData)
   }
 
@@ -1415,10 +1432,10 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterPoundEndif` replaced.
   /// - param newChild: The new `unexpectedAfterPoundEndif` to replace the node's
   ///                   current `unexpectedAfterPoundEndif`, if present.
-  public func withUnexpectedAfterPoundEndif(
-    _ newChild: UnexpectedNodesSyntax?) -> IfConfigDeclSyntax {
+  public func withUnexpectedAfterPoundEndif(_ newChild: UnexpectedNodesSyntax?) -> IfConfigDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return IfConfigDeclSyntax(newData)
   }
 
@@ -1504,9 +1521,11 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundErrorDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundErrorDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1524,10 +1543,10 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundError` replaced.
   /// - param newChild: The new `unexpectedBeforePoundError` to replace the node's
   ///                   current `unexpectedBeforePoundError`, if present.
-  public func withUnexpectedBeforePoundError(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
+  public func withUnexpectedBeforePoundError(_ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PoundErrorDeclSyntax(newData)
   }
 
@@ -1544,10 +1563,10 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundError` replaced.
   /// - param newChild: The new `poundError` to replace the node's
   ///                   current `poundError`, if present.
-  public func withPoundError(
-    _ newChild: TokenSyntax?) -> PoundErrorDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundErrorKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundError(_ newChild: TokenSyntax?) -> PoundErrorDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundErrorKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PoundErrorDeclSyntax(newData)
   }
 
@@ -1565,10 +1584,10 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPoundErrorAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenPoundErrorAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenPoundErrorAndLeftParen`, if present.
-  public func withUnexpectedBetweenPoundErrorAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
+  public func withUnexpectedBetweenPoundErrorAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PoundErrorDeclSyntax(newData)
   }
 
@@ -1585,10 +1604,10 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> PoundErrorDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> PoundErrorDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PoundErrorDeclSyntax(newData)
   }
 
@@ -1606,10 +1625,10 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndMessage` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndMessage` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndMessage`, if present.
-  public func withUnexpectedBetweenLeftParenAndMessage(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
+  public func withUnexpectedBetweenLeftParenAndMessage(_ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PoundErrorDeclSyntax(newData)
   }
 
@@ -1626,10 +1645,10 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `message` replaced.
   /// - param newChild: The new `message` to replace the node's
   ///                   current `message`, if present.
-  public func withMessage(
-    _ newChild: StringLiteralExprSyntax?) -> PoundErrorDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withMessage(_ newChild: StringLiteralExprSyntax?) -> PoundErrorDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return PoundErrorDeclSyntax(newData)
   }
 
@@ -1647,10 +1666,10 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenMessageAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenMessageAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenMessageAndRightParen`, if present.
-  public func withUnexpectedBetweenMessageAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
+  public func withUnexpectedBetweenMessageAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return PoundErrorDeclSyntax(newData)
   }
 
@@ -1667,10 +1686,10 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> PoundErrorDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withRightParen(_ newChild: TokenSyntax?) -> PoundErrorDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return PoundErrorDeclSyntax(newData)
   }
 
@@ -1688,10 +1707,10 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return PoundErrorDeclSyntax(newData)
   }
 
@@ -1793,9 +1812,11 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundWarningDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundWarningDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1813,10 +1834,10 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundWarning` replaced.
   /// - param newChild: The new `unexpectedBeforePoundWarning` to replace the node's
   ///                   current `unexpectedBeforePoundWarning`, if present.
-  public func withUnexpectedBeforePoundWarning(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
+  public func withUnexpectedBeforePoundWarning(_ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PoundWarningDeclSyntax(newData)
   }
 
@@ -1833,10 +1854,10 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundWarning` replaced.
   /// - param newChild: The new `poundWarning` to replace the node's
   ///                   current `poundWarning`, if present.
-  public func withPoundWarning(
-    _ newChild: TokenSyntax?) -> PoundWarningDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundWarningKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundWarning(_ newChild: TokenSyntax?) -> PoundWarningDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundWarningKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PoundWarningDeclSyntax(newData)
   }
 
@@ -1854,10 +1875,10 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPoundWarningAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenPoundWarningAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenPoundWarningAndLeftParen`, if present.
-  public func withUnexpectedBetweenPoundWarningAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
+  public func withUnexpectedBetweenPoundWarningAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PoundWarningDeclSyntax(newData)
   }
 
@@ -1874,10 +1895,10 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> PoundWarningDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> PoundWarningDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PoundWarningDeclSyntax(newData)
   }
 
@@ -1895,10 +1916,10 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndMessage` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndMessage` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndMessage`, if present.
-  public func withUnexpectedBetweenLeftParenAndMessage(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
+  public func withUnexpectedBetweenLeftParenAndMessage(_ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PoundWarningDeclSyntax(newData)
   }
 
@@ -1915,10 +1936,10 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `message` replaced.
   /// - param newChild: The new `message` to replace the node's
   ///                   current `message`, if present.
-  public func withMessage(
-    _ newChild: StringLiteralExprSyntax?) -> PoundWarningDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withMessage(_ newChild: StringLiteralExprSyntax?) -> PoundWarningDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return PoundWarningDeclSyntax(newData)
   }
 
@@ -1936,10 +1957,10 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenMessageAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenMessageAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenMessageAndRightParen`, if present.
-  public func withUnexpectedBetweenMessageAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
+  public func withUnexpectedBetweenMessageAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return PoundWarningDeclSyntax(newData)
   }
 
@@ -1956,10 +1977,10 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> PoundWarningDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withRightParen(_ newChild: TokenSyntax?) -> PoundWarningDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return PoundWarningDeclSyntax(newData)
   }
 
@@ -1977,10 +1998,10 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return PoundWarningDeclSyntax(newData)
   }
 
@@ -2082,9 +2103,11 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundSourceLocation,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundSourceLocation,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2102,10 +2125,10 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundSourceLocation` replaced.
   /// - param newChild: The new `unexpectedBeforePoundSourceLocation` to replace the node's
   ///                   current `unexpectedBeforePoundSourceLocation`, if present.
-  public func withUnexpectedBeforePoundSourceLocation(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
+  public func withUnexpectedBeforePoundSourceLocation(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PoundSourceLocationSyntax(newData)
   }
 
@@ -2122,10 +2145,10 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundSourceLocation` replaced.
   /// - param newChild: The new `poundSourceLocation` to replace the node's
   ///                   current `poundSourceLocation`, if present.
-  public func withPoundSourceLocation(
-    _ newChild: TokenSyntax?) -> PoundSourceLocationSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundSourceLocationKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundSourceLocation(_ newChild: TokenSyntax?) -> PoundSourceLocationSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundSourceLocationKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PoundSourceLocationSyntax(newData)
   }
 
@@ -2143,10 +2166,10 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPoundSourceLocationAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenPoundSourceLocationAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenPoundSourceLocationAndLeftParen`, if present.
-  public func withUnexpectedBetweenPoundSourceLocationAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
+  public func withUnexpectedBetweenPoundSourceLocationAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PoundSourceLocationSyntax(newData)
   }
 
@@ -2163,10 +2186,10 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> PoundSourceLocationSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> PoundSourceLocationSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PoundSourceLocationSyntax(newData)
   }
 
@@ -2184,10 +2207,10 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArgs` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndArgs` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndArgs`, if present.
-  public func withUnexpectedBetweenLeftParenAndArgs(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
+  public func withUnexpectedBetweenLeftParenAndArgs(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PoundSourceLocationSyntax(newData)
   }
 
@@ -2205,10 +2228,10 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `args` replaced.
   /// - param newChild: The new `args` to replace the node's
   ///                   current `args`, if present.
-  public func withArgs(
-    _ newChild: PoundSourceLocationArgsSyntax?) -> PoundSourceLocationSyntax {
+  public func withArgs(_ newChild: PoundSourceLocationArgsSyntax?) -> PoundSourceLocationSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return PoundSourceLocationSyntax(newData)
   }
 
@@ -2226,10 +2249,10 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenArgsAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenArgsAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenArgsAndRightParen`, if present.
-  public func withUnexpectedBetweenArgsAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
+  public func withUnexpectedBetweenArgsAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return PoundSourceLocationSyntax(newData)
   }
 
@@ -2246,10 +2269,10 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> PoundSourceLocationSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withRightParen(_ newChild: TokenSyntax?) -> PoundSourceLocationSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return PoundSourceLocationSyntax(newData)
   }
 
@@ -2267,10 +2290,10 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return PoundSourceLocationSyntax(newData)
   }
 
@@ -2388,9 +2411,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       members.raw,
       unexpectedAfterMembers?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.classDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.classDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2408,10 +2433,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2434,23 +2459,24 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> ClassDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> ClassDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2468,10 +2494,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2494,23 +2520,24 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> ClassDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> ClassDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2528,10 +2555,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndClassKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndClassKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndClassKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndClassKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndClassKeyword(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2548,10 +2575,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `classKeyword` replaced.
   /// - param newChild: The new `classKeyword` to replace the node's
   ///                   current `classKeyword`, if present.
-  public func withClassKeyword(
-    _ newChild: TokenSyntax?) -> ClassDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.classKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withClassKeyword(_ newChild: TokenSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.classKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2569,10 +2596,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenClassKeywordAndIdentifier` replaced.
   /// - param newChild: The new `unexpectedBetweenClassKeywordAndIdentifier` to replace the node's
   ///                   current `unexpectedBetweenClassKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenClassKeywordAndIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+  public func withUnexpectedBetweenClassKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2589,10 +2616,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> ClassDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2610,10 +2637,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndGenericParameterClause` replaced.
   /// - param newChild: The new `unexpectedBetweenIdentifierAndGenericParameterClause` to replace the node's
   ///                   current `unexpectedBetweenIdentifierAndGenericParameterClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(
-    _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2631,10 +2658,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericParameterClause` replaced.
   /// - param newChild: The new `genericParameterClause` to replace the node's
   ///                   current `genericParameterClause`, if present.
-  public func withGenericParameterClause(
-    _ newChild: GenericParameterClauseSyntax?) -> ClassDeclSyntax {
+  public func withGenericParameterClause(_ newChild: GenericParameterClauseSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2652,10 +2679,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterClauseAndInheritanceClause` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericParameterClauseAndInheritanceClause` to replace the node's
   ///                   current `unexpectedBetweenGenericParameterClauseAndInheritanceClause`, if present.
-  public func withUnexpectedBetweenGenericParameterClauseAndInheritanceClause(
-    _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+  public func withUnexpectedBetweenGenericParameterClauseAndInheritanceClause(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2673,10 +2700,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `inheritanceClause` replaced.
   /// - param newChild: The new `inheritanceClause` to replace the node's
   ///                   current `inheritanceClause`, if present.
-  public func withInheritanceClause(
-    _ newChild: TypeInheritanceClauseSyntax?) -> ClassDeclSyntax {
+  public func withInheritanceClause(_ newChild: TypeInheritanceClauseSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2694,10 +2721,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInheritanceClauseAndGenericWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenInheritanceClauseAndGenericWhereClause` to replace the node's
   ///                   current `unexpectedBetweenInheritanceClauseAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2715,10 +2742,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericWhereClause` replaced.
   /// - param newChild: The new `genericWhereClause` to replace the node's
   ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(
-    _ newChild: GenericWhereClauseSyntax?) -> ClassDeclSyntax {
+  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2736,10 +2763,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndMembers` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndMembers` to replace the node's
   ///                   current `unexpectedBetweenGenericWhereClauseAndMembers`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndMembers(
-    _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+  public func withUnexpectedBetweenGenericWhereClauseAndMembers(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2756,10 +2783,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `members` replaced.
   /// - param newChild: The new `members` to replace the node's
   ///                   current `members`, if present.
-  public func withMembers(
-    _ newChild: MemberDeclBlockSyntax?) -> ClassDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: 15)
+  public func withMembers(_ newChild: MemberDeclBlockSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena)
+    let newData = data.replacingChild(raw, at: 15, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2777,10 +2804,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
   /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
   ///                   current `unexpectedAfterMembers`, if present.
-  public func withUnexpectedAfterMembers(
-    _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+  public func withUnexpectedAfterMembers(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 16)
+    let newData = data.replacingChild(raw, at: 16, arena: arena)
     return ClassDeclSyntax(newData)
   }
 
@@ -2930,9 +2957,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       members.raw,
       unexpectedAfterMembers?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.actorDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.actorDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2950,10 +2979,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -2976,23 +3005,24 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> ActorDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> ActorDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3010,10 +3040,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3036,23 +3066,24 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> ActorDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> ActorDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3070,10 +3101,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndActorKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndActorKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndActorKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndActorKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndActorKeyword(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3090,10 +3121,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `actorKeyword` replaced.
   /// - param newChild: The new `actorKeyword` to replace the node's
   ///                   current `actorKeyword`, if present.
-  public func withActorKeyword(
-    _ newChild: TokenSyntax?) -> ActorDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withActorKeyword(_ newChild: TokenSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3111,10 +3142,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenActorKeywordAndIdentifier` replaced.
   /// - param newChild: The new `unexpectedBetweenActorKeywordAndIdentifier` to replace the node's
   ///                   current `unexpectedBetweenActorKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenActorKeywordAndIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+  public func withUnexpectedBetweenActorKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3131,10 +3162,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> ActorDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3152,10 +3183,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndGenericParameterClause` replaced.
   /// - param newChild: The new `unexpectedBetweenIdentifierAndGenericParameterClause` to replace the node's
   ///                   current `unexpectedBetweenIdentifierAndGenericParameterClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(
-    _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3173,10 +3204,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericParameterClause` replaced.
   /// - param newChild: The new `genericParameterClause` to replace the node's
   ///                   current `genericParameterClause`, if present.
-  public func withGenericParameterClause(
-    _ newChild: GenericParameterClauseSyntax?) -> ActorDeclSyntax {
+  public func withGenericParameterClause(_ newChild: GenericParameterClauseSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3194,10 +3225,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterClauseAndInheritanceClause` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericParameterClauseAndInheritanceClause` to replace the node's
   ///                   current `unexpectedBetweenGenericParameterClauseAndInheritanceClause`, if present.
-  public func withUnexpectedBetweenGenericParameterClauseAndInheritanceClause(
-    _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+  public func withUnexpectedBetweenGenericParameterClauseAndInheritanceClause(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3215,10 +3246,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `inheritanceClause` replaced.
   /// - param newChild: The new `inheritanceClause` to replace the node's
   ///                   current `inheritanceClause`, if present.
-  public func withInheritanceClause(
-    _ newChild: TypeInheritanceClauseSyntax?) -> ActorDeclSyntax {
+  public func withInheritanceClause(_ newChild: TypeInheritanceClauseSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3236,10 +3267,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInheritanceClauseAndGenericWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenInheritanceClauseAndGenericWhereClause` to replace the node's
   ///                   current `unexpectedBetweenInheritanceClauseAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3257,10 +3288,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericWhereClause` replaced.
   /// - param newChild: The new `genericWhereClause` to replace the node's
   ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(
-    _ newChild: GenericWhereClauseSyntax?) -> ActorDeclSyntax {
+  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3278,10 +3309,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndMembers` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndMembers` to replace the node's
   ///                   current `unexpectedBetweenGenericWhereClauseAndMembers`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndMembers(
-    _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+  public func withUnexpectedBetweenGenericWhereClauseAndMembers(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3298,10 +3329,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `members` replaced.
   /// - param newChild: The new `members` to replace the node's
   ///                   current `members`, if present.
-  public func withMembers(
-    _ newChild: MemberDeclBlockSyntax?) -> ActorDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: 15)
+  public func withMembers(_ newChild: MemberDeclBlockSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena)
+    let newData = data.replacingChild(raw, at: 15, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3319,10 +3350,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
   /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
   ///                   current `unexpectedAfterMembers`, if present.
-  public func withUnexpectedAfterMembers(
-    _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+  public func withUnexpectedAfterMembers(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 16)
+    let newData = data.replacingChild(raw, at: 16, arena: arena)
     return ActorDeclSyntax(newData)
   }
 
@@ -3472,9 +3503,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       members.raw,
       unexpectedAfterMembers?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.structDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.structDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3492,10 +3525,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3518,23 +3551,24 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> StructDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return StructDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> StructDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3552,10 +3586,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3578,23 +3612,24 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> StructDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return StructDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> StructDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3612,10 +3647,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndStructKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndStructKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndStructKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndStructKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndStructKeyword(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3632,10 +3667,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `structKeyword` replaced.
   /// - param newChild: The new `structKeyword` to replace the node's
   ///                   current `structKeyword`, if present.
-  public func withStructKeyword(
-    _ newChild: TokenSyntax?) -> StructDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.structKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withStructKeyword(_ newChild: TokenSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.structKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3653,10 +3688,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenStructKeywordAndIdentifier` replaced.
   /// - param newChild: The new `unexpectedBetweenStructKeywordAndIdentifier` to replace the node's
   ///                   current `unexpectedBetweenStructKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenStructKeywordAndIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+  public func withUnexpectedBetweenStructKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3673,10 +3708,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> StructDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3694,10 +3729,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndGenericParameterClause` replaced.
   /// - param newChild: The new `unexpectedBetweenIdentifierAndGenericParameterClause` to replace the node's
   ///                   current `unexpectedBetweenIdentifierAndGenericParameterClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(
-    _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3715,10 +3750,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericParameterClause` replaced.
   /// - param newChild: The new `genericParameterClause` to replace the node's
   ///                   current `genericParameterClause`, if present.
-  public func withGenericParameterClause(
-    _ newChild: GenericParameterClauseSyntax?) -> StructDeclSyntax {
+  public func withGenericParameterClause(_ newChild: GenericParameterClauseSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3736,10 +3771,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterClauseAndInheritanceClause` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericParameterClauseAndInheritanceClause` to replace the node's
   ///                   current `unexpectedBetweenGenericParameterClauseAndInheritanceClause`, if present.
-  public func withUnexpectedBetweenGenericParameterClauseAndInheritanceClause(
-    _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+  public func withUnexpectedBetweenGenericParameterClauseAndInheritanceClause(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3757,10 +3792,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `inheritanceClause` replaced.
   /// - param newChild: The new `inheritanceClause` to replace the node's
   ///                   current `inheritanceClause`, if present.
-  public func withInheritanceClause(
-    _ newChild: TypeInheritanceClauseSyntax?) -> StructDeclSyntax {
+  public func withInheritanceClause(_ newChild: TypeInheritanceClauseSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3778,10 +3813,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInheritanceClauseAndGenericWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenInheritanceClauseAndGenericWhereClause` to replace the node's
   ///                   current `unexpectedBetweenInheritanceClauseAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3799,10 +3834,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericWhereClause` replaced.
   /// - param newChild: The new `genericWhereClause` to replace the node's
   ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(
-    _ newChild: GenericWhereClauseSyntax?) -> StructDeclSyntax {
+  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3820,10 +3855,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndMembers` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndMembers` to replace the node's
   ///                   current `unexpectedBetweenGenericWhereClauseAndMembers`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndMembers(
-    _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+  public func withUnexpectedBetweenGenericWhereClauseAndMembers(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3840,10 +3875,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `members` replaced.
   /// - param newChild: The new `members` to replace the node's
   ///                   current `members`, if present.
-  public func withMembers(
-    _ newChild: MemberDeclBlockSyntax?) -> StructDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: 15)
+  public func withMembers(_ newChild: MemberDeclBlockSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena)
+    let newData = data.replacingChild(raw, at: 15, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -3861,10 +3896,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
   /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
   ///                   current `unexpectedAfterMembers`, if present.
-  public func withUnexpectedAfterMembers(
-    _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+  public func withUnexpectedAfterMembers(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 16)
+    let newData = data.replacingChild(raw, at: 16, arena: arena)
     return StructDeclSyntax(newData)
   }
 
@@ -4014,9 +4049,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       members.raw,
       unexpectedAfterMembers?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.protocolDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.protocolDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4034,10 +4071,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4060,23 +4097,24 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> ProtocolDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> ProtocolDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4094,10 +4132,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4120,23 +4158,24 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> ProtocolDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> ProtocolDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4154,10 +4193,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndProtocolKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndProtocolKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndProtocolKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndProtocolKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndProtocolKeyword(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4174,10 +4213,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `protocolKeyword` replaced.
   /// - param newChild: The new `protocolKeyword` to replace the node's
   ///                   current `protocolKeyword`, if present.
-  public func withProtocolKeyword(
-    _ newChild: TokenSyntax?) -> ProtocolDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.protocolKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withProtocolKeyword(_ newChild: TokenSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.protocolKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4195,10 +4234,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenProtocolKeywordAndIdentifier` replaced.
   /// - param newChild: The new `unexpectedBetweenProtocolKeywordAndIdentifier` to replace the node's
   ///                   current `unexpectedBetweenProtocolKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenProtocolKeywordAndIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+  public func withUnexpectedBetweenProtocolKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4215,10 +4254,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> ProtocolDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4236,10 +4275,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause` replaced.
   /// - param newChild: The new `unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause` to replace the node's
   ///                   current `unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause(
-    _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+  public func withUnexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4257,10 +4296,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `primaryAssociatedTypeClause` replaced.
   /// - param newChild: The new `primaryAssociatedTypeClause` to replace the node's
   ///                   current `primaryAssociatedTypeClause`, if present.
-  public func withPrimaryAssociatedTypeClause(
-    _ newChild: PrimaryAssociatedTypeClauseSyntax?) -> ProtocolDeclSyntax {
+  public func withPrimaryAssociatedTypeClause(_ newChild: PrimaryAssociatedTypeClauseSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4278,10 +4317,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause` replaced.
   /// - param newChild: The new `unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause` to replace the node's
   ///                   current `unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause`, if present.
-  public func withUnexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause(
-    _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+  public func withUnexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4299,10 +4338,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `inheritanceClause` replaced.
   /// - param newChild: The new `inheritanceClause` to replace the node's
   ///                   current `inheritanceClause`, if present.
-  public func withInheritanceClause(
-    _ newChild: TypeInheritanceClauseSyntax?) -> ProtocolDeclSyntax {
+  public func withInheritanceClause(_ newChild: TypeInheritanceClauseSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4320,10 +4359,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInheritanceClauseAndGenericWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenInheritanceClauseAndGenericWhereClause` to replace the node's
   ///                   current `unexpectedBetweenInheritanceClauseAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4341,10 +4380,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericWhereClause` replaced.
   /// - param newChild: The new `genericWhereClause` to replace the node's
   ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(
-    _ newChild: GenericWhereClauseSyntax?) -> ProtocolDeclSyntax {
+  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4362,10 +4401,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndMembers` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndMembers` to replace the node's
   ///                   current `unexpectedBetweenGenericWhereClauseAndMembers`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndMembers(
-    _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+  public func withUnexpectedBetweenGenericWhereClauseAndMembers(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4382,10 +4421,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `members` replaced.
   /// - param newChild: The new `members` to replace the node's
   ///                   current `members`, if present.
-  public func withMembers(
-    _ newChild: MemberDeclBlockSyntax?) -> ProtocolDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: 15)
+  public func withMembers(_ newChild: MemberDeclBlockSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena)
+    let newData = data.replacingChild(raw, at: 15, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4403,10 +4442,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
   /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
   ///                   current `unexpectedAfterMembers`, if present.
-  public func withUnexpectedAfterMembers(
-    _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+  public func withUnexpectedAfterMembers(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 16)
+    let newData = data.replacingChild(raw, at: 16, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -4552,9 +4591,11 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       members.raw,
       unexpectedAfterMembers?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.extensionDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.extensionDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4572,10 +4613,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4598,23 +4639,24 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> ExtensionDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> ExtensionDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> ExtensionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4632,10 +4674,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4658,23 +4700,24 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> ExtensionDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> ExtensionDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> ExtensionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4692,10 +4735,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndExtensionKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndExtensionKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndExtensionKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndExtensionKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndExtensionKeyword(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4712,10 +4755,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `extensionKeyword` replaced.
   /// - param newChild: The new `extensionKeyword` to replace the node's
   ///                   current `extensionKeyword`, if present.
-  public func withExtensionKeyword(
-    _ newChild: TokenSyntax?) -> ExtensionDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.extensionKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withExtensionKeyword(_ newChild: TokenSyntax?) -> ExtensionDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.extensionKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4733,10 +4776,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenExtensionKeywordAndExtendedType` replaced.
   /// - param newChild: The new `unexpectedBetweenExtensionKeywordAndExtendedType` to replace the node's
   ///                   current `unexpectedBetweenExtensionKeywordAndExtendedType`, if present.
-  public func withUnexpectedBetweenExtensionKeywordAndExtendedType(
-    _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+  public func withUnexpectedBetweenExtensionKeywordAndExtendedType(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4753,10 +4796,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `extendedType` replaced.
   /// - param newChild: The new `extendedType` to replace the node's
   ///                   current `extendedType`, if present.
-  public func withExtendedType(
-    _ newChild: TypeSyntax?) -> ExtensionDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withExtendedType(_ newChild: TypeSyntax?) -> ExtensionDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4774,10 +4817,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenExtendedTypeAndInheritanceClause` replaced.
   /// - param newChild: The new `unexpectedBetweenExtendedTypeAndInheritanceClause` to replace the node's
   ///                   current `unexpectedBetweenExtendedTypeAndInheritanceClause`, if present.
-  public func withUnexpectedBetweenExtendedTypeAndInheritanceClause(
-    _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+  public func withUnexpectedBetweenExtendedTypeAndInheritanceClause(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4795,10 +4838,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `inheritanceClause` replaced.
   /// - param newChild: The new `inheritanceClause` to replace the node's
   ///                   current `inheritanceClause`, if present.
-  public func withInheritanceClause(
-    _ newChild: TypeInheritanceClauseSyntax?) -> ExtensionDeclSyntax {
+  public func withInheritanceClause(_ newChild: TypeInheritanceClauseSyntax?) -> ExtensionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4816,10 +4859,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInheritanceClauseAndGenericWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenInheritanceClauseAndGenericWhereClause` to replace the node's
   ///                   current `unexpectedBetweenInheritanceClauseAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4837,10 +4880,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericWhereClause` replaced.
   /// - param newChild: The new `genericWhereClause` to replace the node's
   ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(
-    _ newChild: GenericWhereClauseSyntax?) -> ExtensionDeclSyntax {
+  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> ExtensionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4858,10 +4901,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndMembers` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndMembers` to replace the node's
   ///                   current `unexpectedBetweenGenericWhereClauseAndMembers`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndMembers(
-    _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+  public func withUnexpectedBetweenGenericWhereClauseAndMembers(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4878,10 +4921,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `members` replaced.
   /// - param newChild: The new `members` to replace the node's
   ///                   current `members`, if present.
-  public func withMembers(
-    _ newChild: MemberDeclBlockSyntax?) -> ExtensionDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: 13)
+  public func withMembers(_ newChild: MemberDeclBlockSyntax?) -> ExtensionDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4899,10 +4942,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
   /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
   ///                   current `unexpectedAfterMembers`, if present.
-  public func withUnexpectedAfterMembers(
-    _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+  public func withUnexpectedAfterMembers(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -5044,9 +5087,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       body?.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -5064,10 +5109,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5090,23 +5135,24 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> FunctionDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> FunctionDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5124,10 +5170,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5150,23 +5196,24 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> FunctionDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> FunctionDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5184,10 +5231,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndFuncKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndFuncKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndFuncKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndFuncKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndFuncKeyword(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5204,10 +5251,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `funcKeyword` replaced.
   /// - param newChild: The new `funcKeyword` to replace the node's
   ///                   current `funcKeyword`, if present.
-  public func withFuncKeyword(
-    _ newChild: TokenSyntax?) -> FunctionDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.funcKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withFuncKeyword(_ newChild: TokenSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.funcKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5225,10 +5272,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenFuncKeywordAndIdentifier` replaced.
   /// - param newChild: The new `unexpectedBetweenFuncKeywordAndIdentifier` to replace the node's
   ///                   current `unexpectedBetweenFuncKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenFuncKeywordAndIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+  public func withUnexpectedBetweenFuncKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5245,10 +5292,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> FunctionDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5266,10 +5313,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndGenericParameterClause` replaced.
   /// - param newChild: The new `unexpectedBetweenIdentifierAndGenericParameterClause` to replace the node's
   ///                   current `unexpectedBetweenIdentifierAndGenericParameterClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5287,10 +5334,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericParameterClause` replaced.
   /// - param newChild: The new `genericParameterClause` to replace the node's
   ///                   current `genericParameterClause`, if present.
-  public func withGenericParameterClause(
-    _ newChild: GenericParameterClauseSyntax?) -> FunctionDeclSyntax {
+  public func withGenericParameterClause(_ newChild: GenericParameterClauseSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5308,10 +5355,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterClauseAndSignature` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericParameterClauseAndSignature` to replace the node's
   ///                   current `unexpectedBetweenGenericParameterClauseAndSignature`, if present.
-  public func withUnexpectedBetweenGenericParameterClauseAndSignature(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+  public func withUnexpectedBetweenGenericParameterClauseAndSignature(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5328,10 +5375,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `signature` replaced.
   /// - param newChild: The new `signature` to replace the node's
   ///                   current `signature`, if present.
-  public func withSignature(
-    _ newChild: FunctionSignatureSyntax?) -> FunctionDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionSignature, arena: .default)
-    let newData = data.replacingChild(raw, at: 11)
+  public func withSignature(_ newChild: FunctionSignatureSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionSignature, arena: arena)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5349,10 +5396,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenSignatureAndGenericWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenSignatureAndGenericWhereClause` to replace the node's
   ///                   current `unexpectedBetweenSignatureAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenSignatureAndGenericWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+  public func withUnexpectedBetweenSignatureAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5370,10 +5417,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericWhereClause` replaced.
   /// - param newChild: The new `genericWhereClause` to replace the node's
   ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(
-    _ newChild: GenericWhereClauseSyntax?) -> FunctionDeclSyntax {
+  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5391,10 +5438,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndBody` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndBody` to replace the node's
   ///                   current `unexpectedBetweenGenericWhereClauseAndBody`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndBody(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+  public func withUnexpectedBetweenGenericWhereClauseAndBody(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5412,10 +5459,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(
-    _ newChild: CodeBlockSyntax?) -> FunctionDeclSyntax {
+  public func withBody(_ newChild: CodeBlockSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 15)
+    let newData = data.replacingChild(raw, at: 15, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5433,10 +5480,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
   /// - param newChild: The new `unexpectedAfterBody` to replace the node's
   ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 16)
+    let newData = data.replacingChild(raw, at: 16, arena: arena)
     return FunctionDeclSyntax(newData)
   }
 
@@ -5586,9 +5633,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       body?.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.initializerDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.initializerDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -5606,10 +5655,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5632,23 +5681,24 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> InitializerDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> InitializerDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5666,10 +5716,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5692,23 +5742,24 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> InitializerDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> InitializerDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5726,10 +5777,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndInitKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndInitKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndInitKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndInitKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndInitKeyword(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5746,10 +5797,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `initKeyword` replaced.
   /// - param newChild: The new `initKeyword` to replace the node's
   ///                   current `initKeyword`, if present.
-  public func withInitKeyword(
-    _ newChild: TokenSyntax?) -> InitializerDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.initKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withInitKeyword(_ newChild: TokenSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.initKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5767,10 +5818,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInitKeywordAndOptionalMark` replaced.
   /// - param newChild: The new `unexpectedBetweenInitKeywordAndOptionalMark` to replace the node's
   ///                   current `unexpectedBetweenInitKeywordAndOptionalMark`, if present.
-  public func withUnexpectedBetweenInitKeywordAndOptionalMark(
-    _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+  public func withUnexpectedBetweenInitKeywordAndOptionalMark(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5788,10 +5839,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `optionalMark` replaced.
   /// - param newChild: The new `optionalMark` to replace the node's
   ///                   current `optionalMark`, if present.
-  public func withOptionalMark(
-    _ newChild: TokenSyntax?) -> InitializerDeclSyntax {
+  public func withOptionalMark(_ newChild: TokenSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5809,10 +5860,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenOptionalMarkAndGenericParameterClause` replaced.
   /// - param newChild: The new `unexpectedBetweenOptionalMarkAndGenericParameterClause` to replace the node's
   ///                   current `unexpectedBetweenOptionalMarkAndGenericParameterClause`, if present.
-  public func withUnexpectedBetweenOptionalMarkAndGenericParameterClause(
-    _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+  public func withUnexpectedBetweenOptionalMarkAndGenericParameterClause(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5830,10 +5881,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericParameterClause` replaced.
   /// - param newChild: The new `genericParameterClause` to replace the node's
   ///                   current `genericParameterClause`, if present.
-  public func withGenericParameterClause(
-    _ newChild: GenericParameterClauseSyntax?) -> InitializerDeclSyntax {
+  public func withGenericParameterClause(_ newChild: GenericParameterClauseSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5851,10 +5902,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterClauseAndSignature` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericParameterClauseAndSignature` to replace the node's
   ///                   current `unexpectedBetweenGenericParameterClauseAndSignature`, if present.
-  public func withUnexpectedBetweenGenericParameterClauseAndSignature(
-    _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+  public func withUnexpectedBetweenGenericParameterClauseAndSignature(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5871,10 +5922,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `signature` replaced.
   /// - param newChild: The new `signature` to replace the node's
   ///                   current `signature`, if present.
-  public func withSignature(
-    _ newChild: FunctionSignatureSyntax?) -> InitializerDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionSignature, arena: .default)
-    let newData = data.replacingChild(raw, at: 11)
+  public func withSignature(_ newChild: FunctionSignatureSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionSignature, arena: arena)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5892,10 +5943,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenSignatureAndGenericWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenSignatureAndGenericWhereClause` to replace the node's
   ///                   current `unexpectedBetweenSignatureAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenSignatureAndGenericWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+  public func withUnexpectedBetweenSignatureAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5913,10 +5964,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericWhereClause` replaced.
   /// - param newChild: The new `genericWhereClause` to replace the node's
   ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(
-    _ newChild: GenericWhereClauseSyntax?) -> InitializerDeclSyntax {
+  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5934,10 +5985,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndBody` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndBody` to replace the node's
   ///                   current `unexpectedBetweenGenericWhereClauseAndBody`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndBody(
-    _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+  public func withUnexpectedBetweenGenericWhereClauseAndBody(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5955,10 +6006,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(
-    _ newChild: CodeBlockSyntax?) -> InitializerDeclSyntax {
+  public func withBody(_ newChild: CodeBlockSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 15)
+    let newData = data.replacingChild(raw, at: 15, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5976,10 +6027,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
   /// - param newChild: The new `unexpectedAfterBody` to replace the node's
   ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(
-    _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 16)
+    let newData = data.replacingChild(raw, at: 16, arena: arena)
     return InitializerDeclSyntax(newData)
   }
 
@@ -6113,9 +6164,11 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       body?.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.deinitializerDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.deinitializerDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -6133,10 +6186,10 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DeinitializerDeclSyntax(newData)
   }
 
@@ -6159,23 +6212,24 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> DeinitializerDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return DeinitializerDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> DeinitializerDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> DeinitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DeinitializerDeclSyntax(newData)
   }
 
@@ -6193,10 +6247,10 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DeinitializerDeclSyntax(newData)
   }
 
@@ -6219,23 +6273,24 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> DeinitializerDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return DeinitializerDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> DeinitializerDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> DeinitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DeinitializerDeclSyntax(newData)
   }
 
@@ -6253,10 +6308,10 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndDeinitKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndDeinitKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndDeinitKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndDeinitKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndDeinitKeyword(_ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DeinitializerDeclSyntax(newData)
   }
 
@@ -6273,10 +6328,10 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `deinitKeyword` replaced.
   /// - param newChild: The new `deinitKeyword` to replace the node's
   ///                   current `deinitKeyword`, if present.
-  public func withDeinitKeyword(
-    _ newChild: TokenSyntax?) -> DeinitializerDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.deinitKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withDeinitKeyword(_ newChild: TokenSyntax?) -> DeinitializerDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.deinitKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return DeinitializerDeclSyntax(newData)
   }
 
@@ -6294,10 +6349,10 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenDeinitKeywordAndBody` replaced.
   /// - param newChild: The new `unexpectedBetweenDeinitKeywordAndBody` to replace the node's
   ///                   current `unexpectedBetweenDeinitKeywordAndBody`, if present.
-  public func withUnexpectedBetweenDeinitKeywordAndBody(
-    _ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
+  public func withUnexpectedBetweenDeinitKeywordAndBody(_ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return DeinitializerDeclSyntax(newData)
   }
 
@@ -6315,10 +6370,10 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(
-    _ newChild: CodeBlockSyntax?) -> DeinitializerDeclSyntax {
+  public func withBody(_ newChild: CodeBlockSyntax?) -> DeinitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return DeinitializerDeclSyntax(newData)
   }
 
@@ -6336,10 +6391,10 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
   /// - param newChild: The new `unexpectedAfterBody` to replace the node's
   ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(
-    _ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
+  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return DeinitializerDeclSyntax(newData)
   }
 
@@ -6493,9 +6548,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       accessor?.raw,
       unexpectedAfterAccessor?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.subscriptDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.subscriptDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -6513,10 +6570,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6539,23 +6596,24 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> SubscriptDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> SubscriptDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6573,10 +6631,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6599,23 +6657,24 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> SubscriptDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> SubscriptDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6633,10 +6692,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndSubscriptKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndSubscriptKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndSubscriptKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndSubscriptKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndSubscriptKeyword(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6653,10 +6712,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `subscriptKeyword` replaced.
   /// - param newChild: The new `subscriptKeyword` to replace the node's
   ///                   current `subscriptKeyword`, if present.
-  public func withSubscriptKeyword(
-    _ newChild: TokenSyntax?) -> SubscriptDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.subscriptKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withSubscriptKeyword(_ newChild: TokenSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.subscriptKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6674,10 +6733,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenSubscriptKeywordAndGenericParameterClause` replaced.
   /// - param newChild: The new `unexpectedBetweenSubscriptKeywordAndGenericParameterClause` to replace the node's
   ///                   current `unexpectedBetweenSubscriptKeywordAndGenericParameterClause`, if present.
-  public func withUnexpectedBetweenSubscriptKeywordAndGenericParameterClause(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+  public func withUnexpectedBetweenSubscriptKeywordAndGenericParameterClause(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6695,10 +6754,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericParameterClause` replaced.
   /// - param newChild: The new `genericParameterClause` to replace the node's
   ///                   current `genericParameterClause`, if present.
-  public func withGenericParameterClause(
-    _ newChild: GenericParameterClauseSyntax?) -> SubscriptDeclSyntax {
+  public func withGenericParameterClause(_ newChild: GenericParameterClauseSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6716,10 +6775,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterClauseAndIndices` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericParameterClauseAndIndices` to replace the node's
   ///                   current `unexpectedBetweenGenericParameterClauseAndIndices`, if present.
-  public func withUnexpectedBetweenGenericParameterClauseAndIndices(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+  public func withUnexpectedBetweenGenericParameterClauseAndIndices(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6736,10 +6795,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `indices` replaced.
   /// - param newChild: The new `indices` to replace the node's
   ///                   current `indices`, if present.
-  public func withIndices(
-    _ newChild: ParameterClauseSyntax?) -> SubscriptDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.parameterClause, arena: .default)
-    let newData = data.replacingChild(raw, at: 9)
+  public func withIndices(_ newChild: ParameterClauseSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.parameterClause, arena: arena)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6757,10 +6816,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIndicesAndResult` replaced.
   /// - param newChild: The new `unexpectedBetweenIndicesAndResult` to replace the node's
   ///                   current `unexpectedBetweenIndicesAndResult`, if present.
-  public func withUnexpectedBetweenIndicesAndResult(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+  public func withUnexpectedBetweenIndicesAndResult(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6777,10 +6836,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `result` replaced.
   /// - param newChild: The new `result` to replace the node's
   ///                   current `result`, if present.
-  public func withResult(
-    _ newChild: ReturnClauseSyntax?) -> SubscriptDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.returnClause, arena: .default)
-    let newData = data.replacingChild(raw, at: 11)
+  public func withResult(_ newChild: ReturnClauseSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.returnClause, arena: arena)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6798,10 +6857,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenResultAndGenericWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenResultAndGenericWhereClause` to replace the node's
   ///                   current `unexpectedBetweenResultAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenResultAndGenericWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+  public func withUnexpectedBetweenResultAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6819,10 +6878,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericWhereClause` replaced.
   /// - param newChild: The new `genericWhereClause` to replace the node's
   ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(
-    _ newChild: GenericWhereClauseSyntax?) -> SubscriptDeclSyntax {
+  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6840,10 +6899,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndAccessor` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndAccessor` to replace the node's
   ///                   current `unexpectedBetweenGenericWhereClauseAndAccessor`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndAccessor(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+  public func withUnexpectedBetweenGenericWhereClauseAndAccessor(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6861,10 +6920,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `accessor` replaced.
   /// - param newChild: The new `accessor` to replace the node's
   ///                   current `accessor`, if present.
-  public func withAccessor(
-    _ newChild: Accessor?) -> SubscriptDeclSyntax {
+  public func withAccessor(_ newChild: Accessor?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 15)
+    let newData = data.replacingChild(raw, at: 15, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -6882,10 +6941,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterAccessor` replaced.
   /// - param newChild: The new `unexpectedAfterAccessor` to replace the node's
   ///                   current `unexpectedAfterAccessor`, if present.
-  public func withUnexpectedAfterAccessor(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+  public func withUnexpectedAfterAccessor(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 16)
+    let newData = data.replacingChild(raw, at: 16, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -7023,9 +7082,11 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       path.raw,
       unexpectedAfterPath?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.importDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.importDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -7043,10 +7104,10 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ImportDeclSyntax(newData)
   }
 
@@ -7069,23 +7130,24 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> ImportDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return ImportDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> ImportDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> ImportDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ImportDeclSyntax(newData)
   }
 
@@ -7103,10 +7165,10 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ImportDeclSyntax(newData)
   }
 
@@ -7129,23 +7191,24 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> ImportDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return ImportDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> ImportDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> ImportDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ImportDeclSyntax(newData)
   }
 
@@ -7163,10 +7226,10 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndImportTok` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndImportTok` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndImportTok`, if present.
-  public func withUnexpectedBetweenModifiersAndImportTok(
-    _ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndImportTok(_ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ImportDeclSyntax(newData)
   }
 
@@ -7183,10 +7246,10 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `importTok` replaced.
   /// - param newChild: The new `importTok` to replace the node's
   ///                   current `importTok`, if present.
-  public func withImportTok(
-    _ newChild: TokenSyntax?) -> ImportDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.importKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withImportTok(_ newChild: TokenSyntax?) -> ImportDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.importKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ImportDeclSyntax(newData)
   }
 
@@ -7204,10 +7267,10 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenImportTokAndImportKind` replaced.
   /// - param newChild: The new `unexpectedBetweenImportTokAndImportKind` to replace the node's
   ///                   current `unexpectedBetweenImportTokAndImportKind`, if present.
-  public func withUnexpectedBetweenImportTokAndImportKind(
-    _ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
+  public func withUnexpectedBetweenImportTokAndImportKind(_ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ImportDeclSyntax(newData)
   }
 
@@ -7225,10 +7288,10 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `importKind` replaced.
   /// - param newChild: The new `importKind` to replace the node's
   ///                   current `importKind`, if present.
-  public func withImportKind(
-    _ newChild: TokenSyntax?) -> ImportDeclSyntax {
+  public func withImportKind(_ newChild: TokenSyntax?) -> ImportDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return ImportDeclSyntax(newData)
   }
 
@@ -7246,10 +7309,10 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenImportKindAndPath` replaced.
   /// - param newChild: The new `unexpectedBetweenImportKindAndPath` to replace the node's
   ///                   current `unexpectedBetweenImportKindAndPath`, if present.
-  public func withUnexpectedBetweenImportKindAndPath(
-    _ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
+  public func withUnexpectedBetweenImportKindAndPath(_ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return ImportDeclSyntax(newData)
   }
 
@@ -7271,23 +7334,24 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `path` collection.
   public func addPathComponent(_ element: AccessPathComponentSyntax) -> ImportDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[9] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.accessPath,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 9)
+    let newData = data.replacingChild(collection, at: 9, arena: arena)
     return ImportDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `path` replaced.
   /// - param newChild: The new `path` to replace the node's
   ///                   current `path`, if present.
-  public func withPath(
-    _ newChild: AccessPathSyntax?) -> ImportDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.accessPath, arena: .default)
-    let newData = data.replacingChild(raw, at: 9)
+  public func withPath(_ newChild: AccessPathSyntax?) -> ImportDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.accessPath, arena: arena)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return ImportDeclSyntax(newData)
   }
 
@@ -7305,10 +7369,10 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterPath` replaced.
   /// - param newChild: The new `unexpectedAfterPath` to replace the node's
   ///                   current `unexpectedAfterPath`, if present.
-  public func withUnexpectedAfterPath(
-    _ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
+  public func withUnexpectedAfterPath(_ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return ImportDeclSyntax(newData)
   }
 
@@ -7430,9 +7494,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       body?.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -7450,10 +7516,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
@@ -7476,23 +7542,24 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> AccessorDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> AccessorDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> AccessorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
@@ -7510,10 +7577,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifier` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifier` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifier`, if present.
-  public func withUnexpectedBetweenAttributesAndModifier(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifier(_ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
@@ -7531,10 +7598,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `modifier` replaced.
   /// - param newChild: The new `modifier` to replace the node's
   ///                   current `modifier`, if present.
-  public func withModifier(
-    _ newChild: DeclModifierSyntax?) -> AccessorDeclSyntax {
+  public func withModifier(_ newChild: DeclModifierSyntax?) -> AccessorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
@@ -7552,10 +7619,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifierAndAccessorKind` replaced.
   /// - param newChild: The new `unexpectedBetweenModifierAndAccessorKind` to replace the node's
   ///                   current `unexpectedBetweenModifierAndAccessorKind`, if present.
-  public func withUnexpectedBetweenModifierAndAccessorKind(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+  public func withUnexpectedBetweenModifierAndAccessorKind(_ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
@@ -7572,10 +7639,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `accessorKind` replaced.
   /// - param newChild: The new `accessorKind` to replace the node's
   ///                   current `accessorKind`, if present.
-  public func withAccessorKind(
-    _ newChild: TokenSyntax?) -> AccessorDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withAccessorKind(_ newChild: TokenSyntax?) -> AccessorDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
@@ -7593,10 +7660,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAccessorKindAndParameter` replaced.
   /// - param newChild: The new `unexpectedBetweenAccessorKindAndParameter` to replace the node's
   ///                   current `unexpectedBetweenAccessorKindAndParameter`, if present.
-  public func withUnexpectedBetweenAccessorKindAndParameter(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+  public func withUnexpectedBetweenAccessorKindAndParameter(_ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
@@ -7614,10 +7681,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `parameter` replaced.
   /// - param newChild: The new `parameter` to replace the node's
   ///                   current `parameter`, if present.
-  public func withParameter(
-    _ newChild: AccessorParameterSyntax?) -> AccessorDeclSyntax {
+  public func withParameter(_ newChild: AccessorParameterSyntax?) -> AccessorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
@@ -7635,10 +7702,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenParameterAndAsyncKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenParameterAndAsyncKeyword` to replace the node's
   ///                   current `unexpectedBetweenParameterAndAsyncKeyword`, if present.
-  public func withUnexpectedBetweenParameterAndAsyncKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+  public func withUnexpectedBetweenParameterAndAsyncKeyword(_ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
@@ -7656,10 +7723,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `asyncKeyword` replaced.
   /// - param newChild: The new `asyncKeyword` to replace the node's
   ///                   current `asyncKeyword`, if present.
-  public func withAsyncKeyword(
-    _ newChild: TokenSyntax?) -> AccessorDeclSyntax {
+  public func withAsyncKeyword(_ newChild: TokenSyntax?) -> AccessorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
@@ -7677,10 +7744,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAsyncKeywordAndThrowsKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenAsyncKeywordAndThrowsKeyword` to replace the node's
   ///                   current `unexpectedBetweenAsyncKeywordAndThrowsKeyword`, if present.
-  public func withUnexpectedBetweenAsyncKeywordAndThrowsKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+  public func withUnexpectedBetweenAsyncKeywordAndThrowsKeyword(_ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
@@ -7698,10 +7765,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `throwsKeyword` replaced.
   /// - param newChild: The new `throwsKeyword` to replace the node's
   ///                   current `throwsKeyword`, if present.
-  public func withThrowsKeyword(
-    _ newChild: TokenSyntax?) -> AccessorDeclSyntax {
+  public func withThrowsKeyword(_ newChild: TokenSyntax?) -> AccessorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
@@ -7719,10 +7786,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenThrowsKeywordAndBody` replaced.
   /// - param newChild: The new `unexpectedBetweenThrowsKeywordAndBody` to replace the node's
   ///                   current `unexpectedBetweenThrowsKeywordAndBody`, if present.
-  public func withUnexpectedBetweenThrowsKeywordAndBody(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+  public func withUnexpectedBetweenThrowsKeywordAndBody(_ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
@@ -7740,10 +7807,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(
-    _ newChild: CodeBlockSyntax?) -> AccessorDeclSyntax {
+  public func withBody(_ newChild: CodeBlockSyntax?) -> AccessorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
@@ -7761,10 +7828,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
   /// - param newChild: The new `unexpectedAfterBody` to replace the node's
   ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return AccessorDeclSyntax(newData)
   }
 
@@ -7890,9 +7957,11 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       bindings.raw,
       unexpectedAfterBindings?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.variableDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.variableDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -7910,10 +7979,10 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return VariableDeclSyntax(newData)
   }
 
@@ -7936,23 +8005,24 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> VariableDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return VariableDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> VariableDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> VariableDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return VariableDeclSyntax(newData)
   }
 
@@ -7970,10 +8040,10 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return VariableDeclSyntax(newData)
   }
 
@@ -7996,23 +8066,24 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> VariableDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return VariableDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> VariableDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> VariableDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return VariableDeclSyntax(newData)
   }
 
@@ -8030,10 +8101,10 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndLetOrVarKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndLetOrVarKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndLetOrVarKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndLetOrVarKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndLetOrVarKeyword(_ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return VariableDeclSyntax(newData)
   }
 
@@ -8050,10 +8121,10 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `letOrVarKeyword` replaced.
   /// - param newChild: The new `letOrVarKeyword` to replace the node's
   ///                   current `letOrVarKeyword`, if present.
-  public func withLetOrVarKeyword(
-    _ newChild: TokenSyntax?) -> VariableDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withLetOrVarKeyword(_ newChild: TokenSyntax?) -> VariableDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return VariableDeclSyntax(newData)
   }
 
@@ -8071,10 +8142,10 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLetOrVarKeywordAndBindings` replaced.
   /// - param newChild: The new `unexpectedBetweenLetOrVarKeywordAndBindings` to replace the node's
   ///                   current `unexpectedBetweenLetOrVarKeywordAndBindings`, if present.
-  public func withUnexpectedBetweenLetOrVarKeywordAndBindings(
-    _ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
+  public func withUnexpectedBetweenLetOrVarKeywordAndBindings(_ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return VariableDeclSyntax(newData)
   }
 
@@ -8096,23 +8167,24 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `bindings` collection.
   public func addBinding(_ element: PatternBindingSyntax) -> VariableDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[7] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.patternBindingList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 7)
+    let newData = data.replacingChild(collection, at: 7, arena: arena)
     return VariableDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `bindings` replaced.
   /// - param newChild: The new `bindings` to replace the node's
   ///                   current `bindings`, if present.
-  public func withBindings(
-    _ newChild: PatternBindingListSyntax?) -> VariableDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.patternBindingList, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withBindings(_ newChild: PatternBindingListSyntax?) -> VariableDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.patternBindingList, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return VariableDeclSyntax(newData)
   }
 
@@ -8130,10 +8202,10 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterBindings` replaced.
   /// - param newChild: The new `unexpectedAfterBindings` to replace the node's
   ///                   current `unexpectedAfterBindings`, if present.
-  public func withUnexpectedAfterBindings(
-    _ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
+  public func withUnexpectedAfterBindings(_ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return VariableDeclSyntax(newData)
   }
 
@@ -8240,9 +8312,11 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       elements.raw,
       unexpectedAfterElements?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -8260,10 +8334,10 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return EnumCaseDeclSyntax(newData)
   }
 
@@ -8289,23 +8363,24 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> EnumCaseDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return EnumCaseDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> EnumCaseDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> EnumCaseDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return EnumCaseDeclSyntax(newData)
   }
 
@@ -8323,10 +8398,10 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return EnumCaseDeclSyntax(newData)
   }
 
@@ -8352,23 +8427,24 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> EnumCaseDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return EnumCaseDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> EnumCaseDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> EnumCaseDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return EnumCaseDeclSyntax(newData)
   }
 
@@ -8386,10 +8462,10 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndCaseKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndCaseKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndCaseKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndCaseKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndCaseKeyword(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return EnumCaseDeclSyntax(newData)
   }
 
@@ -8407,10 +8483,10 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `caseKeyword` replaced.
   /// - param newChild: The new `caseKeyword` to replace the node's
   ///                   current `caseKeyword`, if present.
-  public func withCaseKeyword(
-    _ newChild: TokenSyntax?) -> EnumCaseDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withCaseKeyword(_ newChild: TokenSyntax?) -> EnumCaseDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return EnumCaseDeclSyntax(newData)
   }
 
@@ -8428,10 +8504,10 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCaseKeywordAndElements` replaced.
   /// - param newChild: The new `unexpectedBetweenCaseKeywordAndElements` to replace the node's
   ///                   current `unexpectedBetweenCaseKeywordAndElements`, if present.
-  public func withUnexpectedBetweenCaseKeywordAndElements(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
+  public func withUnexpectedBetweenCaseKeywordAndElements(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return EnumCaseDeclSyntax(newData)
   }
 
@@ -8454,23 +8530,24 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `elements` collection.
   public func addElement(_ element: EnumCaseElementSyntax) -> EnumCaseDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[7] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 7)
+    let newData = data.replacingChild(collection, at: 7, arena: arena)
     return EnumCaseDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `elements` replaced.
   /// - param newChild: The new `elements` to replace the node's
   ///                   current `elements`, if present.
-  public func withElements(
-    _ newChild: EnumCaseElementListSyntax?) -> EnumCaseDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.enumCaseElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withElements(_ newChild: EnumCaseElementListSyntax?) -> EnumCaseDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.enumCaseElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return EnumCaseDeclSyntax(newData)
   }
 
@@ -8488,10 +8565,10 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterElements` replaced.
   /// - param newChild: The new `unexpectedAfterElements` to replace the node's
   ///                   current `unexpectedAfterElements`, if present.
-  public func withUnexpectedAfterElements(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
+  public func withUnexpectedAfterElements(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return EnumCaseDeclSyntax(newData)
   }
 
@@ -8610,9 +8687,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       members.raw,
       unexpectedAfterMembers?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -8630,10 +8709,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -8659,23 +8738,24 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> EnumDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> EnumDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -8693,10 +8773,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -8722,23 +8802,24 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> EnumDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> EnumDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -8756,10 +8837,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndEnumKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndEnumKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndEnumKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndEnumKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndEnumKeyword(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -8779,10 +8860,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `enumKeyword` replaced.
   /// - param newChild: The new `enumKeyword` to replace the node's
   ///                   current `enumKeyword`, if present.
-  public func withEnumKeyword(
-    _ newChild: TokenSyntax?) -> EnumDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.enumKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withEnumKeyword(_ newChild: TokenSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.enumKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -8800,10 +8881,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenEnumKeywordAndIdentifier` replaced.
   /// - param newChild: The new `unexpectedBetweenEnumKeywordAndIdentifier` to replace the node's
   ///                   current `unexpectedBetweenEnumKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenEnumKeywordAndIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+  public func withUnexpectedBetweenEnumKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -8823,10 +8904,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> EnumDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -8844,10 +8925,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndGenericParameters` replaced.
   /// - param newChild: The new `unexpectedBetweenIdentifierAndGenericParameters` to replace the node's
   ///                   current `unexpectedBetweenIdentifierAndGenericParameters`, if present.
-  public func withUnexpectedBetweenIdentifierAndGenericParameters(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+  public func withUnexpectedBetweenIdentifierAndGenericParameters(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -8868,10 +8949,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericParameters` replaced.
   /// - param newChild: The new `genericParameters` to replace the node's
   ///                   current `genericParameters`, if present.
-  public func withGenericParameters(
-    _ newChild: GenericParameterClauseSyntax?) -> EnumDeclSyntax {
+  public func withGenericParameters(_ newChild: GenericParameterClauseSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -8889,10 +8970,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericParametersAndInheritanceClause` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericParametersAndInheritanceClause` to replace the node's
   ///                   current `unexpectedBetweenGenericParametersAndInheritanceClause`, if present.
-  public func withUnexpectedBetweenGenericParametersAndInheritanceClause(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+  public func withUnexpectedBetweenGenericParametersAndInheritanceClause(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -8914,10 +8995,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `inheritanceClause` replaced.
   /// - param newChild: The new `inheritanceClause` to replace the node's
   ///                   current `inheritanceClause`, if present.
-  public func withInheritanceClause(
-    _ newChild: TypeInheritanceClauseSyntax?) -> EnumDeclSyntax {
+  public func withInheritanceClause(_ newChild: TypeInheritanceClauseSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -8935,10 +9016,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInheritanceClauseAndGenericWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenInheritanceClauseAndGenericWhereClause` to replace the node's
   ///                   current `unexpectedBetweenInheritanceClauseAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -8960,10 +9041,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericWhereClause` replaced.
   /// - param newChild: The new `genericWhereClause` to replace the node's
   ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(
-    _ newChild: GenericWhereClauseSyntax?) -> EnumDeclSyntax {
+  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -8981,10 +9062,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndMembers` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndMembers` to replace the node's
   ///                   current `unexpectedBetweenGenericWhereClauseAndMembers`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndMembers(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+  public func withUnexpectedBetweenGenericWhereClauseAndMembers(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -9004,10 +9085,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `members` replaced.
   /// - param newChild: The new `members` to replace the node's
   ///                   current `members`, if present.
-  public func withMembers(
-    _ newChild: MemberDeclBlockSyntax?) -> EnumDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: 15)
+  public func withMembers(_ newChild: MemberDeclBlockSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena)
+    let newData = data.replacingChild(raw, at: 15, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -9025,10 +9106,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
   /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
   ///                   current `unexpectedAfterMembers`, if present.
-  public func withUnexpectedAfterMembers(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+  public func withUnexpectedAfterMembers(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 16)
+    let newData = data.replacingChild(raw, at: 16, arena: arena)
     return EnumDeclSyntax(newData)
   }
 
@@ -9167,9 +9248,11 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       operatorPrecedenceAndTypes?.raw,
       unexpectedAfterOperatorPrecedenceAndTypes?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9187,10 +9270,10 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return OperatorDeclSyntax(newData)
   }
 
@@ -9216,23 +9299,24 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> OperatorDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return OperatorDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> OperatorDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> OperatorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return OperatorDeclSyntax(newData)
   }
 
@@ -9250,10 +9334,10 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return OperatorDeclSyntax(newData)
   }
 
@@ -9280,23 +9364,24 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> OperatorDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return OperatorDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> OperatorDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> OperatorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return OperatorDeclSyntax(newData)
   }
 
@@ -9314,10 +9399,10 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndOperatorKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndOperatorKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndOperatorKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndOperatorKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndOperatorKeyword(_ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return OperatorDeclSyntax(newData)
   }
 
@@ -9334,10 +9419,10 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `operatorKeyword` replaced.
   /// - param newChild: The new `operatorKeyword` to replace the node's
   ///                   current `operatorKeyword`, if present.
-  public func withOperatorKeyword(
-    _ newChild: TokenSyntax?) -> OperatorDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.operatorKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withOperatorKeyword(_ newChild: TokenSyntax?) -> OperatorDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.operatorKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return OperatorDeclSyntax(newData)
   }
 
@@ -9355,10 +9440,10 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenOperatorKeywordAndIdentifier` replaced.
   /// - param newChild: The new `unexpectedBetweenOperatorKeywordAndIdentifier` to replace the node's
   ///                   current `unexpectedBetweenOperatorKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenOperatorKeywordAndIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
+  public func withUnexpectedBetweenOperatorKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return OperatorDeclSyntax(newData)
   }
 
@@ -9375,10 +9460,10 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> OperatorDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unspacedBinaryOperator(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> OperatorDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unspacedBinaryOperator(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return OperatorDeclSyntax(newData)
   }
 
@@ -9396,10 +9481,10 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes` replaced.
   /// - param newChild: The new `unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes` to replace the node's
   ///                   current `unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes`, if present.
-  public func withUnexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes(
-    _ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
+  public func withUnexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes(_ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return OperatorDeclSyntax(newData)
   }
 
@@ -9420,10 +9505,10 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `operatorPrecedenceAndTypes` replaced.
   /// - param newChild: The new `operatorPrecedenceAndTypes` to replace the node's
   ///                   current `operatorPrecedenceAndTypes`, if present.
-  public func withOperatorPrecedenceAndTypes(
-    _ newChild: OperatorPrecedenceAndTypesSyntax?) -> OperatorDeclSyntax {
+  public func withOperatorPrecedenceAndTypes(_ newChild: OperatorPrecedenceAndTypesSyntax?) -> OperatorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return OperatorDeclSyntax(newData)
   }
 
@@ -9441,10 +9526,10 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterOperatorPrecedenceAndTypes` replaced.
   /// - param newChild: The new `unexpectedAfterOperatorPrecedenceAndTypes` to replace the node's
   ///                   current `unexpectedAfterOperatorPrecedenceAndTypes`, if present.
-  public func withUnexpectedAfterOperatorPrecedenceAndTypes(
-    _ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
+  public func withUnexpectedAfterOperatorPrecedenceAndTypes(_ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return OperatorDeclSyntax(newData)
   }
 
@@ -9567,9 +9652,11 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       rightBrace.raw,
       unexpectedAfterRightBrace?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9587,10 +9674,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -9616,23 +9703,24 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> PrecedenceGroupDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> PrecedenceGroupDeclSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> PrecedenceGroupDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -9650,10 +9738,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -9680,23 +9768,24 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> PrecedenceGroupDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> PrecedenceGroupDeclSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> PrecedenceGroupDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -9714,10 +9803,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndPrecedencegroupKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndPrecedencegroupKeyword` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndPrecedencegroupKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndPrecedencegroupKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+  public func withUnexpectedBetweenModifiersAndPrecedencegroupKeyword(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -9734,10 +9823,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `precedencegroupKeyword` replaced.
   /// - param newChild: The new `precedencegroupKeyword` to replace the node's
   ///                   current `precedencegroupKeyword`, if present.
-  public func withPrecedencegroupKeyword(
-    _ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.precedencegroupKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withPrecedencegroupKeyword(_ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.precedencegroupKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -9755,10 +9844,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPrecedencegroupKeywordAndIdentifier` replaced.
   /// - param newChild: The new `unexpectedBetweenPrecedencegroupKeywordAndIdentifier` to replace the node's
   ///                   current `unexpectedBetweenPrecedencegroupKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenPrecedencegroupKeywordAndIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+  public func withUnexpectedBetweenPrecedencegroupKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -9778,10 +9867,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -9799,10 +9888,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndLeftBrace` replaced.
   /// - param newChild: The new `unexpectedBetweenIdentifierAndLeftBrace` to replace the node's
   ///                   current `unexpectedBetweenIdentifierAndLeftBrace`, if present.
-  public func withUnexpectedBetweenIdentifierAndLeftBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+  public func withUnexpectedBetweenIdentifierAndLeftBrace(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -9819,10 +9908,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBrace` replaced.
   /// - param newChild: The new `leftBrace` to replace the node's
   ///                   current `leftBrace`, if present.
-  public func withLeftBrace(
-    _ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: 9)
+  public func withLeftBrace(_ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -9840,10 +9929,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftBraceAndGroupAttributes` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftBraceAndGroupAttributes` to replace the node's
   ///                   current `unexpectedBetweenLeftBraceAndGroupAttributes`, if present.
-  public func withUnexpectedBetweenLeftBraceAndGroupAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+  public func withUnexpectedBetweenLeftBraceAndGroupAttributes(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -9868,23 +9957,24 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `groupAttributes` collection.
   public func addGroupAttribute(_ element: Syntax) -> PrecedenceGroupDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[11] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAttributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 11)
+    let newData = data.replacingChild(collection, at: 11, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `groupAttributes` replaced.
   /// - param newChild: The new `groupAttributes` to replace the node's
   ///                   current `groupAttributes`, if present.
-  public func withGroupAttributes(
-    _ newChild: PrecedenceGroupAttributeListSyntax?) -> PrecedenceGroupDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.precedenceGroupAttributeList, arena: .default)
-    let newData = data.replacingChild(raw, at: 11)
+  public func withGroupAttributes(_ newChild: PrecedenceGroupAttributeListSyntax?) -> PrecedenceGroupDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.precedenceGroupAttributeList, arena: arena)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -9902,10 +9992,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGroupAttributesAndRightBrace` replaced.
   /// - param newChild: The new `unexpectedBetweenGroupAttributesAndRightBrace` to replace the node's
   ///                   current `unexpectedBetweenGroupAttributesAndRightBrace`, if present.
-  public func withUnexpectedBetweenGroupAttributesAndRightBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+  public func withUnexpectedBetweenGroupAttributesAndRightBrace(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -9922,10 +10012,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBrace` replaced.
   /// - param newChild: The new `rightBrace` to replace the node's
   ///                   current `rightBrace`, if present.
-  public func withRightBrace(
-    _ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: 13)
+  public func withRightBrace(_ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -9943,10 +10033,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
   /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
   ///                   current `unexpectedAfterRightBrace`, if present.
-  public func withUnexpectedAfterRightBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+  public func withUnexpectedAfterRightBrace(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -10084,9 +10174,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       additionalTrailingClosures?.raw,
       unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.macroExpansionDecl,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.macroExpansionDecl,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -10104,10 +10196,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundToken` replaced.
   /// - param newChild: The new `unexpectedBeforePoundToken` to replace the node's
   ///                   current `unexpectedBeforePoundToken`, if present.
-  public func withUnexpectedBeforePoundToken(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+  public func withUnexpectedBeforePoundToken(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
@@ -10125,10 +10217,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundToken` replaced.
   /// - param newChild: The new `poundToken` to replace the node's
   ///                   current `poundToken`, if present.
-  public func withPoundToken(
-    _ newChild: TokenSyntax?) -> MacroExpansionDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.pound, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundToken(_ newChild: TokenSyntax?) -> MacroExpansionDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.pound, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
@@ -10146,10 +10238,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPoundTokenAndMacro` replaced.
   /// - param newChild: The new `unexpectedBetweenPoundTokenAndMacro` to replace the node's
   ///                   current `unexpectedBetweenPoundTokenAndMacro`, if present.
-  public func withUnexpectedBetweenPoundTokenAndMacro(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+  public func withUnexpectedBetweenPoundTokenAndMacro(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
@@ -10166,10 +10258,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `macro` replaced.
   /// - param newChild: The new `macro` to replace the node's
   ///                   current `macro`, if present.
-  public func withMacro(
-    _ newChild: TokenSyntax?) -> MacroExpansionDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withMacro(_ newChild: TokenSyntax?) -> MacroExpansionDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
@@ -10187,10 +10279,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenMacroAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenMacroAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenMacroAndLeftParen`, if present.
-  public func withUnexpectedBetweenMacroAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+  public func withUnexpectedBetweenMacroAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
@@ -10208,10 +10300,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> MacroExpansionDeclSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax?) -> MacroExpansionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
@@ -10229,10 +10321,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArgumentList` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndArgumentList` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndArgumentList`, if present.
-  public func withUnexpectedBetweenLeftParenAndArgumentList(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+  public func withUnexpectedBetweenLeftParenAndArgumentList(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
@@ -10254,23 +10346,24 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `argumentList` collection.
   public func addArgument(_ element: TupleExprElementSyntax) -> MacroExpansionDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[7] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 7)
+    let newData = data.replacingChild(collection, at: 7, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `argumentList` replaced.
   /// - param newChild: The new `argumentList` to replace the node's
   ///                   current `argumentList`, if present.
-  public func withArgumentList(
-    _ newChild: TupleExprElementListSyntax?) -> MacroExpansionDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withArgumentList(_ newChild: TupleExprElementListSyntax?) -> MacroExpansionDeclSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
@@ -10288,10 +10381,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenArgumentListAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenArgumentListAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenArgumentListAndRightParen`, if present.
-  public func withUnexpectedBetweenArgumentListAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+  public func withUnexpectedBetweenArgumentListAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
@@ -10309,10 +10402,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> MacroExpansionDeclSyntax {
+  public func withRightParen(_ newChild: TokenSyntax?) -> MacroExpansionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
@@ -10330,10 +10423,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenRightParenAndTrailingClosure` replaced.
   /// - param newChild: The new `unexpectedBetweenRightParenAndTrailingClosure` to replace the node's
   ///                   current `unexpectedBetweenRightParenAndTrailingClosure`, if present.
-  public func withUnexpectedBetweenRightParenAndTrailingClosure(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+  public func withUnexpectedBetweenRightParenAndTrailingClosure(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
@@ -10351,10 +10444,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingClosure` replaced.
   /// - param newChild: The new `trailingClosure` to replace the node's
   ///                   current `trailingClosure`, if present.
-  public func withTrailingClosure(
-    _ newChild: ClosureExprSyntax?) -> MacroExpansionDeclSyntax {
+  public func withTrailingClosure(_ newChild: ClosureExprSyntax?) -> MacroExpansionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
@@ -10372,10 +10465,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` replaced.
   /// - param newChild: The new `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` to replace the node's
   ///                   current `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures`, if present.
-  public func withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+  public func withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
@@ -10398,23 +10491,24 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `additionalTrailingClosures` collection.
   public func addAdditionalTrailingClosure(_ element: MultipleTrailingClosureElementSyntax) -> MacroExpansionDeclSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[13] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 13)
+    let newData = data.replacingChild(collection, at: 13, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `additionalTrailingClosures` replaced.
   /// - param newChild: The new `additionalTrailingClosures` to replace the node's
   ///                   current `additionalTrailingClosures`, if present.
-  public func withAdditionalTrailingClosures(
-    _ newChild: MultipleTrailingClosureElementListSyntax?) -> MacroExpansionDeclSyntax {
+  public func withAdditionalTrailingClosures(_ newChild: MultipleTrailingClosureElementListSyntax?) -> MacroExpansionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 
@@ -10432,10 +10526,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterAdditionalTrailingClosures` replaced.
   /// - param newChild: The new `unexpectedAfterAdditionalTrailingClosures` to replace the node's
   ///                   current `unexpectedAfterAdditionalTrailingClosures`, if present.
-  public func withUnexpectedAfterAdditionalTrailingClosures(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+  public func withUnexpectedAfterAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
 

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -37,9 +37,11 @@ public struct UnknownExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     let layout: [RawSyntax?] = [
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unknownExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unknownExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -87,9 +89,11 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ) {
     let layout: [RawSyntax?] = [
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -147,9 +151,11 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.inOutExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.inOutExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -167,10 +173,10 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAmpersand` replaced.
   /// - param newChild: The new `unexpectedBeforeAmpersand` to replace the node's
   ///                   current `unexpectedBeforeAmpersand`, if present.
-  public func withUnexpectedBeforeAmpersand(
-    _ newChild: UnexpectedNodesSyntax?) -> InOutExprSyntax {
+  public func withUnexpectedBeforeAmpersand(_ newChild: UnexpectedNodesSyntax?) -> InOutExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return InOutExprSyntax(newData)
   }
 
@@ -187,10 +193,10 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `ampersand` replaced.
   /// - param newChild: The new `ampersand` to replace the node's
   ///                   current `ampersand`, if present.
-  public func withAmpersand(
-    _ newChild: TokenSyntax?) -> InOutExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.prefixAmpersand, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withAmpersand(_ newChild: TokenSyntax?) -> InOutExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.prefixAmpersand, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return InOutExprSyntax(newData)
   }
 
@@ -208,10 +214,10 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAmpersandAndExpression` replaced.
   /// - param newChild: The new `unexpectedBetweenAmpersandAndExpression` to replace the node's
   ///                   current `unexpectedBetweenAmpersandAndExpression`, if present.
-  public func withUnexpectedBetweenAmpersandAndExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> InOutExprSyntax {
+  public func withUnexpectedBetweenAmpersandAndExpression(_ newChild: UnexpectedNodesSyntax?) -> InOutExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return InOutExprSyntax(newData)
   }
 
@@ -228,10 +234,10 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> InOutExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withExpression(_ newChild: ExprSyntax?) -> InOutExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return InOutExprSyntax(newData)
   }
 
@@ -249,10 +255,10 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
   /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
   ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> InOutExprSyntax {
+  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> InOutExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return InOutExprSyntax(newData)
   }
 
@@ -326,9 +332,11 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       poundColumn.raw,
       unexpectedAfterPoundColumn?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundColumnExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundColumnExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -346,10 +354,10 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundColumn` replaced.
   /// - param newChild: The new `unexpectedBeforePoundColumn` to replace the node's
   ///                   current `unexpectedBeforePoundColumn`, if present.
-  public func withUnexpectedBeforePoundColumn(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundColumnExprSyntax {
+  public func withUnexpectedBeforePoundColumn(_ newChild: UnexpectedNodesSyntax?) -> PoundColumnExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PoundColumnExprSyntax(newData)
   }
 
@@ -366,10 +374,10 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundColumn` replaced.
   /// - param newChild: The new `poundColumn` to replace the node's
   ///                   current `poundColumn`, if present.
-  public func withPoundColumn(
-    _ newChild: TokenSyntax?) -> PoundColumnExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundColumnKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundColumn(_ newChild: TokenSyntax?) -> PoundColumnExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundColumnKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PoundColumnExprSyntax(newData)
   }
 
@@ -387,10 +395,10 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterPoundColumn` replaced.
   /// - param newChild: The new `unexpectedAfterPoundColumn` to replace the node's
   ///                   current `unexpectedAfterPoundColumn`, if present.
-  public func withUnexpectedAfterPoundColumn(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundColumnExprSyntax {
+  public func withUnexpectedAfterPoundColumn(_ newChild: UnexpectedNodesSyntax?) -> PoundColumnExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PoundColumnExprSyntax(newData)
   }
 
@@ -464,9 +472,11 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tryExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tryExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -484,10 +494,10 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeTryKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeTryKeyword` to replace the node's
   ///                   current `unexpectedBeforeTryKeyword`, if present.
-  public func withUnexpectedBeforeTryKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
+  public func withUnexpectedBeforeTryKeyword(_ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return TryExprSyntax(newData)
   }
 
@@ -504,10 +514,10 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `tryKeyword` replaced.
   /// - param newChild: The new `tryKeyword` to replace the node's
   ///                   current `tryKeyword`, if present.
-  public func withTryKeyword(
-    _ newChild: TokenSyntax?) -> TryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.tryKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withTryKeyword(_ newChild: TokenSyntax?) -> TryExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.tryKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return TryExprSyntax(newData)
   }
 
@@ -525,10 +535,10 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTryKeywordAndQuestionOrExclamationMark` replaced.
   /// - param newChild: The new `unexpectedBetweenTryKeywordAndQuestionOrExclamationMark` to replace the node's
   ///                   current `unexpectedBetweenTryKeywordAndQuestionOrExclamationMark`, if present.
-  public func withUnexpectedBetweenTryKeywordAndQuestionOrExclamationMark(
-    _ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
+  public func withUnexpectedBetweenTryKeywordAndQuestionOrExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return TryExprSyntax(newData)
   }
 
@@ -546,10 +556,10 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `questionOrExclamationMark` replaced.
   /// - param newChild: The new `questionOrExclamationMark` to replace the node's
   ///                   current `questionOrExclamationMark`, if present.
-  public func withQuestionOrExclamationMark(
-    _ newChild: TokenSyntax?) -> TryExprSyntax {
+  public func withQuestionOrExclamationMark(_ newChild: TokenSyntax?) -> TryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return TryExprSyntax(newData)
   }
 
@@ -567,10 +577,10 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenQuestionOrExclamationMarkAndExpression` replaced.
   /// - param newChild: The new `unexpectedBetweenQuestionOrExclamationMarkAndExpression` to replace the node's
   ///                   current `unexpectedBetweenQuestionOrExclamationMarkAndExpression`, if present.
-  public func withUnexpectedBetweenQuestionOrExclamationMarkAndExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
+  public func withUnexpectedBetweenQuestionOrExclamationMarkAndExpression(_ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return TryExprSyntax(newData)
   }
 
@@ -587,10 +597,10 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> TryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withExpression(_ newChild: ExprSyntax?) -> TryExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return TryExprSyntax(newData)
   }
 
@@ -608,10 +618,10 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
   /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
   ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
+  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return TryExprSyntax(newData)
   }
 
@@ -697,9 +707,11 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.awaitExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.awaitExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -717,10 +729,10 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAwaitKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeAwaitKeyword` to replace the node's
   ///                   current `unexpectedBeforeAwaitKeyword`, if present.
-  public func withUnexpectedBeforeAwaitKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> AwaitExprSyntax {
+  public func withUnexpectedBeforeAwaitKeyword(_ newChild: UnexpectedNodesSyntax?) -> AwaitExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AwaitExprSyntax(newData)
   }
 
@@ -737,10 +749,10 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `awaitKeyword` replaced.
   /// - param newChild: The new `awaitKeyword` to replace the node's
   ///                   current `awaitKeyword`, if present.
-  public func withAwaitKeyword(
-    _ newChild: TokenSyntax?) -> AwaitExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withAwaitKeyword(_ newChild: TokenSyntax?) -> AwaitExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AwaitExprSyntax(newData)
   }
 
@@ -758,10 +770,10 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAwaitKeywordAndExpression` replaced.
   /// - param newChild: The new `unexpectedBetweenAwaitKeywordAndExpression` to replace the node's
   ///                   current `unexpectedBetweenAwaitKeywordAndExpression`, if present.
-  public func withUnexpectedBetweenAwaitKeywordAndExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> AwaitExprSyntax {
+  public func withUnexpectedBetweenAwaitKeywordAndExpression(_ newChild: UnexpectedNodesSyntax?) -> AwaitExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AwaitExprSyntax(newData)
   }
 
@@ -778,10 +790,10 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> AwaitExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withExpression(_ newChild: ExprSyntax?) -> AwaitExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AwaitExprSyntax(newData)
   }
 
@@ -799,10 +811,10 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
   /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
   ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> AwaitExprSyntax {
+  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> AwaitExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AwaitExprSyntax(newData)
   }
 
@@ -880,9 +892,11 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.moveExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.moveExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -900,10 +914,10 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeMoveKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeMoveKeyword` to replace the node's
   ///                   current `unexpectedBeforeMoveKeyword`, if present.
-  public func withUnexpectedBeforeMoveKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> MoveExprSyntax {
+  public func withUnexpectedBeforeMoveKeyword(_ newChild: UnexpectedNodesSyntax?) -> MoveExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return MoveExprSyntax(newData)
   }
 
@@ -920,10 +934,10 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `moveKeyword` replaced.
   /// - param newChild: The new `moveKeyword` to replace the node's
   ///                   current `moveKeyword`, if present.
-  public func withMoveKeyword(
-    _ newChild: TokenSyntax?) -> MoveExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withMoveKeyword(_ newChild: TokenSyntax?) -> MoveExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return MoveExprSyntax(newData)
   }
 
@@ -941,10 +955,10 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenMoveKeywordAndExpression` replaced.
   /// - param newChild: The new `unexpectedBetweenMoveKeywordAndExpression` to replace the node's
   ///                   current `unexpectedBetweenMoveKeywordAndExpression`, if present.
-  public func withUnexpectedBetweenMoveKeywordAndExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> MoveExprSyntax {
+  public func withUnexpectedBetweenMoveKeywordAndExpression(_ newChild: UnexpectedNodesSyntax?) -> MoveExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return MoveExprSyntax(newData)
   }
 
@@ -961,10 +975,10 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> MoveExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withExpression(_ newChild: ExprSyntax?) -> MoveExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return MoveExprSyntax(newData)
   }
 
@@ -982,10 +996,10 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
   /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
   ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> MoveExprSyntax {
+  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> MoveExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return MoveExprSyntax(newData)
   }
 
@@ -1063,9 +1077,11 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       declNameArguments?.raw,
       unexpectedAfterDeclNameArguments?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.identifierExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.identifierExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1083,10 +1099,10 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeIdentifier` replaced.
   /// - param newChild: The new `unexpectedBeforeIdentifier` to replace the node's
   ///                   current `unexpectedBeforeIdentifier`, if present.
-  public func withUnexpectedBeforeIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> IdentifierExprSyntax {
+  public func withUnexpectedBeforeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> IdentifierExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return IdentifierExprSyntax(newData)
   }
 
@@ -1103,10 +1119,10 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> IdentifierExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> IdentifierExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return IdentifierExprSyntax(newData)
   }
 
@@ -1124,10 +1140,10 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndDeclNameArguments` replaced.
   /// - param newChild: The new `unexpectedBetweenIdentifierAndDeclNameArguments` to replace the node's
   ///                   current `unexpectedBetweenIdentifierAndDeclNameArguments`, if present.
-  public func withUnexpectedBetweenIdentifierAndDeclNameArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> IdentifierExprSyntax {
+  public func withUnexpectedBetweenIdentifierAndDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> IdentifierExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return IdentifierExprSyntax(newData)
   }
 
@@ -1145,10 +1161,10 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `declNameArguments` replaced.
   /// - param newChild: The new `declNameArguments` to replace the node's
   ///                   current `declNameArguments`, if present.
-  public func withDeclNameArguments(
-    _ newChild: DeclNameArgumentsSyntax?) -> IdentifierExprSyntax {
+  public func withDeclNameArguments(_ newChild: DeclNameArgumentsSyntax?) -> IdentifierExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return IdentifierExprSyntax(newData)
   }
 
@@ -1166,10 +1182,10 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterDeclNameArguments` replaced.
   /// - param newChild: The new `unexpectedAfterDeclNameArguments` to replace the node's
   ///                   current `unexpectedAfterDeclNameArguments`, if present.
-  public func withUnexpectedAfterDeclNameArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> IdentifierExprSyntax {
+  public func withUnexpectedAfterDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> IdentifierExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return IdentifierExprSyntax(newData)
   }
 
@@ -1243,9 +1259,11 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       superKeyword.raw,
       unexpectedAfterSuperKeyword?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.superRefExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.superRefExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1263,10 +1281,10 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeSuperKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeSuperKeyword` to replace the node's
   ///                   current `unexpectedBeforeSuperKeyword`, if present.
-  public func withUnexpectedBeforeSuperKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> SuperRefExprSyntax {
+  public func withUnexpectedBeforeSuperKeyword(_ newChild: UnexpectedNodesSyntax?) -> SuperRefExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return SuperRefExprSyntax(newData)
   }
 
@@ -1283,10 +1301,10 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `superKeyword` replaced.
   /// - param newChild: The new `superKeyword` to replace the node's
   ///                   current `superKeyword`, if present.
-  public func withSuperKeyword(
-    _ newChild: TokenSyntax?) -> SuperRefExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.superKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withSuperKeyword(_ newChild: TokenSyntax?) -> SuperRefExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.superKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return SuperRefExprSyntax(newData)
   }
 
@@ -1304,10 +1322,10 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterSuperKeyword` replaced.
   /// - param newChild: The new `unexpectedAfterSuperKeyword` to replace the node's
   ///                   current `unexpectedAfterSuperKeyword`, if present.
-  public func withUnexpectedAfterSuperKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> SuperRefExprSyntax {
+  public func withUnexpectedAfterSuperKeyword(_ newChild: UnexpectedNodesSyntax?) -> SuperRefExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return SuperRefExprSyntax(newData)
   }
 
@@ -1373,9 +1391,11 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       nilKeyword.raw,
       unexpectedAfterNilKeyword?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.nilLiteralExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.nilLiteralExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1393,10 +1413,10 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeNilKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeNilKeyword` to replace the node's
   ///                   current `unexpectedBeforeNilKeyword`, if present.
-  public func withUnexpectedBeforeNilKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> NilLiteralExprSyntax {
+  public func withUnexpectedBeforeNilKeyword(_ newChild: UnexpectedNodesSyntax?) -> NilLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return NilLiteralExprSyntax(newData)
   }
 
@@ -1413,10 +1433,10 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `nilKeyword` replaced.
   /// - param newChild: The new `nilKeyword` to replace the node's
   ///                   current `nilKeyword`, if present.
-  public func withNilKeyword(
-    _ newChild: TokenSyntax?) -> NilLiteralExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.nilKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withNilKeyword(_ newChild: TokenSyntax?) -> NilLiteralExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.nilKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return NilLiteralExprSyntax(newData)
   }
 
@@ -1434,10 +1454,10 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterNilKeyword` replaced.
   /// - param newChild: The new `unexpectedAfterNilKeyword` to replace the node's
   ///                   current `unexpectedAfterNilKeyword`, if present.
-  public func withUnexpectedAfterNilKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> NilLiteralExprSyntax {
+  public func withUnexpectedAfterNilKeyword(_ newChild: UnexpectedNodesSyntax?) -> NilLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return NilLiteralExprSyntax(newData)
   }
 
@@ -1503,9 +1523,11 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       wildcard.raw,
       unexpectedAfterWildcard?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.discardAssignmentExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.discardAssignmentExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1523,10 +1545,10 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeWildcard` replaced.
   /// - param newChild: The new `unexpectedBeforeWildcard` to replace the node's
   ///                   current `unexpectedBeforeWildcard`, if present.
-  public func withUnexpectedBeforeWildcard(
-    _ newChild: UnexpectedNodesSyntax?) -> DiscardAssignmentExprSyntax {
+  public func withUnexpectedBeforeWildcard(_ newChild: UnexpectedNodesSyntax?) -> DiscardAssignmentExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DiscardAssignmentExprSyntax(newData)
   }
 
@@ -1543,10 +1565,10 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `wildcard` replaced.
   /// - param newChild: The new `wildcard` to replace the node's
   ///                   current `wildcard`, if present.
-  public func withWildcard(
-    _ newChild: TokenSyntax?) -> DiscardAssignmentExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.wildcardKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withWildcard(_ newChild: TokenSyntax?) -> DiscardAssignmentExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.wildcardKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DiscardAssignmentExprSyntax(newData)
   }
 
@@ -1564,10 +1586,10 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterWildcard` replaced.
   /// - param newChild: The new `unexpectedAfterWildcard` to replace the node's
   ///                   current `unexpectedAfterWildcard`, if present.
-  public func withUnexpectedAfterWildcard(
-    _ newChild: UnexpectedNodesSyntax?) -> DiscardAssignmentExprSyntax {
+  public func withUnexpectedAfterWildcard(_ newChild: UnexpectedNodesSyntax?) -> DiscardAssignmentExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DiscardAssignmentExprSyntax(newData)
   }
 
@@ -1633,9 +1655,11 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       assignToken.raw,
       unexpectedAfterAssignToken?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.assignmentExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.assignmentExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1653,10 +1677,10 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAssignToken` replaced.
   /// - param newChild: The new `unexpectedBeforeAssignToken` to replace the node's
   ///                   current `unexpectedBeforeAssignToken`, if present.
-  public func withUnexpectedBeforeAssignToken(
-    _ newChild: UnexpectedNodesSyntax?) -> AssignmentExprSyntax {
+  public func withUnexpectedBeforeAssignToken(_ newChild: UnexpectedNodesSyntax?) -> AssignmentExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AssignmentExprSyntax(newData)
   }
 
@@ -1673,10 +1697,10 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `assignToken` replaced.
   /// - param newChild: The new `assignToken` to replace the node's
   ///                   current `assignToken`, if present.
-  public func withAssignToken(
-    _ newChild: TokenSyntax?) -> AssignmentExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withAssignToken(_ newChild: TokenSyntax?) -> AssignmentExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AssignmentExprSyntax(newData)
   }
 
@@ -1694,10 +1718,10 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterAssignToken` replaced.
   /// - param newChild: The new `unexpectedAfterAssignToken` to replace the node's
   ///                   current `unexpectedAfterAssignToken`, if present.
-  public func withUnexpectedAfterAssignToken(
-    _ newChild: UnexpectedNodesSyntax?) -> AssignmentExprSyntax {
+  public func withUnexpectedAfterAssignToken(_ newChild: UnexpectedNodesSyntax?) -> AssignmentExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AssignmentExprSyntax(newData)
   }
 
@@ -1763,9 +1787,11 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       elements.raw,
       unexpectedAfterElements?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.sequenceExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.sequenceExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1783,10 +1809,10 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeElements` replaced.
   /// - param newChild: The new `unexpectedBeforeElements` to replace the node's
   ///                   current `unexpectedBeforeElements`, if present.
-  public func withUnexpectedBeforeElements(
-    _ newChild: UnexpectedNodesSyntax?) -> SequenceExprSyntax {
+  public func withUnexpectedBeforeElements(_ newChild: UnexpectedNodesSyntax?) -> SequenceExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return SequenceExprSyntax(newData)
   }
 
@@ -1808,23 +1834,24 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `elements` collection.
   public func addElement(_ element: ExprSyntax) -> SequenceExprSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.exprList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return SequenceExprSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `elements` replaced.
   /// - param newChild: The new `elements` to replace the node's
   ///                   current `elements`, if present.
-  public func withElements(
-    _ newChild: ExprListSyntax?) -> SequenceExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.exprList, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withElements(_ newChild: ExprListSyntax?) -> SequenceExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.exprList, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return SequenceExprSyntax(newData)
   }
 
@@ -1842,10 +1869,10 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterElements` replaced.
   /// - param newChild: The new `unexpectedAfterElements` to replace the node's
   ///                   current `unexpectedAfterElements`, if present.
-  public func withUnexpectedAfterElements(
-    _ newChild: UnexpectedNodesSyntax?) -> SequenceExprSyntax {
+  public func withUnexpectedAfterElements(_ newChild: UnexpectedNodesSyntax?) -> SequenceExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return SequenceExprSyntax(newData)
   }
 
@@ -1911,9 +1938,11 @@ public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       poundLine.raw,
       unexpectedAfterPoundLine?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundLineExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundLineExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1931,10 +1960,10 @@ public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundLine` replaced.
   /// - param newChild: The new `unexpectedBeforePoundLine` to replace the node's
   ///                   current `unexpectedBeforePoundLine`, if present.
-  public func withUnexpectedBeforePoundLine(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundLineExprSyntax {
+  public func withUnexpectedBeforePoundLine(_ newChild: UnexpectedNodesSyntax?) -> PoundLineExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PoundLineExprSyntax(newData)
   }
 
@@ -1951,10 +1980,10 @@ public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundLine` replaced.
   /// - param newChild: The new `poundLine` to replace the node's
   ///                   current `poundLine`, if present.
-  public func withPoundLine(
-    _ newChild: TokenSyntax?) -> PoundLineExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundLineKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundLine(_ newChild: TokenSyntax?) -> PoundLineExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundLineKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PoundLineExprSyntax(newData)
   }
 
@@ -1972,10 +2001,10 @@ public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterPoundLine` replaced.
   /// - param newChild: The new `unexpectedAfterPoundLine` to replace the node's
   ///                   current `unexpectedAfterPoundLine`, if present.
-  public func withUnexpectedAfterPoundLine(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundLineExprSyntax {
+  public func withUnexpectedAfterPoundLine(_ newChild: UnexpectedNodesSyntax?) -> PoundLineExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PoundLineExprSyntax(newData)
   }
 
@@ -2041,9 +2070,11 @@ public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       poundFile.raw,
       unexpectedAfterPoundFile?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFileExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFileExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2061,10 +2092,10 @@ public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundFile` replaced.
   /// - param newChild: The new `unexpectedBeforePoundFile` to replace the node's
   ///                   current `unexpectedBeforePoundFile`, if present.
-  public func withUnexpectedBeforePoundFile(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundFileExprSyntax {
+  public func withUnexpectedBeforePoundFile(_ newChild: UnexpectedNodesSyntax?) -> PoundFileExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PoundFileExprSyntax(newData)
   }
 
@@ -2081,10 +2112,10 @@ public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundFile` replaced.
   /// - param newChild: The new `poundFile` to replace the node's
   ///                   current `poundFile`, if present.
-  public func withPoundFile(
-    _ newChild: TokenSyntax?) -> PoundFileExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundFileKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundFile(_ newChild: TokenSyntax?) -> PoundFileExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundFileKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PoundFileExprSyntax(newData)
   }
 
@@ -2102,10 +2133,10 @@ public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterPoundFile` replaced.
   /// - param newChild: The new `unexpectedAfterPoundFile` to replace the node's
   ///                   current `unexpectedAfterPoundFile`, if present.
-  public func withUnexpectedAfterPoundFile(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundFileExprSyntax {
+  public func withUnexpectedAfterPoundFile(_ newChild: UnexpectedNodesSyntax?) -> PoundFileExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PoundFileExprSyntax(newData)
   }
 
@@ -2171,9 +2202,11 @@ public struct PoundFileIDExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       poundFileID.raw,
       unexpectedAfterPoundFileID?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFileIDExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFileIDExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2191,10 +2224,10 @@ public struct PoundFileIDExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundFileID` replaced.
   /// - param newChild: The new `unexpectedBeforePoundFileID` to replace the node's
   ///                   current `unexpectedBeforePoundFileID`, if present.
-  public func withUnexpectedBeforePoundFileID(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundFileIDExprSyntax {
+  public func withUnexpectedBeforePoundFileID(_ newChild: UnexpectedNodesSyntax?) -> PoundFileIDExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PoundFileIDExprSyntax(newData)
   }
 
@@ -2211,10 +2244,10 @@ public struct PoundFileIDExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundFileID` replaced.
   /// - param newChild: The new `poundFileID` to replace the node's
   ///                   current `poundFileID`, if present.
-  public func withPoundFileID(
-    _ newChild: TokenSyntax?) -> PoundFileIDExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundFileIDKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundFileID(_ newChild: TokenSyntax?) -> PoundFileIDExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundFileIDKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PoundFileIDExprSyntax(newData)
   }
 
@@ -2232,10 +2265,10 @@ public struct PoundFileIDExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterPoundFileID` replaced.
   /// - param newChild: The new `unexpectedAfterPoundFileID` to replace the node's
   ///                   current `unexpectedAfterPoundFileID`, if present.
-  public func withUnexpectedAfterPoundFileID(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundFileIDExprSyntax {
+  public func withUnexpectedAfterPoundFileID(_ newChild: UnexpectedNodesSyntax?) -> PoundFileIDExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PoundFileIDExprSyntax(newData)
   }
 
@@ -2301,9 +2334,11 @@ public struct PoundFilePathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       poundFilePath.raw,
       unexpectedAfterPoundFilePath?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFilePathExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFilePathExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2321,10 +2356,10 @@ public struct PoundFilePathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundFilePath` replaced.
   /// - param newChild: The new `unexpectedBeforePoundFilePath` to replace the node's
   ///                   current `unexpectedBeforePoundFilePath`, if present.
-  public func withUnexpectedBeforePoundFilePath(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundFilePathExprSyntax {
+  public func withUnexpectedBeforePoundFilePath(_ newChild: UnexpectedNodesSyntax?) -> PoundFilePathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PoundFilePathExprSyntax(newData)
   }
 
@@ -2341,10 +2376,10 @@ public struct PoundFilePathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundFilePath` replaced.
   /// - param newChild: The new `poundFilePath` to replace the node's
   ///                   current `poundFilePath`, if present.
-  public func withPoundFilePath(
-    _ newChild: TokenSyntax?) -> PoundFilePathExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundFilePathKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundFilePath(_ newChild: TokenSyntax?) -> PoundFilePathExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundFilePathKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PoundFilePathExprSyntax(newData)
   }
 
@@ -2362,10 +2397,10 @@ public struct PoundFilePathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterPoundFilePath` replaced.
   /// - param newChild: The new `unexpectedAfterPoundFilePath` to replace the node's
   ///                   current `unexpectedAfterPoundFilePath`, if present.
-  public func withUnexpectedAfterPoundFilePath(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundFilePathExprSyntax {
+  public func withUnexpectedAfterPoundFilePath(_ newChild: UnexpectedNodesSyntax?) -> PoundFilePathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PoundFilePathExprSyntax(newData)
   }
 
@@ -2431,9 +2466,11 @@ public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       poundFunction.raw,
       unexpectedAfterPoundFunction?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFunctionExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFunctionExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2451,10 +2488,10 @@ public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundFunction` replaced.
   /// - param newChild: The new `unexpectedBeforePoundFunction` to replace the node's
   ///                   current `unexpectedBeforePoundFunction`, if present.
-  public func withUnexpectedBeforePoundFunction(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundFunctionExprSyntax {
+  public func withUnexpectedBeforePoundFunction(_ newChild: UnexpectedNodesSyntax?) -> PoundFunctionExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PoundFunctionExprSyntax(newData)
   }
 
@@ -2471,10 +2508,10 @@ public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundFunction` replaced.
   /// - param newChild: The new `poundFunction` to replace the node's
   ///                   current `poundFunction`, if present.
-  public func withPoundFunction(
-    _ newChild: TokenSyntax?) -> PoundFunctionExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundFunctionKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundFunction(_ newChild: TokenSyntax?) -> PoundFunctionExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundFunctionKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PoundFunctionExprSyntax(newData)
   }
 
@@ -2492,10 +2529,10 @@ public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterPoundFunction` replaced.
   /// - param newChild: The new `unexpectedAfterPoundFunction` to replace the node's
   ///                   current `unexpectedAfterPoundFunction`, if present.
-  public func withUnexpectedAfterPoundFunction(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundFunctionExprSyntax {
+  public func withUnexpectedAfterPoundFunction(_ newChild: UnexpectedNodesSyntax?) -> PoundFunctionExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PoundFunctionExprSyntax(newData)
   }
 
@@ -2561,9 +2598,11 @@ public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       poundDsohandle.raw,
       unexpectedAfterPoundDsohandle?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundDsohandleExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundDsohandleExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2581,10 +2620,10 @@ public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundDsohandle` replaced.
   /// - param newChild: The new `unexpectedBeforePoundDsohandle` to replace the node's
   ///                   current `unexpectedBeforePoundDsohandle`, if present.
-  public func withUnexpectedBeforePoundDsohandle(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundDsohandleExprSyntax {
+  public func withUnexpectedBeforePoundDsohandle(_ newChild: UnexpectedNodesSyntax?) -> PoundDsohandleExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PoundDsohandleExprSyntax(newData)
   }
 
@@ -2601,10 +2640,10 @@ public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundDsohandle` replaced.
   /// - param newChild: The new `poundDsohandle` to replace the node's
   ///                   current `poundDsohandle`, if present.
-  public func withPoundDsohandle(
-    _ newChild: TokenSyntax?) -> PoundDsohandleExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundDsohandleKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundDsohandle(_ newChild: TokenSyntax?) -> PoundDsohandleExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundDsohandleKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PoundDsohandleExprSyntax(newData)
   }
 
@@ -2622,10 +2661,10 @@ public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterPoundDsohandle` replaced.
   /// - param newChild: The new `unexpectedAfterPoundDsohandle` to replace the node's
   ///                   current `unexpectedAfterPoundDsohandle`, if present.
-  public func withUnexpectedAfterPoundDsohandle(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundDsohandleExprSyntax {
+  public func withUnexpectedAfterPoundDsohandle(_ newChild: UnexpectedNodesSyntax?) -> PoundDsohandleExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PoundDsohandleExprSyntax(newData)
   }
 
@@ -2695,9 +2734,11 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       genericArgumentClause?.raw,
       unexpectedAfterGenericArgumentClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.symbolicReferenceExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.symbolicReferenceExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2715,10 +2756,10 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeIdentifier` replaced.
   /// - param newChild: The new `unexpectedBeforeIdentifier` to replace the node's
   ///                   current `unexpectedBeforeIdentifier`, if present.
-  public func withUnexpectedBeforeIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> SymbolicReferenceExprSyntax {
+  public func withUnexpectedBeforeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> SymbolicReferenceExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return SymbolicReferenceExprSyntax(newData)
   }
 
@@ -2735,10 +2776,10 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> SymbolicReferenceExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> SymbolicReferenceExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return SymbolicReferenceExprSyntax(newData)
   }
 
@@ -2756,10 +2797,10 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndGenericArgumentClause` replaced.
   /// - param newChild: The new `unexpectedBetweenIdentifierAndGenericArgumentClause` to replace the node's
   ///                   current `unexpectedBetweenIdentifierAndGenericArgumentClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndGenericArgumentClause(
-    _ newChild: UnexpectedNodesSyntax?) -> SymbolicReferenceExprSyntax {
+  public func withUnexpectedBetweenIdentifierAndGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> SymbolicReferenceExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return SymbolicReferenceExprSyntax(newData)
   }
 
@@ -2777,10 +2818,10 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericArgumentClause` replaced.
   /// - param newChild: The new `genericArgumentClause` to replace the node's
   ///                   current `genericArgumentClause`, if present.
-  public func withGenericArgumentClause(
-    _ newChild: GenericArgumentClauseSyntax?) -> SymbolicReferenceExprSyntax {
+  public func withGenericArgumentClause(_ newChild: GenericArgumentClauseSyntax?) -> SymbolicReferenceExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return SymbolicReferenceExprSyntax(newData)
   }
 
@@ -2798,10 +2839,10 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterGenericArgumentClause` replaced.
   /// - param newChild: The new `unexpectedAfterGenericArgumentClause` to replace the node's
   ///                   current `unexpectedAfterGenericArgumentClause`, if present.
-  public func withUnexpectedAfterGenericArgumentClause(
-    _ newChild: UnexpectedNodesSyntax?) -> SymbolicReferenceExprSyntax {
+  public func withUnexpectedAfterGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> SymbolicReferenceExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return SymbolicReferenceExprSyntax(newData)
   }
 
@@ -2879,9 +2920,11 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       postfixExpression.raw,
       unexpectedAfterPostfixExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.prefixOperatorExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.prefixOperatorExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2899,10 +2942,10 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeOperatorToken` replaced.
   /// - param newChild: The new `unexpectedBeforeOperatorToken` to replace the node's
   ///                   current `unexpectedBeforeOperatorToken`, if present.
-  public func withUnexpectedBeforeOperatorToken(
-    _ newChild: UnexpectedNodesSyntax?) -> PrefixOperatorExprSyntax {
+  public func withUnexpectedBeforeOperatorToken(_ newChild: UnexpectedNodesSyntax?) -> PrefixOperatorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PrefixOperatorExprSyntax(newData)
   }
 
@@ -2920,10 +2963,10 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `operatorToken` replaced.
   /// - param newChild: The new `operatorToken` to replace the node's
   ///                   current `operatorToken`, if present.
-  public func withOperatorToken(
-    _ newChild: TokenSyntax?) -> PrefixOperatorExprSyntax {
+  public func withOperatorToken(_ newChild: TokenSyntax?) -> PrefixOperatorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PrefixOperatorExprSyntax(newData)
   }
 
@@ -2941,10 +2984,10 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenOperatorTokenAndPostfixExpression` replaced.
   /// - param newChild: The new `unexpectedBetweenOperatorTokenAndPostfixExpression` to replace the node's
   ///                   current `unexpectedBetweenOperatorTokenAndPostfixExpression`, if present.
-  public func withUnexpectedBetweenOperatorTokenAndPostfixExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> PrefixOperatorExprSyntax {
+  public func withUnexpectedBetweenOperatorTokenAndPostfixExpression(_ newChild: UnexpectedNodesSyntax?) -> PrefixOperatorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PrefixOperatorExprSyntax(newData)
   }
 
@@ -2961,10 +3004,10 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `postfixExpression` replaced.
   /// - param newChild: The new `postfixExpression` to replace the node's
   ///                   current `postfixExpression`, if present.
-  public func withPostfixExpression(
-    _ newChild: ExprSyntax?) -> PrefixOperatorExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withPostfixExpression(_ newChild: ExprSyntax?) -> PrefixOperatorExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PrefixOperatorExprSyntax(newData)
   }
 
@@ -2982,10 +3025,10 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterPostfixExpression` replaced.
   /// - param newChild: The new `unexpectedAfterPostfixExpression` to replace the node's
   ///                   current `unexpectedAfterPostfixExpression`, if present.
-  public func withUnexpectedAfterPostfixExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> PrefixOperatorExprSyntax {
+  public func withUnexpectedAfterPostfixExpression(_ newChild: UnexpectedNodesSyntax?) -> PrefixOperatorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PrefixOperatorExprSyntax(newData)
   }
 
@@ -3059,9 +3102,11 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       operatorToken.raw,
       unexpectedAfterOperatorToken?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.binaryOperatorExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.binaryOperatorExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3079,10 +3124,10 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeOperatorToken` replaced.
   /// - param newChild: The new `unexpectedBeforeOperatorToken` to replace the node's
   ///                   current `unexpectedBeforeOperatorToken`, if present.
-  public func withUnexpectedBeforeOperatorToken(
-    _ newChild: UnexpectedNodesSyntax?) -> BinaryOperatorExprSyntax {
+  public func withUnexpectedBeforeOperatorToken(_ newChild: UnexpectedNodesSyntax?) -> BinaryOperatorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return BinaryOperatorExprSyntax(newData)
   }
 
@@ -3099,10 +3144,10 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `operatorToken` replaced.
   /// - param newChild: The new `operatorToken` to replace the node's
   ///                   current `operatorToken`, if present.
-  public func withOperatorToken(
-    _ newChild: TokenSyntax?) -> BinaryOperatorExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withOperatorToken(_ newChild: TokenSyntax?) -> BinaryOperatorExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return BinaryOperatorExprSyntax(newData)
   }
 
@@ -3120,10 +3165,10 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterOperatorToken` replaced.
   /// - param newChild: The new `unexpectedAfterOperatorToken` to replace the node's
   ///                   current `unexpectedAfterOperatorToken`, if present.
-  public func withUnexpectedAfterOperatorToken(
-    _ newChild: UnexpectedNodesSyntax?) -> BinaryOperatorExprSyntax {
+  public func withUnexpectedAfterOperatorToken(_ newChild: UnexpectedNodesSyntax?) -> BinaryOperatorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return BinaryOperatorExprSyntax(newData)
   }
 
@@ -3197,9 +3242,11 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       arrowToken.raw,
       unexpectedAfterArrowToken?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrowExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrowExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3217,10 +3264,10 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAsyncKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeAsyncKeyword` to replace the node's
   ///                   current `unexpectedBeforeAsyncKeyword`, if present.
-  public func withUnexpectedBeforeAsyncKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ArrowExprSyntax {
+  public func withUnexpectedBeforeAsyncKeyword(_ newChild: UnexpectedNodesSyntax?) -> ArrowExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ArrowExprSyntax(newData)
   }
 
@@ -3238,10 +3285,10 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `asyncKeyword` replaced.
   /// - param newChild: The new `asyncKeyword` to replace the node's
   ///                   current `asyncKeyword`, if present.
-  public func withAsyncKeyword(
-    _ newChild: TokenSyntax?) -> ArrowExprSyntax {
+  public func withAsyncKeyword(_ newChild: TokenSyntax?) -> ArrowExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ArrowExprSyntax(newData)
   }
 
@@ -3259,10 +3306,10 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAsyncKeywordAndThrowsToken` replaced.
   /// - param newChild: The new `unexpectedBetweenAsyncKeywordAndThrowsToken` to replace the node's
   ///                   current `unexpectedBetweenAsyncKeywordAndThrowsToken`, if present.
-  public func withUnexpectedBetweenAsyncKeywordAndThrowsToken(
-    _ newChild: UnexpectedNodesSyntax?) -> ArrowExprSyntax {
+  public func withUnexpectedBetweenAsyncKeywordAndThrowsToken(_ newChild: UnexpectedNodesSyntax?) -> ArrowExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ArrowExprSyntax(newData)
   }
 
@@ -3280,10 +3327,10 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `throwsToken` replaced.
   /// - param newChild: The new `throwsToken` to replace the node's
   ///                   current `throwsToken`, if present.
-  public func withThrowsToken(
-    _ newChild: TokenSyntax?) -> ArrowExprSyntax {
+  public func withThrowsToken(_ newChild: TokenSyntax?) -> ArrowExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ArrowExprSyntax(newData)
   }
 
@@ -3301,10 +3348,10 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenThrowsTokenAndArrowToken` replaced.
   /// - param newChild: The new `unexpectedBetweenThrowsTokenAndArrowToken` to replace the node's
   ///                   current `unexpectedBetweenThrowsTokenAndArrowToken`, if present.
-  public func withUnexpectedBetweenThrowsTokenAndArrowToken(
-    _ newChild: UnexpectedNodesSyntax?) -> ArrowExprSyntax {
+  public func withUnexpectedBetweenThrowsTokenAndArrowToken(_ newChild: UnexpectedNodesSyntax?) -> ArrowExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ArrowExprSyntax(newData)
   }
 
@@ -3321,10 +3368,10 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `arrowToken` replaced.
   /// - param newChild: The new `arrowToken` to replace the node's
   ///                   current `arrowToken`, if present.
-  public func withArrowToken(
-    _ newChild: TokenSyntax?) -> ArrowExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withArrowToken(_ newChild: TokenSyntax?) -> ArrowExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ArrowExprSyntax(newData)
   }
 
@@ -3342,10 +3389,10 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterArrowToken` replaced.
   /// - param newChild: The new `unexpectedAfterArrowToken` to replace the node's
   ///                   current `unexpectedAfterArrowToken`, if present.
-  public func withUnexpectedAfterArrowToken(
-    _ newChild: UnexpectedNodesSyntax?) -> ArrowExprSyntax {
+  public func withUnexpectedAfterArrowToken(_ newChild: UnexpectedNodesSyntax?) -> ArrowExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ArrowExprSyntax(newData)
   }
 
@@ -3435,9 +3482,11 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       rightOperand.raw,
       unexpectedAfterRightOperand?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.infixOperatorExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.infixOperatorExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3455,10 +3504,10 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftOperand` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftOperand` to replace the node's
   ///                   current `unexpectedBeforeLeftOperand`, if present.
-  public func withUnexpectedBeforeLeftOperand(
-    _ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
+  public func withUnexpectedBeforeLeftOperand(_ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return InfixOperatorExprSyntax(newData)
   }
 
@@ -3475,10 +3524,10 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftOperand` replaced.
   /// - param newChild: The new `leftOperand` to replace the node's
   ///                   current `leftOperand`, if present.
-  public func withLeftOperand(
-    _ newChild: ExprSyntax?) -> InfixOperatorExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftOperand(_ newChild: ExprSyntax?) -> InfixOperatorExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return InfixOperatorExprSyntax(newData)
   }
 
@@ -3496,10 +3545,10 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftOperandAndOperatorOperand` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftOperandAndOperatorOperand` to replace the node's
   ///                   current `unexpectedBetweenLeftOperandAndOperatorOperand`, if present.
-  public func withUnexpectedBetweenLeftOperandAndOperatorOperand(
-    _ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
+  public func withUnexpectedBetweenLeftOperandAndOperatorOperand(_ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return InfixOperatorExprSyntax(newData)
   }
 
@@ -3516,10 +3565,10 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `operatorOperand` replaced.
   /// - param newChild: The new `operatorOperand` to replace the node's
   ///                   current `operatorOperand`, if present.
-  public func withOperatorOperand(
-    _ newChild: ExprSyntax?) -> InfixOperatorExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withOperatorOperand(_ newChild: ExprSyntax?) -> InfixOperatorExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return InfixOperatorExprSyntax(newData)
   }
 
@@ -3537,10 +3586,10 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenOperatorOperandAndRightOperand` replaced.
   /// - param newChild: The new `unexpectedBetweenOperatorOperandAndRightOperand` to replace the node's
   ///                   current `unexpectedBetweenOperatorOperandAndRightOperand`, if present.
-  public func withUnexpectedBetweenOperatorOperandAndRightOperand(
-    _ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
+  public func withUnexpectedBetweenOperatorOperandAndRightOperand(_ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return InfixOperatorExprSyntax(newData)
   }
 
@@ -3557,10 +3606,10 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightOperand` replaced.
   /// - param newChild: The new `rightOperand` to replace the node's
   ///                   current `rightOperand`, if present.
-  public func withRightOperand(
-    _ newChild: ExprSyntax?) -> InfixOperatorExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightOperand(_ newChild: ExprSyntax?) -> InfixOperatorExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return InfixOperatorExprSyntax(newData)
   }
 
@@ -3578,10 +3627,10 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightOperand` replaced.
   /// - param newChild: The new `unexpectedAfterRightOperand` to replace the node's
   ///                   current `unexpectedAfterRightOperand`, if present.
-  public func withUnexpectedAfterRightOperand(
-    _ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
+  public func withUnexpectedAfterRightOperand(_ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return InfixOperatorExprSyntax(newData)
   }
 
@@ -3663,9 +3712,11 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       floatingDigits.raw,
       unexpectedAfterFloatingDigits?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.floatLiteralExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.floatLiteralExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3683,10 +3734,10 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeFloatingDigits` replaced.
   /// - param newChild: The new `unexpectedBeforeFloatingDigits` to replace the node's
   ///                   current `unexpectedBeforeFloatingDigits`, if present.
-  public func withUnexpectedBeforeFloatingDigits(
-    _ newChild: UnexpectedNodesSyntax?) -> FloatLiteralExprSyntax {
+  public func withUnexpectedBeforeFloatingDigits(_ newChild: UnexpectedNodesSyntax?) -> FloatLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return FloatLiteralExprSyntax(newData)
   }
 
@@ -3703,10 +3754,10 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `floatingDigits` replaced.
   /// - param newChild: The new `floatingDigits` to replace the node's
   ///                   current `floatingDigits`, if present.
-  public func withFloatingDigits(
-    _ newChild: TokenSyntax?) -> FloatLiteralExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.floatingLiteral(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withFloatingDigits(_ newChild: TokenSyntax?) -> FloatLiteralExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.floatingLiteral(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return FloatLiteralExprSyntax(newData)
   }
 
@@ -3724,10 +3775,10 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterFloatingDigits` replaced.
   /// - param newChild: The new `unexpectedAfterFloatingDigits` to replace the node's
   ///                   current `unexpectedAfterFloatingDigits`, if present.
-  public func withUnexpectedAfterFloatingDigits(
-    _ newChild: UnexpectedNodesSyntax?) -> FloatLiteralExprSyntax {
+  public func withUnexpectedAfterFloatingDigits(_ newChild: UnexpectedNodesSyntax?) -> FloatLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return FloatLiteralExprSyntax(newData)
   }
 
@@ -3801,9 +3852,11 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3821,10 +3874,10 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
   ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
+  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return TupleExprSyntax(newData)
   }
 
@@ -3841,10 +3894,10 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> TupleExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> TupleExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return TupleExprSyntax(newData)
   }
 
@@ -3862,10 +3915,10 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndElementList` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndElementList` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndElementList`, if present.
-  public func withUnexpectedBetweenLeftParenAndElementList(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
+  public func withUnexpectedBetweenLeftParenAndElementList(_ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return TupleExprSyntax(newData)
   }
 
@@ -3887,23 +3940,24 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `elementList` collection.
   public func addElement(_ element: TupleExprElementSyntax) -> TupleExprSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return TupleExprSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `elementList` replaced.
   /// - param newChild: The new `elementList` to replace the node's
   ///                   current `elementList`, if present.
-  public func withElementList(
-    _ newChild: TupleExprElementListSyntax?) -> TupleExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withElementList(_ newChild: TupleExprElementListSyntax?) -> TupleExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return TupleExprSyntax(newData)
   }
 
@@ -3921,10 +3975,10 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenElementListAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenElementListAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenElementListAndRightParen`, if present.
-  public func withUnexpectedBetweenElementListAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
+  public func withUnexpectedBetweenElementListAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return TupleExprSyntax(newData)
   }
 
@@ -3941,10 +3995,10 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> TupleExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightParen(_ newChild: TokenSyntax?) -> TupleExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return TupleExprSyntax(newData)
   }
 
@@ -3962,10 +4016,10 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return TupleExprSyntax(newData)
   }
 
@@ -4055,9 +4109,11 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       rightSquare.raw,
       unexpectedAfterRightSquare?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4075,10 +4131,10 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftSquare` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftSquare` to replace the node's
   ///                   current `unexpectedBeforeLeftSquare`, if present.
-  public func withUnexpectedBeforeLeftSquare(
-    _ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
+  public func withUnexpectedBeforeLeftSquare(_ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ArrayExprSyntax(newData)
   }
 
@@ -4095,10 +4151,10 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftSquare` replaced.
   /// - param newChild: The new `leftSquare` to replace the node's
   ///                   current `leftSquare`, if present.
-  public func withLeftSquare(
-    _ newChild: TokenSyntax?) -> ArrayExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftSquare(_ newChild: TokenSyntax?) -> ArrayExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ArrayExprSyntax(newData)
   }
 
@@ -4116,10 +4172,10 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftSquareAndElements` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftSquareAndElements` to replace the node's
   ///                   current `unexpectedBetweenLeftSquareAndElements`, if present.
-  public func withUnexpectedBetweenLeftSquareAndElements(
-    _ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
+  public func withUnexpectedBetweenLeftSquareAndElements(_ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ArrayExprSyntax(newData)
   }
 
@@ -4141,23 +4197,24 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `elements` collection.
   public func addElement(_ element: ArrayElementSyntax) -> ArrayExprSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.arrayElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return ArrayExprSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `elements` replaced.
   /// - param newChild: The new `elements` to replace the node's
   ///                   current `elements`, if present.
-  public func withElements(
-    _ newChild: ArrayElementListSyntax?) -> ArrayExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.arrayElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withElements(_ newChild: ArrayElementListSyntax?) -> ArrayExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.arrayElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ArrayExprSyntax(newData)
   }
 
@@ -4175,10 +4232,10 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenElementsAndRightSquare` replaced.
   /// - param newChild: The new `unexpectedBetweenElementsAndRightSquare` to replace the node's
   ///                   current `unexpectedBetweenElementsAndRightSquare`, if present.
-  public func withUnexpectedBetweenElementsAndRightSquare(
-    _ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
+  public func withUnexpectedBetweenElementsAndRightSquare(_ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ArrayExprSyntax(newData)
   }
 
@@ -4195,10 +4252,10 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightSquare` replaced.
   /// - param newChild: The new `rightSquare` to replace the node's
   ///                   current `rightSquare`, if present.
-  public func withRightSquare(
-    _ newChild: TokenSyntax?) -> ArrayExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightSquare(_ newChild: TokenSyntax?) -> ArrayExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ArrayExprSyntax(newData)
   }
 
@@ -4216,10 +4273,10 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightSquare` replaced.
   /// - param newChild: The new `unexpectedAfterRightSquare` to replace the node's
   ///                   current `unexpectedAfterRightSquare`, if present.
-  public func withUnexpectedAfterRightSquare(
-    _ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
+  public func withUnexpectedAfterRightSquare(_ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ArrayExprSyntax(newData)
   }
 
@@ -4345,9 +4402,11 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       rightSquare.raw,
       unexpectedAfterRightSquare?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4365,10 +4424,10 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftSquare` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftSquare` to replace the node's
   ///                   current `unexpectedBeforeLeftSquare`, if present.
-  public func withUnexpectedBeforeLeftSquare(
-    _ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
+  public func withUnexpectedBeforeLeftSquare(_ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DictionaryExprSyntax(newData)
   }
 
@@ -4385,10 +4444,10 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftSquare` replaced.
   /// - param newChild: The new `leftSquare` to replace the node's
   ///                   current `leftSquare`, if present.
-  public func withLeftSquare(
-    _ newChild: TokenSyntax?) -> DictionaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftSquare(_ newChild: TokenSyntax?) -> DictionaryExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DictionaryExprSyntax(newData)
   }
 
@@ -4406,10 +4465,10 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftSquareAndContent` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftSquareAndContent` to replace the node's
   ///                   current `unexpectedBetweenLeftSquareAndContent`, if present.
-  public func withUnexpectedBetweenLeftSquareAndContent(
-    _ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
+  public func withUnexpectedBetweenLeftSquareAndContent(_ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DictionaryExprSyntax(newData)
   }
 
@@ -4426,10 +4485,10 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `content` replaced.
   /// - param newChild: The new `content` to replace the node's
   ///                   current `content`, if present.
-  public func withContent(
-    _ newChild: Content?) -> DictionaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withContent(_ newChild: Content?) -> DictionaryExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DictionaryExprSyntax(newData)
   }
 
@@ -4447,10 +4506,10 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenContentAndRightSquare` replaced.
   /// - param newChild: The new `unexpectedBetweenContentAndRightSquare` to replace the node's
   ///                   current `unexpectedBetweenContentAndRightSquare`, if present.
-  public func withUnexpectedBetweenContentAndRightSquare(
-    _ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
+  public func withUnexpectedBetweenContentAndRightSquare(_ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DictionaryExprSyntax(newData)
   }
 
@@ -4467,10 +4526,10 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightSquare` replaced.
   /// - param newChild: The new `rightSquare` to replace the node's
   ///                   current `rightSquare`, if present.
-  public func withRightSquare(
-    _ newChild: TokenSyntax?) -> DictionaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightSquare(_ newChild: TokenSyntax?) -> DictionaryExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return DictionaryExprSyntax(newData)
   }
 
@@ -4488,10 +4547,10 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightSquare` replaced.
   /// - param newChild: The new `unexpectedAfterRightSquare` to replace the node's
   ///                   current `unexpectedAfterRightSquare`, if present.
-  public func withUnexpectedAfterRightSquare(
-    _ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
+  public func withUnexpectedAfterRightSquare(_ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return DictionaryExprSyntax(newData)
   }
 
@@ -4573,9 +4632,11 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       digits.raw,
       unexpectedAfterDigits?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.integerLiteralExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.integerLiteralExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4593,10 +4654,10 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeDigits` replaced.
   /// - param newChild: The new `unexpectedBeforeDigits` to replace the node's
   ///                   current `unexpectedBeforeDigits`, if present.
-  public func withUnexpectedBeforeDigits(
-    _ newChild: UnexpectedNodesSyntax?) -> IntegerLiteralExprSyntax {
+  public func withUnexpectedBeforeDigits(_ newChild: UnexpectedNodesSyntax?) -> IntegerLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return IntegerLiteralExprSyntax(newData)
   }
 
@@ -4613,10 +4674,10 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `digits` replaced.
   /// - param newChild: The new `digits` to replace the node's
   ///                   current `digits`, if present.
-  public func withDigits(
-    _ newChild: TokenSyntax?) -> IntegerLiteralExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withDigits(_ newChild: TokenSyntax?) -> IntegerLiteralExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return IntegerLiteralExprSyntax(newData)
   }
 
@@ -4634,10 +4695,10 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterDigits` replaced.
   /// - param newChild: The new `unexpectedAfterDigits` to replace the node's
   ///                   current `unexpectedAfterDigits`, if present.
-  public func withUnexpectedAfterDigits(
-    _ newChild: UnexpectedNodesSyntax?) -> IntegerLiteralExprSyntax {
+  public func withUnexpectedAfterDigits(_ newChild: UnexpectedNodesSyntax?) -> IntegerLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return IntegerLiteralExprSyntax(newData)
   }
 
@@ -4703,9 +4764,11 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       booleanLiteral.raw,
       unexpectedAfterBooleanLiteral?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.booleanLiteralExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.booleanLiteralExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4723,10 +4786,10 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeBooleanLiteral` replaced.
   /// - param newChild: The new `unexpectedBeforeBooleanLiteral` to replace the node's
   ///                   current `unexpectedBeforeBooleanLiteral`, if present.
-  public func withUnexpectedBeforeBooleanLiteral(
-    _ newChild: UnexpectedNodesSyntax?) -> BooleanLiteralExprSyntax {
+  public func withUnexpectedBeforeBooleanLiteral(_ newChild: UnexpectedNodesSyntax?) -> BooleanLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return BooleanLiteralExprSyntax(newData)
   }
 
@@ -4743,10 +4806,10 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `booleanLiteral` replaced.
   /// - param newChild: The new `booleanLiteral` to replace the node's
   ///                   current `booleanLiteral`, if present.
-  public func withBooleanLiteral(
-    _ newChild: TokenSyntax?) -> BooleanLiteralExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.trueKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withBooleanLiteral(_ newChild: TokenSyntax?) -> BooleanLiteralExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.trueKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return BooleanLiteralExprSyntax(newData)
   }
 
@@ -4764,10 +4827,10 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterBooleanLiteral` replaced.
   /// - param newChild: The new `unexpectedAfterBooleanLiteral` to replace the node's
   ///                   current `unexpectedAfterBooleanLiteral`, if present.
-  public func withUnexpectedAfterBooleanLiteral(
-    _ newChild: UnexpectedNodesSyntax?) -> BooleanLiteralExprSyntax {
+  public func withUnexpectedAfterBooleanLiteral(_ newChild: UnexpectedNodesSyntax?) -> BooleanLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return BooleanLiteralExprSyntax(newData)
   }
 
@@ -4841,9 +4904,11 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       colonMark.raw,
       unexpectedAfterColonMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedTernaryExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedTernaryExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4861,10 +4926,10 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeQuestionMark` replaced.
   /// - param newChild: The new `unexpectedBeforeQuestionMark` to replace the node's
   ///                   current `unexpectedBeforeQuestionMark`, if present.
-  public func withUnexpectedBeforeQuestionMark(
-    _ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
+  public func withUnexpectedBeforeQuestionMark(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return UnresolvedTernaryExprSyntax(newData)
   }
 
@@ -4881,10 +4946,10 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `questionMark` replaced.
   /// - param newChild: The new `questionMark` to replace the node's
   ///                   current `questionMark`, if present.
-  public func withQuestionMark(
-    _ newChild: TokenSyntax?) -> UnresolvedTernaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.infixQuestionMark, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withQuestionMark(_ newChild: TokenSyntax?) -> UnresolvedTernaryExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.infixQuestionMark, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return UnresolvedTernaryExprSyntax(newData)
   }
 
@@ -4902,10 +4967,10 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenQuestionMarkAndFirstChoice` replaced.
   /// - param newChild: The new `unexpectedBetweenQuestionMarkAndFirstChoice` to replace the node's
   ///                   current `unexpectedBetweenQuestionMarkAndFirstChoice`, if present.
-  public func withUnexpectedBetweenQuestionMarkAndFirstChoice(
-    _ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
+  public func withUnexpectedBetweenQuestionMarkAndFirstChoice(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return UnresolvedTernaryExprSyntax(newData)
   }
 
@@ -4922,10 +4987,10 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `firstChoice` replaced.
   /// - param newChild: The new `firstChoice` to replace the node's
   ///                   current `firstChoice`, if present.
-  public func withFirstChoice(
-    _ newChild: ExprSyntax?) -> UnresolvedTernaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withFirstChoice(_ newChild: ExprSyntax?) -> UnresolvedTernaryExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return UnresolvedTernaryExprSyntax(newData)
   }
 
@@ -4943,10 +5008,10 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenFirstChoiceAndColonMark` replaced.
   /// - param newChild: The new `unexpectedBetweenFirstChoiceAndColonMark` to replace the node's
   ///                   current `unexpectedBetweenFirstChoiceAndColonMark`, if present.
-  public func withUnexpectedBetweenFirstChoiceAndColonMark(
-    _ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
+  public func withUnexpectedBetweenFirstChoiceAndColonMark(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return UnresolvedTernaryExprSyntax(newData)
   }
 
@@ -4963,10 +5028,10 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colonMark` replaced.
   /// - param newChild: The new `colonMark` to replace the node's
   ///                   current `colonMark`, if present.
-  public func withColonMark(
-    _ newChild: TokenSyntax?) -> UnresolvedTernaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withColonMark(_ newChild: TokenSyntax?) -> UnresolvedTernaryExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return UnresolvedTernaryExprSyntax(newData)
   }
 
@@ -4984,10 +5049,10 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterColonMark` replaced.
   /// - param newChild: The new `unexpectedAfterColonMark` to replace the node's
   ///                   current `unexpectedAfterColonMark`, if present.
-  public func withUnexpectedAfterColonMark(
-    _ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
+  public func withUnexpectedAfterColonMark(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return UnresolvedTernaryExprSyntax(newData)
   }
 
@@ -5085,9 +5150,11 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       secondChoice.raw,
       unexpectedAfterSecondChoice?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.ternaryExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.ternaryExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -5105,10 +5172,10 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeConditionExpression` replaced.
   /// - param newChild: The new `unexpectedBeforeConditionExpression` to replace the node's
   ///                   current `unexpectedBeforeConditionExpression`, if present.
-  public func withUnexpectedBeforeConditionExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
+  public func withUnexpectedBeforeConditionExpression(_ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return TernaryExprSyntax(newData)
   }
 
@@ -5125,10 +5192,10 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `conditionExpression` replaced.
   /// - param newChild: The new `conditionExpression` to replace the node's
   ///                   current `conditionExpression`, if present.
-  public func withConditionExpression(
-    _ newChild: ExprSyntax?) -> TernaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withConditionExpression(_ newChild: ExprSyntax?) -> TernaryExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return TernaryExprSyntax(newData)
   }
 
@@ -5146,10 +5213,10 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenConditionExpressionAndQuestionMark` replaced.
   /// - param newChild: The new `unexpectedBetweenConditionExpressionAndQuestionMark` to replace the node's
   ///                   current `unexpectedBetweenConditionExpressionAndQuestionMark`, if present.
-  public func withUnexpectedBetweenConditionExpressionAndQuestionMark(
-    _ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
+  public func withUnexpectedBetweenConditionExpressionAndQuestionMark(_ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return TernaryExprSyntax(newData)
   }
 
@@ -5166,10 +5233,10 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `questionMark` replaced.
   /// - param newChild: The new `questionMark` to replace the node's
   ///                   current `questionMark`, if present.
-  public func withQuestionMark(
-    _ newChild: TokenSyntax?) -> TernaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.infixQuestionMark, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withQuestionMark(_ newChild: TokenSyntax?) -> TernaryExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.infixQuestionMark, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return TernaryExprSyntax(newData)
   }
 
@@ -5187,10 +5254,10 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenQuestionMarkAndFirstChoice` replaced.
   /// - param newChild: The new `unexpectedBetweenQuestionMarkAndFirstChoice` to replace the node's
   ///                   current `unexpectedBetweenQuestionMarkAndFirstChoice`, if present.
-  public func withUnexpectedBetweenQuestionMarkAndFirstChoice(
-    _ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
+  public func withUnexpectedBetweenQuestionMarkAndFirstChoice(_ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return TernaryExprSyntax(newData)
   }
 
@@ -5207,10 +5274,10 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `firstChoice` replaced.
   /// - param newChild: The new `firstChoice` to replace the node's
   ///                   current `firstChoice`, if present.
-  public func withFirstChoice(
-    _ newChild: ExprSyntax?) -> TernaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withFirstChoice(_ newChild: ExprSyntax?) -> TernaryExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return TernaryExprSyntax(newData)
   }
 
@@ -5228,10 +5295,10 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenFirstChoiceAndColonMark` replaced.
   /// - param newChild: The new `unexpectedBetweenFirstChoiceAndColonMark` to replace the node's
   ///                   current `unexpectedBetweenFirstChoiceAndColonMark`, if present.
-  public func withUnexpectedBetweenFirstChoiceAndColonMark(
-    _ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
+  public func withUnexpectedBetweenFirstChoiceAndColonMark(_ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return TernaryExprSyntax(newData)
   }
 
@@ -5248,10 +5315,10 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colonMark` replaced.
   /// - param newChild: The new `colonMark` to replace the node's
   ///                   current `colonMark`, if present.
-  public func withColonMark(
-    _ newChild: TokenSyntax?) -> TernaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withColonMark(_ newChild: TokenSyntax?) -> TernaryExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return TernaryExprSyntax(newData)
   }
 
@@ -5269,10 +5336,10 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonMarkAndSecondChoice` replaced.
   /// - param newChild: The new `unexpectedBetweenColonMarkAndSecondChoice` to replace the node's
   ///                   current `unexpectedBetweenColonMarkAndSecondChoice`, if present.
-  public func withUnexpectedBetweenColonMarkAndSecondChoice(
-    _ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
+  public func withUnexpectedBetweenColonMarkAndSecondChoice(_ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return TernaryExprSyntax(newData)
   }
 
@@ -5289,10 +5356,10 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `secondChoice` replaced.
   /// - param newChild: The new `secondChoice` to replace the node's
   ///                   current `secondChoice`, if present.
-  public func withSecondChoice(
-    _ newChild: ExprSyntax?) -> TernaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 9)
+  public func withSecondChoice(_ newChild: ExprSyntax?) -> TernaryExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return TernaryExprSyntax(newData)
   }
 
@@ -5310,10 +5377,10 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterSecondChoice` replaced.
   /// - param newChild: The new `unexpectedAfterSecondChoice` to replace the node's
   ///                   current `unexpectedAfterSecondChoice`, if present.
-  public func withUnexpectedAfterSecondChoice(
-    _ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
+  public func withUnexpectedAfterSecondChoice(_ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return TernaryExprSyntax(newData)
   }
 
@@ -5423,9 +5490,11 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       declNameArguments?.raw,
       unexpectedAfterDeclNameArguments?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberAccessExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberAccessExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -5443,10 +5512,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeBase` replaced.
   /// - param newChild: The new `unexpectedBeforeBase` to replace the node's
   ///                   current `unexpectedBeforeBase`, if present.
-  public func withUnexpectedBeforeBase(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
+  public func withUnexpectedBeforeBase(_ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return MemberAccessExprSyntax(newData)
   }
 
@@ -5464,10 +5533,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `base` replaced.
   /// - param newChild: The new `base` to replace the node's
   ///                   current `base`, if present.
-  public func withBase(
-    _ newChild: ExprSyntax?) -> MemberAccessExprSyntax {
+  public func withBase(_ newChild: ExprSyntax?) -> MemberAccessExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return MemberAccessExprSyntax(newData)
   }
 
@@ -5485,10 +5554,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenBaseAndDot` replaced.
   /// - param newChild: The new `unexpectedBetweenBaseAndDot` to replace the node's
   ///                   current `unexpectedBetweenBaseAndDot`, if present.
-  public func withUnexpectedBetweenBaseAndDot(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
+  public func withUnexpectedBetweenBaseAndDot(_ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return MemberAccessExprSyntax(newData)
   }
 
@@ -5505,10 +5574,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `dot` replaced.
   /// - param newChild: The new `dot` to replace the node's
   ///                   current `dot`, if present.
-  public func withDot(
-    _ newChild: TokenSyntax?) -> MemberAccessExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withDot(_ newChild: TokenSyntax?) -> MemberAccessExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return MemberAccessExprSyntax(newData)
   }
 
@@ -5526,10 +5595,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenDotAndName` replaced.
   /// - param newChild: The new `unexpectedBetweenDotAndName` to replace the node's
   ///                   current `unexpectedBetweenDotAndName`, if present.
-  public func withUnexpectedBetweenDotAndName(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
+  public func withUnexpectedBetweenDotAndName(_ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return MemberAccessExprSyntax(newData)
   }
 
@@ -5546,10 +5615,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> MemberAccessExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withName(_ newChild: TokenSyntax?) -> MemberAccessExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return MemberAccessExprSyntax(newData)
   }
 
@@ -5567,10 +5636,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndDeclNameArguments` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndDeclNameArguments` to replace the node's
   ///                   current `unexpectedBetweenNameAndDeclNameArguments`, if present.
-  public func withUnexpectedBetweenNameAndDeclNameArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
+  public func withUnexpectedBetweenNameAndDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return MemberAccessExprSyntax(newData)
   }
 
@@ -5588,10 +5657,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `declNameArguments` replaced.
   /// - param newChild: The new `declNameArguments` to replace the node's
   ///                   current `declNameArguments`, if present.
-  public func withDeclNameArguments(
-    _ newChild: DeclNameArgumentsSyntax?) -> MemberAccessExprSyntax {
+  public func withDeclNameArguments(_ newChild: DeclNameArgumentsSyntax?) -> MemberAccessExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return MemberAccessExprSyntax(newData)
   }
 
@@ -5609,10 +5678,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterDeclNameArguments` replaced.
   /// - param newChild: The new `unexpectedAfterDeclNameArguments` to replace the node's
   ///                   current `unexpectedAfterDeclNameArguments`, if present.
-  public func withUnexpectedAfterDeclNameArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
+  public func withUnexpectedAfterDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return MemberAccessExprSyntax(newData)
   }
 
@@ -5702,9 +5771,11 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       isTok.raw,
       unexpectedAfterIsTok?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedIsExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedIsExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -5722,10 +5793,10 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeIsTok` replaced.
   /// - param newChild: The new `unexpectedBeforeIsTok` to replace the node's
   ///                   current `unexpectedBeforeIsTok`, if present.
-  public func withUnexpectedBeforeIsTok(
-    _ newChild: UnexpectedNodesSyntax?) -> UnresolvedIsExprSyntax {
+  public func withUnexpectedBeforeIsTok(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedIsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return UnresolvedIsExprSyntax(newData)
   }
 
@@ -5742,10 +5813,10 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `isTok` replaced.
   /// - param newChild: The new `isTok` to replace the node's
   ///                   current `isTok`, if present.
-  public func withIsTok(
-    _ newChild: TokenSyntax?) -> UnresolvedIsExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withIsTok(_ newChild: TokenSyntax?) -> UnresolvedIsExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return UnresolvedIsExprSyntax(newData)
   }
 
@@ -5763,10 +5834,10 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterIsTok` replaced.
   /// - param newChild: The new `unexpectedAfterIsTok` to replace the node's
   ///                   current `unexpectedAfterIsTok`, if present.
-  public func withUnexpectedAfterIsTok(
-    _ newChild: UnexpectedNodesSyntax?) -> UnresolvedIsExprSyntax {
+  public func withUnexpectedAfterIsTok(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedIsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return UnresolvedIsExprSyntax(newData)
   }
 
@@ -5840,9 +5911,11 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       typeName.raw,
       unexpectedAfterTypeName?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.isExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.isExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -5860,10 +5933,10 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
   /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
   ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> IsExprSyntax {
+  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> IsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return IsExprSyntax(newData)
   }
 
@@ -5880,10 +5953,10 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> IsExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withExpression(_ newChild: ExprSyntax?) -> IsExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return IsExprSyntax(newData)
   }
 
@@ -5901,10 +5974,10 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndIsTok` replaced.
   /// - param newChild: The new `unexpectedBetweenExpressionAndIsTok` to replace the node's
   ///                   current `unexpectedBetweenExpressionAndIsTok`, if present.
-  public func withUnexpectedBetweenExpressionAndIsTok(
-    _ newChild: UnexpectedNodesSyntax?) -> IsExprSyntax {
+  public func withUnexpectedBetweenExpressionAndIsTok(_ newChild: UnexpectedNodesSyntax?) -> IsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return IsExprSyntax(newData)
   }
 
@@ -5921,10 +5994,10 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `isTok` replaced.
   /// - param newChild: The new `isTok` to replace the node's
   ///                   current `isTok`, if present.
-  public func withIsTok(
-    _ newChild: TokenSyntax?) -> IsExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withIsTok(_ newChild: TokenSyntax?) -> IsExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return IsExprSyntax(newData)
   }
 
@@ -5942,10 +6015,10 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIsTokAndTypeName` replaced.
   /// - param newChild: The new `unexpectedBetweenIsTokAndTypeName` to replace the node's
   ///                   current `unexpectedBetweenIsTokAndTypeName`, if present.
-  public func withUnexpectedBetweenIsTokAndTypeName(
-    _ newChild: UnexpectedNodesSyntax?) -> IsExprSyntax {
+  public func withUnexpectedBetweenIsTokAndTypeName(_ newChild: UnexpectedNodesSyntax?) -> IsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return IsExprSyntax(newData)
   }
 
@@ -5962,10 +6035,10 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typeName` replaced.
   /// - param newChild: The new `typeName` to replace the node's
   ///                   current `typeName`, if present.
-  public func withTypeName(
-    _ newChild: TypeSyntax?) -> IsExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withTypeName(_ newChild: TypeSyntax?) -> IsExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return IsExprSyntax(newData)
   }
 
@@ -5983,10 +6056,10 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTypeName` replaced.
   /// - param newChild: The new `unexpectedAfterTypeName` to replace the node's
   ///                   current `unexpectedAfterTypeName`, if present.
-  public func withUnexpectedAfterTypeName(
-    _ newChild: UnexpectedNodesSyntax?) -> IsExprSyntax {
+  public func withUnexpectedAfterTypeName(_ newChild: UnexpectedNodesSyntax?) -> IsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return IsExprSyntax(newData)
   }
 
@@ -6072,9 +6145,11 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       questionOrExclamationMark?.raw,
       unexpectedAfterQuestionOrExclamationMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedAsExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedAsExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -6092,10 +6167,10 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAsTok` replaced.
   /// - param newChild: The new `unexpectedBeforeAsTok` to replace the node's
   ///                   current `unexpectedBeforeAsTok`, if present.
-  public func withUnexpectedBeforeAsTok(
-    _ newChild: UnexpectedNodesSyntax?) -> UnresolvedAsExprSyntax {
+  public func withUnexpectedBeforeAsTok(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedAsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return UnresolvedAsExprSyntax(newData)
   }
 
@@ -6112,10 +6187,10 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `asTok` replaced.
   /// - param newChild: The new `asTok` to replace the node's
   ///                   current `asTok`, if present.
-  public func withAsTok(
-    _ newChild: TokenSyntax?) -> UnresolvedAsExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withAsTok(_ newChild: TokenSyntax?) -> UnresolvedAsExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return UnresolvedAsExprSyntax(newData)
   }
 
@@ -6133,10 +6208,10 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAsTokAndQuestionOrExclamationMark` replaced.
   /// - param newChild: The new `unexpectedBetweenAsTokAndQuestionOrExclamationMark` to replace the node's
   ///                   current `unexpectedBetweenAsTokAndQuestionOrExclamationMark`, if present.
-  public func withUnexpectedBetweenAsTokAndQuestionOrExclamationMark(
-    _ newChild: UnexpectedNodesSyntax?) -> UnresolvedAsExprSyntax {
+  public func withUnexpectedBetweenAsTokAndQuestionOrExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedAsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return UnresolvedAsExprSyntax(newData)
   }
 
@@ -6154,10 +6229,10 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `questionOrExclamationMark` replaced.
   /// - param newChild: The new `questionOrExclamationMark` to replace the node's
   ///                   current `questionOrExclamationMark`, if present.
-  public func withQuestionOrExclamationMark(
-    _ newChild: TokenSyntax?) -> UnresolvedAsExprSyntax {
+  public func withQuestionOrExclamationMark(_ newChild: TokenSyntax?) -> UnresolvedAsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return UnresolvedAsExprSyntax(newData)
   }
 
@@ -6175,10 +6250,10 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterQuestionOrExclamationMark` replaced.
   /// - param newChild: The new `unexpectedAfterQuestionOrExclamationMark` to replace the node's
   ///                   current `unexpectedAfterQuestionOrExclamationMark`, if present.
-  public func withUnexpectedAfterQuestionOrExclamationMark(
-    _ newChild: UnexpectedNodesSyntax?) -> UnresolvedAsExprSyntax {
+  public func withUnexpectedAfterQuestionOrExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedAsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return UnresolvedAsExprSyntax(newData)
   }
 
@@ -6264,9 +6339,11 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       typeName.raw,
       unexpectedAfterTypeName?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.asExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.asExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -6284,10 +6361,10 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
   /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
   ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
+  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AsExprSyntax(newData)
   }
 
@@ -6304,10 +6381,10 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> AsExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withExpression(_ newChild: ExprSyntax?) -> AsExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AsExprSyntax(newData)
   }
 
@@ -6325,10 +6402,10 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndAsTok` replaced.
   /// - param newChild: The new `unexpectedBetweenExpressionAndAsTok` to replace the node's
   ///                   current `unexpectedBetweenExpressionAndAsTok`, if present.
-  public func withUnexpectedBetweenExpressionAndAsTok(
-    _ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
+  public func withUnexpectedBetweenExpressionAndAsTok(_ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AsExprSyntax(newData)
   }
 
@@ -6345,10 +6422,10 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `asTok` replaced.
   /// - param newChild: The new `asTok` to replace the node's
   ///                   current `asTok`, if present.
-  public func withAsTok(
-    _ newChild: TokenSyntax?) -> AsExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withAsTok(_ newChild: TokenSyntax?) -> AsExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AsExprSyntax(newData)
   }
 
@@ -6366,10 +6443,10 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAsTokAndQuestionOrExclamationMark` replaced.
   /// - param newChild: The new `unexpectedBetweenAsTokAndQuestionOrExclamationMark` to replace the node's
   ///                   current `unexpectedBetweenAsTokAndQuestionOrExclamationMark`, if present.
-  public func withUnexpectedBetweenAsTokAndQuestionOrExclamationMark(
-    _ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
+  public func withUnexpectedBetweenAsTokAndQuestionOrExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AsExprSyntax(newData)
   }
 
@@ -6387,10 +6464,10 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `questionOrExclamationMark` replaced.
   /// - param newChild: The new `questionOrExclamationMark` to replace the node's
   ///                   current `questionOrExclamationMark`, if present.
-  public func withQuestionOrExclamationMark(
-    _ newChild: TokenSyntax?) -> AsExprSyntax {
+  public func withQuestionOrExclamationMark(_ newChild: TokenSyntax?) -> AsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return AsExprSyntax(newData)
   }
 
@@ -6408,10 +6485,10 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenQuestionOrExclamationMarkAndTypeName` replaced.
   /// - param newChild: The new `unexpectedBetweenQuestionOrExclamationMarkAndTypeName` to replace the node's
   ///                   current `unexpectedBetweenQuestionOrExclamationMarkAndTypeName`, if present.
-  public func withUnexpectedBetweenQuestionOrExclamationMarkAndTypeName(
-    _ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
+  public func withUnexpectedBetweenQuestionOrExclamationMarkAndTypeName(_ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return AsExprSyntax(newData)
   }
 
@@ -6428,10 +6505,10 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typeName` replaced.
   /// - param newChild: The new `typeName` to replace the node's
   ///                   current `typeName`, if present.
-  public func withTypeName(
-    _ newChild: TypeSyntax?) -> AsExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withTypeName(_ newChild: TypeSyntax?) -> AsExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return AsExprSyntax(newData)
   }
 
@@ -6449,10 +6526,10 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTypeName` replaced.
   /// - param newChild: The new `unexpectedAfterTypeName` to replace the node's
   ///                   current `unexpectedAfterTypeName`, if present.
-  public func withUnexpectedAfterTypeName(
-    _ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
+  public func withUnexpectedAfterTypeName(_ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return AsExprSyntax(newData)
   }
 
@@ -6542,9 +6619,11 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       type.raw,
       unexpectedAfterType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -6562,10 +6641,10 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeType` replaced.
   /// - param newChild: The new `unexpectedBeforeType` to replace the node's
   ///                   current `unexpectedBeforeType`, if present.
-  public func withUnexpectedBeforeType(
-    _ newChild: UnexpectedNodesSyntax?) -> TypeExprSyntax {
+  public func withUnexpectedBeforeType(_ newChild: UnexpectedNodesSyntax?) -> TypeExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return TypeExprSyntax(newData)
   }
 
@@ -6582,10 +6661,10 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `type` replaced.
   /// - param newChild: The new `type` to replace the node's
   ///                   current `type`, if present.
-  public func withType(
-    _ newChild: TypeSyntax?) -> TypeExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withType(_ newChild: TypeSyntax?) -> TypeExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return TypeExprSyntax(newData)
   }
 
@@ -6603,10 +6682,10 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterType` replaced.
   /// - param newChild: The new `unexpectedAfterType` to replace the node's
   ///                   current `unexpectedAfterType`, if present.
-  public func withUnexpectedAfterType(
-    _ newChild: UnexpectedNodesSyntax?) -> TypeExprSyntax {
+  public func withUnexpectedAfterType(_ newChild: UnexpectedNodesSyntax?) -> TypeExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return TypeExprSyntax(newData)
   }
 
@@ -6684,9 +6763,11 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       rightBrace.raw,
       unexpectedAfterRightBrace?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -6704,10 +6785,10 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftBrace` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftBrace` to replace the node's
   ///                   current `unexpectedBeforeLeftBrace`, if present.
-  public func withUnexpectedBeforeLeftBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
+  public func withUnexpectedBeforeLeftBrace(_ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ClosureExprSyntax(newData)
   }
 
@@ -6724,10 +6805,10 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBrace` replaced.
   /// - param newChild: The new `leftBrace` to replace the node's
   ///                   current `leftBrace`, if present.
-  public func withLeftBrace(
-    _ newChild: TokenSyntax?) -> ClosureExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftBrace(_ newChild: TokenSyntax?) -> ClosureExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ClosureExprSyntax(newData)
   }
 
@@ -6745,10 +6826,10 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftBraceAndSignature` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftBraceAndSignature` to replace the node's
   ///                   current `unexpectedBetweenLeftBraceAndSignature`, if present.
-  public func withUnexpectedBetweenLeftBraceAndSignature(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
+  public func withUnexpectedBetweenLeftBraceAndSignature(_ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ClosureExprSyntax(newData)
   }
 
@@ -6766,10 +6847,10 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `signature` replaced.
   /// - param newChild: The new `signature` to replace the node's
   ///                   current `signature`, if present.
-  public func withSignature(
-    _ newChild: ClosureSignatureSyntax?) -> ClosureExprSyntax {
+  public func withSignature(_ newChild: ClosureSignatureSyntax?) -> ClosureExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ClosureExprSyntax(newData)
   }
 
@@ -6787,10 +6868,10 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenSignatureAndStatements` replaced.
   /// - param newChild: The new `unexpectedBetweenSignatureAndStatements` to replace the node's
   ///                   current `unexpectedBetweenSignatureAndStatements`, if present.
-  public func withUnexpectedBetweenSignatureAndStatements(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
+  public func withUnexpectedBetweenSignatureAndStatements(_ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ClosureExprSyntax(newData)
   }
 
@@ -6812,23 +6893,24 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `statements` collection.
   public func addStatement(_ element: CodeBlockItemSyntax) -> ClosureExprSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 5)
+    let newData = data.replacingChild(collection, at: 5, arena: arena)
     return ClosureExprSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `statements` replaced.
   /// - param newChild: The new `statements` to replace the node's
   ///                   current `statements`, if present.
-  public func withStatements(
-    _ newChild: CodeBlockItemListSyntax?) -> ClosureExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withStatements(_ newChild: CodeBlockItemListSyntax?) -> ClosureExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ClosureExprSyntax(newData)
   }
 
@@ -6846,10 +6928,10 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenStatementsAndRightBrace` replaced.
   /// - param newChild: The new `unexpectedBetweenStatementsAndRightBrace` to replace the node's
   ///                   current `unexpectedBetweenStatementsAndRightBrace`, if present.
-  public func withUnexpectedBetweenStatementsAndRightBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
+  public func withUnexpectedBetweenStatementsAndRightBrace(_ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ClosureExprSyntax(newData)
   }
 
@@ -6866,10 +6948,10 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBrace` replaced.
   /// - param newChild: The new `rightBrace` to replace the node's
   ///                   current `rightBrace`, if present.
-  public func withRightBrace(
-    _ newChild: TokenSyntax?) -> ClosureExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withRightBrace(_ newChild: TokenSyntax?) -> ClosureExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return ClosureExprSyntax(newData)
   }
 
@@ -6887,10 +6969,10 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
   /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
   ///                   current `unexpectedAfterRightBrace`, if present.
-  public func withUnexpectedAfterRightBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
+  public func withUnexpectedAfterRightBrace(_ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return ClosureExprSyntax(newData)
   }
 
@@ -6980,9 +7062,11 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       pattern.raw,
       unexpectedAfterPattern?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedPatternExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedPatternExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -7000,10 +7084,10 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePattern` replaced.
   /// - param newChild: The new `unexpectedBeforePattern` to replace the node's
   ///                   current `unexpectedBeforePattern`, if present.
-  public func withUnexpectedBeforePattern(
-    _ newChild: UnexpectedNodesSyntax?) -> UnresolvedPatternExprSyntax {
+  public func withUnexpectedBeforePattern(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedPatternExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return UnresolvedPatternExprSyntax(newData)
   }
 
@@ -7020,10 +7104,10 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(
-    _ newChild: PatternSyntax?) -> UnresolvedPatternExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPattern(_ newChild: PatternSyntax?) -> UnresolvedPatternExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return UnresolvedPatternExprSyntax(newData)
   }
 
@@ -7041,10 +7125,10 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterPattern` replaced.
   /// - param newChild: The new `unexpectedAfterPattern` to replace the node's
   ///                   current `unexpectedAfterPattern`, if present.
-  public func withUnexpectedAfterPattern(
-    _ newChild: UnexpectedNodesSyntax?) -> UnresolvedPatternExprSyntax {
+  public func withUnexpectedAfterPattern(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedPatternExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return UnresolvedPatternExprSyntax(newData)
   }
 
@@ -7130,9 +7214,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       additionalTrailingClosures?.raw,
       unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionCallExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionCallExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -7150,10 +7236,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeCalledExpression` replaced.
   /// - param newChild: The new `unexpectedBeforeCalledExpression` to replace the node's
   ///                   current `unexpectedBeforeCalledExpression`, if present.
-  public func withUnexpectedBeforeCalledExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
+  public func withUnexpectedBeforeCalledExpression(_ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
 
@@ -7170,10 +7256,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `calledExpression` replaced.
   /// - param newChild: The new `calledExpression` to replace the node's
   ///                   current `calledExpression`, if present.
-  public func withCalledExpression(
-    _ newChild: ExprSyntax?) -> FunctionCallExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withCalledExpression(_ newChild: ExprSyntax?) -> FunctionCallExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
 
@@ -7191,10 +7277,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCalledExpressionAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenCalledExpressionAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenCalledExpressionAndLeftParen`, if present.
-  public func withUnexpectedBetweenCalledExpressionAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
+  public func withUnexpectedBetweenCalledExpressionAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
 
@@ -7212,10 +7298,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> FunctionCallExprSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax?) -> FunctionCallExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
 
@@ -7233,10 +7319,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArgumentList` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndArgumentList` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndArgumentList`, if present.
-  public func withUnexpectedBetweenLeftParenAndArgumentList(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
+  public func withUnexpectedBetweenLeftParenAndArgumentList(_ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
 
@@ -7258,23 +7344,24 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `argumentList` collection.
   public func addArgument(_ element: TupleExprElementSyntax) -> FunctionCallExprSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 5)
+    let newData = data.replacingChild(collection, at: 5, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `argumentList` replaced.
   /// - param newChild: The new `argumentList` to replace the node's
   ///                   current `argumentList`, if present.
-  public func withArgumentList(
-    _ newChild: TupleExprElementListSyntax?) -> FunctionCallExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withArgumentList(_ newChild: TupleExprElementListSyntax?) -> FunctionCallExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
 
@@ -7292,10 +7379,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenArgumentListAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenArgumentListAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenArgumentListAndRightParen`, if present.
-  public func withUnexpectedBetweenArgumentListAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
+  public func withUnexpectedBetweenArgumentListAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
 
@@ -7313,10 +7400,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> FunctionCallExprSyntax {
+  public func withRightParen(_ newChild: TokenSyntax?) -> FunctionCallExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
 
@@ -7334,10 +7421,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenRightParenAndTrailingClosure` replaced.
   /// - param newChild: The new `unexpectedBetweenRightParenAndTrailingClosure` to replace the node's
   ///                   current `unexpectedBetweenRightParenAndTrailingClosure`, if present.
-  public func withUnexpectedBetweenRightParenAndTrailingClosure(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
+  public func withUnexpectedBetweenRightParenAndTrailingClosure(_ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
 
@@ -7355,10 +7442,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingClosure` replaced.
   /// - param newChild: The new `trailingClosure` to replace the node's
   ///                   current `trailingClosure`, if present.
-  public func withTrailingClosure(
-    _ newChild: ClosureExprSyntax?) -> FunctionCallExprSyntax {
+  public func withTrailingClosure(_ newChild: ClosureExprSyntax?) -> FunctionCallExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
 
@@ -7376,10 +7463,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` replaced.
   /// - param newChild: The new `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` to replace the node's
   ///                   current `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures`, if present.
-  public func withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
+  public func withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
 
@@ -7402,23 +7489,24 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `additionalTrailingClosures` collection.
   public func addAdditionalTrailingClosure(_ element: MultipleTrailingClosureElementSyntax) -> FunctionCallExprSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[11] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 11)
+    let newData = data.replacingChild(collection, at: 11, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `additionalTrailingClosures` replaced.
   /// - param newChild: The new `additionalTrailingClosures` to replace the node's
   ///                   current `additionalTrailingClosures`, if present.
-  public func withAdditionalTrailingClosures(
-    _ newChild: MultipleTrailingClosureElementListSyntax?) -> FunctionCallExprSyntax {
+  public func withAdditionalTrailingClosures(_ newChild: MultipleTrailingClosureElementListSyntax?) -> FunctionCallExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
 
@@ -7436,10 +7524,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterAdditionalTrailingClosures` replaced.
   /// - param newChild: The new `unexpectedAfterAdditionalTrailingClosures` to replace the node's
   ///                   current `unexpectedAfterAdditionalTrailingClosures`, if present.
-  public func withUnexpectedAfterAdditionalTrailingClosures(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
+  public func withUnexpectedAfterAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
 
@@ -7565,9 +7653,11 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       additionalTrailingClosures?.raw,
       unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.subscriptExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.subscriptExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -7585,10 +7675,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeCalledExpression` replaced.
   /// - param newChild: The new `unexpectedBeforeCalledExpression` to replace the node's
   ///                   current `unexpectedBeforeCalledExpression`, if present.
-  public func withUnexpectedBeforeCalledExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
+  public func withUnexpectedBeforeCalledExpression(_ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return SubscriptExprSyntax(newData)
   }
 
@@ -7605,10 +7695,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `calledExpression` replaced.
   /// - param newChild: The new `calledExpression` to replace the node's
   ///                   current `calledExpression`, if present.
-  public func withCalledExpression(
-    _ newChild: ExprSyntax?) -> SubscriptExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withCalledExpression(_ newChild: ExprSyntax?) -> SubscriptExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return SubscriptExprSyntax(newData)
   }
 
@@ -7626,10 +7716,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCalledExpressionAndLeftBracket` replaced.
   /// - param newChild: The new `unexpectedBetweenCalledExpressionAndLeftBracket` to replace the node's
   ///                   current `unexpectedBetweenCalledExpressionAndLeftBracket`, if present.
-  public func withUnexpectedBetweenCalledExpressionAndLeftBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
+  public func withUnexpectedBetweenCalledExpressionAndLeftBracket(_ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return SubscriptExprSyntax(newData)
   }
 
@@ -7646,10 +7736,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBracket` replaced.
   /// - param newChild: The new `leftBracket` to replace the node's
   ///                   current `leftBracket`, if present.
-  public func withLeftBracket(
-    _ newChild: TokenSyntax?) -> SubscriptExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withLeftBracket(_ newChild: TokenSyntax?) -> SubscriptExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return SubscriptExprSyntax(newData)
   }
 
@@ -7667,10 +7757,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftBracketAndArgumentList` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftBracketAndArgumentList` to replace the node's
   ///                   current `unexpectedBetweenLeftBracketAndArgumentList`, if present.
-  public func withUnexpectedBetweenLeftBracketAndArgumentList(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
+  public func withUnexpectedBetweenLeftBracketAndArgumentList(_ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return SubscriptExprSyntax(newData)
   }
 
@@ -7692,23 +7782,24 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `argumentList` collection.
   public func addArgument(_ element: TupleExprElementSyntax) -> SubscriptExprSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 5)
+    let newData = data.replacingChild(collection, at: 5, arena: arena)
     return SubscriptExprSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `argumentList` replaced.
   /// - param newChild: The new `argumentList` to replace the node's
   ///                   current `argumentList`, if present.
-  public func withArgumentList(
-    _ newChild: TupleExprElementListSyntax?) -> SubscriptExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withArgumentList(_ newChild: TupleExprElementListSyntax?) -> SubscriptExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return SubscriptExprSyntax(newData)
   }
 
@@ -7726,10 +7817,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenArgumentListAndRightBracket` replaced.
   /// - param newChild: The new `unexpectedBetweenArgumentListAndRightBracket` to replace the node's
   ///                   current `unexpectedBetweenArgumentListAndRightBracket`, if present.
-  public func withUnexpectedBetweenArgumentListAndRightBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
+  public func withUnexpectedBetweenArgumentListAndRightBracket(_ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return SubscriptExprSyntax(newData)
   }
 
@@ -7746,10 +7837,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBracket` replaced.
   /// - param newChild: The new `rightBracket` to replace the node's
   ///                   current `rightBracket`, if present.
-  public func withRightBracket(
-    _ newChild: TokenSyntax?) -> SubscriptExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withRightBracket(_ newChild: TokenSyntax?) -> SubscriptExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return SubscriptExprSyntax(newData)
   }
 
@@ -7767,10 +7858,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenRightBracketAndTrailingClosure` replaced.
   /// - param newChild: The new `unexpectedBetweenRightBracketAndTrailingClosure` to replace the node's
   ///                   current `unexpectedBetweenRightBracketAndTrailingClosure`, if present.
-  public func withUnexpectedBetweenRightBracketAndTrailingClosure(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
+  public func withUnexpectedBetweenRightBracketAndTrailingClosure(_ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return SubscriptExprSyntax(newData)
   }
 
@@ -7788,10 +7879,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingClosure` replaced.
   /// - param newChild: The new `trailingClosure` to replace the node's
   ///                   current `trailingClosure`, if present.
-  public func withTrailingClosure(
-    _ newChild: ClosureExprSyntax?) -> SubscriptExprSyntax {
+  public func withTrailingClosure(_ newChild: ClosureExprSyntax?) -> SubscriptExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return SubscriptExprSyntax(newData)
   }
 
@@ -7809,10 +7900,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` replaced.
   /// - param newChild: The new `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` to replace the node's
   ///                   current `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures`, if present.
-  public func withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
+  public func withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return SubscriptExprSyntax(newData)
   }
 
@@ -7835,23 +7926,24 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `additionalTrailingClosures` collection.
   public func addAdditionalTrailingClosure(_ element: MultipleTrailingClosureElementSyntax) -> SubscriptExprSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[11] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 11)
+    let newData = data.replacingChild(collection, at: 11, arena: arena)
     return SubscriptExprSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `additionalTrailingClosures` replaced.
   /// - param newChild: The new `additionalTrailingClosures` to replace the node's
   ///                   current `additionalTrailingClosures`, if present.
-  public func withAdditionalTrailingClosures(
-    _ newChild: MultipleTrailingClosureElementListSyntax?) -> SubscriptExprSyntax {
+  public func withAdditionalTrailingClosures(_ newChild: MultipleTrailingClosureElementListSyntax?) -> SubscriptExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return SubscriptExprSyntax(newData)
   }
 
@@ -7869,10 +7961,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterAdditionalTrailingClosures` replaced.
   /// - param newChild: The new `unexpectedAfterAdditionalTrailingClosures` to replace the node's
   ///                   current `unexpectedAfterAdditionalTrailingClosures`, if present.
-  public func withUnexpectedAfterAdditionalTrailingClosures(
-    _ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
+  public func withUnexpectedAfterAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return SubscriptExprSyntax(newData)
   }
 
@@ -7982,9 +8074,11 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       questionMark.raw,
       unexpectedAfterQuestionMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalChainingExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalChainingExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -8002,10 +8096,10 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
   /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
   ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> OptionalChainingExprSyntax {
+  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> OptionalChainingExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return OptionalChainingExprSyntax(newData)
   }
 
@@ -8022,10 +8116,10 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> OptionalChainingExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withExpression(_ newChild: ExprSyntax?) -> OptionalChainingExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return OptionalChainingExprSyntax(newData)
   }
 
@@ -8043,10 +8137,10 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndQuestionMark` replaced.
   /// - param newChild: The new `unexpectedBetweenExpressionAndQuestionMark` to replace the node's
   ///                   current `unexpectedBetweenExpressionAndQuestionMark`, if present.
-  public func withUnexpectedBetweenExpressionAndQuestionMark(
-    _ newChild: UnexpectedNodesSyntax?) -> OptionalChainingExprSyntax {
+  public func withUnexpectedBetweenExpressionAndQuestionMark(_ newChild: UnexpectedNodesSyntax?) -> OptionalChainingExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return OptionalChainingExprSyntax(newData)
   }
 
@@ -8063,10 +8157,10 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `questionMark` replaced.
   /// - param newChild: The new `questionMark` to replace the node's
   ///                   current `questionMark`, if present.
-  public func withQuestionMark(
-    _ newChild: TokenSyntax?) -> OptionalChainingExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withQuestionMark(_ newChild: TokenSyntax?) -> OptionalChainingExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return OptionalChainingExprSyntax(newData)
   }
 
@@ -8084,10 +8178,10 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterQuestionMark` replaced.
   /// - param newChild: The new `unexpectedAfterQuestionMark` to replace the node's
   ///                   current `unexpectedAfterQuestionMark`, if present.
-  public func withUnexpectedAfterQuestionMark(
-    _ newChild: UnexpectedNodesSyntax?) -> OptionalChainingExprSyntax {
+  public func withUnexpectedAfterQuestionMark(_ newChild: UnexpectedNodesSyntax?) -> OptionalChainingExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return OptionalChainingExprSyntax(newData)
   }
 
@@ -8165,9 +8259,11 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       exclamationMark.raw,
       unexpectedAfterExclamationMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.forcedValueExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.forcedValueExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -8185,10 +8281,10 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
   /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
   ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> ForcedValueExprSyntax {
+  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> ForcedValueExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ForcedValueExprSyntax(newData)
   }
 
@@ -8205,10 +8301,10 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> ForcedValueExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withExpression(_ newChild: ExprSyntax?) -> ForcedValueExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ForcedValueExprSyntax(newData)
   }
 
@@ -8226,10 +8322,10 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndExclamationMark` replaced.
   /// - param newChild: The new `unexpectedBetweenExpressionAndExclamationMark` to replace the node's
   ///                   current `unexpectedBetweenExpressionAndExclamationMark`, if present.
-  public func withUnexpectedBetweenExpressionAndExclamationMark(
-    _ newChild: UnexpectedNodesSyntax?) -> ForcedValueExprSyntax {
+  public func withUnexpectedBetweenExpressionAndExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> ForcedValueExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ForcedValueExprSyntax(newData)
   }
 
@@ -8246,10 +8342,10 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `exclamationMark` replaced.
   /// - param newChild: The new `exclamationMark` to replace the node's
   ///                   current `exclamationMark`, if present.
-  public func withExclamationMark(
-    _ newChild: TokenSyntax?) -> ForcedValueExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.exclamationMark, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withExclamationMark(_ newChild: TokenSyntax?) -> ForcedValueExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.exclamationMark, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ForcedValueExprSyntax(newData)
   }
 
@@ -8267,10 +8363,10 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterExclamationMark` replaced.
   /// - param newChild: The new `unexpectedAfterExclamationMark` to replace the node's
   ///                   current `unexpectedAfterExclamationMark`, if present.
-  public func withUnexpectedAfterExclamationMark(
-    _ newChild: UnexpectedNodesSyntax?) -> ForcedValueExprSyntax {
+  public func withUnexpectedAfterExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> ForcedValueExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ForcedValueExprSyntax(newData)
   }
 
@@ -8348,9 +8444,11 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       operatorToken.raw,
       unexpectedAfterOperatorToken?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.postfixUnaryExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.postfixUnaryExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -8368,10 +8466,10 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
   /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
   ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> PostfixUnaryExprSyntax {
+  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> PostfixUnaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PostfixUnaryExprSyntax(newData)
   }
 
@@ -8388,10 +8486,10 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> PostfixUnaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withExpression(_ newChild: ExprSyntax?) -> PostfixUnaryExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PostfixUnaryExprSyntax(newData)
   }
 
@@ -8409,10 +8507,10 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndOperatorToken` replaced.
   /// - param newChild: The new `unexpectedBetweenExpressionAndOperatorToken` to replace the node's
   ///                   current `unexpectedBetweenExpressionAndOperatorToken`, if present.
-  public func withUnexpectedBetweenExpressionAndOperatorToken(
-    _ newChild: UnexpectedNodesSyntax?) -> PostfixUnaryExprSyntax {
+  public func withUnexpectedBetweenExpressionAndOperatorToken(_ newChild: UnexpectedNodesSyntax?) -> PostfixUnaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PostfixUnaryExprSyntax(newData)
   }
 
@@ -8429,10 +8527,10 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `operatorToken` replaced.
   /// - param newChild: The new `operatorToken` to replace the node's
   ///                   current `operatorToken`, if present.
-  public func withOperatorToken(
-    _ newChild: TokenSyntax?) -> PostfixUnaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixOperator(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withOperatorToken(_ newChild: TokenSyntax?) -> PostfixUnaryExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixOperator(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PostfixUnaryExprSyntax(newData)
   }
 
@@ -8450,10 +8548,10 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterOperatorToken` replaced.
   /// - param newChild: The new `unexpectedAfterOperatorToken` to replace the node's
   ///                   current `unexpectedAfterOperatorToken`, if present.
-  public func withUnexpectedAfterOperatorToken(
-    _ newChild: UnexpectedNodesSyntax?) -> PostfixUnaryExprSyntax {
+  public func withUnexpectedAfterOperatorToken(_ newChild: UnexpectedNodesSyntax?) -> PostfixUnaryExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PostfixUnaryExprSyntax(newData)
   }
 
@@ -8531,9 +8629,11 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       genericArgumentClause.raw,
       unexpectedAfterGenericArgumentClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.specializeExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.specializeExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -8551,10 +8651,10 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
   /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
   ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> SpecializeExprSyntax {
+  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> SpecializeExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return SpecializeExprSyntax(newData)
   }
 
@@ -8571,10 +8671,10 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> SpecializeExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withExpression(_ newChild: ExprSyntax?) -> SpecializeExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return SpecializeExprSyntax(newData)
   }
 
@@ -8592,10 +8692,10 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndGenericArgumentClause` replaced.
   /// - param newChild: The new `unexpectedBetweenExpressionAndGenericArgumentClause` to replace the node's
   ///                   current `unexpectedBetweenExpressionAndGenericArgumentClause`, if present.
-  public func withUnexpectedBetweenExpressionAndGenericArgumentClause(
-    _ newChild: UnexpectedNodesSyntax?) -> SpecializeExprSyntax {
+  public func withUnexpectedBetweenExpressionAndGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> SpecializeExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return SpecializeExprSyntax(newData)
   }
 
@@ -8612,10 +8712,10 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericArgumentClause` replaced.
   /// - param newChild: The new `genericArgumentClause` to replace the node's
   ///                   current `genericArgumentClause`, if present.
-  public func withGenericArgumentClause(
-    _ newChild: GenericArgumentClauseSyntax?) -> SpecializeExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericArgumentClause, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withGenericArgumentClause(_ newChild: GenericArgumentClauseSyntax?) -> SpecializeExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericArgumentClause, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return SpecializeExprSyntax(newData)
   }
 
@@ -8633,10 +8733,10 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterGenericArgumentClause` replaced.
   /// - param newChild: The new `unexpectedAfterGenericArgumentClause` to replace the node's
   ///                   current `unexpectedAfterGenericArgumentClause`, if present.
-  public func withUnexpectedAfterGenericArgumentClause(
-    _ newChild: UnexpectedNodesSyntax?) -> SpecializeExprSyntax {
+  public func withUnexpectedAfterGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> SpecializeExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return SpecializeExprSyntax(newData)
   }
 
@@ -8726,9 +8826,11 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       closeDelimiter?.raw,
       unexpectedAfterCloseDelimiter?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -8746,10 +8848,10 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeOpenDelimiter` replaced.
   /// - param newChild: The new `unexpectedBeforeOpenDelimiter` to replace the node's
   ///                   current `unexpectedBeforeOpenDelimiter`, if present.
-  public func withUnexpectedBeforeOpenDelimiter(
-    _ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
+  public func withUnexpectedBeforeOpenDelimiter(_ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return StringLiteralExprSyntax(newData)
   }
 
@@ -8767,10 +8869,10 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `openDelimiter` replaced.
   /// - param newChild: The new `openDelimiter` to replace the node's
   ///                   current `openDelimiter`, if present.
-  public func withOpenDelimiter(
-    _ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
+  public func withOpenDelimiter(_ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return StringLiteralExprSyntax(newData)
   }
 
@@ -8788,10 +8890,10 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenOpenDelimiterAndOpenQuote` replaced.
   /// - param newChild: The new `unexpectedBetweenOpenDelimiterAndOpenQuote` to replace the node's
   ///                   current `unexpectedBetweenOpenDelimiterAndOpenQuote`, if present.
-  public func withUnexpectedBetweenOpenDelimiterAndOpenQuote(
-    _ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
+  public func withUnexpectedBetweenOpenDelimiterAndOpenQuote(_ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return StringLiteralExprSyntax(newData)
   }
 
@@ -8808,10 +8910,10 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `openQuote` replaced.
   /// - param newChild: The new `openQuote` to replace the node's
   ///                   current `openQuote`, if present.
-  public func withOpenQuote(
-    _ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringQuote, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withOpenQuote(_ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringQuote, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return StringLiteralExprSyntax(newData)
   }
 
@@ -8829,10 +8931,10 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenOpenQuoteAndSegments` replaced.
   /// - param newChild: The new `unexpectedBetweenOpenQuoteAndSegments` to replace the node's
   ///                   current `unexpectedBetweenOpenQuoteAndSegments`, if present.
-  public func withUnexpectedBetweenOpenQuoteAndSegments(
-    _ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
+  public func withUnexpectedBetweenOpenQuoteAndSegments(_ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return StringLiteralExprSyntax(newData)
   }
 
@@ -8854,23 +8956,24 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `segments` collection.
   public func addSegment(_ element: Syntax) -> StringLiteralExprSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralSegments,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 5)
+    let newData = data.replacingChild(collection, at: 5, arena: arena)
     return StringLiteralExprSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `segments` replaced.
   /// - param newChild: The new `segments` to replace the node's
   ///                   current `segments`, if present.
-  public func withSegments(
-    _ newChild: StringLiteralSegmentsSyntax?) -> StringLiteralExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralSegments, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withSegments(_ newChild: StringLiteralSegmentsSyntax?) -> StringLiteralExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralSegments, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return StringLiteralExprSyntax(newData)
   }
 
@@ -8888,10 +8991,10 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenSegmentsAndCloseQuote` replaced.
   /// - param newChild: The new `unexpectedBetweenSegmentsAndCloseQuote` to replace the node's
   ///                   current `unexpectedBetweenSegmentsAndCloseQuote`, if present.
-  public func withUnexpectedBetweenSegmentsAndCloseQuote(
-    _ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
+  public func withUnexpectedBetweenSegmentsAndCloseQuote(_ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return StringLiteralExprSyntax(newData)
   }
 
@@ -8908,10 +9011,10 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `closeQuote` replaced.
   /// - param newChild: The new `closeQuote` to replace the node's
   ///                   current `closeQuote`, if present.
-  public func withCloseQuote(
-    _ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringQuote, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withCloseQuote(_ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringQuote, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return StringLiteralExprSyntax(newData)
   }
 
@@ -8929,10 +9032,10 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCloseQuoteAndCloseDelimiter` replaced.
   /// - param newChild: The new `unexpectedBetweenCloseQuoteAndCloseDelimiter` to replace the node's
   ///                   current `unexpectedBetweenCloseQuoteAndCloseDelimiter`, if present.
-  public func withUnexpectedBetweenCloseQuoteAndCloseDelimiter(
-    _ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
+  public func withUnexpectedBetweenCloseQuoteAndCloseDelimiter(_ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return StringLiteralExprSyntax(newData)
   }
 
@@ -8950,10 +9053,10 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `closeDelimiter` replaced.
   /// - param newChild: The new `closeDelimiter` to replace the node's
   ///                   current `closeDelimiter`, if present.
-  public func withCloseDelimiter(
-    _ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
+  public func withCloseDelimiter(_ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return StringLiteralExprSyntax(newData)
   }
 
@@ -8971,10 +9074,10 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterCloseDelimiter` replaced.
   /// - param newChild: The new `unexpectedAfterCloseDelimiter` to replace the node's
   ///                   current `unexpectedAfterCloseDelimiter`, if present.
-  public func withUnexpectedAfterCloseDelimiter(
-    _ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
+  public func withUnexpectedAfterCloseDelimiter(_ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return StringLiteralExprSyntax(newData)
   }
 
@@ -9072,9 +9175,11 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       regex.raw,
       unexpectedAfterRegex?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.regexLiteralExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.regexLiteralExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9092,10 +9197,10 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeRegex` replaced.
   /// - param newChild: The new `unexpectedBeforeRegex` to replace the node's
   ///                   current `unexpectedBeforeRegex`, if present.
-  public func withUnexpectedBeforeRegex(
-    _ newChild: UnexpectedNodesSyntax?) -> RegexLiteralExprSyntax {
+  public func withUnexpectedBeforeRegex(_ newChild: UnexpectedNodesSyntax?) -> RegexLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return RegexLiteralExprSyntax(newData)
   }
 
@@ -9112,10 +9217,10 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `regex` replaced.
   /// - param newChild: The new `regex` to replace the node's
   ///                   current `regex`, if present.
-  public func withRegex(
-    _ newChild: TokenSyntax?) -> RegexLiteralExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.regexLiteral(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withRegex(_ newChild: TokenSyntax?) -> RegexLiteralExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.regexLiteral(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return RegexLiteralExprSyntax(newData)
   }
 
@@ -9133,10 +9238,10 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRegex` replaced.
   /// - param newChild: The new `unexpectedAfterRegex` to replace the node's
   ///                   current `unexpectedAfterRegex`, if present.
-  public func withUnexpectedAfterRegex(
-    _ newChild: UnexpectedNodesSyntax?) -> RegexLiteralExprSyntax {
+  public func withUnexpectedAfterRegex(_ newChild: UnexpectedNodesSyntax?) -> RegexLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return RegexLiteralExprSyntax(newData)
   }
 
@@ -9210,9 +9315,11 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       components.raw,
       unexpectedAfterComponents?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9230,10 +9337,10 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeBackslash` replaced.
   /// - param newChild: The new `unexpectedBeforeBackslash` to replace the node's
   ///                   current `unexpectedBeforeBackslash`, if present.
-  public func withUnexpectedBeforeBackslash(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
+  public func withUnexpectedBeforeBackslash(_ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return KeyPathExprSyntax(newData)
   }
 
@@ -9250,10 +9357,10 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `backslash` replaced.
   /// - param newChild: The new `backslash` to replace the node's
   ///                   current `backslash`, if present.
-  public func withBackslash(
-    _ newChild: TokenSyntax?) -> KeyPathExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withBackslash(_ newChild: TokenSyntax?) -> KeyPathExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return KeyPathExprSyntax(newData)
   }
 
@@ -9271,10 +9378,10 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenBackslashAndRoot` replaced.
   /// - param newChild: The new `unexpectedBetweenBackslashAndRoot` to replace the node's
   ///                   current `unexpectedBetweenBackslashAndRoot`, if present.
-  public func withUnexpectedBetweenBackslashAndRoot(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
+  public func withUnexpectedBetweenBackslashAndRoot(_ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return KeyPathExprSyntax(newData)
   }
 
@@ -9292,10 +9399,10 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `root` replaced.
   /// - param newChild: The new `root` to replace the node's
   ///                   current `root`, if present.
-  public func withRoot(
-    _ newChild: TypeSyntax?) -> KeyPathExprSyntax {
+  public func withRoot(_ newChild: TypeSyntax?) -> KeyPathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return KeyPathExprSyntax(newData)
   }
 
@@ -9313,10 +9420,10 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenRootAndComponents` replaced.
   /// - param newChild: The new `unexpectedBetweenRootAndComponents` to replace the node's
   ///                   current `unexpectedBetweenRootAndComponents`, if present.
-  public func withUnexpectedBetweenRootAndComponents(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
+  public func withUnexpectedBetweenRootAndComponents(_ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return KeyPathExprSyntax(newData)
   }
 
@@ -9338,23 +9445,24 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `components` collection.
   public func addKeyPathComponent(_ element: KeyPathComponentSyntax) -> KeyPathExprSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.keyPathComponentList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 5)
+    let newData = data.replacingChild(collection, at: 5, arena: arena)
     return KeyPathExprSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `components` replaced.
   /// - param newChild: The new `components` to replace the node's
   ///                   current `components`, if present.
-  public func withComponents(
-    _ newChild: KeyPathComponentListSyntax?) -> KeyPathExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.keyPathComponentList, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withComponents(_ newChild: KeyPathComponentListSyntax?) -> KeyPathExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.keyPathComponentList, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return KeyPathExprSyntax(newData)
   }
 
@@ -9372,10 +9480,10 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterComponents` replaced.
   /// - param newChild: The new `unexpectedAfterComponents` to replace the node's
   ///                   current `unexpectedAfterComponents`, if present.
-  public func withUnexpectedAfterComponents(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
+  public func withUnexpectedAfterComponents(_ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return KeyPathExprSyntax(newData)
   }
 
@@ -9511,9 +9619,11 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.oldKeyPathExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.oldKeyPathExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9531,10 +9641,10 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeBackslash` replaced.
   /// - param newChild: The new `unexpectedBeforeBackslash` to replace the node's
   ///                   current `unexpectedBeforeBackslash`, if present.
-  public func withUnexpectedBeforeBackslash(
-    _ newChild: UnexpectedNodesSyntax?) -> OldKeyPathExprSyntax {
+  public func withUnexpectedBeforeBackslash(_ newChild: UnexpectedNodesSyntax?) -> OldKeyPathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return OldKeyPathExprSyntax(newData)
   }
 
@@ -9551,10 +9661,10 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `backslash` replaced.
   /// - param newChild: The new `backslash` to replace the node's
   ///                   current `backslash`, if present.
-  public func withBackslash(
-    _ newChild: TokenSyntax?) -> OldKeyPathExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withBackslash(_ newChild: TokenSyntax?) -> OldKeyPathExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return OldKeyPathExprSyntax(newData)
   }
 
@@ -9572,10 +9682,10 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenBackslashAndRootExpr` replaced.
   /// - param newChild: The new `unexpectedBetweenBackslashAndRootExpr` to replace the node's
   ///                   current `unexpectedBetweenBackslashAndRootExpr`, if present.
-  public func withUnexpectedBetweenBackslashAndRootExpr(
-    _ newChild: UnexpectedNodesSyntax?) -> OldKeyPathExprSyntax {
+  public func withUnexpectedBetweenBackslashAndRootExpr(_ newChild: UnexpectedNodesSyntax?) -> OldKeyPathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return OldKeyPathExprSyntax(newData)
   }
 
@@ -9593,10 +9703,10 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rootExpr` replaced.
   /// - param newChild: The new `rootExpr` to replace the node's
   ///                   current `rootExpr`, if present.
-  public func withRootExpr(
-    _ newChild: RootExpr?) -> OldKeyPathExprSyntax {
+  public func withRootExpr(_ newChild: RootExpr?) -> OldKeyPathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return OldKeyPathExprSyntax(newData)
   }
 
@@ -9614,10 +9724,10 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenRootExprAndExpression` replaced.
   /// - param newChild: The new `unexpectedBetweenRootExprAndExpression` to replace the node's
   ///                   current `unexpectedBetweenRootExprAndExpression`, if present.
-  public func withUnexpectedBetweenRootExprAndExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> OldKeyPathExprSyntax {
+  public func withUnexpectedBetweenRootExprAndExpression(_ newChild: UnexpectedNodesSyntax?) -> OldKeyPathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return OldKeyPathExprSyntax(newData)
   }
 
@@ -9634,10 +9744,10 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> OldKeyPathExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withExpression(_ newChild: ExprSyntax?) -> OldKeyPathExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return OldKeyPathExprSyntax(newData)
   }
 
@@ -9655,10 +9765,10 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
   /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
   ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> OldKeyPathExprSyntax {
+  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> OldKeyPathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return OldKeyPathExprSyntax(newData)
   }
 
@@ -9740,9 +9850,11 @@ public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       period.raw,
       unexpectedAfterPeriod?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathBaseExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathBaseExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9760,10 +9872,10 @@ public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePeriod` replaced.
   /// - param newChild: The new `unexpectedBeforePeriod` to replace the node's
   ///                   current `unexpectedBeforePeriod`, if present.
-  public func withUnexpectedBeforePeriod(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathBaseExprSyntax {
+  public func withUnexpectedBeforePeriod(_ newChild: UnexpectedNodesSyntax?) -> KeyPathBaseExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return KeyPathBaseExprSyntax(newData)
   }
 
@@ -9780,10 +9892,10 @@ public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `period` replaced.
   /// - param newChild: The new `period` to replace the node's
   ///                   current `period`, if present.
-  public func withPeriod(
-    _ newChild: TokenSyntax?) -> KeyPathBaseExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPeriod(_ newChild: TokenSyntax?) -> KeyPathBaseExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return KeyPathBaseExprSyntax(newData)
   }
 
@@ -9801,10 +9913,10 @@ public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterPeriod` replaced.
   /// - param newChild: The new `unexpectedAfterPeriod` to replace the node's
   ///                   current `unexpectedAfterPeriod`, if present.
-  public func withUnexpectedAfterPeriod(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathBaseExprSyntax {
+  public func withUnexpectedAfterPeriod(_ newChild: UnexpectedNodesSyntax?) -> KeyPathBaseExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return KeyPathBaseExprSyntax(newData)
   }
 
@@ -9882,9 +9994,11 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcKeyPathExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcKeyPathExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9902,10 +10016,10 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeKeyPath` replaced.
   /// - param newChild: The new `unexpectedBeforeKeyPath` to replace the node's
   ///                   current `unexpectedBeforeKeyPath`, if present.
-  public func withUnexpectedBeforeKeyPath(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjcKeyPathExprSyntax {
+  public func withUnexpectedBeforeKeyPath(_ newChild: UnexpectedNodesSyntax?) -> ObjcKeyPathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ObjcKeyPathExprSyntax(newData)
   }
 
@@ -9922,10 +10036,10 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `keyPath` replaced.
   /// - param newChild: The new `keyPath` to replace the node's
   ///                   current `keyPath`, if present.
-  public func withKeyPath(
-    _ newChild: TokenSyntax?) -> ObjcKeyPathExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundKeyPathKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withKeyPath(_ newChild: TokenSyntax?) -> ObjcKeyPathExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundKeyPathKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ObjcKeyPathExprSyntax(newData)
   }
 
@@ -9943,10 +10057,10 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenKeyPathAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenKeyPathAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenKeyPathAndLeftParen`, if present.
-  public func withUnexpectedBetweenKeyPathAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjcKeyPathExprSyntax {
+  public func withUnexpectedBetweenKeyPathAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> ObjcKeyPathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ObjcKeyPathExprSyntax(newData)
   }
 
@@ -9963,10 +10077,10 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> ObjcKeyPathExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> ObjcKeyPathExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ObjcKeyPathExprSyntax(newData)
   }
 
@@ -9984,10 +10098,10 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndName` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndName` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndName`, if present.
-  public func withUnexpectedBetweenLeftParenAndName(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjcKeyPathExprSyntax {
+  public func withUnexpectedBetweenLeftParenAndName(_ newChild: UnexpectedNodesSyntax?) -> ObjcKeyPathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ObjcKeyPathExprSyntax(newData)
   }
 
@@ -10009,23 +10123,24 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `name` collection.
   public func addNamePiece(_ element: ObjcNamePieceSyntax) -> ObjcKeyPathExprSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.objcName,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 5)
+    let newData = data.replacingChild(collection, at: 5, arena: arena)
     return ObjcKeyPathExprSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: ObjcNameSyntax?) -> ObjcKeyPathExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.objcName, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withName(_ newChild: ObjcNameSyntax?) -> ObjcKeyPathExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.objcName, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ObjcKeyPathExprSyntax(newData)
   }
 
@@ -10043,10 +10158,10 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenNameAndRightParen`, if present.
-  public func withUnexpectedBetweenNameAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjcKeyPathExprSyntax {
+  public func withUnexpectedBetweenNameAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> ObjcKeyPathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ObjcKeyPathExprSyntax(newData)
   }
 
@@ -10063,10 +10178,10 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> ObjcKeyPathExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withRightParen(_ newChild: TokenSyntax?) -> ObjcKeyPathExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return ObjcKeyPathExprSyntax(newData)
   }
 
@@ -10084,10 +10199,10 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjcKeyPathExprSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> ObjcKeyPathExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return ObjcKeyPathExprSyntax(newData)
   }
 
@@ -10197,9 +10312,11 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcSelectorExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcSelectorExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -10217,10 +10334,10 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundSelector` replaced.
   /// - param newChild: The new `unexpectedBeforePoundSelector` to replace the node's
   ///                   current `unexpectedBeforePoundSelector`, if present.
-  public func withUnexpectedBeforePoundSelector(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
+  public func withUnexpectedBeforePoundSelector(_ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ObjcSelectorExprSyntax(newData)
   }
 
@@ -10237,10 +10354,10 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundSelector` replaced.
   /// - param newChild: The new `poundSelector` to replace the node's
   ///                   current `poundSelector`, if present.
-  public func withPoundSelector(
-    _ newChild: TokenSyntax?) -> ObjcSelectorExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundSelectorKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundSelector(_ newChild: TokenSyntax?) -> ObjcSelectorExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundSelectorKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ObjcSelectorExprSyntax(newData)
   }
 
@@ -10258,10 +10375,10 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPoundSelectorAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenPoundSelectorAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenPoundSelectorAndLeftParen`, if present.
-  public func withUnexpectedBetweenPoundSelectorAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
+  public func withUnexpectedBetweenPoundSelectorAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ObjcSelectorExprSyntax(newData)
   }
 
@@ -10278,10 +10395,10 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> ObjcSelectorExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> ObjcSelectorExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ObjcSelectorExprSyntax(newData)
   }
 
@@ -10299,10 +10416,10 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndKind` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndKind` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndKind`, if present.
-  public func withUnexpectedBetweenLeftParenAndKind(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
+  public func withUnexpectedBetweenLeftParenAndKind(_ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ObjcSelectorExprSyntax(newData)
   }
 
@@ -10320,10 +10437,10 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `kind` replaced.
   /// - param newChild: The new `kind` to replace the node's
   ///                   current `kind`, if present.
-  public func withKind(
-    _ newChild: TokenSyntax?) -> ObjcSelectorExprSyntax {
+  public func withKind(_ newChild: TokenSyntax?) -> ObjcSelectorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ObjcSelectorExprSyntax(newData)
   }
 
@@ -10341,10 +10458,10 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenKindAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenKindAndColon` to replace the node's
   ///                   current `unexpectedBetweenKindAndColon`, if present.
-  public func withUnexpectedBetweenKindAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
+  public func withUnexpectedBetweenKindAndColon(_ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ObjcSelectorExprSyntax(newData)
   }
 
@@ -10362,10 +10479,10 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> ObjcSelectorExprSyntax {
+  public func withColon(_ newChild: TokenSyntax?) -> ObjcSelectorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return ObjcSelectorExprSyntax(newData)
   }
 
@@ -10383,10 +10500,10 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndName` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndName` to replace the node's
   ///                   current `unexpectedBetweenColonAndName`, if present.
-  public func withUnexpectedBetweenColonAndName(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
+  public func withUnexpectedBetweenColonAndName(_ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return ObjcSelectorExprSyntax(newData)
   }
 
@@ -10403,10 +10520,10 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: ExprSyntax?) -> ObjcSelectorExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 9)
+  public func withName(_ newChild: ExprSyntax?) -> ObjcSelectorExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return ObjcSelectorExprSyntax(newData)
   }
 
@@ -10424,10 +10541,10 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenNameAndRightParen`, if present.
-  public func withUnexpectedBetweenNameAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
+  public func withUnexpectedBetweenNameAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return ObjcSelectorExprSyntax(newData)
   }
 
@@ -10444,10 +10561,10 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> ObjcSelectorExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 11)
+  public func withRightParen(_ newChild: TokenSyntax?) -> ObjcSelectorExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return ObjcSelectorExprSyntax(newData)
   }
 
@@ -10465,10 +10582,10 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return ObjcSelectorExprSyntax(newData)
   }
 
@@ -10598,9 +10715,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       additionalTrailingClosures?.raw,
       unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.macroExpansionExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.macroExpansionExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -10618,10 +10737,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundToken` replaced.
   /// - param newChild: The new `unexpectedBeforePoundToken` to replace the node's
   ///                   current `unexpectedBeforePoundToken`, if present.
-  public func withUnexpectedBeforePoundToken(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+  public func withUnexpectedBeforePoundToken(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
@@ -10639,10 +10758,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundToken` replaced.
   /// - param newChild: The new `poundToken` to replace the node's
   ///                   current `poundToken`, if present.
-  public func withPoundToken(
-    _ newChild: TokenSyntax?) -> MacroExpansionExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.pound, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundToken(_ newChild: TokenSyntax?) -> MacroExpansionExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.pound, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
@@ -10660,10 +10779,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPoundTokenAndMacro` replaced.
   /// - param newChild: The new `unexpectedBetweenPoundTokenAndMacro` to replace the node's
   ///                   current `unexpectedBetweenPoundTokenAndMacro`, if present.
-  public func withUnexpectedBetweenPoundTokenAndMacro(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+  public func withUnexpectedBetweenPoundTokenAndMacro(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
@@ -10680,10 +10799,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `macro` replaced.
   /// - param newChild: The new `macro` to replace the node's
   ///                   current `macro`, if present.
-  public func withMacro(
-    _ newChild: TokenSyntax?) -> MacroExpansionExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withMacro(_ newChild: TokenSyntax?) -> MacroExpansionExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
@@ -10701,10 +10820,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenMacroAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenMacroAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenMacroAndLeftParen`, if present.
-  public func withUnexpectedBetweenMacroAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+  public func withUnexpectedBetweenMacroAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
@@ -10722,10 +10841,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> MacroExpansionExprSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax?) -> MacroExpansionExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
@@ -10743,10 +10862,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArgumentList` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndArgumentList` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndArgumentList`, if present.
-  public func withUnexpectedBetweenLeftParenAndArgumentList(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+  public func withUnexpectedBetweenLeftParenAndArgumentList(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
@@ -10768,23 +10887,24 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `argumentList` collection.
   public func addArgument(_ element: TupleExprElementSyntax) -> MacroExpansionExprSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[7] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 7)
+    let newData = data.replacingChild(collection, at: 7, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `argumentList` replaced.
   /// - param newChild: The new `argumentList` to replace the node's
   ///                   current `argumentList`, if present.
-  public func withArgumentList(
-    _ newChild: TupleExprElementListSyntax?) -> MacroExpansionExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withArgumentList(_ newChild: TupleExprElementListSyntax?) -> MacroExpansionExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
@@ -10802,10 +10922,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenArgumentListAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenArgumentListAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenArgumentListAndRightParen`, if present.
-  public func withUnexpectedBetweenArgumentListAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+  public func withUnexpectedBetweenArgumentListAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
@@ -10823,10 +10943,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> MacroExpansionExprSyntax {
+  public func withRightParen(_ newChild: TokenSyntax?) -> MacroExpansionExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
@@ -10844,10 +10964,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenRightParenAndTrailingClosure` replaced.
   /// - param newChild: The new `unexpectedBetweenRightParenAndTrailingClosure` to replace the node's
   ///                   current `unexpectedBetweenRightParenAndTrailingClosure`, if present.
-  public func withUnexpectedBetweenRightParenAndTrailingClosure(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+  public func withUnexpectedBetweenRightParenAndTrailingClosure(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
@@ -10865,10 +10985,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingClosure` replaced.
   /// - param newChild: The new `trailingClosure` to replace the node's
   ///                   current `trailingClosure`, if present.
-  public func withTrailingClosure(
-    _ newChild: ClosureExprSyntax?) -> MacroExpansionExprSyntax {
+  public func withTrailingClosure(_ newChild: ClosureExprSyntax?) -> MacroExpansionExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
@@ -10886,10 +11006,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` replaced.
   /// - param newChild: The new `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` to replace the node's
   ///                   current `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures`, if present.
-  public func withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+  public func withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
@@ -10912,23 +11032,24 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `additionalTrailingClosures` collection.
   public func addAdditionalTrailingClosure(_ element: MultipleTrailingClosureElementSyntax) -> MacroExpansionExprSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[13] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 13)
+    let newData = data.replacingChild(collection, at: 13, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `additionalTrailingClosures` replaced.
   /// - param newChild: The new `additionalTrailingClosures` to replace the node's
   ///                   current `additionalTrailingClosures`, if present.
-  public func withAdditionalTrailingClosures(
-    _ newChild: MultipleTrailingClosureElementListSyntax?) -> MacroExpansionExprSyntax {
+  public func withAdditionalTrailingClosures(_ newChild: MultipleTrailingClosureElementListSyntax?) -> MacroExpansionExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
@@ -10946,10 +11067,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterAdditionalTrailingClosures` replaced.
   /// - param newChild: The new `unexpectedAfterAdditionalTrailingClosures` to replace the node's
   ///                   current `unexpectedAfterAdditionalTrailingClosures`, if present.
-  public func withUnexpectedAfterAdditionalTrailingClosures(
-    _ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+  public func withUnexpectedAfterAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
 
@@ -11067,9 +11188,11 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       config.raw,
       unexpectedAfterConfig?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.postfixIfConfigExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.postfixIfConfigExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -11087,10 +11210,10 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeBase` replaced.
   /// - param newChild: The new `unexpectedBeforeBase` to replace the node's
   ///                   current `unexpectedBeforeBase`, if present.
-  public func withUnexpectedBeforeBase(
-    _ newChild: UnexpectedNodesSyntax?) -> PostfixIfConfigExprSyntax {
+  public func withUnexpectedBeforeBase(_ newChild: UnexpectedNodesSyntax?) -> PostfixIfConfigExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PostfixIfConfigExprSyntax(newData)
   }
 
@@ -11108,10 +11231,10 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `base` replaced.
   /// - param newChild: The new `base` to replace the node's
   ///                   current `base`, if present.
-  public func withBase(
-    _ newChild: ExprSyntax?) -> PostfixIfConfigExprSyntax {
+  public func withBase(_ newChild: ExprSyntax?) -> PostfixIfConfigExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PostfixIfConfigExprSyntax(newData)
   }
 
@@ -11129,10 +11252,10 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenBaseAndConfig` replaced.
   /// - param newChild: The new `unexpectedBetweenBaseAndConfig` to replace the node's
   ///                   current `unexpectedBetweenBaseAndConfig`, if present.
-  public func withUnexpectedBetweenBaseAndConfig(
-    _ newChild: UnexpectedNodesSyntax?) -> PostfixIfConfigExprSyntax {
+  public func withUnexpectedBetweenBaseAndConfig(_ newChild: UnexpectedNodesSyntax?) -> PostfixIfConfigExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PostfixIfConfigExprSyntax(newData)
   }
 
@@ -11149,10 +11272,10 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `config` replaced.
   /// - param newChild: The new `config` to replace the node's
   ///                   current `config`, if present.
-  public func withConfig(
-    _ newChild: IfConfigDeclSyntax?) -> PostfixIfConfigExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifConfigDecl, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withConfig(_ newChild: IfConfigDeclSyntax?) -> PostfixIfConfigExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifConfigDecl, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PostfixIfConfigExprSyntax(newData)
   }
 
@@ -11170,10 +11293,10 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterConfig` replaced.
   /// - param newChild: The new `unexpectedAfterConfig` to replace the node's
   ///                   current `unexpectedAfterConfig`, if present.
-  public func withUnexpectedAfterConfig(
-    _ newChild: UnexpectedNodesSyntax?) -> PostfixIfConfigExprSyntax {
+  public func withUnexpectedAfterConfig(_ newChild: UnexpectedNodesSyntax?) -> PostfixIfConfigExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PostfixIfConfigExprSyntax(newData)
   }
 
@@ -11247,9 +11370,11 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       identifier.raw,
       unexpectedAfterIdentifier?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.editorPlaceholderExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.editorPlaceholderExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -11267,10 +11392,10 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeIdentifier` replaced.
   /// - param newChild: The new `unexpectedBeforeIdentifier` to replace the node's
   ///                   current `unexpectedBeforeIdentifier`, if present.
-  public func withUnexpectedBeforeIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> EditorPlaceholderExprSyntax {
+  public func withUnexpectedBeforeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> EditorPlaceholderExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return EditorPlaceholderExprSyntax(newData)
   }
 
@@ -11287,10 +11412,10 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> EditorPlaceholderExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> EditorPlaceholderExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return EditorPlaceholderExprSyntax(newData)
   }
 
@@ -11308,10 +11433,10 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterIdentifier` replaced.
   /// - param newChild: The new `unexpectedAfterIdentifier` to replace the node's
   ///                   current `unexpectedAfterIdentifier`, if present.
-  public func withUnexpectedAfterIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> EditorPlaceholderExprSyntax {
+  public func withUnexpectedAfterIdentifier(_ newChild: UnexpectedNodesSyntax?) -> EditorPlaceholderExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return EditorPlaceholderExprSyntax(newData)
   }
 
@@ -11389,9 +11514,11 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.objectLiteralExpr,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.objectLiteralExpr,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -11409,10 +11536,10 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeIdentifier` replaced.
   /// - param newChild: The new `unexpectedBeforeIdentifier` to replace the node's
   ///                   current `unexpectedBeforeIdentifier`, if present.
-  public func withUnexpectedBeforeIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjectLiteralExprSyntax {
+  public func withUnexpectedBeforeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> ObjectLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ObjectLiteralExprSyntax(newData)
   }
 
@@ -11429,10 +11556,10 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> ObjectLiteralExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundColorLiteralKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> ObjectLiteralExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundColorLiteralKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ObjectLiteralExprSyntax(newData)
   }
 
@@ -11450,10 +11577,10 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenIdentifierAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenIdentifierAndLeftParen`, if present.
-  public func withUnexpectedBetweenIdentifierAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjectLiteralExprSyntax {
+  public func withUnexpectedBetweenIdentifierAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> ObjectLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ObjectLiteralExprSyntax(newData)
   }
 
@@ -11470,10 +11597,10 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> ObjectLiteralExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> ObjectLiteralExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ObjectLiteralExprSyntax(newData)
   }
 
@@ -11491,10 +11618,10 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArguments` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndArguments` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndArguments`, if present.
-  public func withUnexpectedBetweenLeftParenAndArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjectLiteralExprSyntax {
+  public func withUnexpectedBetweenLeftParenAndArguments(_ newChild: UnexpectedNodesSyntax?) -> ObjectLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ObjectLiteralExprSyntax(newData)
   }
 
@@ -11516,23 +11643,24 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `arguments` collection.
   public func addArgument(_ element: TupleExprElementSyntax) -> ObjectLiteralExprSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 5)
+    let newData = data.replacingChild(collection, at: 5, arena: arena)
     return ObjectLiteralExprSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `arguments` replaced.
   /// - param newChild: The new `arguments` to replace the node's
   ///                   current `arguments`, if present.
-  public func withArguments(
-    _ newChild: TupleExprElementListSyntax?) -> ObjectLiteralExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withArguments(_ newChild: TupleExprElementListSyntax?) -> ObjectLiteralExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ObjectLiteralExprSyntax(newData)
   }
 
@@ -11550,10 +11678,10 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenArgumentsAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenArgumentsAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenArgumentsAndRightParen`, if present.
-  public func withUnexpectedBetweenArgumentsAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjectLiteralExprSyntax {
+  public func withUnexpectedBetweenArgumentsAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> ObjectLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ObjectLiteralExprSyntax(newData)
   }
 
@@ -11570,10 +11698,10 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> ObjectLiteralExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withRightParen(_ newChild: TokenSyntax?) -> ObjectLiteralExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return ObjectLiteralExprSyntax(newData)
   }
 
@@ -11591,10 +11719,10 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjectLiteralExprSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> ObjectLiteralExprSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return ObjectLiteralExprSyntax(newData)
   }
 

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -37,9 +37,11 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
   ) {
     let layout: [RawSyntax?] = [
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.missing,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missing,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -171,9 +173,11 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
       errorTokens?.raw,
       unexpectedAfterErrorTokens?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItem,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItem,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -191,10 +195,10 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeItem` replaced.
   /// - param newChild: The new `unexpectedBeforeItem` to replace the node's
   ///                   current `unexpectedBeforeItem`, if present.
-  public func withUnexpectedBeforeItem(
-    _ newChild: UnexpectedNodesSyntax?) -> CodeBlockItemSyntax {
+  public func withUnexpectedBeforeItem(_ newChild: UnexpectedNodesSyntax?) -> CodeBlockItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return CodeBlockItemSyntax(newData)
   }
 
@@ -212,10 +216,10 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `item` replaced.
   /// - param newChild: The new `item` to replace the node's
   ///                   current `item`, if present.
-  public func withItem(
-    _ newChild: Item?) -> CodeBlockItemSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withItem(_ newChild: Item?) -> CodeBlockItemSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return CodeBlockItemSyntax(newData)
   }
 
@@ -233,10 +237,10 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenItemAndSemicolon` replaced.
   /// - param newChild: The new `unexpectedBetweenItemAndSemicolon` to replace the node's
   ///                   current `unexpectedBetweenItemAndSemicolon`, if present.
-  public func withUnexpectedBetweenItemAndSemicolon(
-    _ newChild: UnexpectedNodesSyntax?) -> CodeBlockItemSyntax {
+  public func withUnexpectedBetweenItemAndSemicolon(_ newChild: UnexpectedNodesSyntax?) -> CodeBlockItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return CodeBlockItemSyntax(newData)
   }
 
@@ -257,10 +261,10 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `semicolon` replaced.
   /// - param newChild: The new `semicolon` to replace the node's
   ///                   current `semicolon`, if present.
-  public func withSemicolon(
-    _ newChild: TokenSyntax?) -> CodeBlockItemSyntax {
+  public func withSemicolon(_ newChild: TokenSyntax?) -> CodeBlockItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return CodeBlockItemSyntax(newData)
   }
 
@@ -278,10 +282,10 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenSemicolonAndErrorTokens` replaced.
   /// - param newChild: The new `unexpectedBetweenSemicolonAndErrorTokens` to replace the node's
   ///                   current `unexpectedBetweenSemicolonAndErrorTokens`, if present.
-  public func withUnexpectedBetweenSemicolonAndErrorTokens(
-    _ newChild: UnexpectedNodesSyntax?) -> CodeBlockItemSyntax {
+  public func withUnexpectedBetweenSemicolonAndErrorTokens(_ newChild: UnexpectedNodesSyntax?) -> CodeBlockItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return CodeBlockItemSyntax(newData)
   }
 
@@ -299,10 +303,10 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `errorTokens` replaced.
   /// - param newChild: The new `errorTokens` to replace the node's
   ///                   current `errorTokens`, if present.
-  public func withErrorTokens(
-    _ newChild: Syntax?) -> CodeBlockItemSyntax {
+  public func withErrorTokens(_ newChild: Syntax?) -> CodeBlockItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return CodeBlockItemSyntax(newData)
   }
 
@@ -320,10 +324,10 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterErrorTokens` replaced.
   /// - param newChild: The new `unexpectedAfterErrorTokens` to replace the node's
   ///                   current `unexpectedAfterErrorTokens`, if present.
-  public func withUnexpectedAfterErrorTokens(
-    _ newChild: UnexpectedNodesSyntax?) -> CodeBlockItemSyntax {
+  public func withUnexpectedAfterErrorTokens(_ newChild: UnexpectedNodesSyntax?) -> CodeBlockItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return CodeBlockItemSyntax(newData)
   }
 
@@ -413,9 +417,11 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
       rightBrace.raw,
       unexpectedAfterRightBrace?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlock,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlock,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -433,10 +439,10 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftBrace` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftBrace` to replace the node's
   ///                   current `unexpectedBeforeLeftBrace`, if present.
-  public func withUnexpectedBeforeLeftBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
+  public func withUnexpectedBeforeLeftBrace(_ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return CodeBlockSyntax(newData)
   }
 
@@ -453,10 +459,10 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBrace` replaced.
   /// - param newChild: The new `leftBrace` to replace the node's
   ///                   current `leftBrace`, if present.
-  public func withLeftBrace(
-    _ newChild: TokenSyntax?) -> CodeBlockSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftBrace(_ newChild: TokenSyntax?) -> CodeBlockSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return CodeBlockSyntax(newData)
   }
 
@@ -474,10 +480,10 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftBraceAndStatements` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftBraceAndStatements` to replace the node's
   ///                   current `unexpectedBetweenLeftBraceAndStatements`, if present.
-  public func withUnexpectedBetweenLeftBraceAndStatements(
-    _ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
+  public func withUnexpectedBetweenLeftBraceAndStatements(_ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return CodeBlockSyntax(newData)
   }
 
@@ -499,23 +505,24 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `statements` collection.
   public func addStatement(_ element: CodeBlockItemSyntax) -> CodeBlockSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return CodeBlockSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `statements` replaced.
   /// - param newChild: The new `statements` to replace the node's
   ///                   current `statements`, if present.
-  public func withStatements(
-    _ newChild: CodeBlockItemListSyntax?) -> CodeBlockSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withStatements(_ newChild: CodeBlockItemListSyntax?) -> CodeBlockSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return CodeBlockSyntax(newData)
   }
 
@@ -533,10 +540,10 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenStatementsAndRightBrace` replaced.
   /// - param newChild: The new `unexpectedBetweenStatementsAndRightBrace` to replace the node's
   ///                   current `unexpectedBetweenStatementsAndRightBrace`, if present.
-  public func withUnexpectedBetweenStatementsAndRightBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
+  public func withUnexpectedBetweenStatementsAndRightBrace(_ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return CodeBlockSyntax(newData)
   }
 
@@ -553,10 +560,10 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBrace` replaced.
   /// - param newChild: The new `rightBrace` to replace the node's
   ///                   current `rightBrace`, if present.
-  public func withRightBrace(
-    _ newChild: TokenSyntax?) -> CodeBlockSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightBrace(_ newChild: TokenSyntax?) -> CodeBlockSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return CodeBlockSyntax(newData)
   }
 
@@ -574,10 +581,10 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
   /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
   ///                   current `unexpectedAfterRightBrace`, if present.
-  public func withUnexpectedAfterRightBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
+  public func withUnexpectedAfterRightBrace(_ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return CodeBlockSyntax(newData)
   }
 
@@ -663,9 +670,11 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       colon.raw,
       unexpectedAfterColon?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgument,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgument,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -683,10 +692,10 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
   /// - param newChild: The new `unexpectedBeforeName` to replace the node's
   ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentSyntax {
+  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DeclNameArgumentSyntax(newData)
   }
 
@@ -703,10 +712,10 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> DeclNameArgumentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withName(_ newChild: TokenSyntax?) -> DeclNameArgumentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DeclNameArgumentSyntax(newData)
   }
 
@@ -724,10 +733,10 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndColon` to replace the node's
   ///                   current `unexpectedBetweenNameAndColon`, if present.
-  public func withUnexpectedBetweenNameAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentSyntax {
+  public func withUnexpectedBetweenNameAndColon(_ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DeclNameArgumentSyntax(newData)
   }
 
@@ -744,10 +753,10 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> DeclNameArgumentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> DeclNameArgumentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DeclNameArgumentSyntax(newData)
   }
 
@@ -765,10 +774,10 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterColon` replaced.
   /// - param newChild: The new `unexpectedAfterColon` to replace the node's
   ///                   current `unexpectedAfterColon`, if present.
-  public func withUnexpectedAfterColon(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentSyntax {
+  public func withUnexpectedAfterColon(_ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DeclNameArgumentSyntax(newData)
   }
 
@@ -850,9 +859,11 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArguments,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArguments,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -870,10 +881,10 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
   ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
+  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DeclNameArgumentsSyntax(newData)
   }
 
@@ -890,10 +901,10 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> DeclNameArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> DeclNameArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DeclNameArgumentsSyntax(newData)
   }
 
@@ -911,10 +922,10 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArguments` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndArguments` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndArguments`, if present.
-  public func withUnexpectedBetweenLeftParenAndArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
+  public func withUnexpectedBetweenLeftParenAndArguments(_ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DeclNameArgumentsSyntax(newData)
   }
 
@@ -936,23 +947,24 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `arguments` collection.
   public func addArgument(_ element: DeclNameArgumentSyntax) -> DeclNameArgumentsSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgumentList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return DeclNameArgumentsSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `arguments` replaced.
   /// - param newChild: The new `arguments` to replace the node's
   ///                   current `arguments`, if present.
-  public func withArguments(
-    _ newChild: DeclNameArgumentListSyntax?) -> DeclNameArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.declNameArgumentList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withArguments(_ newChild: DeclNameArgumentListSyntax?) -> DeclNameArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.declNameArgumentList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DeclNameArgumentsSyntax(newData)
   }
 
@@ -970,10 +982,10 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenArgumentsAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenArgumentsAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenArgumentsAndRightParen`, if present.
-  public func withUnexpectedBetweenArgumentsAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
+  public func withUnexpectedBetweenArgumentsAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DeclNameArgumentsSyntax(newData)
   }
 
@@ -990,10 +1002,10 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> DeclNameArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightParen(_ newChild: TokenSyntax?) -> DeclNameArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return DeclNameArgumentsSyntax(newData)
   }
 
@@ -1011,10 +1023,10 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return DeclNameArgumentsSyntax(newData)
   }
 
@@ -1108,9 +1120,11 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1128,10 +1142,10 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLabel` replaced.
   /// - param newChild: The new `unexpectedBeforeLabel` to replace the node's
   ///                   current `unexpectedBeforeLabel`, if present.
-  public func withUnexpectedBeforeLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
+  public func withUnexpectedBeforeLabel(_ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return TupleExprElementSyntax(newData)
   }
 
@@ -1149,10 +1163,10 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `label` replaced.
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
-  public func withLabel(
-    _ newChild: TokenSyntax?) -> TupleExprElementSyntax {
+  public func withLabel(_ newChild: TokenSyntax?) -> TupleExprElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return TupleExprElementSyntax(newData)
   }
 
@@ -1170,10 +1184,10 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLabelAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenLabelAndColon` to replace the node's
   ///                   current `unexpectedBetweenLabelAndColon`, if present.
-  public func withUnexpectedBetweenLabelAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
+  public func withUnexpectedBetweenLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return TupleExprElementSyntax(newData)
   }
 
@@ -1191,10 +1205,10 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> TupleExprElementSyntax {
+  public func withColon(_ newChild: TokenSyntax?) -> TupleExprElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return TupleExprElementSyntax(newData)
   }
 
@@ -1212,10 +1226,10 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndExpression` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndExpression` to replace the node's
   ///                   current `unexpectedBetweenColonAndExpression`, if present.
-  public func withUnexpectedBetweenColonAndExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
+  public func withUnexpectedBetweenColonAndExpression(_ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return TupleExprElementSyntax(newData)
   }
 
@@ -1232,10 +1246,10 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> TupleExprElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withExpression(_ newChild: ExprSyntax?) -> TupleExprElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return TupleExprElementSyntax(newData)
   }
 
@@ -1253,10 +1267,10 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenExpressionAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenExpressionAndTrailingComma`, if present.
-  public func withUnexpectedBetweenExpressionAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
+  public func withUnexpectedBetweenExpressionAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return TupleExprElementSyntax(newData)
   }
 
@@ -1274,10 +1288,10 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> TupleExprElementSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> TupleExprElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return TupleExprElementSyntax(newData)
   }
 
@@ -1295,10 +1309,10 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return TupleExprElementSyntax(newData)
   }
 
@@ -1392,9 +1406,11 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayElement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1412,10 +1428,10 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
   /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
   ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> ArrayElementSyntax {
+  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> ArrayElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ArrayElementSyntax(newData)
   }
 
@@ -1432,10 +1448,10 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> ArrayElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withExpression(_ newChild: ExprSyntax?) -> ArrayElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ArrayElementSyntax(newData)
   }
 
@@ -1453,10 +1469,10 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenExpressionAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenExpressionAndTrailingComma`, if present.
-  public func withUnexpectedBetweenExpressionAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> ArrayElementSyntax {
+  public func withUnexpectedBetweenExpressionAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ArrayElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ArrayElementSyntax(newData)
   }
 
@@ -1474,10 +1490,10 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> ArrayElementSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> ArrayElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ArrayElementSyntax(newData)
   }
 
@@ -1495,10 +1511,10 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> ArrayElementSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ArrayElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ArrayElementSyntax(newData)
   }
 
@@ -1584,9 +1600,11 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryElement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1604,10 +1622,10 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeKeyExpression` replaced.
   /// - param newChild: The new `unexpectedBeforeKeyExpression` to replace the node's
   ///                   current `unexpectedBeforeKeyExpression`, if present.
-  public func withUnexpectedBeforeKeyExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
+  public func withUnexpectedBeforeKeyExpression(_ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DictionaryElementSyntax(newData)
   }
 
@@ -1624,10 +1642,10 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `keyExpression` replaced.
   /// - param newChild: The new `keyExpression` to replace the node's
   ///                   current `keyExpression`, if present.
-  public func withKeyExpression(
-    _ newChild: ExprSyntax?) -> DictionaryElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withKeyExpression(_ newChild: ExprSyntax?) -> DictionaryElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DictionaryElementSyntax(newData)
   }
 
@@ -1645,10 +1663,10 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenKeyExpressionAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenKeyExpressionAndColon` to replace the node's
   ///                   current `unexpectedBetweenKeyExpressionAndColon`, if present.
-  public func withUnexpectedBetweenKeyExpressionAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
+  public func withUnexpectedBetweenKeyExpressionAndColon(_ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DictionaryElementSyntax(newData)
   }
 
@@ -1665,10 +1683,10 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> DictionaryElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> DictionaryElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DictionaryElementSyntax(newData)
   }
 
@@ -1686,10 +1704,10 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndValueExpression` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndValueExpression` to replace the node's
   ///                   current `unexpectedBetweenColonAndValueExpression`, if present.
-  public func withUnexpectedBetweenColonAndValueExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
+  public func withUnexpectedBetweenColonAndValueExpression(_ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DictionaryElementSyntax(newData)
   }
 
@@ -1706,10 +1724,10 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `valueExpression` replaced.
   /// - param newChild: The new `valueExpression` to replace the node's
   ///                   current `valueExpression`, if present.
-  public func withValueExpression(
-    _ newChild: ExprSyntax?) -> DictionaryElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withValueExpression(_ newChild: ExprSyntax?) -> DictionaryElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return DictionaryElementSyntax(newData)
   }
 
@@ -1727,10 +1745,10 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenValueExpressionAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenValueExpressionAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenValueExpressionAndTrailingComma`, if present.
-  public func withUnexpectedBetweenValueExpressionAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
+  public func withUnexpectedBetweenValueExpressionAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return DictionaryElementSyntax(newData)
   }
 
@@ -1748,10 +1766,10 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> DictionaryElementSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> DictionaryElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return DictionaryElementSyntax(newData)
   }
 
@@ -1769,10 +1787,10 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return DictionaryElementSyntax(newData)
   }
 
@@ -1878,9 +1896,11 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItem,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItem,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1898,10 +1918,10 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeSpecifier` replaced.
   /// - param newChild: The new `unexpectedBeforeSpecifier` to replace the node's
   ///                   current `unexpectedBeforeSpecifier`, if present.
-  public func withUnexpectedBeforeSpecifier(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
+  public func withUnexpectedBeforeSpecifier(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ClosureCaptureItemSyntax(newData)
   }
 
@@ -1924,23 +1944,24 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `specifier` collection.
   public func addSpecifierToken(_ element: TokenSyntax) -> ClosureCaptureItemSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tokenList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return ClosureCaptureItemSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `specifier` replaced.
   /// - param newChild: The new `specifier` to replace the node's
   ///                   current `specifier`, if present.
-  public func withSpecifier(
-    _ newChild: TokenListSyntax?) -> ClosureCaptureItemSyntax {
+  public func withSpecifier(_ newChild: TokenListSyntax?) -> ClosureCaptureItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ClosureCaptureItemSyntax(newData)
   }
 
@@ -1958,10 +1979,10 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenSpecifierAndName` replaced.
   /// - param newChild: The new `unexpectedBetweenSpecifierAndName` to replace the node's
   ///                   current `unexpectedBetweenSpecifierAndName`, if present.
-  public func withUnexpectedBetweenSpecifierAndName(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
+  public func withUnexpectedBetweenSpecifierAndName(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ClosureCaptureItemSyntax(newData)
   }
 
@@ -1979,10 +2000,10 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> ClosureCaptureItemSyntax {
+  public func withName(_ newChild: TokenSyntax?) -> ClosureCaptureItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ClosureCaptureItemSyntax(newData)
   }
 
@@ -2000,10 +2021,10 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndAssignToken` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndAssignToken` to replace the node's
   ///                   current `unexpectedBetweenNameAndAssignToken`, if present.
-  public func withUnexpectedBetweenNameAndAssignToken(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
+  public func withUnexpectedBetweenNameAndAssignToken(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ClosureCaptureItemSyntax(newData)
   }
 
@@ -2021,10 +2042,10 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `assignToken` replaced.
   /// - param newChild: The new `assignToken` to replace the node's
   ///                   current `assignToken`, if present.
-  public func withAssignToken(
-    _ newChild: TokenSyntax?) -> ClosureCaptureItemSyntax {
+  public func withAssignToken(_ newChild: TokenSyntax?) -> ClosureCaptureItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ClosureCaptureItemSyntax(newData)
   }
 
@@ -2042,10 +2063,10 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAssignTokenAndExpression` replaced.
   /// - param newChild: The new `unexpectedBetweenAssignTokenAndExpression` to replace the node's
   ///                   current `unexpectedBetweenAssignTokenAndExpression`, if present.
-  public func withUnexpectedBetweenAssignTokenAndExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
+  public func withUnexpectedBetweenAssignTokenAndExpression(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ClosureCaptureItemSyntax(newData)
   }
 
@@ -2062,10 +2083,10 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> ClosureCaptureItemSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withExpression(_ newChild: ExprSyntax?) -> ClosureCaptureItemSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return ClosureCaptureItemSyntax(newData)
   }
 
@@ -2083,10 +2104,10 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenExpressionAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenExpressionAndTrailingComma`, if present.
-  public func withUnexpectedBetweenExpressionAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
+  public func withUnexpectedBetweenExpressionAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return ClosureCaptureItemSyntax(newData)
   }
 
@@ -2104,10 +2125,10 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> ClosureCaptureItemSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> ClosureCaptureItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return ClosureCaptureItemSyntax(newData)
   }
 
@@ -2125,10 +2146,10 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return ClosureCaptureItemSyntax(newData)
   }
 
@@ -2234,9 +2255,11 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       rightSquare.raw,
       unexpectedAfterRightSquare?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureSignature,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureSignature,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2254,10 +2277,10 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftSquare` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftSquare` to replace the node's
   ///                   current `unexpectedBeforeLeftSquare`, if present.
-  public func withUnexpectedBeforeLeftSquare(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
+  public func withUnexpectedBeforeLeftSquare(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ClosureCaptureSignatureSyntax(newData)
   }
 
@@ -2274,10 +2297,10 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftSquare` replaced.
   /// - param newChild: The new `leftSquare` to replace the node's
   ///                   current `leftSquare`, if present.
-  public func withLeftSquare(
-    _ newChild: TokenSyntax?) -> ClosureCaptureSignatureSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftSquare(_ newChild: TokenSyntax?) -> ClosureCaptureSignatureSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ClosureCaptureSignatureSyntax(newData)
   }
 
@@ -2295,10 +2318,10 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftSquareAndItems` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftSquareAndItems` to replace the node's
   ///                   current `unexpectedBetweenLeftSquareAndItems`, if present.
-  public func withUnexpectedBetweenLeftSquareAndItems(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
+  public func withUnexpectedBetweenLeftSquareAndItems(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ClosureCaptureSignatureSyntax(newData)
   }
 
@@ -2321,23 +2344,24 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `items` collection.
   public func addItem(_ element: ClosureCaptureItemSyntax) -> ClosureCaptureSignatureSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItemList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return ClosureCaptureSignatureSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `items` replaced.
   /// - param newChild: The new `items` to replace the node's
   ///                   current `items`, if present.
-  public func withItems(
-    _ newChild: ClosureCaptureItemListSyntax?) -> ClosureCaptureSignatureSyntax {
+  public func withItems(_ newChild: ClosureCaptureItemListSyntax?) -> ClosureCaptureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ClosureCaptureSignatureSyntax(newData)
   }
 
@@ -2355,10 +2379,10 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenItemsAndRightSquare` replaced.
   /// - param newChild: The new `unexpectedBetweenItemsAndRightSquare` to replace the node's
   ///                   current `unexpectedBetweenItemsAndRightSquare`, if present.
-  public func withUnexpectedBetweenItemsAndRightSquare(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
+  public func withUnexpectedBetweenItemsAndRightSquare(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ClosureCaptureSignatureSyntax(newData)
   }
 
@@ -2375,10 +2399,10 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightSquare` replaced.
   /// - param newChild: The new `rightSquare` to replace the node's
   ///                   current `rightSquare`, if present.
-  public func withRightSquare(
-    _ newChild: TokenSyntax?) -> ClosureCaptureSignatureSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightSquare(_ newChild: TokenSyntax?) -> ClosureCaptureSignatureSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ClosureCaptureSignatureSyntax(newData)
   }
 
@@ -2396,10 +2420,10 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightSquare` replaced.
   /// - param newChild: The new `unexpectedAfterRightSquare` to replace the node's
   ///                   current `unexpectedAfterRightSquare`, if present.
-  public func withUnexpectedAfterRightSquare(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
+  public func withUnexpectedAfterRightSquare(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ClosureCaptureSignatureSyntax(newData)
   }
 
@@ -2485,9 +2509,11 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParam,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParam,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2505,10 +2531,10 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
   /// - param newChild: The new `unexpectedBeforeName` to replace the node's
   ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureParamSyntax {
+  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> ClosureParamSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ClosureParamSyntax(newData)
   }
 
@@ -2525,10 +2551,10 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> ClosureParamSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withName(_ newChild: TokenSyntax?) -> ClosureParamSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ClosureParamSyntax(newData)
   }
 
@@ -2546,10 +2572,10 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenNameAndTrailingComma`, if present.
-  public func withUnexpectedBetweenNameAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureParamSyntax {
+  public func withUnexpectedBetweenNameAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ClosureParamSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ClosureParamSyntax(newData)
   }
 
@@ -2567,10 +2593,10 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> ClosureParamSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> ClosureParamSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ClosureParamSyntax(newData)
   }
 
@@ -2588,10 +2614,10 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureParamSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ClosureParamSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ClosureParamSyntax(newData)
   }
 
@@ -2725,9 +2751,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       inTok.raw,
       unexpectedAfterInTok?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureSignature,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureSignature,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2745,10 +2773,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -2771,23 +2799,24 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> ClosureSignatureSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> ClosureSignatureSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> ClosureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -2805,10 +2834,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndCapture` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndCapture` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndCapture`, if present.
-  public func withUnexpectedBetweenAttributesAndCapture(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+  public func withUnexpectedBetweenAttributesAndCapture(_ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -2826,10 +2855,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `capture` replaced.
   /// - param newChild: The new `capture` to replace the node's
   ///                   current `capture`, if present.
-  public func withCapture(
-    _ newChild: ClosureCaptureSignatureSyntax?) -> ClosureSignatureSyntax {
+  public func withCapture(_ newChild: ClosureCaptureSignatureSyntax?) -> ClosureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -2847,10 +2876,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCaptureAndInput` replaced.
   /// - param newChild: The new `unexpectedBetweenCaptureAndInput` to replace the node's
   ///                   current `unexpectedBetweenCaptureAndInput`, if present.
-  public func withUnexpectedBetweenCaptureAndInput(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+  public func withUnexpectedBetweenCaptureAndInput(_ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -2868,10 +2897,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `input` replaced.
   /// - param newChild: The new `input` to replace the node's
   ///                   current `input`, if present.
-  public func withInput(
-    _ newChild: Input?) -> ClosureSignatureSyntax {
+  public func withInput(_ newChild: Input?) -> ClosureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -2889,10 +2918,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInputAndAsyncKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenInputAndAsyncKeyword` to replace the node's
   ///                   current `unexpectedBetweenInputAndAsyncKeyword`, if present.
-  public func withUnexpectedBetweenInputAndAsyncKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+  public func withUnexpectedBetweenInputAndAsyncKeyword(_ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -2910,10 +2939,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `asyncKeyword` replaced.
   /// - param newChild: The new `asyncKeyword` to replace the node's
   ///                   current `asyncKeyword`, if present.
-  public func withAsyncKeyword(
-    _ newChild: TokenSyntax?) -> ClosureSignatureSyntax {
+  public func withAsyncKeyword(_ newChild: TokenSyntax?) -> ClosureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -2931,10 +2960,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAsyncKeywordAndThrowsTok` replaced.
   /// - param newChild: The new `unexpectedBetweenAsyncKeywordAndThrowsTok` to replace the node's
   ///                   current `unexpectedBetweenAsyncKeywordAndThrowsTok`, if present.
-  public func withUnexpectedBetweenAsyncKeywordAndThrowsTok(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+  public func withUnexpectedBetweenAsyncKeywordAndThrowsTok(_ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -2952,10 +2981,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `throwsTok` replaced.
   /// - param newChild: The new `throwsTok` to replace the node's
   ///                   current `throwsTok`, if present.
-  public func withThrowsTok(
-    _ newChild: TokenSyntax?) -> ClosureSignatureSyntax {
+  public func withThrowsTok(_ newChild: TokenSyntax?) -> ClosureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -2973,10 +3002,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenThrowsTokAndOutput` replaced.
   /// - param newChild: The new `unexpectedBetweenThrowsTokAndOutput` to replace the node's
   ///                   current `unexpectedBetweenThrowsTokAndOutput`, if present.
-  public func withUnexpectedBetweenThrowsTokAndOutput(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+  public func withUnexpectedBetweenThrowsTokAndOutput(_ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -2994,10 +3023,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `output` replaced.
   /// - param newChild: The new `output` to replace the node's
   ///                   current `output`, if present.
-  public func withOutput(
-    _ newChild: ReturnClauseSyntax?) -> ClosureSignatureSyntax {
+  public func withOutput(_ newChild: ReturnClauseSyntax?) -> ClosureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -3015,10 +3044,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenOutputAndInTok` replaced.
   /// - param newChild: The new `unexpectedBetweenOutputAndInTok` to replace the node's
   ///                   current `unexpectedBetweenOutputAndInTok`, if present.
-  public func withUnexpectedBetweenOutputAndInTok(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+  public func withUnexpectedBetweenOutputAndInTok(_ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -3035,10 +3064,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `inTok` replaced.
   /// - param newChild: The new `inTok` to replace the node's
   ///                   current `inTok`, if present.
-  public func withInTok(
-    _ newChild: TokenSyntax?) -> ClosureSignatureSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.inKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 13)
+  public func withInTok(_ newChild: TokenSyntax?) -> ClosureSignatureSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.inKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -3056,10 +3085,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterInTok` replaced.
   /// - param newChild: The new `unexpectedAfterInTok` to replace the node's
   ///                   current `unexpectedAfterInTok`, if present.
-  public func withUnexpectedAfterInTok(
-    _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+  public func withUnexpectedAfterInTok(_ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -3181,9 +3210,11 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
       closure.raw,
       unexpectedAfterClosure?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3201,10 +3232,10 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `unexpectedBeforeLabel` replaced.
   /// - param newChild: The new `unexpectedBeforeLabel` to replace the node's
   ///                   current `unexpectedBeforeLabel`, if present.
-  public func withUnexpectedBeforeLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
+  public func withUnexpectedBeforeLabel(_ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return MultipleTrailingClosureElementSyntax(newData)
   }
 
@@ -3221,10 +3252,10 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `label` replaced.
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
-  public func withLabel(
-    _ newChild: TokenSyntax?) -> MultipleTrailingClosureElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLabel(_ newChild: TokenSyntax?) -> MultipleTrailingClosureElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return MultipleTrailingClosureElementSyntax(newData)
   }
 
@@ -3242,10 +3273,10 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `unexpectedBetweenLabelAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenLabelAndColon` to replace the node's
   ///                   current `unexpectedBetweenLabelAndColon`, if present.
-  public func withUnexpectedBetweenLabelAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
+  public func withUnexpectedBetweenLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return MultipleTrailingClosureElementSyntax(newData)
   }
 
@@ -3262,10 +3293,10 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> MultipleTrailingClosureElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> MultipleTrailingClosureElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return MultipleTrailingClosureElementSyntax(newData)
   }
 
@@ -3283,10 +3314,10 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndClosure` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndClosure` to replace the node's
   ///                   current `unexpectedBetweenColonAndClosure`, if present.
-  public func withUnexpectedBetweenColonAndClosure(
-    _ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
+  public func withUnexpectedBetweenColonAndClosure(_ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return MultipleTrailingClosureElementSyntax(newData)
   }
 
@@ -3303,10 +3334,10 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `closure` replaced.
   /// - param newChild: The new `closure` to replace the node's
   ///                   current `closure`, if present.
-  public func withClosure(
-    _ newChild: ClosureExprSyntax?) -> MultipleTrailingClosureElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.closureExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withClosure(_ newChild: ClosureExprSyntax?) -> MultipleTrailingClosureElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.closureExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return MultipleTrailingClosureElementSyntax(newData)
   }
 
@@ -3324,10 +3355,10 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `unexpectedAfterClosure` replaced.
   /// - param newChild: The new `unexpectedAfterClosure` to replace the node's
   ///                   current `unexpectedAfterClosure`, if present.
-  public func withUnexpectedAfterClosure(
-    _ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
+  public func withUnexpectedAfterClosure(_ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return MultipleTrailingClosureElementSyntax(newData)
   }
 
@@ -3409,9 +3440,11 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       content.raw,
       unexpectedAfterContent?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringSegment,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringSegment,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3429,10 +3462,10 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeContent` replaced.
   /// - param newChild: The new `unexpectedBeforeContent` to replace the node's
   ///                   current `unexpectedBeforeContent`, if present.
-  public func withUnexpectedBeforeContent(
-    _ newChild: UnexpectedNodesSyntax?) -> StringSegmentSyntax {
+  public func withUnexpectedBeforeContent(_ newChild: UnexpectedNodesSyntax?) -> StringSegmentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return StringSegmentSyntax(newData)
   }
 
@@ -3449,10 +3482,10 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `content` replaced.
   /// - param newChild: The new `content` to replace the node's
   ///                   current `content`, if present.
-  public func withContent(
-    _ newChild: TokenSyntax?) -> StringSegmentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringSegment(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withContent(_ newChild: TokenSyntax?) -> StringSegmentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringSegment(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return StringSegmentSyntax(newData)
   }
 
@@ -3470,10 +3503,10 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterContent` replaced.
   /// - param newChild: The new `unexpectedAfterContent` to replace the node's
   ///                   current `unexpectedAfterContent`, if present.
-  public func withUnexpectedAfterContent(
-    _ newChild: UnexpectedNodesSyntax?) -> StringSegmentSyntax {
+  public func withUnexpectedAfterContent(_ newChild: UnexpectedNodesSyntax?) -> StringSegmentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return StringSegmentSyntax(newData)
   }
 
@@ -3555,9 +3588,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionSegment,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionSegment,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3575,10 +3610,10 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeBackslash` replaced.
   /// - param newChild: The new `unexpectedBeforeBackslash` to replace the node's
   ///                   current `unexpectedBeforeBackslash`, if present.
-  public func withUnexpectedBeforeBackslash(
-    _ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
+  public func withUnexpectedBeforeBackslash(_ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
 
@@ -3595,10 +3630,10 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `backslash` replaced.
   /// - param newChild: The new `backslash` to replace the node's
   ///                   current `backslash`, if present.
-  public func withBackslash(
-    _ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withBackslash(_ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
 
@@ -3616,10 +3651,10 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenBackslashAndDelimiter` replaced.
   /// - param newChild: The new `unexpectedBetweenBackslashAndDelimiter` to replace the node's
   ///                   current `unexpectedBetweenBackslashAndDelimiter`, if present.
-  public func withUnexpectedBetweenBackslashAndDelimiter(
-    _ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
+  public func withUnexpectedBetweenBackslashAndDelimiter(_ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
 
@@ -3637,10 +3672,10 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `delimiter` replaced.
   /// - param newChild: The new `delimiter` to replace the node's
   ///                   current `delimiter`, if present.
-  public func withDelimiter(
-    _ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
+  public func withDelimiter(_ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
 
@@ -3658,10 +3693,10 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenDelimiterAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenDelimiterAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenDelimiterAndLeftParen`, if present.
-  public func withUnexpectedBetweenDelimiterAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
+  public func withUnexpectedBetweenDelimiterAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
 
@@ -3678,10 +3713,10 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
 
@@ -3699,10 +3734,10 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndExpressions` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndExpressions` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndExpressions`, if present.
-  public func withUnexpectedBetweenLeftParenAndExpressions(
-    _ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
+  public func withUnexpectedBetweenLeftParenAndExpressions(_ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
 
@@ -3724,23 +3759,24 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `expressions` collection.
   public func addExpression(_ element: TupleExprElementSyntax) -> ExpressionSegmentSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[7] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 7)
+    let newData = data.replacingChild(collection, at: 7, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `expressions` replaced.
   /// - param newChild: The new `expressions` to replace the node's
   ///                   current `expressions`, if present.
-  public func withExpressions(
-    _ newChild: TupleExprElementListSyntax?) -> ExpressionSegmentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withExpressions(_ newChild: TupleExprElementListSyntax?) -> ExpressionSegmentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
 
@@ -3758,10 +3794,10 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenExpressionsAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenExpressionsAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenExpressionsAndRightParen`, if present.
-  public func withUnexpectedBetweenExpressionsAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
+  public func withUnexpectedBetweenExpressionsAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
 
@@ -3778,10 +3814,10 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringInterpolationAnchor, arena: .default)
-    let newData = data.replacingChild(raw, at: 9)
+  public func withRightParen(_ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringInterpolationAnchor, arena: arena)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
 
@@ -3799,10 +3835,10 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
 
@@ -3950,9 +3986,11 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
       component.raw,
       unexpectedAfterComponent?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathComponent,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathComponent,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3970,10 +4008,10 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePeriod` replaced.
   /// - param newChild: The new `unexpectedBeforePeriod` to replace the node's
   ///                   current `unexpectedBeforePeriod`, if present.
-  public func withUnexpectedBeforePeriod(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathComponentSyntax {
+  public func withUnexpectedBeforePeriod(_ newChild: UnexpectedNodesSyntax?) -> KeyPathComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return KeyPathComponentSyntax(newData)
   }
 
@@ -3991,10 +4029,10 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `period` replaced.
   /// - param newChild: The new `period` to replace the node's
   ///                   current `period`, if present.
-  public func withPeriod(
-    _ newChild: TokenSyntax?) -> KeyPathComponentSyntax {
+  public func withPeriod(_ newChild: TokenSyntax?) -> KeyPathComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return KeyPathComponentSyntax(newData)
   }
 
@@ -4012,10 +4050,10 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPeriodAndComponent` replaced.
   /// - param newChild: The new `unexpectedBetweenPeriodAndComponent` to replace the node's
   ///                   current `unexpectedBetweenPeriodAndComponent`, if present.
-  public func withUnexpectedBetweenPeriodAndComponent(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathComponentSyntax {
+  public func withUnexpectedBetweenPeriodAndComponent(_ newChild: UnexpectedNodesSyntax?) -> KeyPathComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return KeyPathComponentSyntax(newData)
   }
 
@@ -4032,10 +4070,10 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `component` replaced.
   /// - param newChild: The new `component` to replace the node's
   ///                   current `component`, if present.
-  public func withComponent(
-    _ newChild: Component?) -> KeyPathComponentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withComponent(_ newChild: Component?) -> KeyPathComponentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return KeyPathComponentSyntax(newData)
   }
 
@@ -4053,10 +4091,10 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterComponent` replaced.
   /// - param newChild: The new `unexpectedAfterComponent` to replace the node's
   ///                   current `unexpectedAfterComponent`, if present.
-  public func withUnexpectedAfterComponent(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathComponentSyntax {
+  public func withUnexpectedAfterComponent(_ newChild: UnexpectedNodesSyntax?) -> KeyPathComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return KeyPathComponentSyntax(newData)
   }
 
@@ -4138,9 +4176,11 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
       genericArgumentClause?.raw,
       unexpectedAfterGenericArgumentClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathPropertyComponent,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathPropertyComponent,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4158,10 +4198,10 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeIdentifier` replaced.
   /// - param newChild: The new `unexpectedBeforeIdentifier` to replace the node's
   ///                   current `unexpectedBeforeIdentifier`, if present.
-  public func withUnexpectedBeforeIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathPropertyComponentSyntax {
+  public func withUnexpectedBeforeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> KeyPathPropertyComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return KeyPathPropertyComponentSyntax(newData)
   }
 
@@ -4178,10 +4218,10 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> KeyPathPropertyComponentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> KeyPathPropertyComponentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return KeyPathPropertyComponentSyntax(newData)
   }
 
@@ -4199,10 +4239,10 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndDeclNameArguments` replaced.
   /// - param newChild: The new `unexpectedBetweenIdentifierAndDeclNameArguments` to replace the node's
   ///                   current `unexpectedBetweenIdentifierAndDeclNameArguments`, if present.
-  public func withUnexpectedBetweenIdentifierAndDeclNameArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathPropertyComponentSyntax {
+  public func withUnexpectedBetweenIdentifierAndDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> KeyPathPropertyComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return KeyPathPropertyComponentSyntax(newData)
   }
 
@@ -4220,10 +4260,10 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `declNameArguments` replaced.
   /// - param newChild: The new `declNameArguments` to replace the node's
   ///                   current `declNameArguments`, if present.
-  public func withDeclNameArguments(
-    _ newChild: DeclNameArgumentsSyntax?) -> KeyPathPropertyComponentSyntax {
+  public func withDeclNameArguments(_ newChild: DeclNameArgumentsSyntax?) -> KeyPathPropertyComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return KeyPathPropertyComponentSyntax(newData)
   }
 
@@ -4241,10 +4281,10 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause` replaced.
   /// - param newChild: The new `unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause` to replace the node's
   ///                   current `unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause`, if present.
-  public func withUnexpectedBetweenDeclNameArgumentsAndGenericArgumentClause(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathPropertyComponentSyntax {
+  public func withUnexpectedBetweenDeclNameArgumentsAndGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> KeyPathPropertyComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return KeyPathPropertyComponentSyntax(newData)
   }
 
@@ -4262,10 +4302,10 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericArgumentClause` replaced.
   /// - param newChild: The new `genericArgumentClause` to replace the node's
   ///                   current `genericArgumentClause`, if present.
-  public func withGenericArgumentClause(
-    _ newChild: GenericArgumentClauseSyntax?) -> KeyPathPropertyComponentSyntax {
+  public func withGenericArgumentClause(_ newChild: GenericArgumentClauseSyntax?) -> KeyPathPropertyComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return KeyPathPropertyComponentSyntax(newData)
   }
 
@@ -4283,10 +4323,10 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterGenericArgumentClause` replaced.
   /// - param newChild: The new `unexpectedAfterGenericArgumentClause` to replace the node's
   ///                   current `unexpectedAfterGenericArgumentClause`, if present.
-  public func withUnexpectedAfterGenericArgumentClause(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathPropertyComponentSyntax {
+  public func withUnexpectedAfterGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> KeyPathPropertyComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return KeyPathPropertyComponentSyntax(newData)
   }
 
@@ -4376,9 +4416,11 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
       rightBracket.raw,
       unexpectedAfterRightBracket?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathSubscriptComponent,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathSubscriptComponent,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4396,10 +4438,10 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftBracket` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftBracket` to replace the node's
   ///                   current `unexpectedBeforeLeftBracket`, if present.
-  public func withUnexpectedBeforeLeftBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathSubscriptComponentSyntax {
+  public func withUnexpectedBeforeLeftBracket(_ newChild: UnexpectedNodesSyntax?) -> KeyPathSubscriptComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return KeyPathSubscriptComponentSyntax(newData)
   }
 
@@ -4416,10 +4458,10 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBracket` replaced.
   /// - param newChild: The new `leftBracket` to replace the node's
   ///                   current `leftBracket`, if present.
-  public func withLeftBracket(
-    _ newChild: TokenSyntax?) -> KeyPathSubscriptComponentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftBracket(_ newChild: TokenSyntax?) -> KeyPathSubscriptComponentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return KeyPathSubscriptComponentSyntax(newData)
   }
 
@@ -4437,10 +4479,10 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftBracketAndArgumentList` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftBracketAndArgumentList` to replace the node's
   ///                   current `unexpectedBetweenLeftBracketAndArgumentList`, if present.
-  public func withUnexpectedBetweenLeftBracketAndArgumentList(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathSubscriptComponentSyntax {
+  public func withUnexpectedBetweenLeftBracketAndArgumentList(_ newChild: UnexpectedNodesSyntax?) -> KeyPathSubscriptComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return KeyPathSubscriptComponentSyntax(newData)
   }
 
@@ -4462,23 +4504,24 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `argumentList` collection.
   public func addArgument(_ element: TupleExprElementSyntax) -> KeyPathSubscriptComponentSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return KeyPathSubscriptComponentSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `argumentList` replaced.
   /// - param newChild: The new `argumentList` to replace the node's
   ///                   current `argumentList`, if present.
-  public func withArgumentList(
-    _ newChild: TupleExprElementListSyntax?) -> KeyPathSubscriptComponentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withArgumentList(_ newChild: TupleExprElementListSyntax?) -> KeyPathSubscriptComponentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return KeyPathSubscriptComponentSyntax(newData)
   }
 
@@ -4496,10 +4539,10 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenArgumentListAndRightBracket` replaced.
   /// - param newChild: The new `unexpectedBetweenArgumentListAndRightBracket` to replace the node's
   ///                   current `unexpectedBetweenArgumentListAndRightBracket`, if present.
-  public func withUnexpectedBetweenArgumentListAndRightBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathSubscriptComponentSyntax {
+  public func withUnexpectedBetweenArgumentListAndRightBracket(_ newChild: UnexpectedNodesSyntax?) -> KeyPathSubscriptComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return KeyPathSubscriptComponentSyntax(newData)
   }
 
@@ -4516,10 +4559,10 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBracket` replaced.
   /// - param newChild: The new `rightBracket` to replace the node's
   ///                   current `rightBracket`, if present.
-  public func withRightBracket(
-    _ newChild: TokenSyntax?) -> KeyPathSubscriptComponentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightBracket(_ newChild: TokenSyntax?) -> KeyPathSubscriptComponentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return KeyPathSubscriptComponentSyntax(newData)
   }
 
@@ -4537,10 +4580,10 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightBracket` replaced.
   /// - param newChild: The new `unexpectedAfterRightBracket` to replace the node's
   ///                   current `unexpectedAfterRightBracket`, if present.
-  public func withUnexpectedAfterRightBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathSubscriptComponentSyntax {
+  public func withUnexpectedAfterRightBracket(_ newChild: UnexpectedNodesSyntax?) -> KeyPathSubscriptComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return KeyPathSubscriptComponentSyntax(newData)
   }
 
@@ -4622,9 +4665,11 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
       questionOrExclamationMark.raw,
       unexpectedAfterQuestionOrExclamationMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathOptionalComponent,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathOptionalComponent,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4642,10 +4687,10 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeQuestionOrExclamationMark` replaced.
   /// - param newChild: The new `unexpectedBeforeQuestionOrExclamationMark` to replace the node's
   ///                   current `unexpectedBeforeQuestionOrExclamationMark`, if present.
-  public func withUnexpectedBeforeQuestionOrExclamationMark(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathOptionalComponentSyntax {
+  public func withUnexpectedBeforeQuestionOrExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> KeyPathOptionalComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return KeyPathOptionalComponentSyntax(newData)
   }
 
@@ -4662,10 +4707,10 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `questionOrExclamationMark` replaced.
   /// - param newChild: The new `questionOrExclamationMark` to replace the node's
   ///                   current `questionOrExclamationMark`, if present.
-  public func withQuestionOrExclamationMark(
-    _ newChild: TokenSyntax?) -> KeyPathOptionalComponentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withQuestionOrExclamationMark(_ newChild: TokenSyntax?) -> KeyPathOptionalComponentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return KeyPathOptionalComponentSyntax(newData)
   }
 
@@ -4683,10 +4728,10 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterQuestionOrExclamationMark` replaced.
   /// - param newChild: The new `unexpectedAfterQuestionOrExclamationMark` to replace the node's
   ///                   current `unexpectedAfterQuestionOrExclamationMark`, if present.
-  public func withUnexpectedAfterQuestionOrExclamationMark(
-    _ newChild: UnexpectedNodesSyntax?) -> KeyPathOptionalComponentSyntax {
+  public func withUnexpectedAfterQuestionOrExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> KeyPathOptionalComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return KeyPathOptionalComponentSyntax(newData)
   }
 
@@ -4756,9 +4801,11 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
       dot?.raw,
       unexpectedAfterDot?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcNamePiece,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcNamePiece,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4776,10 +4823,10 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
   /// - param newChild: The new `unexpectedBeforeName` to replace the node's
   ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjcNamePieceSyntax {
+  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> ObjcNamePieceSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ObjcNamePieceSyntax(newData)
   }
 
@@ -4796,10 +4843,10 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> ObjcNamePieceSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withName(_ newChild: TokenSyntax?) -> ObjcNamePieceSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ObjcNamePieceSyntax(newData)
   }
 
@@ -4817,10 +4864,10 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndDot` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndDot` to replace the node's
   ///                   current `unexpectedBetweenNameAndDot`, if present.
-  public func withUnexpectedBetweenNameAndDot(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjcNamePieceSyntax {
+  public func withUnexpectedBetweenNameAndDot(_ newChild: UnexpectedNodesSyntax?) -> ObjcNamePieceSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ObjcNamePieceSyntax(newData)
   }
 
@@ -4838,10 +4885,10 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `dot` replaced.
   /// - param newChild: The new `dot` to replace the node's
   ///                   current `dot`, if present.
-  public func withDot(
-    _ newChild: TokenSyntax?) -> ObjcNamePieceSyntax {
+  public func withDot(_ newChild: TokenSyntax?) -> ObjcNamePieceSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ObjcNamePieceSyntax(newData)
   }
 
@@ -4859,10 +4906,10 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterDot` replaced.
   /// - param newChild: The new `unexpectedAfterDot` to replace the node's
   ///                   current `unexpectedAfterDot`, if present.
-  public func withUnexpectedAfterDot(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjcNamePieceSyntax {
+  public func withUnexpectedAfterDot(_ newChild: UnexpectedNodesSyntax?) -> ObjcNamePieceSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ObjcNamePieceSyntax(newData)
   }
 
@@ -4940,9 +4987,11 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
       comma?.raw,
       unexpectedAfterComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprListElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprListElement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4960,10 +5009,10 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
   /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
   ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> YieldExprListElementSyntax {
+  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> YieldExprListElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return YieldExprListElementSyntax(newData)
   }
 
@@ -4980,10 +5029,10 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> YieldExprListElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withExpression(_ newChild: ExprSyntax?) -> YieldExprListElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return YieldExprListElementSyntax(newData)
   }
 
@@ -5001,10 +5050,10 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndComma` replaced.
   /// - param newChild: The new `unexpectedBetweenExpressionAndComma` to replace the node's
   ///                   current `unexpectedBetweenExpressionAndComma`, if present.
-  public func withUnexpectedBetweenExpressionAndComma(
-    _ newChild: UnexpectedNodesSyntax?) -> YieldExprListElementSyntax {
+  public func withUnexpectedBetweenExpressionAndComma(_ newChild: UnexpectedNodesSyntax?) -> YieldExprListElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return YieldExprListElementSyntax(newData)
   }
 
@@ -5022,10 +5071,10 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `comma` replaced.
   /// - param newChild: The new `comma` to replace the node's
   ///                   current `comma`, if present.
-  public func withComma(
-    _ newChild: TokenSyntax?) -> YieldExprListElementSyntax {
+  public func withComma(_ newChild: TokenSyntax?) -> YieldExprListElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return YieldExprListElementSyntax(newData)
   }
 
@@ -5043,10 +5092,10 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterComma` replaced.
   /// - param newChild: The new `unexpectedAfterComma` to replace the node's
   ///                   current `unexpectedAfterComma`, if present.
-  public func withUnexpectedAfterComma(
-    _ newChild: UnexpectedNodesSyntax?) -> YieldExprListElementSyntax {
+  public func withUnexpectedAfterComma(_ newChild: UnexpectedNodesSyntax?) -> YieldExprListElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return YieldExprListElementSyntax(newData)
   }
 
@@ -5124,9 +5173,11 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
       value.raw,
       unexpectedAfterValue?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeInitializerClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeInitializerClause,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -5144,10 +5195,10 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeEqual` replaced.
   /// - param newChild: The new `unexpectedBeforeEqual` to replace the node's
   ///                   current `unexpectedBeforeEqual`, if present.
-  public func withUnexpectedBeforeEqual(
-    _ newChild: UnexpectedNodesSyntax?) -> TypeInitializerClauseSyntax {
+  public func withUnexpectedBeforeEqual(_ newChild: UnexpectedNodesSyntax?) -> TypeInitializerClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return TypeInitializerClauseSyntax(newData)
   }
 
@@ -5164,10 +5215,10 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `equal` replaced.
   /// - param newChild: The new `equal` to replace the node's
   ///                   current `equal`, if present.
-  public func withEqual(
-    _ newChild: TokenSyntax?) -> TypeInitializerClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withEqual(_ newChild: TokenSyntax?) -> TypeInitializerClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return TypeInitializerClauseSyntax(newData)
   }
 
@@ -5185,10 +5236,10 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenEqualAndValue` replaced.
   /// - param newChild: The new `unexpectedBetweenEqualAndValue` to replace the node's
   ///                   current `unexpectedBetweenEqualAndValue`, if present.
-  public func withUnexpectedBetweenEqualAndValue(
-    _ newChild: UnexpectedNodesSyntax?) -> TypeInitializerClauseSyntax {
+  public func withUnexpectedBetweenEqualAndValue(_ newChild: UnexpectedNodesSyntax?) -> TypeInitializerClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return TypeInitializerClauseSyntax(newData)
   }
 
@@ -5205,10 +5256,10 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `value` replaced.
   /// - param newChild: The new `value` to replace the node's
   ///                   current `value`, if present.
-  public func withValue(
-    _ newChild: TypeSyntax?) -> TypeInitializerClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withValue(_ newChild: TypeSyntax?) -> TypeInitializerClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return TypeInitializerClauseSyntax(newData)
   }
 
@@ -5226,10 +5277,10 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterValue` replaced.
   /// - param newChild: The new `unexpectedAfterValue` to replace the node's
   ///                   current `unexpectedAfterValue`, if present.
-  public func withUnexpectedAfterValue(
-    _ newChild: UnexpectedNodesSyntax?) -> TypeInitializerClauseSyntax {
+  public func withUnexpectedAfterValue(_ newChild: UnexpectedNodesSyntax?) -> TypeInitializerClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return TypeInitializerClauseSyntax(newData)
   }
 
@@ -5311,9 +5362,11 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.parameterClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.parameterClause,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -5331,10 +5384,10 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
   ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
+  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ParameterClauseSyntax(newData)
   }
 
@@ -5351,10 +5404,10 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> ParameterClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> ParameterClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ParameterClauseSyntax(newData)
   }
 
@@ -5372,10 +5425,10 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndParameterList` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndParameterList` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndParameterList`, if present.
-  public func withUnexpectedBetweenLeftParenAndParameterList(
-    _ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
+  public func withUnexpectedBetweenLeftParenAndParameterList(_ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ParameterClauseSyntax(newData)
   }
 
@@ -5397,23 +5450,24 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `parameterList` collection.
   public func addParameter(_ element: FunctionParameterSyntax) -> ParameterClauseSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.functionParameterList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return ParameterClauseSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `parameterList` replaced.
   /// - param newChild: The new `parameterList` to replace the node's
   ///                   current `parameterList`, if present.
-  public func withParameterList(
-    _ newChild: FunctionParameterListSyntax?) -> ParameterClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionParameterList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withParameterList(_ newChild: FunctionParameterListSyntax?) -> ParameterClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionParameterList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ParameterClauseSyntax(newData)
   }
 
@@ -5431,10 +5485,10 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenParameterListAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenParameterListAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenParameterListAndRightParen`, if present.
-  public func withUnexpectedBetweenParameterListAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
+  public func withUnexpectedBetweenParameterListAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ParameterClauseSyntax(newData)
   }
 
@@ -5451,10 +5505,10 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> ParameterClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightParen(_ newChild: TokenSyntax?) -> ParameterClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ParameterClauseSyntax(newData)
   }
 
@@ -5472,10 +5526,10 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ParameterClauseSyntax(newData)
   }
 
@@ -5561,9 +5615,11 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
       returnType.raw,
       unexpectedAfterReturnType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.returnClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.returnClause,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -5581,10 +5637,10 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeArrow` replaced.
   /// - param newChild: The new `unexpectedBeforeArrow` to replace the node's
   ///                   current `unexpectedBeforeArrow`, if present.
-  public func withUnexpectedBeforeArrow(
-    _ newChild: UnexpectedNodesSyntax?) -> ReturnClauseSyntax {
+  public func withUnexpectedBeforeArrow(_ newChild: UnexpectedNodesSyntax?) -> ReturnClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ReturnClauseSyntax(newData)
   }
 
@@ -5601,10 +5657,10 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `arrow` replaced.
   /// - param newChild: The new `arrow` to replace the node's
   ///                   current `arrow`, if present.
-  public func withArrow(
-    _ newChild: TokenSyntax?) -> ReturnClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withArrow(_ newChild: TokenSyntax?) -> ReturnClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ReturnClauseSyntax(newData)
   }
 
@@ -5622,10 +5678,10 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenArrowAndReturnType` replaced.
   /// - param newChild: The new `unexpectedBetweenArrowAndReturnType` to replace the node's
   ///                   current `unexpectedBetweenArrowAndReturnType`, if present.
-  public func withUnexpectedBetweenArrowAndReturnType(
-    _ newChild: UnexpectedNodesSyntax?) -> ReturnClauseSyntax {
+  public func withUnexpectedBetweenArrowAndReturnType(_ newChild: UnexpectedNodesSyntax?) -> ReturnClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ReturnClauseSyntax(newData)
   }
 
@@ -5642,10 +5698,10 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `returnType` replaced.
   /// - param newChild: The new `returnType` to replace the node's
   ///                   current `returnType`, if present.
-  public func withReturnType(
-    _ newChild: TypeSyntax?) -> ReturnClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withReturnType(_ newChild: TypeSyntax?) -> ReturnClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ReturnClauseSyntax(newData)
   }
 
@@ -5663,10 +5719,10 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterReturnType` replaced.
   /// - param newChild: The new `unexpectedAfterReturnType` to replace the node's
   ///                   current `unexpectedAfterReturnType`, if present.
-  public func withUnexpectedAfterReturnType(
-    _ newChild: UnexpectedNodesSyntax?) -> ReturnClauseSyntax {
+  public func withUnexpectedAfterReturnType(_ newChild: UnexpectedNodesSyntax?) -> ReturnClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ReturnClauseSyntax(newData)
   }
 
@@ -5752,9 +5808,11 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       output?.raw,
       unexpectedAfterOutput?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionSignature,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionSignature,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -5772,10 +5830,10 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeInput` replaced.
   /// - param newChild: The new `unexpectedBeforeInput` to replace the node's
   ///                   current `unexpectedBeforeInput`, if present.
-  public func withUnexpectedBeforeInput(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
+  public func withUnexpectedBeforeInput(_ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return FunctionSignatureSyntax(newData)
   }
 
@@ -5792,10 +5850,10 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `input` replaced.
   /// - param newChild: The new `input` to replace the node's
   ///                   current `input`, if present.
-  public func withInput(
-    _ newChild: ParameterClauseSyntax?) -> FunctionSignatureSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.parameterClause, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withInput(_ newChild: ParameterClauseSyntax?) -> FunctionSignatureSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.parameterClause, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return FunctionSignatureSyntax(newData)
   }
 
@@ -5813,10 +5871,10 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInputAndAsyncOrReasyncKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenInputAndAsyncOrReasyncKeyword` to replace the node's
   ///                   current `unexpectedBetweenInputAndAsyncOrReasyncKeyword`, if present.
-  public func withUnexpectedBetweenInputAndAsyncOrReasyncKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
+  public func withUnexpectedBetweenInputAndAsyncOrReasyncKeyword(_ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return FunctionSignatureSyntax(newData)
   }
 
@@ -5834,10 +5892,10 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `asyncOrReasyncKeyword` replaced.
   /// - param newChild: The new `asyncOrReasyncKeyword` to replace the node's
   ///                   current `asyncOrReasyncKeyword`, if present.
-  public func withAsyncOrReasyncKeyword(
-    _ newChild: TokenSyntax?) -> FunctionSignatureSyntax {
+  public func withAsyncOrReasyncKeyword(_ newChild: TokenSyntax?) -> FunctionSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return FunctionSignatureSyntax(newData)
   }
 
@@ -5855,10 +5913,10 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword` to replace the node's
   ///                   current `unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword`, if present.
-  public func withUnexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
+  public func withUnexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword(_ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return FunctionSignatureSyntax(newData)
   }
 
@@ -5876,10 +5934,10 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `throwsOrRethrowsKeyword` replaced.
   /// - param newChild: The new `throwsOrRethrowsKeyword` to replace the node's
   ///                   current `throwsOrRethrowsKeyword`, if present.
-  public func withThrowsOrRethrowsKeyword(
-    _ newChild: TokenSyntax?) -> FunctionSignatureSyntax {
+  public func withThrowsOrRethrowsKeyword(_ newChild: TokenSyntax?) -> FunctionSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return FunctionSignatureSyntax(newData)
   }
 
@@ -5897,10 +5955,10 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenThrowsOrRethrowsKeywordAndOutput` replaced.
   /// - param newChild: The new `unexpectedBetweenThrowsOrRethrowsKeywordAndOutput` to replace the node's
   ///                   current `unexpectedBetweenThrowsOrRethrowsKeywordAndOutput`, if present.
-  public func withUnexpectedBetweenThrowsOrRethrowsKeywordAndOutput(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
+  public func withUnexpectedBetweenThrowsOrRethrowsKeywordAndOutput(_ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return FunctionSignatureSyntax(newData)
   }
 
@@ -5918,10 +5976,10 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `output` replaced.
   /// - param newChild: The new `output` to replace the node's
   ///                   current `output`, if present.
-  public func withOutput(
-    _ newChild: ReturnClauseSyntax?) -> FunctionSignatureSyntax {
+  public func withOutput(_ newChild: ReturnClauseSyntax?) -> FunctionSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return FunctionSignatureSyntax(newData)
   }
 
@@ -5939,10 +5997,10 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterOutput` replaced.
   /// - param newChild: The new `unexpectedAfterOutput` to replace the node's
   ///                   current `unexpectedAfterOutput`, if present.
-  public func withUnexpectedAfterOutput(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
+  public func withUnexpectedAfterOutput(_ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return FunctionSignatureSyntax(newData)
   }
 
@@ -6106,9 +6164,11 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       elements?.raw,
       unexpectedAfterElements?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClause,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -6126,10 +6186,10 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforePoundKeyword` to replace the node's
   ///                   current `unexpectedBeforePoundKeyword`, if present.
-  public func withUnexpectedBeforePoundKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
+  public func withUnexpectedBeforePoundKeyword(_ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return IfConfigClauseSyntax(newData)
   }
 
@@ -6146,10 +6206,10 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundKeyword` replaced.
   /// - param newChild: The new `poundKeyword` to replace the node's
   ///                   current `poundKeyword`, if present.
-  public func withPoundKeyword(
-    _ newChild: TokenSyntax?) -> IfConfigClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundIfKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundKeyword(_ newChild: TokenSyntax?) -> IfConfigClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundIfKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return IfConfigClauseSyntax(newData)
   }
 
@@ -6167,10 +6227,10 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPoundKeywordAndCondition` replaced.
   /// - param newChild: The new `unexpectedBetweenPoundKeywordAndCondition` to replace the node's
   ///                   current `unexpectedBetweenPoundKeywordAndCondition`, if present.
-  public func withUnexpectedBetweenPoundKeywordAndCondition(
-    _ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
+  public func withUnexpectedBetweenPoundKeywordAndCondition(_ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return IfConfigClauseSyntax(newData)
   }
 
@@ -6188,10 +6248,10 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `condition` replaced.
   /// - param newChild: The new `condition` to replace the node's
   ///                   current `condition`, if present.
-  public func withCondition(
-    _ newChild: ExprSyntax?) -> IfConfigClauseSyntax {
+  public func withCondition(_ newChild: ExprSyntax?) -> IfConfigClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return IfConfigClauseSyntax(newData)
   }
 
@@ -6209,10 +6269,10 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenConditionAndElements` replaced.
   /// - param newChild: The new `unexpectedBetweenConditionAndElements` to replace the node's
   ///                   current `unexpectedBetweenConditionAndElements`, if present.
-  public func withUnexpectedBetweenConditionAndElements(
-    _ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
+  public func withUnexpectedBetweenConditionAndElements(_ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return IfConfigClauseSyntax(newData)
   }
 
@@ -6230,10 +6290,10 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `elements` replaced.
   /// - param newChild: The new `elements` to replace the node's
   ///                   current `elements`, if present.
-  public func withElements(
-    _ newChild: Elements?) -> IfConfigClauseSyntax {
+  public func withElements(_ newChild: Elements?) -> IfConfigClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return IfConfigClauseSyntax(newData)
   }
 
@@ -6251,10 +6311,10 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterElements` replaced.
   /// - param newChild: The new `unexpectedAfterElements` to replace the node's
   ///                   current `unexpectedAfterElements`, if present.
-  public func withUnexpectedAfterElements(
-    _ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
+  public func withUnexpectedAfterElements(_ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return IfConfigClauseSyntax(newData)
   }
 
@@ -6360,9 +6420,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       lineNumber.raw,
       unexpectedAfterLineNumber?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundSourceLocationArgs,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundSourceLocationArgs,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -6380,10 +6442,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeFileArgLabel` replaced.
   /// - param newChild: The new `unexpectedBeforeFileArgLabel` to replace the node's
   ///                   current `unexpectedBeforeFileArgLabel`, if present.
-  public func withUnexpectedBeforeFileArgLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+  public func withUnexpectedBeforeFileArgLabel(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
@@ -6400,10 +6462,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `fileArgLabel` replaced.
   /// - param newChild: The new `fileArgLabel` to replace the node's
   ///                   current `fileArgLabel`, if present.
-  public func withFileArgLabel(
-    _ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withFileArgLabel(_ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
@@ -6421,10 +6483,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenFileArgLabelAndFileArgColon` replaced.
   /// - param newChild: The new `unexpectedBetweenFileArgLabelAndFileArgColon` to replace the node's
   ///                   current `unexpectedBetweenFileArgLabelAndFileArgColon`, if present.
-  public func withUnexpectedBetweenFileArgLabelAndFileArgColon(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+  public func withUnexpectedBetweenFileArgLabelAndFileArgColon(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
@@ -6441,10 +6503,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `fileArgColon` replaced.
   /// - param newChild: The new `fileArgColon` to replace the node's
   ///                   current `fileArgColon`, if present.
-  public func withFileArgColon(
-    _ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withFileArgColon(_ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
@@ -6462,10 +6524,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenFileArgColonAndFileName` replaced.
   /// - param newChild: The new `unexpectedBetweenFileArgColonAndFileName` to replace the node's
   ///                   current `unexpectedBetweenFileArgColonAndFileName`, if present.
-  public func withUnexpectedBetweenFileArgColonAndFileName(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+  public func withUnexpectedBetweenFileArgColonAndFileName(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
@@ -6482,10 +6544,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `fileName` replaced.
   /// - param newChild: The new `fileName` to replace the node's
   ///                   current `fileName`, if present.
-  public func withFileName(
-    _ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withFileName(_ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
@@ -6503,10 +6565,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenFileNameAndComma` replaced.
   /// - param newChild: The new `unexpectedBetweenFileNameAndComma` to replace the node's
   ///                   current `unexpectedBetweenFileNameAndComma`, if present.
-  public func withUnexpectedBetweenFileNameAndComma(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+  public func withUnexpectedBetweenFileNameAndComma(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
@@ -6523,10 +6585,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `comma` replaced.
   /// - param newChild: The new `comma` to replace the node's
   ///                   current `comma`, if present.
-  public func withComma(
-    _ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withComma(_ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
@@ -6544,10 +6606,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndLineArgLabel` replaced.
   /// - param newChild: The new `unexpectedBetweenCommaAndLineArgLabel` to replace the node's
   ///                   current `unexpectedBetweenCommaAndLineArgLabel`, if present.
-  public func withUnexpectedBetweenCommaAndLineArgLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+  public func withUnexpectedBetweenCommaAndLineArgLabel(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
@@ -6564,10 +6626,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `lineArgLabel` replaced.
   /// - param newChild: The new `lineArgLabel` to replace the node's
   ///                   current `lineArgLabel`, if present.
-  public func withLineArgLabel(
-    _ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 9)
+  public func withLineArgLabel(_ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
@@ -6585,10 +6647,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLineArgLabelAndLineArgColon` replaced.
   /// - param newChild: The new `unexpectedBetweenLineArgLabelAndLineArgColon` to replace the node's
   ///                   current `unexpectedBetweenLineArgLabelAndLineArgColon`, if present.
-  public func withUnexpectedBetweenLineArgLabelAndLineArgColon(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+  public func withUnexpectedBetweenLineArgLabelAndLineArgColon(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
@@ -6605,10 +6667,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `lineArgColon` replaced.
   /// - param newChild: The new `lineArgColon` to replace the node's
   ///                   current `lineArgColon`, if present.
-  public func withLineArgColon(
-    _ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 11)
+  public func withLineArgColon(_ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
@@ -6626,10 +6688,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLineArgColonAndLineNumber` replaced.
   /// - param newChild: The new `unexpectedBetweenLineArgColonAndLineNumber` to replace the node's
   ///                   current `unexpectedBetweenLineArgColonAndLineNumber`, if present.
-  public func withUnexpectedBetweenLineArgColonAndLineNumber(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+  public func withUnexpectedBetweenLineArgColonAndLineNumber(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
@@ -6646,10 +6708,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `lineNumber` replaced.
   /// - param newChild: The new `lineNumber` to replace the node's
   ///                   current `lineNumber`, if present.
-  public func withLineNumber(
-    _ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 13)
+  public func withLineNumber(_ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
@@ -6667,10 +6729,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterLineNumber` replaced.
   /// - param newChild: The new `unexpectedAfterLineNumber` to replace the node's
   ///                   current `unexpectedAfterLineNumber`, if present.
-  public func withUnexpectedAfterLineNumber(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+  public func withUnexpectedAfterLineNumber(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
@@ -6792,9 +6854,11 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.declModifierDetail,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declModifierDetail,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -6812,10 +6876,10 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
   ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
+  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DeclModifierDetailSyntax(newData)
   }
 
@@ -6832,10 +6896,10 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> DeclModifierDetailSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> DeclModifierDetailSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DeclModifierDetailSyntax(newData)
   }
 
@@ -6853,10 +6917,10 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndDetail` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndDetail` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndDetail`, if present.
-  public func withUnexpectedBetweenLeftParenAndDetail(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
+  public func withUnexpectedBetweenLeftParenAndDetail(_ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DeclModifierDetailSyntax(newData)
   }
 
@@ -6873,10 +6937,10 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `detail` replaced.
   /// - param newChild: The new `detail` to replace the node's
   ///                   current `detail`, if present.
-  public func withDetail(
-    _ newChild: TokenSyntax?) -> DeclModifierDetailSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withDetail(_ newChild: TokenSyntax?) -> DeclModifierDetailSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DeclModifierDetailSyntax(newData)
   }
 
@@ -6894,10 +6958,10 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenDetailAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenDetailAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenDetailAndRightParen`, if present.
-  public func withUnexpectedBetweenDetailAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
+  public func withUnexpectedBetweenDetailAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DeclModifierDetailSyntax(newData)
   }
 
@@ -6914,10 +6978,10 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> DeclModifierDetailSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightParen(_ newChild: TokenSyntax?) -> DeclModifierDetailSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return DeclModifierDetailSyntax(newData)
   }
 
@@ -6935,10 +6999,10 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return DeclModifierDetailSyntax(newData)
   }
 
@@ -7024,9 +7088,11 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
       detail?.raw,
       unexpectedAfterDetail?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.declModifier,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declModifier,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -7044,10 +7110,10 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
   /// - param newChild: The new `unexpectedBeforeName` to replace the node's
   ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclModifierSyntax {
+  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> DeclModifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DeclModifierSyntax(newData)
   }
 
@@ -7064,10 +7130,10 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> DeclModifierSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withName(_ newChild: TokenSyntax?) -> DeclModifierSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DeclModifierSyntax(newData)
   }
 
@@ -7085,10 +7151,10 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndDetail` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndDetail` to replace the node's
   ///                   current `unexpectedBetweenNameAndDetail`, if present.
-  public func withUnexpectedBetweenNameAndDetail(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclModifierSyntax {
+  public func withUnexpectedBetweenNameAndDetail(_ newChild: UnexpectedNodesSyntax?) -> DeclModifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DeclModifierSyntax(newData)
   }
 
@@ -7106,10 +7172,10 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `detail` replaced.
   /// - param newChild: The new `detail` to replace the node's
   ///                   current `detail`, if present.
-  public func withDetail(
-    _ newChild: DeclModifierDetailSyntax?) -> DeclModifierSyntax {
+  public func withDetail(_ newChild: DeclModifierDetailSyntax?) -> DeclModifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DeclModifierSyntax(newData)
   }
 
@@ -7127,10 +7193,10 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterDetail` replaced.
   /// - param newChild: The new `unexpectedAfterDetail` to replace the node's
   ///                   current `unexpectedAfterDetail`, if present.
-  public func withUnexpectedAfterDetail(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclModifierSyntax {
+  public func withUnexpectedAfterDetail(_ newChild: UnexpectedNodesSyntax?) -> DeclModifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DeclModifierSyntax(newData)
   }
 
@@ -7208,9 +7274,11 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.inheritedType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.inheritedType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -7228,10 +7296,10 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeTypeName` replaced.
   /// - param newChild: The new `unexpectedBeforeTypeName` to replace the node's
   ///                   current `unexpectedBeforeTypeName`, if present.
-  public func withUnexpectedBeforeTypeName(
-    _ newChild: UnexpectedNodesSyntax?) -> InheritedTypeSyntax {
+  public func withUnexpectedBeforeTypeName(_ newChild: UnexpectedNodesSyntax?) -> InheritedTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return InheritedTypeSyntax(newData)
   }
 
@@ -7248,10 +7316,10 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typeName` replaced.
   /// - param newChild: The new `typeName` to replace the node's
   ///                   current `typeName`, if present.
-  public func withTypeName(
-    _ newChild: TypeSyntax?) -> InheritedTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withTypeName(_ newChild: TypeSyntax?) -> InheritedTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return InheritedTypeSyntax(newData)
   }
 
@@ -7269,10 +7337,10 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTypeNameAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenTypeNameAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenTypeNameAndTrailingComma`, if present.
-  public func withUnexpectedBetweenTypeNameAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> InheritedTypeSyntax {
+  public func withUnexpectedBetweenTypeNameAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> InheritedTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return InheritedTypeSyntax(newData)
   }
 
@@ -7290,10 +7358,10 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> InheritedTypeSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> InheritedTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return InheritedTypeSyntax(newData)
   }
 
@@ -7311,10 +7379,10 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> InheritedTypeSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> InheritedTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return InheritedTypeSyntax(newData)
   }
 
@@ -7392,9 +7460,11 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
       inheritedTypeCollection.raw,
       unexpectedAfterInheritedTypeCollection?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeInheritanceClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeInheritanceClause,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -7412,10 +7482,10 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeColon` replaced.
   /// - param newChild: The new `unexpectedBeforeColon` to replace the node's
   ///                   current `unexpectedBeforeColon`, if present.
-  public func withUnexpectedBeforeColon(
-    _ newChild: UnexpectedNodesSyntax?) -> TypeInheritanceClauseSyntax {
+  public func withUnexpectedBeforeColon(_ newChild: UnexpectedNodesSyntax?) -> TypeInheritanceClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return TypeInheritanceClauseSyntax(newData)
   }
 
@@ -7432,10 +7502,10 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> TypeInheritanceClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withColon(_ newChild: TokenSyntax?) -> TypeInheritanceClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return TypeInheritanceClauseSyntax(newData)
   }
 
@@ -7453,10 +7523,10 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndInheritedTypeCollection` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndInheritedTypeCollection` to replace the node's
   ///                   current `unexpectedBetweenColonAndInheritedTypeCollection`, if present.
-  public func withUnexpectedBetweenColonAndInheritedTypeCollection(
-    _ newChild: UnexpectedNodesSyntax?) -> TypeInheritanceClauseSyntax {
+  public func withUnexpectedBetweenColonAndInheritedTypeCollection(_ newChild: UnexpectedNodesSyntax?) -> TypeInheritanceClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return TypeInheritanceClauseSyntax(newData)
   }
 
@@ -7478,23 +7548,24 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `inheritedTypeCollection` collection.
   public func addInheritedType(_ element: InheritedTypeSyntax) -> TypeInheritanceClauseSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.inheritedTypeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return TypeInheritanceClauseSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `inheritedTypeCollection` replaced.
   /// - param newChild: The new `inheritedTypeCollection` to replace the node's
   ///                   current `inheritedTypeCollection`, if present.
-  public func withInheritedTypeCollection(
-    _ newChild: InheritedTypeListSyntax?) -> TypeInheritanceClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.inheritedTypeList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withInheritedTypeCollection(_ newChild: InheritedTypeListSyntax?) -> TypeInheritanceClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.inheritedTypeList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return TypeInheritanceClauseSyntax(newData)
   }
 
@@ -7512,10 +7583,10 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterInheritedTypeCollection` replaced.
   /// - param newChild: The new `unexpectedAfterInheritedTypeCollection` to replace the node's
   ///                   current `unexpectedAfterInheritedTypeCollection`, if present.
-  public func withUnexpectedAfterInheritedTypeCollection(
-    _ newChild: UnexpectedNodesSyntax?) -> TypeInheritanceClauseSyntax {
+  public func withUnexpectedAfterInheritedTypeCollection(_ newChild: UnexpectedNodesSyntax?) -> TypeInheritanceClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return TypeInheritanceClauseSyntax(newData)
   }
 
@@ -7597,9 +7668,11 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
       rightBrace.raw,
       unexpectedAfterRightBrace?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclBlock,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclBlock,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -7617,10 +7690,10 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftBrace` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftBrace` to replace the node's
   ///                   current `unexpectedBeforeLeftBrace`, if present.
-  public func withUnexpectedBeforeLeftBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
+  public func withUnexpectedBeforeLeftBrace(_ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return MemberDeclBlockSyntax(newData)
   }
 
@@ -7637,10 +7710,10 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBrace` replaced.
   /// - param newChild: The new `leftBrace` to replace the node's
   ///                   current `leftBrace`, if present.
-  public func withLeftBrace(
-    _ newChild: TokenSyntax?) -> MemberDeclBlockSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftBrace(_ newChild: TokenSyntax?) -> MemberDeclBlockSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return MemberDeclBlockSyntax(newData)
   }
 
@@ -7658,10 +7731,10 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftBraceAndMembers` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftBraceAndMembers` to replace the node's
   ///                   current `unexpectedBetweenLeftBraceAndMembers`, if present.
-  public func withUnexpectedBetweenLeftBraceAndMembers(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
+  public func withUnexpectedBetweenLeftBraceAndMembers(_ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return MemberDeclBlockSyntax(newData)
   }
 
@@ -7683,23 +7756,24 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `members` collection.
   public func addMember(_ element: MemberDeclListItemSyntax) -> MemberDeclBlockSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return MemberDeclBlockSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `members` replaced.
   /// - param newChild: The new `members` to replace the node's
   ///                   current `members`, if present.
-  public func withMembers(
-    _ newChild: MemberDeclListSyntax?) -> MemberDeclBlockSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withMembers(_ newChild: MemberDeclListSyntax?) -> MemberDeclBlockSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return MemberDeclBlockSyntax(newData)
   }
 
@@ -7717,10 +7791,10 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenMembersAndRightBrace` replaced.
   /// - param newChild: The new `unexpectedBetweenMembersAndRightBrace` to replace the node's
   ///                   current `unexpectedBetweenMembersAndRightBrace`, if present.
-  public func withUnexpectedBetweenMembersAndRightBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
+  public func withUnexpectedBetweenMembersAndRightBrace(_ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return MemberDeclBlockSyntax(newData)
   }
 
@@ -7737,10 +7811,10 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBrace` replaced.
   /// - param newChild: The new `rightBrace` to replace the node's
   ///                   current `rightBrace`, if present.
-  public func withRightBrace(
-    _ newChild: TokenSyntax?) -> MemberDeclBlockSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightBrace(_ newChild: TokenSyntax?) -> MemberDeclBlockSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return MemberDeclBlockSyntax(newData)
   }
 
@@ -7758,10 +7832,10 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
   /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
   ///                   current `unexpectedAfterRightBrace`, if present.
-  public func withUnexpectedAfterRightBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
+  public func withUnexpectedAfterRightBrace(_ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return MemberDeclBlockSyntax(newData)
   }
 
@@ -7851,9 +7925,11 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
       semicolon?.raw,
       unexpectedAfterSemicolon?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclListItem,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclListItem,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -7871,10 +7947,10 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeDecl` replaced.
   /// - param newChild: The new `unexpectedBeforeDecl` to replace the node's
   ///                   current `unexpectedBeforeDecl`, if present.
-  public func withUnexpectedBeforeDecl(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberDeclListItemSyntax {
+  public func withUnexpectedBeforeDecl(_ newChild: UnexpectedNodesSyntax?) -> MemberDeclListItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return MemberDeclListItemSyntax(newData)
   }
 
@@ -7892,10 +7968,10 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `decl` replaced.
   /// - param newChild: The new `decl` to replace the node's
   ///                   current `decl`, if present.
-  public func withDecl(
-    _ newChild: DeclSyntax?) -> MemberDeclListItemSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingDecl, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withDecl(_ newChild: DeclSyntax?) -> MemberDeclListItemSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingDecl, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return MemberDeclListItemSyntax(newData)
   }
 
@@ -7913,10 +7989,10 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenDeclAndSemicolon` replaced.
   /// - param newChild: The new `unexpectedBetweenDeclAndSemicolon` to replace the node's
   ///                   current `unexpectedBetweenDeclAndSemicolon`, if present.
-  public func withUnexpectedBetweenDeclAndSemicolon(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberDeclListItemSyntax {
+  public func withUnexpectedBetweenDeclAndSemicolon(_ newChild: UnexpectedNodesSyntax?) -> MemberDeclListItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return MemberDeclListItemSyntax(newData)
   }
 
@@ -7935,10 +8011,10 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `semicolon` replaced.
   /// - param newChild: The new `semicolon` to replace the node's
   ///                   current `semicolon`, if present.
-  public func withSemicolon(
-    _ newChild: TokenSyntax?) -> MemberDeclListItemSyntax {
+  public func withSemicolon(_ newChild: TokenSyntax?) -> MemberDeclListItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return MemberDeclListItemSyntax(newData)
   }
 
@@ -7956,10 +8032,10 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterSemicolon` replaced.
   /// - param newChild: The new `unexpectedAfterSemicolon` to replace the node's
   ///                   current `unexpectedAfterSemicolon`, if present.
-  public func withUnexpectedAfterSemicolon(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberDeclListItemSyntax {
+  public func withUnexpectedAfterSemicolon(_ newChild: UnexpectedNodesSyntax?) -> MemberDeclListItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return MemberDeclListItemSyntax(newData)
   }
 
@@ -8037,9 +8113,11 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
       eofToken.raw,
       unexpectedAfterEOFToken?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.sourceFile,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.sourceFile,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -8057,10 +8135,10 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeStatements` replaced.
   /// - param newChild: The new `unexpectedBeforeStatements` to replace the node's
   ///                   current `unexpectedBeforeStatements`, if present.
-  public func withUnexpectedBeforeStatements(
-    _ newChild: UnexpectedNodesSyntax?) -> SourceFileSyntax {
+  public func withUnexpectedBeforeStatements(_ newChild: UnexpectedNodesSyntax?) -> SourceFileSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return SourceFileSyntax(newData)
   }
 
@@ -8082,23 +8160,24 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `statements` collection.
   public func addStatement(_ element: CodeBlockItemSyntax) -> SourceFileSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return SourceFileSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `statements` replaced.
   /// - param newChild: The new `statements` to replace the node's
   ///                   current `statements`, if present.
-  public func withStatements(
-    _ newChild: CodeBlockItemListSyntax?) -> SourceFileSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withStatements(_ newChild: CodeBlockItemListSyntax?) -> SourceFileSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return SourceFileSyntax(newData)
   }
 
@@ -8116,10 +8195,10 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenStatementsAndEOFToken` replaced.
   /// - param newChild: The new `unexpectedBetweenStatementsAndEOFToken` to replace the node's
   ///                   current `unexpectedBetweenStatementsAndEOFToken`, if present.
-  public func withUnexpectedBetweenStatementsAndEOFToken(
-    _ newChild: UnexpectedNodesSyntax?) -> SourceFileSyntax {
+  public func withUnexpectedBetweenStatementsAndEOFToken(_ newChild: UnexpectedNodesSyntax?) -> SourceFileSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return SourceFileSyntax(newData)
   }
 
@@ -8136,10 +8215,10 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `eofToken` replaced.
   /// - param newChild: The new `eofToken` to replace the node's
   ///                   current `eofToken`, if present.
-  public func withEOFToken(
-    _ newChild: TokenSyntax?) -> SourceFileSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withEOFToken(_ newChild: TokenSyntax?) -> SourceFileSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return SourceFileSyntax(newData)
   }
 
@@ -8157,10 +8236,10 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterEOFToken` replaced.
   /// - param newChild: The new `unexpectedAfterEOFToken` to replace the node's
   ///                   current `unexpectedAfterEOFToken`, if present.
-  public func withUnexpectedAfterEOFToken(
-    _ newChild: UnexpectedNodesSyntax?) -> SourceFileSyntax {
+  public func withUnexpectedAfterEOFToken(_ newChild: UnexpectedNodesSyntax?) -> SourceFileSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return SourceFileSyntax(newData)
   }
 
@@ -8238,9 +8317,11 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
       value.raw,
       unexpectedAfterValue?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.initializerClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.initializerClause,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -8258,10 +8339,10 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeEqual` replaced.
   /// - param newChild: The new `unexpectedBeforeEqual` to replace the node's
   ///                   current `unexpectedBeforeEqual`, if present.
-  public func withUnexpectedBeforeEqual(
-    _ newChild: UnexpectedNodesSyntax?) -> InitializerClauseSyntax {
+  public func withUnexpectedBeforeEqual(_ newChild: UnexpectedNodesSyntax?) -> InitializerClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return InitializerClauseSyntax(newData)
   }
 
@@ -8278,10 +8359,10 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `equal` replaced.
   /// - param newChild: The new `equal` to replace the node's
   ///                   current `equal`, if present.
-  public func withEqual(
-    _ newChild: TokenSyntax?) -> InitializerClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withEqual(_ newChild: TokenSyntax?) -> InitializerClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return InitializerClauseSyntax(newData)
   }
 
@@ -8299,10 +8380,10 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenEqualAndValue` replaced.
   /// - param newChild: The new `unexpectedBetweenEqualAndValue` to replace the node's
   ///                   current `unexpectedBetweenEqualAndValue`, if present.
-  public func withUnexpectedBetweenEqualAndValue(
-    _ newChild: UnexpectedNodesSyntax?) -> InitializerClauseSyntax {
+  public func withUnexpectedBetweenEqualAndValue(_ newChild: UnexpectedNodesSyntax?) -> InitializerClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return InitializerClauseSyntax(newData)
   }
 
@@ -8319,10 +8400,10 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `value` replaced.
   /// - param newChild: The new `value` to replace the node's
   ///                   current `value`, if present.
-  public func withValue(
-    _ newChild: ExprSyntax?) -> InitializerClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withValue(_ newChild: ExprSyntax?) -> InitializerClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return InitializerClauseSyntax(newData)
   }
 
@@ -8340,10 +8421,10 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterValue` replaced.
   /// - param newChild: The new `unexpectedAfterValue` to replace the node's
   ///                   current `unexpectedAfterValue`, if present.
-  public func withUnexpectedAfterValue(
-    _ newChild: UnexpectedNodesSyntax?) -> InitializerClauseSyntax {
+  public func withUnexpectedAfterValue(_ newChild: UnexpectedNodesSyntax?) -> InitializerClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return InitializerClauseSyntax(newData)
   }
 
@@ -8449,9 +8530,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionParameter,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionParameter,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -8469,10 +8552,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8495,23 +8578,24 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> FunctionParameterSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> FunctionParameterSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8529,10 +8613,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8555,23 +8639,24 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> FunctionParameterSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `modifiers` replaced.
   /// - param newChild: The new `modifiers` to replace the node's
   ///                   current `modifiers`, if present.
-  public func withModifiers(
-    _ newChild: ModifierListSyntax?) -> FunctionParameterSyntax {
+  public func withModifiers(_ newChild: ModifierListSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8589,10 +8674,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndFirstName` replaced.
   /// - param newChild: The new `unexpectedBetweenModifiersAndFirstName` to replace the node's
   ///                   current `unexpectedBetweenModifiersAndFirstName`, if present.
-  public func withUnexpectedBetweenModifiersAndFirstName(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+  public func withUnexpectedBetweenModifiersAndFirstName(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8610,10 +8695,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `firstName` replaced.
   /// - param newChild: The new `firstName` to replace the node's
   ///                   current `firstName`, if present.
-  public func withFirstName(
-    _ newChild: TokenSyntax?) -> FunctionParameterSyntax {
+  public func withFirstName(_ newChild: TokenSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8631,10 +8716,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenFirstNameAndSecondName` replaced.
   /// - param newChild: The new `unexpectedBetweenFirstNameAndSecondName` to replace the node's
   ///                   current `unexpectedBetweenFirstNameAndSecondName`, if present.
-  public func withUnexpectedBetweenFirstNameAndSecondName(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+  public func withUnexpectedBetweenFirstNameAndSecondName(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8652,10 +8737,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `secondName` replaced.
   /// - param newChild: The new `secondName` to replace the node's
   ///                   current `secondName`, if present.
-  public func withSecondName(
-    _ newChild: TokenSyntax?) -> FunctionParameterSyntax {
+  public func withSecondName(_ newChild: TokenSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8673,10 +8758,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenSecondNameAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenSecondNameAndColon` to replace the node's
   ///                   current `unexpectedBetweenSecondNameAndColon`, if present.
-  public func withUnexpectedBetweenSecondNameAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+  public func withUnexpectedBetweenSecondNameAndColon(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8694,10 +8779,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> FunctionParameterSyntax {
+  public func withColon(_ newChild: TokenSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8715,10 +8800,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndType` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndType` to replace the node's
   ///                   current `unexpectedBetweenColonAndType`, if present.
-  public func withUnexpectedBetweenColonAndType(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+  public func withUnexpectedBetweenColonAndType(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8736,10 +8821,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `type` replaced.
   /// - param newChild: The new `type` to replace the node's
   ///                   current `type`, if present.
-  public func withType(
-    _ newChild: TypeSyntax?) -> FunctionParameterSyntax {
+  public func withType(_ newChild: TypeSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8757,10 +8842,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTypeAndEllipsis` replaced.
   /// - param newChild: The new `unexpectedBetweenTypeAndEllipsis` to replace the node's
   ///                   current `unexpectedBetweenTypeAndEllipsis`, if present.
-  public func withUnexpectedBetweenTypeAndEllipsis(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+  public func withUnexpectedBetweenTypeAndEllipsis(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8778,10 +8863,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `ellipsis` replaced.
   /// - param newChild: The new `ellipsis` to replace the node's
   ///                   current `ellipsis`, if present.
-  public func withEllipsis(
-    _ newChild: TokenSyntax?) -> FunctionParameterSyntax {
+  public func withEllipsis(_ newChild: TokenSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8799,10 +8884,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenEllipsisAndDefaultArgument` replaced.
   /// - param newChild: The new `unexpectedBetweenEllipsisAndDefaultArgument` to replace the node's
   ///                   current `unexpectedBetweenEllipsisAndDefaultArgument`, if present.
-  public func withUnexpectedBetweenEllipsisAndDefaultArgument(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+  public func withUnexpectedBetweenEllipsisAndDefaultArgument(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8820,10 +8905,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `defaultArgument` replaced.
   /// - param newChild: The new `defaultArgument` to replace the node's
   ///                   current `defaultArgument`, if present.
-  public func withDefaultArgument(
-    _ newChild: InitializerClauseSyntax?) -> FunctionParameterSyntax {
+  public func withDefaultArgument(_ newChild: InitializerClauseSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 15)
+    let newData = data.replacingChild(raw, at: 15, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8841,10 +8926,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenDefaultArgumentAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenDefaultArgumentAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenDefaultArgumentAndTrailingComma`, if present.
-  public func withUnexpectedBetweenDefaultArgumentAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+  public func withUnexpectedBetweenDefaultArgumentAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 16)
+    let newData = data.replacingChild(raw, at: 16, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8862,10 +8947,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> FunctionParameterSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 17)
+    let newData = data.replacingChild(raw, at: 17, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -8883,10 +8968,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 18)
+    let newData = data.replacingChild(raw, at: 18, arena: arena)
     return FunctionParameterSyntax(newData)
   }
 
@@ -9020,9 +9105,11 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
       modifier?.raw,
       unexpectedAfterModifier?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessLevelModifier,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessLevelModifier,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9040,10 +9127,10 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
   /// - param newChild: The new `unexpectedBeforeName` to replace the node's
   ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessLevelModifierSyntax {
+  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> AccessLevelModifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AccessLevelModifierSyntax(newData)
   }
 
@@ -9060,10 +9147,10 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> AccessLevelModifierSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withName(_ newChild: TokenSyntax?) -> AccessLevelModifierSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AccessLevelModifierSyntax(newData)
   }
 
@@ -9081,10 +9168,10 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndModifier` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndModifier` to replace the node's
   ///                   current `unexpectedBetweenNameAndModifier`, if present.
-  public func withUnexpectedBetweenNameAndModifier(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessLevelModifierSyntax {
+  public func withUnexpectedBetweenNameAndModifier(_ newChild: UnexpectedNodesSyntax?) -> AccessLevelModifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AccessLevelModifierSyntax(newData)
   }
 
@@ -9102,10 +9189,10 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `modifier` replaced.
   /// - param newChild: The new `modifier` to replace the node's
   ///                   current `modifier`, if present.
-  public func withModifier(
-    _ newChild: DeclModifierDetailSyntax?) -> AccessLevelModifierSyntax {
+  public func withModifier(_ newChild: DeclModifierDetailSyntax?) -> AccessLevelModifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AccessLevelModifierSyntax(newData)
   }
 
@@ -9123,10 +9210,10 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterModifier` replaced.
   /// - param newChild: The new `unexpectedAfterModifier` to replace the node's
   ///                   current `unexpectedAfterModifier`, if present.
-  public func withUnexpectedAfterModifier(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessLevelModifierSyntax {
+  public func withUnexpectedAfterModifier(_ newChild: UnexpectedNodesSyntax?) -> AccessLevelModifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AccessLevelModifierSyntax(newData)
   }
 
@@ -9204,9 +9291,11 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
       trailingDot?.raw,
       unexpectedAfterTrailingDot?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessPathComponent,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessPathComponent,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9224,10 +9313,10 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
   /// - param newChild: The new `unexpectedBeforeName` to replace the node's
   ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessPathComponentSyntax {
+  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> AccessPathComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AccessPathComponentSyntax(newData)
   }
 
@@ -9244,10 +9333,10 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> AccessPathComponentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withName(_ newChild: TokenSyntax?) -> AccessPathComponentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AccessPathComponentSyntax(newData)
   }
 
@@ -9265,10 +9354,10 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndTrailingDot` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndTrailingDot` to replace the node's
   ///                   current `unexpectedBetweenNameAndTrailingDot`, if present.
-  public func withUnexpectedBetweenNameAndTrailingDot(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessPathComponentSyntax {
+  public func withUnexpectedBetweenNameAndTrailingDot(_ newChild: UnexpectedNodesSyntax?) -> AccessPathComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AccessPathComponentSyntax(newData)
   }
 
@@ -9286,10 +9375,10 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingDot` replaced.
   /// - param newChild: The new `trailingDot` to replace the node's
   ///                   current `trailingDot`, if present.
-  public func withTrailingDot(
-    _ newChild: TokenSyntax?) -> AccessPathComponentSyntax {
+  public func withTrailingDot(_ newChild: TokenSyntax?) -> AccessPathComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AccessPathComponentSyntax(newData)
   }
 
@@ -9307,10 +9396,10 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingDot` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingDot` to replace the node's
   ///                   current `unexpectedAfterTrailingDot`, if present.
-  public func withUnexpectedAfterTrailingDot(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessPathComponentSyntax {
+  public func withUnexpectedAfterTrailingDot(_ newChild: UnexpectedNodesSyntax?) -> AccessPathComponentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AccessPathComponentSyntax(newData)
   }
 
@@ -9392,9 +9481,11 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorParameter,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorParameter,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9412,10 +9503,10 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
   ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
+  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AccessorParameterSyntax(newData)
   }
 
@@ -9432,10 +9523,10 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> AccessorParameterSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> AccessorParameterSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AccessorParameterSyntax(newData)
   }
 
@@ -9453,10 +9544,10 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndName` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndName` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndName`, if present.
-  public func withUnexpectedBetweenLeftParenAndName(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
+  public func withUnexpectedBetweenLeftParenAndName(_ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AccessorParameterSyntax(newData)
   }
 
@@ -9473,10 +9564,10 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> AccessorParameterSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withName(_ newChild: TokenSyntax?) -> AccessorParameterSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AccessorParameterSyntax(newData)
   }
 
@@ -9494,10 +9585,10 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenNameAndRightParen`, if present.
-  public func withUnexpectedBetweenNameAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
+  public func withUnexpectedBetweenNameAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AccessorParameterSyntax(newData)
   }
 
@@ -9514,10 +9605,10 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> AccessorParameterSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightParen(_ newChild: TokenSyntax?) -> AccessorParameterSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return AccessorParameterSyntax(newData)
   }
 
@@ -9535,10 +9626,10 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return AccessorParameterSyntax(newData)
   }
 
@@ -9628,9 +9719,11 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
       rightBrace.raw,
       unexpectedAfterRightBrace?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorBlock,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorBlock,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9648,10 +9741,10 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftBrace` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftBrace` to replace the node's
   ///                   current `unexpectedBeforeLeftBrace`, if present.
-  public func withUnexpectedBeforeLeftBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
+  public func withUnexpectedBeforeLeftBrace(_ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AccessorBlockSyntax(newData)
   }
 
@@ -9668,10 +9761,10 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBrace` replaced.
   /// - param newChild: The new `leftBrace` to replace the node's
   ///                   current `leftBrace`, if present.
-  public func withLeftBrace(
-    _ newChild: TokenSyntax?) -> AccessorBlockSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftBrace(_ newChild: TokenSyntax?) -> AccessorBlockSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AccessorBlockSyntax(newData)
   }
 
@@ -9689,10 +9782,10 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftBraceAndAccessors` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftBraceAndAccessors` to replace the node's
   ///                   current `unexpectedBetweenLeftBraceAndAccessors`, if present.
-  public func withUnexpectedBetweenLeftBraceAndAccessors(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
+  public func withUnexpectedBetweenLeftBraceAndAccessors(_ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AccessorBlockSyntax(newData)
   }
 
@@ -9714,23 +9807,24 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `accessors` collection.
   public func addAccessor(_ element: AccessorDeclSyntax) -> AccessorBlockSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.accessorList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return AccessorBlockSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `accessors` replaced.
   /// - param newChild: The new `accessors` to replace the node's
   ///                   current `accessors`, if present.
-  public func withAccessors(
-    _ newChild: AccessorListSyntax?) -> AccessorBlockSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.accessorList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withAccessors(_ newChild: AccessorListSyntax?) -> AccessorBlockSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.accessorList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AccessorBlockSyntax(newData)
   }
 
@@ -9748,10 +9842,10 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAccessorsAndRightBrace` replaced.
   /// - param newChild: The new `unexpectedBetweenAccessorsAndRightBrace` to replace the node's
   ///                   current `unexpectedBetweenAccessorsAndRightBrace`, if present.
-  public func withUnexpectedBetweenAccessorsAndRightBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
+  public func withUnexpectedBetweenAccessorsAndRightBrace(_ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AccessorBlockSyntax(newData)
   }
 
@@ -9768,10 +9862,10 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBrace` replaced.
   /// - param newChild: The new `rightBrace` to replace the node's
   ///                   current `rightBrace`, if present.
-  public func withRightBrace(
-    _ newChild: TokenSyntax?) -> AccessorBlockSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightBrace(_ newChild: TokenSyntax?) -> AccessorBlockSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return AccessorBlockSyntax(newData)
   }
 
@@ -9789,10 +9883,10 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
   /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
   ///                   current `unexpectedAfterRightBrace`, if present.
-  public func withUnexpectedAfterRightBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
+  public func withUnexpectedAfterRightBrace(_ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return AccessorBlockSyntax(newData)
   }
 
@@ -9926,9 +10020,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.patternBinding,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.patternBinding,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -9946,10 +10042,10 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePattern` replaced.
   /// - param newChild: The new `unexpectedBeforePattern` to replace the node's
   ///                   current `unexpectedBeforePattern`, if present.
-  public func withUnexpectedBeforePattern(
-    _ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
+  public func withUnexpectedBeforePattern(_ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PatternBindingSyntax(newData)
   }
 
@@ -9966,10 +10062,10 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(
-    _ newChild: PatternSyntax?) -> PatternBindingSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPattern(_ newChild: PatternSyntax?) -> PatternBindingSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PatternBindingSyntax(newData)
   }
 
@@ -9987,10 +10083,10 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPatternAndTypeAnnotation` replaced.
   /// - param newChild: The new `unexpectedBetweenPatternAndTypeAnnotation` to replace the node's
   ///                   current `unexpectedBetweenPatternAndTypeAnnotation`, if present.
-  public func withUnexpectedBetweenPatternAndTypeAnnotation(
-    _ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
+  public func withUnexpectedBetweenPatternAndTypeAnnotation(_ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PatternBindingSyntax(newData)
   }
 
@@ -10008,10 +10104,10 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typeAnnotation` replaced.
   /// - param newChild: The new `typeAnnotation` to replace the node's
   ///                   current `typeAnnotation`, if present.
-  public func withTypeAnnotation(
-    _ newChild: TypeAnnotationSyntax?) -> PatternBindingSyntax {
+  public func withTypeAnnotation(_ newChild: TypeAnnotationSyntax?) -> PatternBindingSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PatternBindingSyntax(newData)
   }
 
@@ -10029,10 +10125,10 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTypeAnnotationAndInitializer` replaced.
   /// - param newChild: The new `unexpectedBetweenTypeAnnotationAndInitializer` to replace the node's
   ///                   current `unexpectedBetweenTypeAnnotationAndInitializer`, if present.
-  public func withUnexpectedBetweenTypeAnnotationAndInitializer(
-    _ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
+  public func withUnexpectedBetweenTypeAnnotationAndInitializer(_ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PatternBindingSyntax(newData)
   }
 
@@ -10050,10 +10146,10 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `initializer` replaced.
   /// - param newChild: The new `initializer` to replace the node's
   ///                   current `initializer`, if present.
-  public func withInitializer(
-    _ newChild: InitializerClauseSyntax?) -> PatternBindingSyntax {
+  public func withInitializer(_ newChild: InitializerClauseSyntax?) -> PatternBindingSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return PatternBindingSyntax(newData)
   }
 
@@ -10071,10 +10167,10 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInitializerAndAccessor` replaced.
   /// - param newChild: The new `unexpectedBetweenInitializerAndAccessor` to replace the node's
   ///                   current `unexpectedBetweenInitializerAndAccessor`, if present.
-  public func withUnexpectedBetweenInitializerAndAccessor(
-    _ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
+  public func withUnexpectedBetweenInitializerAndAccessor(_ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return PatternBindingSyntax(newData)
   }
 
@@ -10092,10 +10188,10 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `accessor` replaced.
   /// - param newChild: The new `accessor` to replace the node's
   ///                   current `accessor`, if present.
-  public func withAccessor(
-    _ newChild: Accessor?) -> PatternBindingSyntax {
+  public func withAccessor(_ newChild: Accessor?) -> PatternBindingSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return PatternBindingSyntax(newData)
   }
 
@@ -10113,10 +10209,10 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAccessorAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenAccessorAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenAccessorAndTrailingComma`, if present.
-  public func withUnexpectedBetweenAccessorAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
+  public func withUnexpectedBetweenAccessorAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return PatternBindingSyntax(newData)
   }
 
@@ -10134,10 +10230,10 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> PatternBindingSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> PatternBindingSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return PatternBindingSyntax(newData)
   }
 
@@ -10155,10 +10251,10 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return PatternBindingSyntax(newData)
   }
 
@@ -10272,9 +10368,11 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -10292,10 +10390,10 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeIdentifier` replaced.
   /// - param newChild: The new `unexpectedBeforeIdentifier` to replace the node's
   ///                   current `unexpectedBeforeIdentifier`, if present.
-  public func withUnexpectedBeforeIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
+  public func withUnexpectedBeforeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return EnumCaseElementSyntax(newData)
   }
 
@@ -10313,10 +10411,10 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> EnumCaseElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> EnumCaseElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return EnumCaseElementSyntax(newData)
   }
 
@@ -10334,10 +10432,10 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndAssociatedValue` replaced.
   /// - param newChild: The new `unexpectedBetweenIdentifierAndAssociatedValue` to replace the node's
   ///                   current `unexpectedBetweenIdentifierAndAssociatedValue`, if present.
-  public func withUnexpectedBetweenIdentifierAndAssociatedValue(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
+  public func withUnexpectedBetweenIdentifierAndAssociatedValue(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return EnumCaseElementSyntax(newData)
   }
 
@@ -10356,10 +10454,10 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `associatedValue` replaced.
   /// - param newChild: The new `associatedValue` to replace the node's
   ///                   current `associatedValue`, if present.
-  public func withAssociatedValue(
-    _ newChild: ParameterClauseSyntax?) -> EnumCaseElementSyntax {
+  public func withAssociatedValue(_ newChild: ParameterClauseSyntax?) -> EnumCaseElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return EnumCaseElementSyntax(newData)
   }
 
@@ -10377,10 +10475,10 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAssociatedValueAndRawValue` replaced.
   /// - param newChild: The new `unexpectedBetweenAssociatedValueAndRawValue` to replace the node's
   ///                   current `unexpectedBetweenAssociatedValueAndRawValue`, if present.
-  public func withUnexpectedBetweenAssociatedValueAndRawValue(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
+  public func withUnexpectedBetweenAssociatedValueAndRawValue(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return EnumCaseElementSyntax(newData)
   }
 
@@ -10401,10 +10499,10 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rawValue` replaced.
   /// - param newChild: The new `rawValue` to replace the node's
   ///                   current `rawValue`, if present.
-  public func withRawValue(
-    _ newChild: InitializerClauseSyntax?) -> EnumCaseElementSyntax {
+  public func withRawValue(_ newChild: InitializerClauseSyntax?) -> EnumCaseElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return EnumCaseElementSyntax(newData)
   }
 
@@ -10422,10 +10520,10 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenRawValueAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenRawValueAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenRawValueAndTrailingComma`, if present.
-  public func withUnexpectedBetweenRawValueAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
+  public func withUnexpectedBetweenRawValueAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return EnumCaseElementSyntax(newData)
   }
 
@@ -10447,10 +10545,10 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> EnumCaseElementSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> EnumCaseElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return EnumCaseElementSyntax(newData)
   }
 
@@ -10468,10 +10566,10 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return EnumCaseElementSyntax(newData)
   }
 
@@ -10565,9 +10663,11 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       name.raw,
       unexpectedAfterName?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeElement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -10585,10 +10685,10 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeadingComma` replaced.
   /// - param newChild: The new `unexpectedBeforeLeadingComma` to replace the node's
   ///                   current `unexpectedBeforeLeadingComma`, if present.
-  public func withUnexpectedBeforeLeadingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> DesignatedTypeElementSyntax {
+  public func withUnexpectedBeforeLeadingComma(_ newChild: UnexpectedNodesSyntax?) -> DesignatedTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DesignatedTypeElementSyntax(newData)
   }
 
@@ -10605,10 +10705,10 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leadingComma` replaced.
   /// - param newChild: The new `leadingComma` to replace the node's
   ///                   current `leadingComma`, if present.
-  public func withLeadingComma(
-    _ newChild: TokenSyntax?) -> DesignatedTypeElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeadingComma(_ newChild: TokenSyntax?) -> DesignatedTypeElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DesignatedTypeElementSyntax(newData)
   }
 
@@ -10626,10 +10726,10 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeadingCommaAndName` replaced.
   /// - param newChild: The new `unexpectedBetweenLeadingCommaAndName` to replace the node's
   ///                   current `unexpectedBetweenLeadingCommaAndName`, if present.
-  public func withUnexpectedBetweenLeadingCommaAndName(
-    _ newChild: UnexpectedNodesSyntax?) -> DesignatedTypeElementSyntax {
+  public func withUnexpectedBetweenLeadingCommaAndName(_ newChild: UnexpectedNodesSyntax?) -> DesignatedTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DesignatedTypeElementSyntax(newData)
   }
 
@@ -10646,10 +10746,10 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> DesignatedTypeElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withName(_ newChild: TokenSyntax?) -> DesignatedTypeElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DesignatedTypeElementSyntax(newData)
   }
 
@@ -10667,10 +10767,10 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterName` replaced.
   /// - param newChild: The new `unexpectedAfterName` to replace the node's
   ///                   current `unexpectedAfterName`, if present.
-  public func withUnexpectedAfterName(
-    _ newChild: UnexpectedNodesSyntax?) -> DesignatedTypeElementSyntax {
+  public func withUnexpectedAfterName(_ newChild: UnexpectedNodesSyntax?) -> DesignatedTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DesignatedTypeElementSyntax(newData)
   }
 
@@ -10755,9 +10855,11 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
       designatedTypes.raw,
       unexpectedAfterDesignatedTypes?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorPrecedenceAndTypes,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorPrecedenceAndTypes,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -10775,10 +10877,10 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeColon` replaced.
   /// - param newChild: The new `unexpectedBeforeColon` to replace the node's
   ///                   current `unexpectedBeforeColon`, if present.
-  public func withUnexpectedBeforeColon(
-    _ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+  public func withUnexpectedBeforeColon(_ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
@@ -10795,10 +10897,10 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> OperatorPrecedenceAndTypesSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withColon(_ newChild: TokenSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
@@ -10816,10 +10918,10 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndPrecedenceGroup` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndPrecedenceGroup` to replace the node's
   ///                   current `unexpectedBetweenColonAndPrecedenceGroup`, if present.
-  public func withUnexpectedBetweenColonAndPrecedenceGroup(
-    _ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+  public func withUnexpectedBetweenColonAndPrecedenceGroup(_ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
@@ -10839,10 +10941,10 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `precedenceGroup` replaced.
   /// - param newChild: The new `precedenceGroup` to replace the node's
   ///                   current `precedenceGroup`, if present.
-  public func withPrecedenceGroup(
-    _ newChild: TokenSyntax?) -> OperatorPrecedenceAndTypesSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withPrecedenceGroup(_ newChild: TokenSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
@@ -10860,10 +10962,10 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPrecedenceGroupAndDesignatedTypes` replaced.
   /// - param newChild: The new `unexpectedBetweenPrecedenceGroupAndDesignatedTypes` to replace the node's
   ///                   current `unexpectedBetweenPrecedenceGroupAndDesignatedTypes`, if present.
-  public func withUnexpectedBetweenPrecedenceGroupAndDesignatedTypes(
-    _ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+  public func withUnexpectedBetweenPrecedenceGroupAndDesignatedTypes(_ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
@@ -10888,23 +10990,24 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `designatedTypes` collection.
   public func addDesignatedTypeElement(_ element: DesignatedTypeElementSyntax) -> OperatorPrecedenceAndTypesSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 5)
+    let newData = data.replacingChild(collection, at: 5, arena: arena)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `designatedTypes` replaced.
   /// - param newChild: The new `designatedTypes` to replace the node's
   ///                   current `designatedTypes`, if present.
-  public func withDesignatedTypes(
-    _ newChild: DesignatedTypeListSyntax?) -> OperatorPrecedenceAndTypesSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.designatedTypeList, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withDesignatedTypes(_ newChild: DesignatedTypeListSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.designatedTypeList, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
@@ -10922,10 +11025,10 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterDesignatedTypes` replaced.
   /// - param newChild: The new `unexpectedAfterDesignatedTypes` to replace the node's
   ///                   current `unexpectedAfterDesignatedTypes`, if present.
-  public func withUnexpectedAfterDesignatedTypes(
-    _ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+  public func withUnexpectedAfterDesignatedTypes(_ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
@@ -11019,9 +11122,11 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
       otherNames.raw,
       unexpectedAfterOtherNames?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupRelation,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupRelation,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -11039,10 +11144,10 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeHigherThanOrLowerThan` replaced.
   /// - param newChild: The new `unexpectedBeforeHigherThanOrLowerThan` to replace the node's
   ///                   current `unexpectedBeforeHigherThanOrLowerThan`, if present.
-  public func withUnexpectedBeforeHigherThanOrLowerThan(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
+  public func withUnexpectedBeforeHigherThanOrLowerThan(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PrecedenceGroupRelationSyntax(newData)
   }
 
@@ -11062,10 +11167,10 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `higherThanOrLowerThan` replaced.
   /// - param newChild: The new `higherThanOrLowerThan` to replace the node's
   ///                   current `higherThanOrLowerThan`, if present.
-  public func withHigherThanOrLowerThan(
-    _ newChild: TokenSyntax?) -> PrecedenceGroupRelationSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withHigherThanOrLowerThan(_ newChild: TokenSyntax?) -> PrecedenceGroupRelationSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PrecedenceGroupRelationSyntax(newData)
   }
 
@@ -11083,10 +11188,10 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenHigherThanOrLowerThanAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenHigherThanOrLowerThanAndColon` to replace the node's
   ///                   current `unexpectedBetweenHigherThanOrLowerThanAndColon`, if present.
-  public func withUnexpectedBetweenHigherThanOrLowerThanAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
+  public func withUnexpectedBetweenHigherThanOrLowerThanAndColon(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PrecedenceGroupRelationSyntax(newData)
   }
 
@@ -11103,10 +11208,10 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> PrecedenceGroupRelationSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> PrecedenceGroupRelationSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PrecedenceGroupRelationSyntax(newData)
   }
 
@@ -11124,10 +11229,10 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndOtherNames` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndOtherNames` to replace the node's
   ///                   current `unexpectedBetweenColonAndOtherNames`, if present.
-  public func withUnexpectedBetweenColonAndOtherNames(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
+  public func withUnexpectedBetweenColonAndOtherNames(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PrecedenceGroupRelationSyntax(newData)
   }
 
@@ -11153,23 +11258,24 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `otherNames` collection.
   public func addOtherName(_ element: PrecedenceGroupNameElementSyntax) -> PrecedenceGroupRelationSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 5)
+    let newData = data.replacingChild(collection, at: 5, arena: arena)
     return PrecedenceGroupRelationSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `otherNames` replaced.
   /// - param newChild: The new `otherNames` to replace the node's
   ///                   current `otherNames`, if present.
-  public func withOtherNames(
-    _ newChild: PrecedenceGroupNameListSyntax?) -> PrecedenceGroupRelationSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.precedenceGroupNameList, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withOtherNames(_ newChild: PrecedenceGroupNameListSyntax?) -> PrecedenceGroupRelationSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.precedenceGroupNameList, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return PrecedenceGroupRelationSyntax(newData)
   }
 
@@ -11187,10 +11293,10 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterOtherNames` replaced.
   /// - param newChild: The new `unexpectedAfterOtherNames` to replace the node's
   ///                   current `unexpectedAfterOtherNames`, if present.
-  public func withUnexpectedAfterOtherNames(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
+  public func withUnexpectedAfterOtherNames(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return PrecedenceGroupRelationSyntax(newData)
   }
 
@@ -11276,9 +11382,11 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameElement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -11296,10 +11404,10 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
   /// - param newChild: The new `unexpectedBeforeName` to replace the node's
   ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupNameElementSyntax {
+  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupNameElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PrecedenceGroupNameElementSyntax(newData)
   }
 
@@ -11316,10 +11424,10 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> PrecedenceGroupNameElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withName(_ newChild: TokenSyntax?) -> PrecedenceGroupNameElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PrecedenceGroupNameElementSyntax(newData)
   }
 
@@ -11337,10 +11445,10 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenNameAndTrailingComma`, if present.
-  public func withUnexpectedBetweenNameAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupNameElementSyntax {
+  public func withUnexpectedBetweenNameAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupNameElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PrecedenceGroupNameElementSyntax(newData)
   }
 
@@ -11358,10 +11466,10 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> PrecedenceGroupNameElementSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> PrecedenceGroupNameElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PrecedenceGroupNameElementSyntax(newData)
   }
 
@@ -11379,10 +11487,10 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupNameElementSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupNameElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PrecedenceGroupNameElementSyntax(newData)
   }
 
@@ -11468,9 +11576,11 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
       flag.raw,
       unexpectedAfterFlag?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAssignment,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAssignment,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -11488,10 +11598,10 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAssignmentKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeAssignmentKeyword` to replace the node's
   ///                   current `unexpectedBeforeAssignmentKeyword`, if present.
-  public func withUnexpectedBeforeAssignmentKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
+  public func withUnexpectedBeforeAssignmentKeyword(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
 
@@ -11508,10 +11618,10 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `assignmentKeyword` replaced.
   /// - param newChild: The new `assignmentKeyword` to replace the node's
   ///                   current `assignmentKeyword`, if present.
-  public func withAssignmentKeyword(
-    _ newChild: TokenSyntax?) -> PrecedenceGroupAssignmentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withAssignmentKeyword(_ newChild: TokenSyntax?) -> PrecedenceGroupAssignmentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
 
@@ -11529,10 +11639,10 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAssignmentKeywordAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenAssignmentKeywordAndColon` to replace the node's
   ///                   current `unexpectedBetweenAssignmentKeywordAndColon`, if present.
-  public func withUnexpectedBetweenAssignmentKeywordAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
+  public func withUnexpectedBetweenAssignmentKeywordAndColon(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
 
@@ -11549,10 +11659,10 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> PrecedenceGroupAssignmentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> PrecedenceGroupAssignmentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
 
@@ -11570,10 +11680,10 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndFlag` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndFlag` to replace the node's
   ///                   current `unexpectedBetweenColonAndFlag`, if present.
-  public func withUnexpectedBetweenColonAndFlag(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
+  public func withUnexpectedBetweenColonAndFlag(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
 
@@ -11597,10 +11707,10 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `flag` replaced.
   /// - param newChild: The new `flag` to replace the node's
   ///                   current `flag`, if present.
-  public func withFlag(
-    _ newChild: TokenSyntax?) -> PrecedenceGroupAssignmentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.trueKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withFlag(_ newChild: TokenSyntax?) -> PrecedenceGroupAssignmentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.trueKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
 
@@ -11618,10 +11728,10 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterFlag` replaced.
   /// - param newChild: The new `unexpectedAfterFlag` to replace the node's
   ///                   current `unexpectedAfterFlag`, if present.
-  public func withUnexpectedAfterFlag(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
+  public func withUnexpectedAfterFlag(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
 
@@ -11715,9 +11825,11 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
       value.raw,
       unexpectedAfterValue?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAssociativity,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAssociativity,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -11735,10 +11847,10 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedBeforeAssociativityKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeAssociativityKeyword` to replace the node's
   ///                   current `unexpectedBeforeAssociativityKeyword`, if present.
-  public func withUnexpectedBeforeAssociativityKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
+  public func withUnexpectedBeforeAssociativityKeyword(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
 
@@ -11755,10 +11867,10 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `associativityKeyword` replaced.
   /// - param newChild: The new `associativityKeyword` to replace the node's
   ///                   current `associativityKeyword`, if present.
-  public func withAssociativityKeyword(
-    _ newChild: TokenSyntax?) -> PrecedenceGroupAssociativitySyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withAssociativityKeyword(_ newChild: TokenSyntax?) -> PrecedenceGroupAssociativitySyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
 
@@ -11776,10 +11888,10 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedBetweenAssociativityKeywordAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenAssociativityKeywordAndColon` to replace the node's
   ///                   current `unexpectedBetweenAssociativityKeywordAndColon`, if present.
-  public func withUnexpectedBetweenAssociativityKeywordAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
+  public func withUnexpectedBetweenAssociativityKeywordAndColon(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
 
@@ -11796,10 +11908,10 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> PrecedenceGroupAssociativitySyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> PrecedenceGroupAssociativitySyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
 
@@ -11817,10 +11929,10 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndValue` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndValue` to replace the node's
   ///                   current `unexpectedBetweenColonAndValue`, if present.
-  public func withUnexpectedBetweenColonAndValue(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
+  public func withUnexpectedBetweenColonAndValue(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
 
@@ -11843,10 +11955,10 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `value` replaced.
   /// - param newChild: The new `value` to replace the node's
   ///                   current `value`, if present.
-  public func withValue(
-    _ newChild: TokenSyntax?) -> PrecedenceGroupAssociativitySyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withValue(_ newChild: TokenSyntax?) -> PrecedenceGroupAssociativitySyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
 
@@ -11864,10 +11976,10 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedAfterValue` replaced.
   /// - param newChild: The new `unexpectedAfterValue` to replace the node's
   ///                   current `unexpectedAfterValue`, if present.
-  public func withUnexpectedAfterValue(
-    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
+  public func withUnexpectedAfterValue(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
 
@@ -11968,9 +12080,11 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
       rightParen?.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.customAttribute,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.customAttribute,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -11988,10 +12102,10 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAtSignToken` replaced.
   /// - param newChild: The new `unexpectedBeforeAtSignToken` to replace the node's
   ///                   current `unexpectedBeforeAtSignToken`, if present.
-  public func withUnexpectedBeforeAtSignToken(
-    _ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
+  public func withUnexpectedBeforeAtSignToken(_ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return CustomAttributeSyntax(newData)
   }
 
@@ -12009,10 +12123,10 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `atSignToken` replaced.
   /// - param newChild: The new `atSignToken` to replace the node's
   ///                   current `atSignToken`, if present.
-  public func withAtSignToken(
-    _ newChild: TokenSyntax?) -> CustomAttributeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.atSign, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withAtSignToken(_ newChild: TokenSyntax?) -> CustomAttributeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.atSign, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return CustomAttributeSyntax(newData)
   }
 
@@ -12030,10 +12144,10 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAtSignTokenAndAttributeName` replaced.
   /// - param newChild: The new `unexpectedBetweenAtSignTokenAndAttributeName` to replace the node's
   ///                   current `unexpectedBetweenAtSignTokenAndAttributeName`, if present.
-  public func withUnexpectedBetweenAtSignTokenAndAttributeName(
-    _ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
+  public func withUnexpectedBetweenAtSignTokenAndAttributeName(_ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return CustomAttributeSyntax(newData)
   }
 
@@ -12051,10 +12165,10 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `attributeName` replaced.
   /// - param newChild: The new `attributeName` to replace the node's
   ///                   current `attributeName`, if present.
-  public func withAttributeName(
-    _ newChild: TypeSyntax?) -> CustomAttributeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withAttributeName(_ newChild: TypeSyntax?) -> CustomAttributeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return CustomAttributeSyntax(newData)
   }
 
@@ -12072,10 +12186,10 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributeNameAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributeNameAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenAttributeNameAndLeftParen`, if present.
-  public func withUnexpectedBetweenAttributeNameAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
+  public func withUnexpectedBetweenAttributeNameAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return CustomAttributeSyntax(newData)
   }
 
@@ -12093,10 +12207,10 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> CustomAttributeSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax?) -> CustomAttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return CustomAttributeSyntax(newData)
   }
 
@@ -12114,10 +12228,10 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArgumentList` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndArgumentList` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndArgumentList`, if present.
-  public func withUnexpectedBetweenLeftParenAndArgumentList(
-    _ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
+  public func withUnexpectedBetweenLeftParenAndArgumentList(_ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return CustomAttributeSyntax(newData)
   }
 
@@ -12140,23 +12254,24 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `argumentList` collection.
   public func addArgument(_ element: TupleExprElementSyntax) -> CustomAttributeSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[7] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 7)
+    let newData = data.replacingChild(collection, at: 7, arena: arena)
     return CustomAttributeSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `argumentList` replaced.
   /// - param newChild: The new `argumentList` to replace the node's
   ///                   current `argumentList`, if present.
-  public func withArgumentList(
-    _ newChild: TupleExprElementListSyntax?) -> CustomAttributeSyntax {
+  public func withArgumentList(_ newChild: TupleExprElementListSyntax?) -> CustomAttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return CustomAttributeSyntax(newData)
   }
 
@@ -12174,10 +12289,10 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenArgumentListAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenArgumentListAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenArgumentListAndRightParen`, if present.
-  public func withUnexpectedBetweenArgumentListAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
+  public func withUnexpectedBetweenArgumentListAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return CustomAttributeSyntax(newData)
   }
 
@@ -12195,10 +12310,10 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> CustomAttributeSyntax {
+  public func withRightParen(_ newChild: TokenSyntax?) -> CustomAttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return CustomAttributeSyntax(newData)
   }
 
@@ -12216,10 +12331,10 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return CustomAttributeSyntax(newData)
   }
 
@@ -12496,9 +12611,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       tokenList?.raw,
       unexpectedAfterTokenList?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.attribute,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.attribute,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -12516,10 +12633,10 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAtSignToken` replaced.
   /// - param newChild: The new `unexpectedBeforeAtSignToken` to replace the node's
   ///                   current `unexpectedBeforeAtSignToken`, if present.
-  public func withUnexpectedBeforeAtSignToken(
-    _ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
+  public func withUnexpectedBeforeAtSignToken(_ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AttributeSyntax(newData)
   }
 
@@ -12537,10 +12654,10 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `atSignToken` replaced.
   /// - param newChild: The new `atSignToken` to replace the node's
   ///                   current `atSignToken`, if present.
-  public func withAtSignToken(
-    _ newChild: TokenSyntax?) -> AttributeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.atSign, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withAtSignToken(_ newChild: TokenSyntax?) -> AttributeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.atSign, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AttributeSyntax(newData)
   }
 
@@ -12558,10 +12675,10 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAtSignTokenAndAttributeName` replaced.
   /// - param newChild: The new `unexpectedBetweenAtSignTokenAndAttributeName` to replace the node's
   ///                   current `unexpectedBetweenAtSignTokenAndAttributeName`, if present.
-  public func withUnexpectedBetweenAtSignTokenAndAttributeName(
-    _ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
+  public func withUnexpectedBetweenAtSignTokenAndAttributeName(_ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AttributeSyntax(newData)
   }
 
@@ -12579,10 +12696,10 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `attributeName` replaced.
   /// - param newChild: The new `attributeName` to replace the node's
   ///                   current `attributeName`, if present.
-  public func withAttributeName(
-    _ newChild: TokenSyntax?) -> AttributeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withAttributeName(_ newChild: TokenSyntax?) -> AttributeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AttributeSyntax(newData)
   }
 
@@ -12600,10 +12717,10 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributeNameAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributeNameAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenAttributeNameAndLeftParen`, if present.
-  public func withUnexpectedBetweenAttributeNameAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
+  public func withUnexpectedBetweenAttributeNameAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AttributeSyntax(newData)
   }
 
@@ -12624,10 +12741,10 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> AttributeSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax?) -> AttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return AttributeSyntax(newData)
   }
 
@@ -12645,10 +12762,10 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArgument` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndArgument` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndArgument`, if present.
-  public func withUnexpectedBetweenLeftParenAndArgument(
-    _ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
+  public func withUnexpectedBetweenLeftParenAndArgument(_ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return AttributeSyntax(newData)
   }
 
@@ -12671,10 +12788,10 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `argument` replaced.
   /// - param newChild: The new `argument` to replace the node's
   ///                   current `argument`, if present.
-  public func withArgument(
-    _ newChild: Argument?) -> AttributeSyntax {
+  public func withArgument(_ newChild: Argument?) -> AttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return AttributeSyntax(newData)
   }
 
@@ -12692,10 +12809,10 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenArgumentAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenArgumentAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenArgumentAndRightParen`, if present.
-  public func withUnexpectedBetweenArgumentAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
+  public func withUnexpectedBetweenArgumentAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return AttributeSyntax(newData)
   }
 
@@ -12716,10 +12833,10 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> AttributeSyntax {
+  public func withRightParen(_ newChild: TokenSyntax?) -> AttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return AttributeSyntax(newData)
   }
 
@@ -12737,10 +12854,10 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenRightParenAndTokenList` replaced.
   /// - param newChild: The new `unexpectedBetweenRightParenAndTokenList` to replace the node's
   ///                   current `unexpectedBetweenRightParenAndTokenList`, if present.
-  public func withUnexpectedBetweenRightParenAndTokenList(
-    _ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
+  public func withUnexpectedBetweenRightParenAndTokenList(_ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return AttributeSyntax(newData)
   }
 
@@ -12763,23 +12880,24 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `tokenList` collection.
   public func addToken(_ element: TokenSyntax) -> AttributeSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[11] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tokenList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 11)
+    let newData = data.replacingChild(collection, at: 11, arena: arena)
     return AttributeSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `tokenList` replaced.
   /// - param newChild: The new `tokenList` to replace the node's
   ///                   current `tokenList`, if present.
-  public func withTokenList(
-    _ newChild: TokenListSyntax?) -> AttributeSyntax {
+  public func withTokenList(_ newChild: TokenListSyntax?) -> AttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return AttributeSyntax(newData)
   }
 
@@ -12797,10 +12915,10 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTokenList` replaced.
   /// - param newChild: The new `unexpectedAfterTokenList` to replace the node's
   ///                   current `unexpectedAfterTokenList`, if present.
-  public func withUnexpectedAfterTokenList(
-    _ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
+  public func withUnexpectedAfterTokenList(_ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return AttributeSyntax(newData)
   }
 
@@ -12921,9 +13039,11 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
       semicolon.raw,
       unexpectedAfterSemicolon?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityEntry,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityEntry,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -12941,10 +13061,10 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLabel` replaced.
   /// - param newChild: The new `unexpectedBeforeLabel` to replace the node's
   ///                   current `unexpectedBeforeLabel`, if present.
-  public func withUnexpectedBeforeLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
+  public func withUnexpectedBeforeLabel(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AvailabilityEntrySyntax(newData)
   }
 
@@ -12962,10 +13082,10 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `label` replaced.
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
-  public func withLabel(
-    _ newChild: TokenSyntax?) -> AvailabilityEntrySyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLabel(_ newChild: TokenSyntax?) -> AvailabilityEntrySyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AvailabilityEntrySyntax(newData)
   }
 
@@ -12983,10 +13103,10 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLabelAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenLabelAndColon` to replace the node's
   ///                   current `unexpectedBetweenLabelAndColon`, if present.
-  public func withUnexpectedBetweenLabelAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
+  public func withUnexpectedBetweenLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AvailabilityEntrySyntax(newData)
   }
 
@@ -13004,10 +13124,10 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> AvailabilityEntrySyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> AvailabilityEntrySyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AvailabilityEntrySyntax(newData)
   }
 
@@ -13025,10 +13145,10 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndAvailabilityList` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndAvailabilityList` to replace the node's
   ///                   current `unexpectedBetweenColonAndAvailabilityList`, if present.
-  public func withUnexpectedBetweenColonAndAvailabilityList(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
+  public func withUnexpectedBetweenColonAndAvailabilityList(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AvailabilityEntrySyntax(newData)
   }
 
@@ -13050,23 +13170,24 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `availabilityList` collection.
   public func addAvailability(_ element: AvailabilityArgumentSyntax) -> AvailabilityEntrySyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.availabilitySpecList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 5)
+    let newData = data.replacingChild(collection, at: 5, arena: arena)
     return AvailabilityEntrySyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `availabilityList` replaced.
   /// - param newChild: The new `availabilityList` to replace the node's
   ///                   current `availabilityList`, if present.
-  public func withAvailabilityList(
-    _ newChild: AvailabilitySpecListSyntax?) -> AvailabilityEntrySyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withAvailabilityList(_ newChild: AvailabilitySpecListSyntax?) -> AvailabilityEntrySyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return AvailabilityEntrySyntax(newData)
   }
 
@@ -13084,10 +13205,10 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAvailabilityListAndSemicolon` replaced.
   /// - param newChild: The new `unexpectedBetweenAvailabilityListAndSemicolon` to replace the node's
   ///                   current `unexpectedBetweenAvailabilityListAndSemicolon`, if present.
-  public func withUnexpectedBetweenAvailabilityListAndSemicolon(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
+  public func withUnexpectedBetweenAvailabilityListAndSemicolon(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return AvailabilityEntrySyntax(newData)
   }
 
@@ -13104,10 +13225,10 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `semicolon` replaced.
   /// - param newChild: The new `semicolon` to replace the node's
   ///                   current `semicolon`, if present.
-  public func withSemicolon(
-    _ newChild: TokenSyntax?) -> AvailabilityEntrySyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.semicolon, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withSemicolon(_ newChild: TokenSyntax?) -> AvailabilityEntrySyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.semicolon, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return AvailabilityEntrySyntax(newData)
   }
 
@@ -13125,10 +13246,10 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterSemicolon` replaced.
   /// - param newChild: The new `unexpectedAfterSemicolon` to replace the node's
   ///                   current `unexpectedAfterSemicolon`, if present.
-  public func withUnexpectedAfterSemicolon(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
+  public func withUnexpectedAfterSemicolon(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return AvailabilityEntrySyntax(newData)
   }
 
@@ -13234,9 +13355,11 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.labeledSpecializeEntry,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.labeledSpecializeEntry,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -13254,10 +13377,10 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLabel` replaced.
   /// - param newChild: The new `unexpectedBeforeLabel` to replace the node's
   ///                   current `unexpectedBeforeLabel`, if present.
-  public func withUnexpectedBeforeLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
+  public func withUnexpectedBeforeLabel(_ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
@@ -13275,10 +13398,10 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `label` replaced.
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
-  public func withLabel(
-    _ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLabel(_ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
@@ -13296,10 +13419,10 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLabelAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenLabelAndColon` to replace the node's
   ///                   current `unexpectedBetweenLabelAndColon`, if present.
-  public func withUnexpectedBetweenLabelAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
+  public func withUnexpectedBetweenLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
@@ -13317,10 +13440,10 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
@@ -13338,10 +13461,10 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndValue` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndValue` to replace the node's
   ///                   current `unexpectedBetweenColonAndValue`, if present.
-  public func withUnexpectedBetweenColonAndValue(
-    _ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
+  public func withUnexpectedBetweenColonAndValue(_ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
@@ -13359,10 +13482,10 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `value` replaced.
   /// - param newChild: The new `value` to replace the node's
   ///                   current `value`, if present.
-  public func withValue(
-    _ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withValue(_ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
@@ -13380,10 +13503,10 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenValueAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenValueAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenValueAndTrailingComma`, if present.
-  public func withUnexpectedBetweenValueAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
+  public func withUnexpectedBetweenValueAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
@@ -13404,10 +13527,10 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
@@ -13425,10 +13548,10 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
@@ -13535,9 +13658,11 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.targetFunctionEntry,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.targetFunctionEntry,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -13555,10 +13680,10 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLabel` replaced.
   /// - param newChild: The new `unexpectedBeforeLabel` to replace the node's
   ///                   current `unexpectedBeforeLabel`, if present.
-  public func withUnexpectedBeforeLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
+  public func withUnexpectedBeforeLabel(_ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return TargetFunctionEntrySyntax(newData)
   }
 
@@ -13576,10 +13701,10 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `label` replaced.
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
-  public func withLabel(
-    _ newChild: TokenSyntax?) -> TargetFunctionEntrySyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLabel(_ newChild: TokenSyntax?) -> TargetFunctionEntrySyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return TargetFunctionEntrySyntax(newData)
   }
 
@@ -13597,10 +13722,10 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLabelAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenLabelAndColon` to replace the node's
   ///                   current `unexpectedBetweenLabelAndColon`, if present.
-  public func withUnexpectedBetweenLabelAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
+  public func withUnexpectedBetweenLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return TargetFunctionEntrySyntax(newData)
   }
 
@@ -13618,10 +13743,10 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> TargetFunctionEntrySyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> TargetFunctionEntrySyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return TargetFunctionEntrySyntax(newData)
   }
 
@@ -13639,10 +13764,10 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndDeclname` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndDeclname` to replace the node's
   ///                   current `unexpectedBetweenColonAndDeclname`, if present.
-  public func withUnexpectedBetweenColonAndDeclname(
-    _ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
+  public func withUnexpectedBetweenColonAndDeclname(_ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return TargetFunctionEntrySyntax(newData)
   }
 
@@ -13660,10 +13785,10 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `declname` replaced.
   /// - param newChild: The new `declname` to replace the node's
   ///                   current `declname`, if present.
-  public func withDeclname(
-    _ newChild: DeclNameSyntax?) -> TargetFunctionEntrySyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.declName, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withDeclname(_ newChild: DeclNameSyntax?) -> TargetFunctionEntrySyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.declName, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return TargetFunctionEntrySyntax(newData)
   }
 
@@ -13681,10 +13806,10 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenDeclnameAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenDeclnameAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenDeclnameAndTrailingComma`, if present.
-  public func withUnexpectedBetweenDeclnameAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
+  public func withUnexpectedBetweenDeclnameAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return TargetFunctionEntrySyntax(newData)
   }
 
@@ -13705,10 +13830,10 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> TargetFunctionEntrySyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> TargetFunctionEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return TargetFunctionEntrySyntax(newData)
   }
 
@@ -13726,10 +13851,10 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return TargetFunctionEntrySyntax(newData)
   }
 
@@ -13868,9 +13993,11 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
       stringOrDeclname.raw,
       unexpectedAfterStringOrDeclname?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.namedAttributeStringArgument,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.namedAttributeStringArgument,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -13888,10 +14015,10 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedBeforeNameTok` replaced.
   /// - param newChild: The new `unexpectedBeforeNameTok` to replace the node's
   ///                   current `unexpectedBeforeNameTok`, if present.
-  public func withUnexpectedBeforeNameTok(
-    _ newChild: UnexpectedNodesSyntax?) -> NamedAttributeStringArgumentSyntax {
+  public func withUnexpectedBeforeNameTok(_ newChild: UnexpectedNodesSyntax?) -> NamedAttributeStringArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return NamedAttributeStringArgumentSyntax(newData)
   }
 
@@ -13909,10 +14036,10 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `nameTok` replaced.
   /// - param newChild: The new `nameTok` to replace the node's
   ///                   current `nameTok`, if present.
-  public func withNameTok(
-    _ newChild: TokenSyntax?) -> NamedAttributeStringArgumentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withNameTok(_ newChild: TokenSyntax?) -> NamedAttributeStringArgumentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return NamedAttributeStringArgumentSyntax(newData)
   }
 
@@ -13930,10 +14057,10 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedBetweenNameTokAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenNameTokAndColon` to replace the node's
   ///                   current `unexpectedBetweenNameTokAndColon`, if present.
-  public func withUnexpectedBetweenNameTokAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> NamedAttributeStringArgumentSyntax {
+  public func withUnexpectedBetweenNameTokAndColon(_ newChild: UnexpectedNodesSyntax?) -> NamedAttributeStringArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return NamedAttributeStringArgumentSyntax(newData)
   }
 
@@ -13951,10 +14078,10 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> NamedAttributeStringArgumentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> NamedAttributeStringArgumentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return NamedAttributeStringArgumentSyntax(newData)
   }
 
@@ -13972,10 +14099,10 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndStringOrDeclname` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndStringOrDeclname` to replace the node's
   ///                   current `unexpectedBetweenColonAndStringOrDeclname`, if present.
-  public func withUnexpectedBetweenColonAndStringOrDeclname(
-    _ newChild: UnexpectedNodesSyntax?) -> NamedAttributeStringArgumentSyntax {
+  public func withUnexpectedBetweenColonAndStringOrDeclname(_ newChild: UnexpectedNodesSyntax?) -> NamedAttributeStringArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return NamedAttributeStringArgumentSyntax(newData)
   }
 
@@ -13992,10 +14119,10 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `stringOrDeclname` replaced.
   /// - param newChild: The new `stringOrDeclname` to replace the node's
   ///                   current `stringOrDeclname`, if present.
-  public func withStringOrDeclname(
-    _ newChild: StringOrDeclname?) -> NamedAttributeStringArgumentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withStringOrDeclname(_ newChild: StringOrDeclname?) -> NamedAttributeStringArgumentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return NamedAttributeStringArgumentSyntax(newData)
   }
 
@@ -14013,10 +14140,10 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedAfterStringOrDeclname` replaced.
   /// - param newChild: The new `unexpectedAfterStringOrDeclname` to replace the node's
   ///                   current `unexpectedAfterStringOrDeclname`, if present.
-  public func withUnexpectedAfterStringOrDeclname(
-    _ newChild: UnexpectedNodesSyntax?) -> NamedAttributeStringArgumentSyntax {
+  public func withUnexpectedAfterStringOrDeclname(_ newChild: UnexpectedNodesSyntax?) -> NamedAttributeStringArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return NamedAttributeStringArgumentSyntax(newData)
   }
 
@@ -14102,9 +14229,11 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       declNameArguments?.raw,
       unexpectedAfterDeclNameArguments?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.declName,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declName,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -14122,10 +14251,10 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeDeclBaseName` replaced.
   /// - param newChild: The new `unexpectedBeforeDeclBaseName` to replace the node's
   ///                   current `unexpectedBeforeDeclBaseName`, if present.
-  public func withUnexpectedBeforeDeclBaseName(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclNameSyntax {
+  public func withUnexpectedBeforeDeclBaseName(_ newChild: UnexpectedNodesSyntax?) -> DeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DeclNameSyntax(newData)
   }
 
@@ -14145,10 +14274,10 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `declBaseName` replaced.
   /// - param newChild: The new `declBaseName` to replace the node's
   ///                   current `declBaseName`, if present.
-  public func withDeclBaseName(
-    _ newChild: TokenSyntax?) -> DeclNameSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withDeclBaseName(_ newChild: TokenSyntax?) -> DeclNameSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DeclNameSyntax(newData)
   }
 
@@ -14166,10 +14295,10 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenDeclBaseNameAndDeclNameArguments` replaced.
   /// - param newChild: The new `unexpectedBetweenDeclBaseNameAndDeclNameArguments` to replace the node's
   ///                   current `unexpectedBetweenDeclBaseNameAndDeclNameArguments`, if present.
-  public func withUnexpectedBetweenDeclBaseNameAndDeclNameArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclNameSyntax {
+  public func withUnexpectedBetweenDeclBaseNameAndDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> DeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DeclNameSyntax(newData)
   }
 
@@ -14191,10 +14320,10 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `declNameArguments` replaced.
   /// - param newChild: The new `declNameArguments` to replace the node's
   ///                   current `declNameArguments`, if present.
-  public func withDeclNameArguments(
-    _ newChild: DeclNameArgumentsSyntax?) -> DeclNameSyntax {
+  public func withDeclNameArguments(_ newChild: DeclNameArgumentsSyntax?) -> DeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DeclNameSyntax(newData)
   }
 
@@ -14212,10 +14341,10 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterDeclNameArguments` replaced.
   /// - param newChild: The new `unexpectedAfterDeclNameArguments` to replace the node's
   ///                   current `unexpectedAfterDeclNameArguments`, if present.
-  public func withUnexpectedAfterDeclNameArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclNameSyntax {
+  public func withUnexpectedAfterDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> DeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DeclNameSyntax(newData)
   }
 
@@ -14305,9 +14434,11 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       declNameArguments?.raw,
       unexpectedAfterDeclNameArguments?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.implementsAttributeArguments,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.implementsAttributeArguments,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -14325,10 +14456,10 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedBeforeType` replaced.
   /// - param newChild: The new `unexpectedBeforeType` to replace the node's
   ///                   current `unexpectedBeforeType`, if present.
-  public func withUnexpectedBeforeType(
-    _ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
+  public func withUnexpectedBeforeType(_ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
@@ -14349,10 +14480,10 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `type` replaced.
   /// - param newChild: The new `type` to replace the node's
   ///                   current `type`, if present.
-  public func withType(
-    _ newChild: TypeSyntax?) -> ImplementsAttributeArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withType(_ newChild: TypeSyntax?) -> ImplementsAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
@@ -14370,10 +14501,10 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedBetweenTypeAndComma` replaced.
   /// - param newChild: The new `unexpectedBetweenTypeAndComma` to replace the node's
   ///                   current `unexpectedBetweenTypeAndComma`, if present.
-  public func withUnexpectedBetweenTypeAndComma(
-    _ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenTypeAndComma(_ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
@@ -14393,10 +14524,10 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `comma` replaced.
   /// - param newChild: The new `comma` to replace the node's
   ///                   current `comma`, if present.
-  public func withComma(
-    _ newChild: TokenSyntax?) -> ImplementsAttributeArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withComma(_ newChild: TokenSyntax?) -> ImplementsAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
@@ -14414,10 +14545,10 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndDeclBaseName` replaced.
   /// - param newChild: The new `unexpectedBetweenCommaAndDeclBaseName` to replace the node's
   ///                   current `unexpectedBetweenCommaAndDeclBaseName`, if present.
-  public func withUnexpectedBetweenCommaAndDeclBaseName(
-    _ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenCommaAndDeclBaseName(_ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
@@ -14437,10 +14568,10 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `declBaseName` replaced.
   /// - param newChild: The new `declBaseName` to replace the node's
   ///                   current `declBaseName`, if present.
-  public func withDeclBaseName(
-    _ newChild: TokenSyntax?) -> ImplementsAttributeArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withDeclBaseName(_ newChild: TokenSyntax?) -> ImplementsAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
@@ -14458,10 +14589,10 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedBetweenDeclBaseNameAndDeclNameArguments` replaced.
   /// - param newChild: The new `unexpectedBetweenDeclBaseNameAndDeclNameArguments` to replace the node's
   ///                   current `unexpectedBetweenDeclBaseNameAndDeclNameArguments`, if present.
-  public func withUnexpectedBetweenDeclBaseNameAndDeclNameArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenDeclBaseNameAndDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
@@ -14483,10 +14614,10 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `declNameArguments` replaced.
   /// - param newChild: The new `declNameArguments` to replace the node's
   ///                   current `declNameArguments`, if present.
-  public func withDeclNameArguments(
-    _ newChild: DeclNameArgumentsSyntax?) -> ImplementsAttributeArgumentsSyntax {
+  public func withDeclNameArguments(_ newChild: DeclNameArgumentsSyntax?) -> ImplementsAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
@@ -14504,10 +14635,10 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedAfterDeclNameArguments` replaced.
   /// - param newChild: The new `unexpectedAfterDeclNameArguments` to replace the node's
   ///                   current `unexpectedAfterDeclNameArguments`, if present.
-  public func withUnexpectedAfterDeclNameArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
+  public func withUnexpectedAfterDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
@@ -14606,9 +14737,11 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
       colon?.raw,
       unexpectedAfterColon?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.objCSelectorPiece,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.objCSelectorPiece,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -14626,10 +14759,10 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
   /// - param newChild: The new `unexpectedBeforeName` to replace the node's
   ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjCSelectorPieceSyntax {
+  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> ObjCSelectorPieceSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ObjCSelectorPieceSyntax(newData)
   }
 
@@ -14647,10 +14780,10 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> ObjCSelectorPieceSyntax {
+  public func withName(_ newChild: TokenSyntax?) -> ObjCSelectorPieceSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ObjCSelectorPieceSyntax(newData)
   }
 
@@ -14668,10 +14801,10 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndColon` to replace the node's
   ///                   current `unexpectedBetweenNameAndColon`, if present.
-  public func withUnexpectedBetweenNameAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjCSelectorPieceSyntax {
+  public func withUnexpectedBetweenNameAndColon(_ newChild: UnexpectedNodesSyntax?) -> ObjCSelectorPieceSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ObjCSelectorPieceSyntax(newData)
   }
 
@@ -14689,10 +14822,10 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> ObjCSelectorPieceSyntax {
+  public func withColon(_ newChild: TokenSyntax?) -> ObjCSelectorPieceSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ObjCSelectorPieceSyntax(newData)
   }
 
@@ -14710,10 +14843,10 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterColon` replaced.
   /// - param newChild: The new `unexpectedAfterColon` to replace the node's
   ///                   current `unexpectedAfterColon`, if present.
-  public func withUnexpectedAfterColon(
-    _ newChild: UnexpectedNodesSyntax?) -> ObjCSelectorPieceSyntax {
+  public func withUnexpectedAfterColon(_ newChild: UnexpectedNodesSyntax?) -> ObjCSelectorPieceSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ObjCSelectorPieceSyntax(newData)
   }
 
@@ -14808,9 +14941,11 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
       whereClause?.raw,
       unexpectedAfterWhereClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiableAttributeArguments,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiableAttributeArguments,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -14828,10 +14963,10 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   /// Returns a copy of the receiver with its `unexpectedBeforeDiffKind` replaced.
   /// - param newChild: The new `unexpectedBeforeDiffKind` to replace the node's
   ///                   current `unexpectedBeforeDiffKind`, if present.
-  public func withUnexpectedBeforeDiffKind(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+  public func withUnexpectedBeforeDiffKind(_ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
@@ -14849,10 +14984,10 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   /// Returns a copy of the receiver with its `diffKind` replaced.
   /// - param newChild: The new `diffKind` to replace the node's
   ///                   current `diffKind`, if present.
-  public func withDiffKind(
-    _ newChild: TokenSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+  public func withDiffKind(_ newChild: TokenSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
@@ -14870,10 +15005,10 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   /// Returns a copy of the receiver with its `unexpectedBetweenDiffKindAndDiffKindComma` replaced.
   /// - param newChild: The new `unexpectedBetweenDiffKindAndDiffKindComma` to replace the node's
   ///                   current `unexpectedBetweenDiffKindAndDiffKindComma`, if present.
-  public func withUnexpectedBetweenDiffKindAndDiffKindComma(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenDiffKindAndDiffKindComma(_ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
@@ -14894,10 +15029,10 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   /// Returns a copy of the receiver with its `diffKindComma` replaced.
   /// - param newChild: The new `diffKindComma` to replace the node's
   ///                   current `diffKindComma`, if present.
-  public func withDiffKindComma(
-    _ newChild: TokenSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+  public func withDiffKindComma(_ newChild: TokenSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
@@ -14915,10 +15050,10 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   /// Returns a copy of the receiver with its `unexpectedBetweenDiffKindCommaAndDiffParams` replaced.
   /// - param newChild: The new `unexpectedBetweenDiffKindCommaAndDiffParams` to replace the node's
   ///                   current `unexpectedBetweenDiffKindCommaAndDiffParams`, if present.
-  public func withUnexpectedBetweenDiffKindCommaAndDiffParams(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenDiffKindCommaAndDiffParams(_ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
@@ -14936,10 +15071,10 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   /// Returns a copy of the receiver with its `diffParams` replaced.
   /// - param newChild: The new `diffParams` to replace the node's
   ///                   current `diffParams`, if present.
-  public func withDiffParams(
-    _ newChild: DifferentiabilityParamsClauseSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+  public func withDiffParams(_ newChild: DifferentiabilityParamsClauseSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
@@ -14957,10 +15092,10 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   /// Returns a copy of the receiver with its `unexpectedBetweenDiffParamsAndDiffParamsComma` replaced.
   /// - param newChild: The new `unexpectedBetweenDiffParamsAndDiffParamsComma` to replace the node's
   ///                   current `unexpectedBetweenDiffParamsAndDiffParamsComma`, if present.
-  public func withUnexpectedBetweenDiffParamsAndDiffParamsComma(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenDiffParamsAndDiffParamsComma(_ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
@@ -14982,10 +15117,10 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   /// Returns a copy of the receiver with its `diffParamsComma` replaced.
   /// - param newChild: The new `diffParamsComma` to replace the node's
   ///                   current `diffParamsComma`, if present.
-  public func withDiffParamsComma(
-    _ newChild: TokenSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+  public func withDiffParamsComma(_ newChild: TokenSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
@@ -15003,10 +15138,10 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   /// Returns a copy of the receiver with its `unexpectedBetweenDiffParamsCommaAndWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenDiffParamsCommaAndWhereClause` to replace the node's
   ///                   current `unexpectedBetweenDiffParamsCommaAndWhereClause`, if present.
-  public func withUnexpectedBetweenDiffParamsCommaAndWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenDiffParamsCommaAndWhereClause(_ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
@@ -15024,10 +15159,10 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   /// Returns a copy of the receiver with its `whereClause` replaced.
   /// - param newChild: The new `whereClause` to replace the node's
   ///                   current `whereClause`, if present.
-  public func withWhereClause(
-    _ newChild: GenericWhereClauseSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+  public func withWhereClause(_ newChild: GenericWhereClauseSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
@@ -15045,10 +15180,10 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   /// Returns a copy of the receiver with its `unexpectedAfterWhereClause` replaced.
   /// - param newChild: The new `unexpectedAfterWhereClause` to replace the node's
   ///                   current `unexpectedAfterWhereClause`, if present.
-  public func withUnexpectedAfterWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+  public func withUnexpectedAfterWhereClause(_ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
@@ -15191,9 +15326,11 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
       parameters.raw,
       unexpectedAfterParameters?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamsClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamsClause,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -15211,10 +15348,10 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   /// Returns a copy of the receiver with its `unexpectedBeforeWrtLabel` replaced.
   /// - param newChild: The new `unexpectedBeforeWrtLabel` to replace the node's
   ///                   current `unexpectedBeforeWrtLabel`, if present.
-  public func withUnexpectedBeforeWrtLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
+  public func withUnexpectedBeforeWrtLabel(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
 
@@ -15232,10 +15369,10 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   /// Returns a copy of the receiver with its `wrtLabel` replaced.
   /// - param newChild: The new `wrtLabel` to replace the node's
   ///                   current `wrtLabel`, if present.
-  public func withWrtLabel(
-    _ newChild: TokenSyntax?) -> DifferentiabilityParamsClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withWrtLabel(_ newChild: TokenSyntax?) -> DifferentiabilityParamsClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
 
@@ -15253,10 +15390,10 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   /// Returns a copy of the receiver with its `unexpectedBetweenWrtLabelAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenWrtLabelAndColon` to replace the node's
   ///                   current `unexpectedBetweenWrtLabelAndColon`, if present.
-  public func withUnexpectedBetweenWrtLabelAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
+  public func withUnexpectedBetweenWrtLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
 
@@ -15276,10 +15413,10 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> DifferentiabilityParamsClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> DifferentiabilityParamsClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
 
@@ -15297,10 +15434,10 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndParameters` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndParameters` to replace the node's
   ///                   current `unexpectedBetweenColonAndParameters`, if present.
-  public func withUnexpectedBetweenColonAndParameters(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
+  public func withUnexpectedBetweenColonAndParameters(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
 
@@ -15317,10 +15454,10 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   /// Returns a copy of the receiver with its `parameters` replaced.
   /// - param newChild: The new `parameters` to replace the node's
   ///                   current `parameters`, if present.
-  public func withParameters(
-    _ newChild: Parameters?) -> DifferentiabilityParamsClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withParameters(_ newChild: Parameters?) -> DifferentiabilityParamsClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
 
@@ -15338,10 +15475,10 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   /// Returns a copy of the receiver with its `unexpectedAfterParameters` replaced.
   /// - param newChild: The new `unexpectedAfterParameters` to replace the node's
   ///                   current `unexpectedAfterParameters`, if present.
-  public func withUnexpectedAfterParameters(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
+  public func withUnexpectedAfterParameters(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
 
@@ -15432,9 +15569,11 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParams,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParams,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -15452,10 +15591,10 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
   ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
+  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DifferentiabilityParamsSyntax(newData)
   }
 
@@ -15472,10 +15611,10 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> DifferentiabilityParamsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> DifferentiabilityParamsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DifferentiabilityParamsSyntax(newData)
   }
 
@@ -15493,10 +15632,10 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndDiffParams` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndDiffParams` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndDiffParams`, if present.
-  public func withUnexpectedBetweenLeftParenAndDiffParams(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
+  public func withUnexpectedBetweenLeftParenAndDiffParams(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DifferentiabilityParamsSyntax(newData)
   }
 
@@ -15519,23 +15658,24 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `diffParams` collection.
   public func addDifferentiabilityParam(_ element: DifferentiabilityParamSyntax) -> DifferentiabilityParamsSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return DifferentiabilityParamsSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `diffParams` replaced.
   /// - param newChild: The new `diffParams` to replace the node's
   ///                   current `diffParams`, if present.
-  public func withDiffParams(
-    _ newChild: DifferentiabilityParamListSyntax?) -> DifferentiabilityParamsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.differentiabilityParamList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withDiffParams(_ newChild: DifferentiabilityParamListSyntax?) -> DifferentiabilityParamsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.differentiabilityParamList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DifferentiabilityParamsSyntax(newData)
   }
 
@@ -15553,10 +15693,10 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenDiffParamsAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenDiffParamsAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenDiffParamsAndRightParen`, if present.
-  public func withUnexpectedBetweenDiffParamsAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
+  public func withUnexpectedBetweenDiffParamsAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DifferentiabilityParamsSyntax(newData)
   }
 
@@ -15573,10 +15713,10 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> DifferentiabilityParamsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightParen(_ newChild: TokenSyntax?) -> DifferentiabilityParamsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return DifferentiabilityParamsSyntax(newData)
   }
 
@@ -15594,10 +15734,10 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return DifferentiabilityParamsSyntax(newData)
   }
 
@@ -15687,9 +15827,11 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParam,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParam,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -15707,10 +15849,10 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeParameter` replaced.
   /// - param newChild: The new `unexpectedBeforeParameter` to replace the node's
   ///                   current `unexpectedBeforeParameter`, if present.
-  public func withUnexpectedBeforeParameter(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamSyntax {
+  public func withUnexpectedBeforeParameter(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DifferentiabilityParamSyntax(newData)
   }
 
@@ -15727,10 +15869,10 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `parameter` replaced.
   /// - param newChild: The new `parameter` to replace the node's
   ///                   current `parameter`, if present.
-  public func withParameter(
-    _ newChild: TokenSyntax?) -> DifferentiabilityParamSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.selfKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withParameter(_ newChild: TokenSyntax?) -> DifferentiabilityParamSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.selfKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DifferentiabilityParamSyntax(newData)
   }
 
@@ -15748,10 +15890,10 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenParameterAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenParameterAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenParameterAndTrailingComma`, if present.
-  public func withUnexpectedBetweenParameterAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamSyntax {
+  public func withUnexpectedBetweenParameterAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DifferentiabilityParamSyntax(newData)
   }
 
@@ -15769,10 +15911,10 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> DifferentiabilityParamSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> DifferentiabilityParamSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DifferentiabilityParamSyntax(newData)
   }
 
@@ -15790,10 +15932,10 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DifferentiabilityParamSyntax(newData)
   }
 
@@ -15896,9 +16038,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       diffParams?.raw,
       unexpectedAfterDiffParams?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.derivativeRegistrationAttributeArguments,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.derivativeRegistrationAttributeArguments,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -15916,10 +16060,10 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `unexpectedBeforeOfLabel` replaced.
   /// - param newChild: The new `unexpectedBeforeOfLabel` to replace the node's
   ///                   current `unexpectedBeforeOfLabel`, if present.
-  public func withUnexpectedBeforeOfLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public func withUnexpectedBeforeOfLabel(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -15937,10 +16081,10 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `ofLabel` replaced.
   /// - param newChild: The new `ofLabel` to replace the node's
   ///                   current `ofLabel`, if present.
-  public func withOfLabel(
-    _ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withOfLabel(_ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -15958,10 +16102,10 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `unexpectedBetweenOfLabelAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenOfLabelAndColon` to replace the node's
   ///                   current `unexpectedBetweenOfLabelAndColon`, if present.
-  public func withUnexpectedBetweenOfLabelAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenOfLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -15982,10 +16126,10 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -16003,10 +16147,10 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndOriginalDeclName` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndOriginalDeclName` to replace the node's
   ///                   current `unexpectedBetweenColonAndOriginalDeclName`, if present.
-  public func withUnexpectedBetweenColonAndOriginalDeclName(
-    _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenColonAndOriginalDeclName(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -16024,10 +16168,10 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `originalDeclName` replaced.
   /// - param newChild: The new `originalDeclName` to replace the node's
   ///                   current `originalDeclName`, if present.
-  public func withOriginalDeclName(
-    _ newChild: QualifiedDeclNameSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.qualifiedDeclName, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withOriginalDeclName(_ newChild: QualifiedDeclNameSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.qualifiedDeclName, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -16045,10 +16189,10 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `unexpectedBetweenOriginalDeclNameAndPeriod` replaced.
   /// - param newChild: The new `unexpectedBetweenOriginalDeclNameAndPeriod` to replace the node's
   ///                   current `unexpectedBetweenOriginalDeclNameAndPeriod`, if present.
-  public func withUnexpectedBetweenOriginalDeclNameAndPeriod(
-    _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenOriginalDeclNameAndPeriod(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -16070,10 +16214,10 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `period` replaced.
   /// - param newChild: The new `period` to replace the node's
   ///                   current `period`, if present.
-  public func withPeriod(
-    _ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public func withPeriod(_ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -16091,10 +16235,10 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `unexpectedBetweenPeriodAndAccessorKind` replaced.
   /// - param newChild: The new `unexpectedBetweenPeriodAndAccessorKind` to replace the node's
   ///                   current `unexpectedBetweenPeriodAndAccessorKind`, if present.
-  public func withUnexpectedBetweenPeriodAndAccessorKind(
-    _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenPeriodAndAccessorKind(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -16113,10 +16257,10 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `accessorKind` replaced.
   /// - param newChild: The new `accessorKind` to replace the node's
   ///                   current `accessorKind`, if present.
-  public func withAccessorKind(
-    _ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public func withAccessorKind(_ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -16134,10 +16278,10 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `unexpectedBetweenAccessorKindAndComma` replaced.
   /// - param newChild: The new `unexpectedBetweenAccessorKindAndComma` to replace the node's
   ///                   current `unexpectedBetweenAccessorKindAndComma`, if present.
-  public func withUnexpectedBetweenAccessorKindAndComma(
-    _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenAccessorKindAndComma(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -16155,10 +16299,10 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `comma` replaced.
   /// - param newChild: The new `comma` to replace the node's
   ///                   current `comma`, if present.
-  public func withComma(
-    _ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public func withComma(_ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -16176,10 +16320,10 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndDiffParams` replaced.
   /// - param newChild: The new `unexpectedBetweenCommaAndDiffParams` to replace the node's
   ///                   current `unexpectedBetweenCommaAndDiffParams`, if present.
-  public func withUnexpectedBetweenCommaAndDiffParams(
-    _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenCommaAndDiffParams(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -16197,10 +16341,10 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `diffParams` replaced.
   /// - param newChild: The new `diffParams` to replace the node's
   ///                   current `diffParams`, if present.
-  public func withDiffParams(
-    _ newChild: DifferentiabilityParamsClauseSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public func withDiffParams(_ newChild: DifferentiabilityParamsClauseSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -16218,10 +16362,10 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `unexpectedAfterDiffParams` replaced.
   /// - param newChild: The new `unexpectedAfterDiffParams` to replace the node's
   ///                   current `unexpectedAfterDiffParams`, if present.
-  public func withUnexpectedAfterDiffParams(
-    _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public func withUnexpectedAfterDiffParams(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -16351,9 +16495,11 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       arguments?.raw,
       unexpectedAfterArguments?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.qualifiedDeclName,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.qualifiedDeclName,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -16371,10 +16517,10 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeBaseType` replaced.
   /// - param newChild: The new `unexpectedBeforeBaseType` to replace the node's
   ///                   current `unexpectedBeforeBaseType`, if present.
-  public func withUnexpectedBeforeBaseType(
-    _ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
+  public func withUnexpectedBeforeBaseType(_ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return QualifiedDeclNameSyntax(newData)
   }
 
@@ -16395,10 +16541,10 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `baseType` replaced.
   /// - param newChild: The new `baseType` to replace the node's
   ///                   current `baseType`, if present.
-  public func withBaseType(
-    _ newChild: TypeSyntax?) -> QualifiedDeclNameSyntax {
+  public func withBaseType(_ newChild: TypeSyntax?) -> QualifiedDeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return QualifiedDeclNameSyntax(newData)
   }
 
@@ -16416,10 +16562,10 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenBaseTypeAndDot` replaced.
   /// - param newChild: The new `unexpectedBetweenBaseTypeAndDot` to replace the node's
   ///                   current `unexpectedBetweenBaseTypeAndDot`, if present.
-  public func withUnexpectedBetweenBaseTypeAndDot(
-    _ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
+  public func withUnexpectedBetweenBaseTypeAndDot(_ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return QualifiedDeclNameSyntax(newData)
   }
 
@@ -16437,10 +16583,10 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `dot` replaced.
   /// - param newChild: The new `dot` to replace the node's
   ///                   current `dot`, if present.
-  public func withDot(
-    _ newChild: TokenSyntax?) -> QualifiedDeclNameSyntax {
+  public func withDot(_ newChild: TokenSyntax?) -> QualifiedDeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return QualifiedDeclNameSyntax(newData)
   }
 
@@ -16458,10 +16604,10 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenDotAndName` replaced.
   /// - param newChild: The new `unexpectedBetweenDotAndName` to replace the node's
   ///                   current `unexpectedBetweenDotAndName`, if present.
-  public func withUnexpectedBetweenDotAndName(
-    _ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
+  public func withUnexpectedBetweenDotAndName(_ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return QualifiedDeclNameSyntax(newData)
   }
 
@@ -16481,10 +16627,10 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> QualifiedDeclNameSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withName(_ newChild: TokenSyntax?) -> QualifiedDeclNameSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return QualifiedDeclNameSyntax(newData)
   }
 
@@ -16502,10 +16648,10 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndArguments` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndArguments` to replace the node's
   ///                   current `unexpectedBetweenNameAndArguments`, if present.
-  public func withUnexpectedBetweenNameAndArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
+  public func withUnexpectedBetweenNameAndArguments(_ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return QualifiedDeclNameSyntax(newData)
   }
 
@@ -16527,10 +16673,10 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `arguments` replaced.
   /// - param newChild: The new `arguments` to replace the node's
   ///                   current `arguments`, if present.
-  public func withArguments(
-    _ newChild: DeclNameArgumentsSyntax?) -> QualifiedDeclNameSyntax {
+  public func withArguments(_ newChild: DeclNameArgumentsSyntax?) -> QualifiedDeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return QualifiedDeclNameSyntax(newData)
   }
 
@@ -16548,10 +16694,10 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterArguments` replaced.
   /// - param newChild: The new `unexpectedAfterArguments` to replace the node's
   ///                   current `unexpectedAfterArguments`, if present.
-  public func withUnexpectedAfterArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
+  public func withUnexpectedAfterArguments(_ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return QualifiedDeclNameSyntax(newData)
   }
 
@@ -16646,9 +16792,11 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       arguments?.raw,
       unexpectedAfterArguments?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionDeclName,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionDeclName,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -16666,10 +16814,10 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
   /// - param newChild: The new `unexpectedBeforeName` to replace the node's
   ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclNameSyntax {
+  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return FunctionDeclNameSyntax(newData)
   }
 
@@ -16689,10 +16837,10 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> FunctionDeclNameSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withName(_ newChild: TokenSyntax?) -> FunctionDeclNameSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return FunctionDeclNameSyntax(newData)
   }
 
@@ -16710,10 +16858,10 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndArguments` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndArguments` to replace the node's
   ///                   current `unexpectedBetweenNameAndArguments`, if present.
-  public func withUnexpectedBetweenNameAndArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclNameSyntax {
+  public func withUnexpectedBetweenNameAndArguments(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return FunctionDeclNameSyntax(newData)
   }
 
@@ -16735,10 +16883,10 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `arguments` replaced.
   /// - param newChild: The new `arguments` to replace the node's
   ///                   current `arguments`, if present.
-  public func withArguments(
-    _ newChild: DeclNameArgumentsSyntax?) -> FunctionDeclNameSyntax {
+  public func withArguments(_ newChild: DeclNameArgumentsSyntax?) -> FunctionDeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return FunctionDeclNameSyntax(newData)
   }
 
@@ -16756,10 +16904,10 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterArguments` replaced.
   /// - param newChild: The new `unexpectedAfterArguments` to replace the node's
   ///                   current `unexpectedAfterArguments`, if present.
-  public func withUnexpectedAfterArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclNameSyntax {
+  public func withUnexpectedAfterArguments(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclNameSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return FunctionDeclNameSyntax(newData)
   }
 
@@ -16844,9 +16992,11 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       versionList.raw,
       unexpectedAfterVersionList?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployAttributeSpecList,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployAttributeSpecList,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -16864,10 +17014,10 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `unexpectedBeforeBeforeLabel` replaced.
   /// - param newChild: The new `unexpectedBeforeBeforeLabel` to replace the node's
   ///                   current `unexpectedBeforeBeforeLabel`, if present.
-  public func withUnexpectedBeforeBeforeLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
+  public func withUnexpectedBeforeBeforeLabel(_ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
@@ -16885,10 +17035,10 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `beforeLabel` replaced.
   /// - param newChild: The new `beforeLabel` to replace the node's
   ///                   current `beforeLabel`, if present.
-  public func withBeforeLabel(
-    _ newChild: TokenSyntax?) -> BackDeployAttributeSpecListSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withBeforeLabel(_ newChild: TokenSyntax?) -> BackDeployAttributeSpecListSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
@@ -16906,10 +17056,10 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `unexpectedBetweenBeforeLabelAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenBeforeLabelAndColon` to replace the node's
   ///                   current `unexpectedBetweenBeforeLabelAndColon`, if present.
-  public func withUnexpectedBetweenBeforeLabelAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
+  public func withUnexpectedBetweenBeforeLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
@@ -16929,10 +17079,10 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> BackDeployAttributeSpecListSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> BackDeployAttributeSpecListSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
@@ -16950,10 +17100,10 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndVersionList` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndVersionList` to replace the node's
   ///                   current `unexpectedBetweenColonAndVersionList`, if present.
-  public func withUnexpectedBetweenColonAndVersionList(
-    _ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
+  public func withUnexpectedBetweenColonAndVersionList(_ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
@@ -16979,23 +17129,24 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   ///            appended to its `versionList` collection.
   public func addAvailability(_ element: BackDeployVersionArgumentSyntax) -> BackDeployAttributeSpecListSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.backDeployVersionList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 5)
+    let newData = data.replacingChild(collection, at: 5, arena: arena)
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `versionList` replaced.
   /// - param newChild: The new `versionList` to replace the node's
   ///                   current `versionList`, if present.
-  public func withVersionList(
-    _ newChild: BackDeployVersionListSyntax?) -> BackDeployAttributeSpecListSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.backDeployVersionList, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withVersionList(_ newChild: BackDeployVersionListSyntax?) -> BackDeployAttributeSpecListSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.backDeployVersionList, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
@@ -17013,10 +17164,10 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `unexpectedAfterVersionList` replaced.
   /// - param newChild: The new `unexpectedAfterVersionList` to replace the node's
   ///                   current `unexpectedAfterVersionList`, if present.
-  public func withUnexpectedAfterVersionList(
-    _ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
+  public func withUnexpectedAfterVersionList(_ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
@@ -17106,9 +17257,11 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployVersionArgument,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployVersionArgument,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -17126,10 +17279,10 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAvailabilityVersionRestriction` replaced.
   /// - param newChild: The new `unexpectedBeforeAvailabilityVersionRestriction` to replace the node's
   ///                   current `unexpectedBeforeAvailabilityVersionRestriction`, if present.
-  public func withUnexpectedBeforeAvailabilityVersionRestriction(
-    _ newChild: UnexpectedNodesSyntax?) -> BackDeployVersionArgumentSyntax {
+  public func withUnexpectedBeforeAvailabilityVersionRestriction(_ newChild: UnexpectedNodesSyntax?) -> BackDeployVersionArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return BackDeployVersionArgumentSyntax(newData)
   }
 
@@ -17146,10 +17299,10 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `availabilityVersionRestriction` replaced.
   /// - param newChild: The new `availabilityVersionRestriction` to replace the node's
   ///                   current `availabilityVersionRestriction`, if present.
-  public func withAvailabilityVersionRestriction(
-    _ newChild: AvailabilityVersionRestrictionSyntax?) -> BackDeployVersionArgumentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilityVersionRestriction, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withAvailabilityVersionRestriction(_ newChild: AvailabilityVersionRestrictionSyntax?) -> BackDeployVersionArgumentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilityVersionRestriction, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return BackDeployVersionArgumentSyntax(newData)
   }
 
@@ -17167,10 +17320,10 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma`, if present.
-  public func withUnexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> BackDeployVersionArgumentSyntax {
+  public func withUnexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> BackDeployVersionArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return BackDeployVersionArgumentSyntax(newData)
   }
 
@@ -17192,10 +17345,10 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> BackDeployVersionArgumentSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> BackDeployVersionArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return BackDeployVersionArgumentSyntax(newData)
   }
 
@@ -17213,10 +17366,10 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> BackDeployVersionArgumentSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> BackDeployVersionArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return BackDeployVersionArgumentSyntax(newData)
   }
 
@@ -17301,9 +17454,11 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
       ordinal.raw,
       unexpectedAfterOrdinal?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.opaqueReturnTypeOfAttributeArguments,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.opaqueReturnTypeOfAttributeArguments,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -17321,10 +17476,10 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
   /// Returns a copy of the receiver with its `unexpectedBeforeMangledName` replaced.
   /// - param newChild: The new `unexpectedBeforeMangledName` to replace the node's
   ///                   current `unexpectedBeforeMangledName`, if present.
-  public func withUnexpectedBeforeMangledName(
-    _ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+  public func withUnexpectedBeforeMangledName(_ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
 
@@ -17342,10 +17497,10 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
   /// Returns a copy of the receiver with its `mangledName` replaced.
   /// - param newChild: The new `mangledName` to replace the node's
   ///                   current `mangledName`, if present.
-  public func withMangledName(
-    _ newChild: TokenSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withMangledName(_ newChild: TokenSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
 
@@ -17363,10 +17518,10 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
   /// Returns a copy of the receiver with its `unexpectedBetweenMangledNameAndComma` replaced.
   /// - param newChild: The new `unexpectedBetweenMangledNameAndComma` to replace the node's
   ///                   current `unexpectedBetweenMangledNameAndComma`, if present.
-  public func withUnexpectedBetweenMangledNameAndComma(
-    _ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenMangledNameAndComma(_ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
 
@@ -17383,10 +17538,10 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
   /// Returns a copy of the receiver with its `comma` replaced.
   /// - param newChild: The new `comma` to replace the node's
   ///                   current `comma`, if present.
-  public func withComma(
-    _ newChild: TokenSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withComma(_ newChild: TokenSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
 
@@ -17404,10 +17559,10 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
   /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndOrdinal` replaced.
   /// - param newChild: The new `unexpectedBetweenCommaAndOrdinal` to replace the node's
   ///                   current `unexpectedBetweenCommaAndOrdinal`, if present.
-  public func withUnexpectedBetweenCommaAndOrdinal(
-    _ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenCommaAndOrdinal(_ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
 
@@ -17425,10 +17580,10 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
   /// Returns a copy of the receiver with its `ordinal` replaced.
   /// - param newChild: The new `ordinal` to replace the node's
   ///                   current `ordinal`, if present.
-  public func withOrdinal(
-    _ newChild: TokenSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withOrdinal(_ newChild: TokenSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
 
@@ -17446,10 +17601,10 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
   /// Returns a copy of the receiver with its `unexpectedAfterOrdinal` replaced.
   /// - param newChild: The new `unexpectedAfterOrdinal` to replace the node's
   ///                   current `unexpectedAfterOrdinal`, if present.
-  public func withUnexpectedAfterOrdinal(
-    _ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+  public func withUnexpectedAfterOrdinal(_ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
 
@@ -17550,9 +17705,11 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       cTypeString?.raw,
       unexpectedAfterCTypeString?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionAttributeArguments,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionAttributeArguments,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -17570,10 +17727,10 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedBeforeConventionLabel` replaced.
   /// - param newChild: The new `unexpectedBeforeConventionLabel` to replace the node's
   ///                   current `unexpectedBeforeConventionLabel`, if present.
-  public func withUnexpectedBeforeConventionLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+  public func withUnexpectedBeforeConventionLabel(_ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ConventionAttributeArgumentsSyntax(newData)
   }
 
@@ -17591,10 +17748,10 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `conventionLabel` replaced.
   /// - param newChild: The new `conventionLabel` to replace the node's
   ///                   current `conventionLabel`, if present.
-  public func withConventionLabel(
-    _ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withConventionLabel(_ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ConventionAttributeArgumentsSyntax(newData)
   }
 
@@ -17612,10 +17769,10 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedBetweenConventionLabelAndComma` replaced.
   /// - param newChild: The new `unexpectedBetweenConventionLabelAndComma` to replace the node's
   ///                   current `unexpectedBetweenConventionLabelAndComma`, if present.
-  public func withUnexpectedBetweenConventionLabelAndComma(
-    _ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenConventionLabelAndComma(_ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ConventionAttributeArgumentsSyntax(newData)
   }
 
@@ -17633,10 +17790,10 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `comma` replaced.
   /// - param newChild: The new `comma` to replace the node's
   ///                   current `comma`, if present.
-  public func withComma(
-    _ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+  public func withComma(_ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ConventionAttributeArgumentsSyntax(newData)
   }
 
@@ -17654,10 +17811,10 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndCTypeLabel` replaced.
   /// - param newChild: The new `unexpectedBetweenCommaAndCTypeLabel` to replace the node's
   ///                   current `unexpectedBetweenCommaAndCTypeLabel`, if present.
-  public func withUnexpectedBetweenCommaAndCTypeLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenCommaAndCTypeLabel(_ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ConventionAttributeArgumentsSyntax(newData)
   }
 
@@ -17675,10 +17832,10 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `cTypeLabel` replaced.
   /// - param newChild: The new `cTypeLabel` to replace the node's
   ///                   current `cTypeLabel`, if present.
-  public func withCTypeLabel(
-    _ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+  public func withCTypeLabel(_ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ConventionAttributeArgumentsSyntax(newData)
   }
 
@@ -17696,10 +17853,10 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedBetweenCTypeLabelAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenCTypeLabelAndColon` to replace the node's
   ///                   current `unexpectedBetweenCTypeLabelAndColon`, if present.
-  public func withUnexpectedBetweenCTypeLabelAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenCTypeLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ConventionAttributeArgumentsSyntax(newData)
   }
 
@@ -17717,10 +17874,10 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+  public func withColon(_ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return ConventionAttributeArgumentsSyntax(newData)
   }
 
@@ -17738,10 +17895,10 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndCTypeString` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndCTypeString` to replace the node's
   ///                   current `unexpectedBetweenColonAndCTypeString`, if present.
-  public func withUnexpectedBetweenColonAndCTypeString(
-    _ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenColonAndCTypeString(_ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return ConventionAttributeArgumentsSyntax(newData)
   }
 
@@ -17759,10 +17916,10 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `cTypeString` replaced.
   /// - param newChild: The new `cTypeString` to replace the node's
   ///                   current `cTypeString`, if present.
-  public func withCTypeString(
-    _ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+  public func withCTypeString(_ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return ConventionAttributeArgumentsSyntax(newData)
   }
 
@@ -17780,10 +17937,10 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `unexpectedAfterCTypeString` replaced.
   /// - param newChild: The new `unexpectedAfterCTypeString` to replace the node's
   ///                   current `unexpectedAfterCTypeString`, if present.
-  public func withUnexpectedAfterCTypeString(
-    _ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+  public func withUnexpectedAfterCTypeString(_ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return ConventionAttributeArgumentsSyntax(newData)
   }
 
@@ -17892,9 +18049,11 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
       protocolName.raw,
       unexpectedAfterProtocolName?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionWitnessMethodAttributeArguments,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionWitnessMethodAttributeArguments,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -17912,10 +18071,10 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
   /// Returns a copy of the receiver with its `unexpectedBeforeWitnessMethodLabel` replaced.
   /// - param newChild: The new `unexpectedBeforeWitnessMethodLabel` to replace the node's
   ///                   current `unexpectedBeforeWitnessMethodLabel`, if present.
-  public func withUnexpectedBeforeWitnessMethodLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+  public func withUnexpectedBeforeWitnessMethodLabel(_ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
 
@@ -17932,10 +18091,10 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
   /// Returns a copy of the receiver with its `witnessMethodLabel` replaced.
   /// - param newChild: The new `witnessMethodLabel` to replace the node's
   ///                   current `witnessMethodLabel`, if present.
-  public func withWitnessMethodLabel(
-    _ newChild: TokenSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withWitnessMethodLabel(_ newChild: TokenSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
 
@@ -17953,10 +18112,10 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
   /// Returns a copy of the receiver with its `unexpectedBetweenWitnessMethodLabelAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenWitnessMethodLabelAndColon` to replace the node's
   ///                   current `unexpectedBetweenWitnessMethodLabelAndColon`, if present.
-  public func withUnexpectedBetweenWitnessMethodLabelAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenWitnessMethodLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
 
@@ -17973,10 +18132,10 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
 
@@ -17994,10 +18153,10 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndProtocolName` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndProtocolName` to replace the node's
   ///                   current `unexpectedBetweenColonAndProtocolName`, if present.
-  public func withUnexpectedBetweenColonAndProtocolName(
-    _ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+  public func withUnexpectedBetweenColonAndProtocolName(_ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
 
@@ -18014,10 +18173,10 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
   /// Returns a copy of the receiver with its `protocolName` replaced.
   /// - param newChild: The new `protocolName` to replace the node's
   ///                   current `protocolName`, if present.
-  public func withProtocolName(
-    _ newChild: TokenSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withProtocolName(_ newChild: TokenSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
 
@@ -18035,10 +18194,10 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
   /// Returns a copy of the receiver with its `unexpectedAfterProtocolName` replaced.
   /// - param newChild: The new `unexpectedAfterProtocolName` to replace the node's
   ///                   current `unexpectedAfterProtocolName`, if present.
-  public func withUnexpectedAfterProtocolName(
-    _ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+  public func withUnexpectedAfterProtocolName(_ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
 
@@ -18124,9 +18283,11 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
       guardResult.raw,
       unexpectedAfterGuardResult?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.whereClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.whereClause,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -18144,10 +18305,10 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeWhereKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeWhereKeyword` to replace the node's
   ///                   current `unexpectedBeforeWhereKeyword`, if present.
-  public func withUnexpectedBeforeWhereKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> WhereClauseSyntax {
+  public func withUnexpectedBeforeWhereKeyword(_ newChild: UnexpectedNodesSyntax?) -> WhereClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return WhereClauseSyntax(newData)
   }
 
@@ -18164,10 +18325,10 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `whereKeyword` replaced.
   /// - param newChild: The new `whereKeyword` to replace the node's
   ///                   current `whereKeyword`, if present.
-  public func withWhereKeyword(
-    _ newChild: TokenSyntax?) -> WhereClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whereKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withWhereKeyword(_ newChild: TokenSyntax?) -> WhereClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whereKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return WhereClauseSyntax(newData)
   }
 
@@ -18185,10 +18346,10 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenWhereKeywordAndGuardResult` replaced.
   /// - param newChild: The new `unexpectedBetweenWhereKeywordAndGuardResult` to replace the node's
   ///                   current `unexpectedBetweenWhereKeywordAndGuardResult`, if present.
-  public func withUnexpectedBetweenWhereKeywordAndGuardResult(
-    _ newChild: UnexpectedNodesSyntax?) -> WhereClauseSyntax {
+  public func withUnexpectedBetweenWhereKeywordAndGuardResult(_ newChild: UnexpectedNodesSyntax?) -> WhereClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return WhereClauseSyntax(newData)
   }
 
@@ -18205,10 +18366,10 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `guardResult` replaced.
   /// - param newChild: The new `guardResult` to replace the node's
   ///                   current `guardResult`, if present.
-  public func withGuardResult(
-    _ newChild: ExprSyntax?) -> WhereClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withGuardResult(_ newChild: ExprSyntax?) -> WhereClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return WhereClauseSyntax(newData)
   }
 
@@ -18226,10 +18387,10 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterGuardResult` replaced.
   /// - param newChild: The new `unexpectedAfterGuardResult` to replace the node's
   ///                   current `unexpectedAfterGuardResult`, if present.
-  public func withUnexpectedAfterGuardResult(
-    _ newChild: UnexpectedNodesSyntax?) -> WhereClauseSyntax {
+  public func withUnexpectedAfterGuardResult(_ newChild: UnexpectedNodesSyntax?) -> WhereClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return WhereClauseSyntax(newData)
   }
 
@@ -18311,9 +18472,11 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldList,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldList,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -18331,10 +18494,10 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
   ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
+  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return YieldListSyntax(newData)
   }
 
@@ -18351,10 +18514,10 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> YieldListSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> YieldListSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return YieldListSyntax(newData)
   }
 
@@ -18372,10 +18535,10 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndElementList` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndElementList` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndElementList`, if present.
-  public func withUnexpectedBetweenLeftParenAndElementList(
-    _ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
+  public func withUnexpectedBetweenLeftParenAndElementList(_ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return YieldListSyntax(newData)
   }
 
@@ -18397,23 +18560,24 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `elementList` collection.
   public func addElement(_ element: YieldExprListElementSyntax) -> YieldListSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return YieldListSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `elementList` replaced.
   /// - param newChild: The new `elementList` to replace the node's
   ///                   current `elementList`, if present.
-  public func withElementList(
-    _ newChild: YieldExprListSyntax?) -> YieldListSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.yieldExprList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withElementList(_ newChild: YieldExprListSyntax?) -> YieldListSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.yieldExprList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return YieldListSyntax(newData)
   }
 
@@ -18431,10 +18595,10 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenElementListAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenElementListAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenElementListAndRightParen`, if present.
-  public func withUnexpectedBetweenElementListAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
+  public func withUnexpectedBetweenElementListAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return YieldListSyntax(newData)
   }
 
@@ -18451,10 +18615,10 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> YieldListSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightParen(_ newChild: TokenSyntax?) -> YieldListSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return YieldListSyntax(newData)
   }
 
@@ -18472,10 +18636,10 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return YieldListSyntax(newData)
   }
 
@@ -18637,9 +18801,11 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.conditionElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.conditionElement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -18657,10 +18823,10 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeCondition` replaced.
   /// - param newChild: The new `unexpectedBeforeCondition` to replace the node's
   ///                   current `unexpectedBeforeCondition`, if present.
-  public func withUnexpectedBeforeCondition(
-    _ newChild: UnexpectedNodesSyntax?) -> ConditionElementSyntax {
+  public func withUnexpectedBeforeCondition(_ newChild: UnexpectedNodesSyntax?) -> ConditionElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ConditionElementSyntax(newData)
   }
 
@@ -18677,10 +18843,10 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `condition` replaced.
   /// - param newChild: The new `condition` to replace the node's
   ///                   current `condition`, if present.
-  public func withCondition(
-    _ newChild: Condition?) -> ConditionElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withCondition(_ newChild: Condition?) -> ConditionElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ConditionElementSyntax(newData)
   }
 
@@ -18698,10 +18864,10 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenConditionAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenConditionAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenConditionAndTrailingComma`, if present.
-  public func withUnexpectedBetweenConditionAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> ConditionElementSyntax {
+  public func withUnexpectedBetweenConditionAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ConditionElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ConditionElementSyntax(newData)
   }
 
@@ -18719,10 +18885,10 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> ConditionElementSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> ConditionElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ConditionElementSyntax(newData)
   }
 
@@ -18740,10 +18906,10 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> ConditionElementSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ConditionElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ConditionElementSyntax(newData)
   }
 
@@ -18829,9 +18995,11 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityCondition,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityCondition,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -18849,10 +19017,10 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundAvailableKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforePoundAvailableKeyword` to replace the node's
   ///                   current `unexpectedBeforePoundAvailableKeyword`, if present.
-  public func withUnexpectedBeforePoundAvailableKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
+  public func withUnexpectedBeforePoundAvailableKeyword(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
 
@@ -18869,10 +19037,10 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundAvailableKeyword` replaced.
   /// - param newChild: The new `poundAvailableKeyword` to replace the node's
   ///                   current `poundAvailableKeyword`, if present.
-  public func withPoundAvailableKeyword(
-    _ newChild: TokenSyntax?) -> AvailabilityConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundAvailableKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundAvailableKeyword(_ newChild: TokenSyntax?) -> AvailabilityConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundAvailableKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
 
@@ -18890,10 +19058,10 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPoundAvailableKeywordAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenPoundAvailableKeywordAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenPoundAvailableKeywordAndLeftParen`, if present.
-  public func withUnexpectedBetweenPoundAvailableKeywordAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
+  public func withUnexpectedBetweenPoundAvailableKeywordAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
 
@@ -18910,10 +19078,10 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> AvailabilityConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> AvailabilityConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
 
@@ -18931,10 +19099,10 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndAvailabilitySpec` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndAvailabilitySpec` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndAvailabilitySpec`, if present.
-  public func withUnexpectedBetweenLeftParenAndAvailabilitySpec(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
+  public func withUnexpectedBetweenLeftParenAndAvailabilitySpec(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
 
@@ -18956,23 +19124,24 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `availabilitySpec` collection.
   public func addAvailabilityArgument(_ element: AvailabilityArgumentSyntax) -> AvailabilityConditionSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.availabilitySpecList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 5)
+    let newData = data.replacingChild(collection, at: 5, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `availabilitySpec` replaced.
   /// - param newChild: The new `availabilitySpec` to replace the node's
   ///                   current `availabilitySpec`, if present.
-  public func withAvailabilitySpec(
-    _ newChild: AvailabilitySpecListSyntax?) -> AvailabilityConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withAvailabilitySpec(_ newChild: AvailabilitySpecListSyntax?) -> AvailabilityConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
 
@@ -18990,10 +19159,10 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAvailabilitySpecAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenAvailabilitySpecAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenAvailabilitySpecAndRightParen`, if present.
-  public func withUnexpectedBetweenAvailabilitySpecAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
+  public func withUnexpectedBetweenAvailabilitySpecAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
 
@@ -19010,10 +19179,10 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> AvailabilityConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withRightParen(_ newChild: TokenSyntax?) -> AvailabilityConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
 
@@ -19031,10 +19200,10 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
 
@@ -19136,9 +19305,11 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
       initializer.raw,
       unexpectedAfterInitializer?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.matchingPatternCondition,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.matchingPatternCondition,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -19156,10 +19327,10 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeCaseKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeCaseKeyword` to replace the node's
   ///                   current `unexpectedBeforeCaseKeyword`, if present.
-  public func withUnexpectedBeforeCaseKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
+  public func withUnexpectedBeforeCaseKeyword(_ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return MatchingPatternConditionSyntax(newData)
   }
 
@@ -19176,10 +19347,10 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `caseKeyword` replaced.
   /// - param newChild: The new `caseKeyword` to replace the node's
   ///                   current `caseKeyword`, if present.
-  public func withCaseKeyword(
-    _ newChild: TokenSyntax?) -> MatchingPatternConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withCaseKeyword(_ newChild: TokenSyntax?) -> MatchingPatternConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return MatchingPatternConditionSyntax(newData)
   }
 
@@ -19197,10 +19368,10 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCaseKeywordAndPattern` replaced.
   /// - param newChild: The new `unexpectedBetweenCaseKeywordAndPattern` to replace the node's
   ///                   current `unexpectedBetweenCaseKeywordAndPattern`, if present.
-  public func withUnexpectedBetweenCaseKeywordAndPattern(
-    _ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
+  public func withUnexpectedBetweenCaseKeywordAndPattern(_ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return MatchingPatternConditionSyntax(newData)
   }
 
@@ -19217,10 +19388,10 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(
-    _ newChild: PatternSyntax?) -> MatchingPatternConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withPattern(_ newChild: PatternSyntax?) -> MatchingPatternConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return MatchingPatternConditionSyntax(newData)
   }
 
@@ -19238,10 +19409,10 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPatternAndTypeAnnotation` replaced.
   /// - param newChild: The new `unexpectedBetweenPatternAndTypeAnnotation` to replace the node's
   ///                   current `unexpectedBetweenPatternAndTypeAnnotation`, if present.
-  public func withUnexpectedBetweenPatternAndTypeAnnotation(
-    _ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
+  public func withUnexpectedBetweenPatternAndTypeAnnotation(_ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return MatchingPatternConditionSyntax(newData)
   }
 
@@ -19259,10 +19430,10 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typeAnnotation` replaced.
   /// - param newChild: The new `typeAnnotation` to replace the node's
   ///                   current `typeAnnotation`, if present.
-  public func withTypeAnnotation(
-    _ newChild: TypeAnnotationSyntax?) -> MatchingPatternConditionSyntax {
+  public func withTypeAnnotation(_ newChild: TypeAnnotationSyntax?) -> MatchingPatternConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return MatchingPatternConditionSyntax(newData)
   }
 
@@ -19280,10 +19451,10 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTypeAnnotationAndInitializer` replaced.
   /// - param newChild: The new `unexpectedBetweenTypeAnnotationAndInitializer` to replace the node's
   ///                   current `unexpectedBetweenTypeAnnotationAndInitializer`, if present.
-  public func withUnexpectedBetweenTypeAnnotationAndInitializer(
-    _ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
+  public func withUnexpectedBetweenTypeAnnotationAndInitializer(_ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return MatchingPatternConditionSyntax(newData)
   }
 
@@ -19300,10 +19471,10 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `initializer` replaced.
   /// - param newChild: The new `initializer` to replace the node's
   ///                   current `initializer`, if present.
-  public func withInitializer(
-    _ newChild: InitializerClauseSyntax?) -> MatchingPatternConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.initializerClause, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withInitializer(_ newChild: InitializerClauseSyntax?) -> MatchingPatternConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.initializerClause, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return MatchingPatternConditionSyntax(newData)
   }
 
@@ -19321,10 +19492,10 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterInitializer` replaced.
   /// - param newChild: The new `unexpectedAfterInitializer` to replace the node's
   ///                   current `unexpectedAfterInitializer`, if present.
-  public func withUnexpectedAfterInitializer(
-    _ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
+  public func withUnexpectedAfterInitializer(_ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return MatchingPatternConditionSyntax(newData)
   }
 
@@ -19426,9 +19597,11 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
       initializer?.raw,
       unexpectedAfterInitializer?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalBindingCondition,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalBindingCondition,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -19446,10 +19619,10 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLetOrVarKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeLetOrVarKeyword` to replace the node's
   ///                   current `unexpectedBeforeLetOrVarKeyword`, if present.
-  public func withUnexpectedBeforeLetOrVarKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
+  public func withUnexpectedBeforeLetOrVarKeyword(_ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return OptionalBindingConditionSyntax(newData)
   }
 
@@ -19466,10 +19639,10 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `letOrVarKeyword` replaced.
   /// - param newChild: The new `letOrVarKeyword` to replace the node's
   ///                   current `letOrVarKeyword`, if present.
-  public func withLetOrVarKeyword(
-    _ newChild: TokenSyntax?) -> OptionalBindingConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLetOrVarKeyword(_ newChild: TokenSyntax?) -> OptionalBindingConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return OptionalBindingConditionSyntax(newData)
   }
 
@@ -19487,10 +19660,10 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLetOrVarKeywordAndPattern` replaced.
   /// - param newChild: The new `unexpectedBetweenLetOrVarKeywordAndPattern` to replace the node's
   ///                   current `unexpectedBetweenLetOrVarKeywordAndPattern`, if present.
-  public func withUnexpectedBetweenLetOrVarKeywordAndPattern(
-    _ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
+  public func withUnexpectedBetweenLetOrVarKeywordAndPattern(_ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return OptionalBindingConditionSyntax(newData)
   }
 
@@ -19507,10 +19680,10 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(
-    _ newChild: PatternSyntax?) -> OptionalBindingConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withPattern(_ newChild: PatternSyntax?) -> OptionalBindingConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return OptionalBindingConditionSyntax(newData)
   }
 
@@ -19528,10 +19701,10 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPatternAndTypeAnnotation` replaced.
   /// - param newChild: The new `unexpectedBetweenPatternAndTypeAnnotation` to replace the node's
   ///                   current `unexpectedBetweenPatternAndTypeAnnotation`, if present.
-  public func withUnexpectedBetweenPatternAndTypeAnnotation(
-    _ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
+  public func withUnexpectedBetweenPatternAndTypeAnnotation(_ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return OptionalBindingConditionSyntax(newData)
   }
 
@@ -19549,10 +19722,10 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typeAnnotation` replaced.
   /// - param newChild: The new `typeAnnotation` to replace the node's
   ///                   current `typeAnnotation`, if present.
-  public func withTypeAnnotation(
-    _ newChild: TypeAnnotationSyntax?) -> OptionalBindingConditionSyntax {
+  public func withTypeAnnotation(_ newChild: TypeAnnotationSyntax?) -> OptionalBindingConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return OptionalBindingConditionSyntax(newData)
   }
 
@@ -19570,10 +19743,10 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTypeAnnotationAndInitializer` replaced.
   /// - param newChild: The new `unexpectedBetweenTypeAnnotationAndInitializer` to replace the node's
   ///                   current `unexpectedBetweenTypeAnnotationAndInitializer`, if present.
-  public func withUnexpectedBetweenTypeAnnotationAndInitializer(
-    _ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
+  public func withUnexpectedBetweenTypeAnnotationAndInitializer(_ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return OptionalBindingConditionSyntax(newData)
   }
 
@@ -19591,10 +19764,10 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `initializer` replaced.
   /// - param newChild: The new `initializer` to replace the node's
   ///                   current `initializer`, if present.
-  public func withInitializer(
-    _ newChild: InitializerClauseSyntax?) -> OptionalBindingConditionSyntax {
+  public func withInitializer(_ newChild: InitializerClauseSyntax?) -> OptionalBindingConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return OptionalBindingConditionSyntax(newData)
   }
 
@@ -19612,10 +19785,10 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterInitializer` replaced.
   /// - param newChild: The new `unexpectedAfterInitializer` to replace the node's
   ///                   current `unexpectedAfterInitializer`, if present.
-  public func withUnexpectedAfterInitializer(
-    _ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
+  public func withUnexpectedAfterInitializer(_ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return OptionalBindingConditionSyntax(newData)
   }
 
@@ -19717,9 +19890,11 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unavailabilityCondition,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unavailabilityCondition,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -19737,10 +19912,10 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundUnavailableKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforePoundUnavailableKeyword` to replace the node's
   ///                   current `unexpectedBeforePoundUnavailableKeyword`, if present.
-  public func withUnexpectedBeforePoundUnavailableKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
+  public func withUnexpectedBeforePoundUnavailableKeyword(_ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return UnavailabilityConditionSyntax(newData)
   }
 
@@ -19757,10 +19932,10 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundUnavailableKeyword` replaced.
   /// - param newChild: The new `poundUnavailableKeyword` to replace the node's
   ///                   current `poundUnavailableKeyword`, if present.
-  public func withPoundUnavailableKeyword(
-    _ newChild: TokenSyntax?) -> UnavailabilityConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundUnavailableKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundUnavailableKeyword(_ newChild: TokenSyntax?) -> UnavailabilityConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundUnavailableKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return UnavailabilityConditionSyntax(newData)
   }
 
@@ -19778,10 +19953,10 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPoundUnavailableKeywordAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenPoundUnavailableKeywordAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenPoundUnavailableKeywordAndLeftParen`, if present.
-  public func withUnexpectedBetweenPoundUnavailableKeywordAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
+  public func withUnexpectedBetweenPoundUnavailableKeywordAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return UnavailabilityConditionSyntax(newData)
   }
 
@@ -19798,10 +19973,10 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> UnavailabilityConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> UnavailabilityConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return UnavailabilityConditionSyntax(newData)
   }
 
@@ -19819,10 +19994,10 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndAvailabilitySpec` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndAvailabilitySpec` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndAvailabilitySpec`, if present.
-  public func withUnexpectedBetweenLeftParenAndAvailabilitySpec(
-    _ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
+  public func withUnexpectedBetweenLeftParenAndAvailabilitySpec(_ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return UnavailabilityConditionSyntax(newData)
   }
 
@@ -19844,23 +20019,24 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `availabilitySpec` collection.
   public func addAvailabilityArgument(_ element: AvailabilityArgumentSyntax) -> UnavailabilityConditionSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.availabilitySpecList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 5)
+    let newData = data.replacingChild(collection, at: 5, arena: arena)
     return UnavailabilityConditionSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `availabilitySpec` replaced.
   /// - param newChild: The new `availabilitySpec` to replace the node's
   ///                   current `availabilitySpec`, if present.
-  public func withAvailabilitySpec(
-    _ newChild: AvailabilitySpecListSyntax?) -> UnavailabilityConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withAvailabilitySpec(_ newChild: AvailabilitySpecListSyntax?) -> UnavailabilityConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return UnavailabilityConditionSyntax(newData)
   }
 
@@ -19878,10 +20054,10 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAvailabilitySpecAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenAvailabilitySpecAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenAvailabilitySpecAndRightParen`, if present.
-  public func withUnexpectedBetweenAvailabilitySpecAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
+  public func withUnexpectedBetweenAvailabilitySpecAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return UnavailabilityConditionSyntax(newData)
   }
 
@@ -19898,10 +20074,10 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> UnavailabilityConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withRightParen(_ newChild: TokenSyntax?) -> UnavailabilityConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return UnavailabilityConditionSyntax(newData)
   }
 
@@ -19919,10 +20095,10 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return UnavailabilityConditionSyntax(newData)
   }
 
@@ -20024,9 +20200,11 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.hasSymbolCondition,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.hasSymbolCondition,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -20044,10 +20222,10 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeHasSymbolKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeHasSymbolKeyword` to replace the node's
   ///                   current `unexpectedBeforeHasSymbolKeyword`, if present.
-  public func withUnexpectedBeforeHasSymbolKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
+  public func withUnexpectedBeforeHasSymbolKeyword(_ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return HasSymbolConditionSyntax(newData)
   }
 
@@ -20064,10 +20242,10 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `hasSymbolKeyword` replaced.
   /// - param newChild: The new `hasSymbolKeyword` to replace the node's
   ///                   current `hasSymbolKeyword`, if present.
-  public func withHasSymbolKeyword(
-    _ newChild: TokenSyntax?) -> HasSymbolConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withHasSymbolKeyword(_ newChild: TokenSyntax?) -> HasSymbolConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return HasSymbolConditionSyntax(newData)
   }
 
@@ -20085,10 +20263,10 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenHasSymbolKeywordAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenHasSymbolKeywordAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenHasSymbolKeywordAndLeftParen`, if present.
-  public func withUnexpectedBetweenHasSymbolKeywordAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
+  public func withUnexpectedBetweenHasSymbolKeywordAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return HasSymbolConditionSyntax(newData)
   }
 
@@ -20105,10 +20283,10 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> HasSymbolConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> HasSymbolConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return HasSymbolConditionSyntax(newData)
   }
 
@@ -20126,10 +20304,10 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndExpression` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndExpression` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndExpression`, if present.
-  public func withUnexpectedBetweenLeftParenAndExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
+  public func withUnexpectedBetweenLeftParenAndExpression(_ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return HasSymbolConditionSyntax(newData)
   }
 
@@ -20146,10 +20324,10 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> HasSymbolConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withExpression(_ newChild: ExprSyntax?) -> HasSymbolConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return HasSymbolConditionSyntax(newData)
   }
 
@@ -20167,10 +20345,10 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenExpressionAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenExpressionAndRightParen`, if present.
-  public func withUnexpectedBetweenExpressionAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
+  public func withUnexpectedBetweenExpressionAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return HasSymbolConditionSyntax(newData)
   }
 
@@ -20187,10 +20365,10 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> HasSymbolConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withRightParen(_ newChild: TokenSyntax?) -> HasSymbolConditionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return HasSymbolConditionSyntax(newData)
   }
 
@@ -20208,10 +20386,10 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return HasSymbolConditionSyntax(newData)
   }
 
@@ -20345,9 +20523,11 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
       statements.raw,
       unexpectedAfterStatements?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCase,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCase,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -20365,10 +20545,10 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeUnknownAttr` replaced.
   /// - param newChild: The new `unexpectedBeforeUnknownAttr` to replace the node's
   ///                   current `unexpectedBeforeUnknownAttr`, if present.
-  public func withUnexpectedBeforeUnknownAttr(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
+  public func withUnexpectedBeforeUnknownAttr(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return SwitchCaseSyntax(newData)
   }
 
@@ -20386,10 +20566,10 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unknownAttr` replaced.
   /// - param newChild: The new `unknownAttr` to replace the node's
   ///                   current `unknownAttr`, if present.
-  public func withUnknownAttr(
-    _ newChild: AttributeSyntax?) -> SwitchCaseSyntax {
+  public func withUnknownAttr(_ newChild: AttributeSyntax?) -> SwitchCaseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return SwitchCaseSyntax(newData)
   }
 
@@ -20407,10 +20587,10 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenUnknownAttrAndLabel` replaced.
   /// - param newChild: The new `unexpectedBetweenUnknownAttrAndLabel` to replace the node's
   ///                   current `unexpectedBetweenUnknownAttrAndLabel`, if present.
-  public func withUnexpectedBetweenUnknownAttrAndLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
+  public func withUnexpectedBetweenUnknownAttrAndLabel(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return SwitchCaseSyntax(newData)
   }
 
@@ -20427,10 +20607,10 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `label` replaced.
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
-  public func withLabel(
-    _ newChild: Label?) -> SwitchCaseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withLabel(_ newChild: Label?) -> SwitchCaseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return SwitchCaseSyntax(newData)
   }
 
@@ -20448,10 +20628,10 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLabelAndStatements` replaced.
   /// - param newChild: The new `unexpectedBetweenLabelAndStatements` to replace the node's
   ///                   current `unexpectedBetweenLabelAndStatements`, if present.
-  public func withUnexpectedBetweenLabelAndStatements(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
+  public func withUnexpectedBetweenLabelAndStatements(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return SwitchCaseSyntax(newData)
   }
 
@@ -20473,23 +20653,24 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `statements` collection.
   public func addStatement(_ element: CodeBlockItemSyntax) -> SwitchCaseSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 5)
+    let newData = data.replacingChild(collection, at: 5, arena: arena)
     return SwitchCaseSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `statements` replaced.
   /// - param newChild: The new `statements` to replace the node's
   ///                   current `statements`, if present.
-  public func withStatements(
-    _ newChild: CodeBlockItemListSyntax?) -> SwitchCaseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withStatements(_ newChild: CodeBlockItemListSyntax?) -> SwitchCaseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return SwitchCaseSyntax(newData)
   }
 
@@ -20507,10 +20688,10 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterStatements` replaced.
   /// - param newChild: The new `unexpectedAfterStatements` to replace the node's
   ///                   current `unexpectedAfterStatements`, if present.
-  public func withUnexpectedAfterStatements(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
+  public func withUnexpectedAfterStatements(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return SwitchCaseSyntax(newData)
   }
 
@@ -20596,9 +20777,11 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
       colon.raw,
       unexpectedAfterColon?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchDefaultLabel,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchDefaultLabel,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -20616,10 +20799,10 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeDefaultKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeDefaultKeyword` to replace the node's
   ///                   current `unexpectedBeforeDefaultKeyword`, if present.
-  public func withUnexpectedBeforeDefaultKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchDefaultLabelSyntax {
+  public func withUnexpectedBeforeDefaultKeyword(_ newChild: UnexpectedNodesSyntax?) -> SwitchDefaultLabelSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return SwitchDefaultLabelSyntax(newData)
   }
 
@@ -20636,10 +20819,10 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `defaultKeyword` replaced.
   /// - param newChild: The new `defaultKeyword` to replace the node's
   ///                   current `defaultKeyword`, if present.
-  public func withDefaultKeyword(
-    _ newChild: TokenSyntax?) -> SwitchDefaultLabelSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.defaultKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withDefaultKeyword(_ newChild: TokenSyntax?) -> SwitchDefaultLabelSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.defaultKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return SwitchDefaultLabelSyntax(newData)
   }
 
@@ -20657,10 +20840,10 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenDefaultKeywordAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenDefaultKeywordAndColon` to replace the node's
   ///                   current `unexpectedBetweenDefaultKeywordAndColon`, if present.
-  public func withUnexpectedBetweenDefaultKeywordAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchDefaultLabelSyntax {
+  public func withUnexpectedBetweenDefaultKeywordAndColon(_ newChild: UnexpectedNodesSyntax?) -> SwitchDefaultLabelSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return SwitchDefaultLabelSyntax(newData)
   }
 
@@ -20677,10 +20860,10 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> SwitchDefaultLabelSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> SwitchDefaultLabelSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return SwitchDefaultLabelSyntax(newData)
   }
 
@@ -20698,10 +20881,10 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterColon` replaced.
   /// - param newChild: The new `unexpectedAfterColon` to replace the node's
   ///                   current `unexpectedAfterColon`, if present.
-  public func withUnexpectedAfterColon(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchDefaultLabelSyntax {
+  public func withUnexpectedAfterColon(_ newChild: UnexpectedNodesSyntax?) -> SwitchDefaultLabelSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return SwitchDefaultLabelSyntax(newData)
   }
 
@@ -20783,9 +20966,11 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.caseItem,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.caseItem,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -20803,10 +20988,10 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePattern` replaced.
   /// - param newChild: The new `unexpectedBeforePattern` to replace the node's
   ///                   current `unexpectedBeforePattern`, if present.
-  public func withUnexpectedBeforePattern(
-    _ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
+  public func withUnexpectedBeforePattern(_ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return CaseItemSyntax(newData)
   }
 
@@ -20823,10 +21008,10 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(
-    _ newChild: PatternSyntax?) -> CaseItemSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPattern(_ newChild: PatternSyntax?) -> CaseItemSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return CaseItemSyntax(newData)
   }
 
@@ -20844,10 +21029,10 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPatternAndWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenPatternAndWhereClause` to replace the node's
   ///                   current `unexpectedBetweenPatternAndWhereClause`, if present.
-  public func withUnexpectedBetweenPatternAndWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
+  public func withUnexpectedBetweenPatternAndWhereClause(_ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return CaseItemSyntax(newData)
   }
 
@@ -20865,10 +21050,10 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `whereClause` replaced.
   /// - param newChild: The new `whereClause` to replace the node's
   ///                   current `whereClause`, if present.
-  public func withWhereClause(
-    _ newChild: WhereClauseSyntax?) -> CaseItemSyntax {
+  public func withWhereClause(_ newChild: WhereClauseSyntax?) -> CaseItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return CaseItemSyntax(newData)
   }
 
@@ -20886,10 +21071,10 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenWhereClauseAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenWhereClauseAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenWhereClauseAndTrailingComma`, if present.
-  public func withUnexpectedBetweenWhereClauseAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
+  public func withUnexpectedBetweenWhereClauseAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return CaseItemSyntax(newData)
   }
 
@@ -20907,10 +21092,10 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> CaseItemSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> CaseItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return CaseItemSyntax(newData)
   }
 
@@ -20928,10 +21113,10 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return CaseItemSyntax(newData)
   }
 
@@ -21021,9 +21206,11 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchItem,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchItem,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -21041,10 +21228,10 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePattern` replaced.
   /// - param newChild: The new `unexpectedBeforePattern` to replace the node's
   ///                   current `unexpectedBeforePattern`, if present.
-  public func withUnexpectedBeforePattern(
-    _ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
+  public func withUnexpectedBeforePattern(_ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return CatchItemSyntax(newData)
   }
 
@@ -21062,10 +21249,10 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(
-    _ newChild: PatternSyntax?) -> CatchItemSyntax {
+  public func withPattern(_ newChild: PatternSyntax?) -> CatchItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return CatchItemSyntax(newData)
   }
 
@@ -21083,10 +21270,10 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPatternAndWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenPatternAndWhereClause` to replace the node's
   ///                   current `unexpectedBetweenPatternAndWhereClause`, if present.
-  public func withUnexpectedBetweenPatternAndWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
+  public func withUnexpectedBetweenPatternAndWhereClause(_ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return CatchItemSyntax(newData)
   }
 
@@ -21104,10 +21291,10 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `whereClause` replaced.
   /// - param newChild: The new `whereClause` to replace the node's
   ///                   current `whereClause`, if present.
-  public func withWhereClause(
-    _ newChild: WhereClauseSyntax?) -> CatchItemSyntax {
+  public func withWhereClause(_ newChild: WhereClauseSyntax?) -> CatchItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return CatchItemSyntax(newData)
   }
 
@@ -21125,10 +21312,10 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenWhereClauseAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenWhereClauseAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenWhereClauseAndTrailingComma`, if present.
-  public func withUnexpectedBetweenWhereClauseAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
+  public func withUnexpectedBetweenWhereClauseAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return CatchItemSyntax(newData)
   }
 
@@ -21146,10 +21333,10 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> CatchItemSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> CatchItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return CatchItemSyntax(newData)
   }
 
@@ -21167,10 +21354,10 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return CatchItemSyntax(newData)
   }
 
@@ -21260,9 +21447,11 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
       colon.raw,
       unexpectedAfterColon?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseLabel,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseLabel,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -21280,10 +21469,10 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeCaseKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeCaseKeyword` to replace the node's
   ///                   current `unexpectedBeforeCaseKeyword`, if present.
-  public func withUnexpectedBeforeCaseKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
+  public func withUnexpectedBeforeCaseKeyword(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return SwitchCaseLabelSyntax(newData)
   }
 
@@ -21300,10 +21489,10 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `caseKeyword` replaced.
   /// - param newChild: The new `caseKeyword` to replace the node's
   ///                   current `caseKeyword`, if present.
-  public func withCaseKeyword(
-    _ newChild: TokenSyntax?) -> SwitchCaseLabelSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withCaseKeyword(_ newChild: TokenSyntax?) -> SwitchCaseLabelSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return SwitchCaseLabelSyntax(newData)
   }
 
@@ -21321,10 +21510,10 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCaseKeywordAndCaseItems` replaced.
   /// - param newChild: The new `unexpectedBetweenCaseKeywordAndCaseItems` to replace the node's
   ///                   current `unexpectedBetweenCaseKeywordAndCaseItems`, if present.
-  public func withUnexpectedBetweenCaseKeywordAndCaseItems(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
+  public func withUnexpectedBetweenCaseKeywordAndCaseItems(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return SwitchCaseLabelSyntax(newData)
   }
 
@@ -21346,23 +21535,24 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `caseItems` collection.
   public func addCaseItem(_ element: CaseItemSyntax) -> SwitchCaseLabelSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.caseItemList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return SwitchCaseLabelSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `caseItems` replaced.
   /// - param newChild: The new `caseItems` to replace the node's
   ///                   current `caseItems`, if present.
-  public func withCaseItems(
-    _ newChild: CaseItemListSyntax?) -> SwitchCaseLabelSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.caseItemList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withCaseItems(_ newChild: CaseItemListSyntax?) -> SwitchCaseLabelSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.caseItemList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return SwitchCaseLabelSyntax(newData)
   }
 
@@ -21380,10 +21570,10 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCaseItemsAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenCaseItemsAndColon` to replace the node's
   ///                   current `unexpectedBetweenCaseItemsAndColon`, if present.
-  public func withUnexpectedBetweenCaseItemsAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
+  public func withUnexpectedBetweenCaseItemsAndColon(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return SwitchCaseLabelSyntax(newData)
   }
 
@@ -21400,10 +21590,10 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> SwitchCaseLabelSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withColon(_ newChild: TokenSyntax?) -> SwitchCaseLabelSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return SwitchCaseLabelSyntax(newData)
   }
 
@@ -21421,10 +21611,10 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterColon` replaced.
   /// - param newChild: The new `unexpectedAfterColon` to replace the node's
   ///                   current `unexpectedAfterColon`, if present.
-  public func withUnexpectedAfterColon(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
+  public func withUnexpectedAfterColon(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return SwitchCaseLabelSyntax(newData)
   }
 
@@ -21514,9 +21704,11 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
       body.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchClause,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -21534,10 +21726,10 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeCatchKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeCatchKeyword` to replace the node's
   ///                   current `unexpectedBeforeCatchKeyword`, if present.
-  public func withUnexpectedBeforeCatchKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
+  public func withUnexpectedBeforeCatchKeyword(_ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return CatchClauseSyntax(newData)
   }
 
@@ -21554,10 +21746,10 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `catchKeyword` replaced.
   /// - param newChild: The new `catchKeyword` to replace the node's
   ///                   current `catchKeyword`, if present.
-  public func withCatchKeyword(
-    _ newChild: TokenSyntax?) -> CatchClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.catchKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withCatchKeyword(_ newChild: TokenSyntax?) -> CatchClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.catchKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return CatchClauseSyntax(newData)
   }
 
@@ -21575,10 +21767,10 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCatchKeywordAndCatchItems` replaced.
   /// - param newChild: The new `unexpectedBetweenCatchKeywordAndCatchItems` to replace the node's
   ///                   current `unexpectedBetweenCatchKeywordAndCatchItems`, if present.
-  public func withUnexpectedBetweenCatchKeywordAndCatchItems(
-    _ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
+  public func withUnexpectedBetweenCatchKeywordAndCatchItems(_ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return CatchClauseSyntax(newData)
   }
 
@@ -21601,23 +21793,24 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `catchItems` collection.
   public func addCatchItem(_ element: CatchItemSyntax) -> CatchClauseSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.catchItemList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return CatchClauseSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `catchItems` replaced.
   /// - param newChild: The new `catchItems` to replace the node's
   ///                   current `catchItems`, if present.
-  public func withCatchItems(
-    _ newChild: CatchItemListSyntax?) -> CatchClauseSyntax {
+  public func withCatchItems(_ newChild: CatchItemListSyntax?) -> CatchClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return CatchClauseSyntax(newData)
   }
 
@@ -21635,10 +21828,10 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCatchItemsAndBody` replaced.
   /// - param newChild: The new `unexpectedBetweenCatchItemsAndBody` to replace the node's
   ///                   current `unexpectedBetweenCatchItemsAndBody`, if present.
-  public func withUnexpectedBetweenCatchItemsAndBody(
-    _ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
+  public func withUnexpectedBetweenCatchItemsAndBody(_ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return CatchClauseSyntax(newData)
   }
 
@@ -21655,10 +21848,10 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(
-    _ newChild: CodeBlockSyntax?) -> CatchClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withBody(_ newChild: CodeBlockSyntax?) -> CatchClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return CatchClauseSyntax(newData)
   }
 
@@ -21676,10 +21869,10 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
   /// - param newChild: The new `unexpectedAfterBody` to replace the node's
   ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(
-    _ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
+  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return CatchClauseSyntax(newData)
   }
 
@@ -21765,9 +21958,11 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
       requirementList.raw,
       unexpectedAfterRequirementList?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericWhereClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericWhereClause,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -21785,10 +21980,10 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeWhereKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeWhereKeyword` to replace the node's
   ///                   current `unexpectedBeforeWhereKeyword`, if present.
-  public func withUnexpectedBeforeWhereKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericWhereClauseSyntax {
+  public func withUnexpectedBeforeWhereKeyword(_ newChild: UnexpectedNodesSyntax?) -> GenericWhereClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return GenericWhereClauseSyntax(newData)
   }
 
@@ -21805,10 +22000,10 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `whereKeyword` replaced.
   /// - param newChild: The new `whereKeyword` to replace the node's
   ///                   current `whereKeyword`, if present.
-  public func withWhereKeyword(
-    _ newChild: TokenSyntax?) -> GenericWhereClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whereKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withWhereKeyword(_ newChild: TokenSyntax?) -> GenericWhereClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whereKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return GenericWhereClauseSyntax(newData)
   }
 
@@ -21826,10 +22021,10 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenWhereKeywordAndRequirementList` replaced.
   /// - param newChild: The new `unexpectedBetweenWhereKeywordAndRequirementList` to replace the node's
   ///                   current `unexpectedBetweenWhereKeywordAndRequirementList`, if present.
-  public func withUnexpectedBetweenWhereKeywordAndRequirementList(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericWhereClauseSyntax {
+  public func withUnexpectedBetweenWhereKeywordAndRequirementList(_ newChild: UnexpectedNodesSyntax?) -> GenericWhereClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return GenericWhereClauseSyntax(newData)
   }
 
@@ -21851,23 +22046,24 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `requirementList` collection.
   public func addRequirement(_ element: GenericRequirementSyntax) -> GenericWhereClauseSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return GenericWhereClauseSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `requirementList` replaced.
   /// - param newChild: The new `requirementList` to replace the node's
   ///                   current `requirementList`, if present.
-  public func withRequirementList(
-    _ newChild: GenericRequirementListSyntax?) -> GenericWhereClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericRequirementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withRequirementList(_ newChild: GenericRequirementListSyntax?) -> GenericWhereClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericRequirementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return GenericWhereClauseSyntax(newData)
   }
 
@@ -21885,10 +22081,10 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRequirementList` replaced.
   /// - param newChild: The new `unexpectedAfterRequirementList` to replace the node's
   ///                   current `unexpectedAfterRequirementList`, if present.
-  public func withUnexpectedAfterRequirementList(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericWhereClauseSyntax {
+  public func withUnexpectedAfterRequirementList(_ newChild: UnexpectedNodesSyntax?) -> GenericWhereClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return GenericWhereClauseSyntax(newData)
   }
 
@@ -22012,9 +22208,11 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -22032,10 +22230,10 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeBody` replaced.
   /// - param newChild: The new `unexpectedBeforeBody` to replace the node's
   ///                   current `unexpectedBeforeBody`, if present.
-  public func withUnexpectedBeforeBody(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericRequirementSyntax {
+  public func withUnexpectedBeforeBody(_ newChild: UnexpectedNodesSyntax?) -> GenericRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return GenericRequirementSyntax(newData)
   }
 
@@ -22052,10 +22250,10 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(
-    _ newChild: Body?) -> GenericRequirementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withBody(_ newChild: Body?) -> GenericRequirementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return GenericRequirementSyntax(newData)
   }
 
@@ -22073,10 +22271,10 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenBodyAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenBodyAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenBodyAndTrailingComma`, if present.
-  public func withUnexpectedBetweenBodyAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericRequirementSyntax {
+  public func withUnexpectedBetweenBodyAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> GenericRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return GenericRequirementSyntax(newData)
   }
 
@@ -22094,10 +22292,10 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> GenericRequirementSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> GenericRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return GenericRequirementSyntax(newData)
   }
 
@@ -22115,10 +22313,10 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericRequirementSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> GenericRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return GenericRequirementSyntax(newData)
   }
 
@@ -22200,9 +22398,11 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       rightTypeIdentifier.raw,
       unexpectedAfterRightTypeIdentifier?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.sameTypeRequirement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.sameTypeRequirement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -22220,10 +22420,10 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftTypeIdentifier` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftTypeIdentifier` to replace the node's
   ///                   current `unexpectedBeforeLeftTypeIdentifier`, if present.
-  public func withUnexpectedBeforeLeftTypeIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
+  public func withUnexpectedBeforeLeftTypeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return SameTypeRequirementSyntax(newData)
   }
 
@@ -22240,10 +22440,10 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftTypeIdentifier` replaced.
   /// - param newChild: The new `leftTypeIdentifier` to replace the node's
   ///                   current `leftTypeIdentifier`, if present.
-  public func withLeftTypeIdentifier(
-    _ newChild: TypeSyntax?) -> SameTypeRequirementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftTypeIdentifier(_ newChild: TypeSyntax?) -> SameTypeRequirementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return SameTypeRequirementSyntax(newData)
   }
 
@@ -22261,10 +22461,10 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftTypeIdentifierAndEqualityToken` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftTypeIdentifierAndEqualityToken` to replace the node's
   ///                   current `unexpectedBetweenLeftTypeIdentifierAndEqualityToken`, if present.
-  public func withUnexpectedBetweenLeftTypeIdentifierAndEqualityToken(
-    _ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
+  public func withUnexpectedBetweenLeftTypeIdentifierAndEqualityToken(_ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return SameTypeRequirementSyntax(newData)
   }
 
@@ -22281,10 +22481,10 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `equalityToken` replaced.
   /// - param newChild: The new `equalityToken` to replace the node's
   ///                   current `equalityToken`, if present.
-  public func withEqualityToken(
-    _ newChild: TokenSyntax?) -> SameTypeRequirementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.spacedBinaryOperator(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withEqualityToken(_ newChild: TokenSyntax?) -> SameTypeRequirementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.spacedBinaryOperator(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return SameTypeRequirementSyntax(newData)
   }
 
@@ -22302,10 +22502,10 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenEqualityTokenAndRightTypeIdentifier` replaced.
   /// - param newChild: The new `unexpectedBetweenEqualityTokenAndRightTypeIdentifier` to replace the node's
   ///                   current `unexpectedBetweenEqualityTokenAndRightTypeIdentifier`, if present.
-  public func withUnexpectedBetweenEqualityTokenAndRightTypeIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
+  public func withUnexpectedBetweenEqualityTokenAndRightTypeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return SameTypeRequirementSyntax(newData)
   }
 
@@ -22322,10 +22522,10 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightTypeIdentifier` replaced.
   /// - param newChild: The new `rightTypeIdentifier` to replace the node's
   ///                   current `rightTypeIdentifier`, if present.
-  public func withRightTypeIdentifier(
-    _ newChild: TypeSyntax?) -> SameTypeRequirementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightTypeIdentifier(_ newChild: TypeSyntax?) -> SameTypeRequirementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return SameTypeRequirementSyntax(newData)
   }
 
@@ -22343,10 +22543,10 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightTypeIdentifier` replaced.
   /// - param newChild: The new `unexpectedAfterRightTypeIdentifier` to replace the node's
   ///                   current `unexpectedAfterRightTypeIdentifier`, if present.
-  public func withUnexpectedAfterRightTypeIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
+  public func withUnexpectedAfterRightTypeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return SameTypeRequirementSyntax(newData)
   }
 
@@ -22456,9 +22656,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       rightParen?.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.layoutRequirement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.layoutRequirement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -22476,10 +22678,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeTypeIdentifier` replaced.
   /// - param newChild: The new `unexpectedBeforeTypeIdentifier` to replace the node's
   ///                   current `unexpectedBeforeTypeIdentifier`, if present.
-  public func withUnexpectedBeforeTypeIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+  public func withUnexpectedBeforeTypeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22496,10 +22698,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typeIdentifier` replaced.
   /// - param newChild: The new `typeIdentifier` to replace the node's
   ///                   current `typeIdentifier`, if present.
-  public func withTypeIdentifier(
-    _ newChild: TypeSyntax?) -> LayoutRequirementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withTypeIdentifier(_ newChild: TypeSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22517,10 +22719,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTypeIdentifierAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenTypeIdentifierAndColon` to replace the node's
   ///                   current `unexpectedBetweenTypeIdentifierAndColon`, if present.
-  public func withUnexpectedBetweenTypeIdentifierAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+  public func withUnexpectedBetweenTypeIdentifierAndColon(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22537,10 +22739,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22558,10 +22760,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndLayoutConstraint` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndLayoutConstraint` to replace the node's
   ///                   current `unexpectedBetweenColonAndLayoutConstraint`, if present.
-  public func withUnexpectedBetweenColonAndLayoutConstraint(
-    _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+  public func withUnexpectedBetweenColonAndLayoutConstraint(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22578,10 +22780,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `layoutConstraint` replaced.
   /// - param newChild: The new `layoutConstraint` to replace the node's
   ///                   current `layoutConstraint`, if present.
-  public func withLayoutConstraint(
-    _ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withLayoutConstraint(_ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22599,10 +22801,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLayoutConstraintAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenLayoutConstraintAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenLayoutConstraintAndLeftParen`, if present.
-  public func withUnexpectedBetweenLayoutConstraintAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+  public func withUnexpectedBetweenLayoutConstraintAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22620,10 +22822,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22641,10 +22843,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndSize` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndSize` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndSize`, if present.
-  public func withUnexpectedBetweenLeftParenAndSize(
-    _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+  public func withUnexpectedBetweenLeftParenAndSize(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22662,10 +22864,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `size` replaced.
   /// - param newChild: The new `size` to replace the node's
   ///                   current `size`, if present.
-  public func withSize(
-    _ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
+  public func withSize(_ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22683,10 +22885,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenSizeAndComma` replaced.
   /// - param newChild: The new `unexpectedBetweenSizeAndComma` to replace the node's
   ///                   current `unexpectedBetweenSizeAndComma`, if present.
-  public func withUnexpectedBetweenSizeAndComma(
-    _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+  public func withUnexpectedBetweenSizeAndComma(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22704,10 +22906,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `comma` replaced.
   /// - param newChild: The new `comma` to replace the node's
   ///                   current `comma`, if present.
-  public func withComma(
-    _ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
+  public func withComma(_ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22725,10 +22927,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndAlignment` replaced.
   /// - param newChild: The new `unexpectedBetweenCommaAndAlignment` to replace the node's
   ///                   current `unexpectedBetweenCommaAndAlignment`, if present.
-  public func withUnexpectedBetweenCommaAndAlignment(
-    _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+  public func withUnexpectedBetweenCommaAndAlignment(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22746,10 +22948,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `alignment` replaced.
   /// - param newChild: The new `alignment` to replace the node's
   ///                   current `alignment`, if present.
-  public func withAlignment(
-    _ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
+  public func withAlignment(_ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22767,10 +22969,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAlignmentAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenAlignmentAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenAlignmentAndRightParen`, if present.
-  public func withUnexpectedBetweenAlignmentAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+  public func withUnexpectedBetweenAlignmentAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22788,10 +22990,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
+  public func withRightParen(_ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 15)
+    let newData = data.replacingChild(raw, at: 15, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22809,10 +23011,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 16)
+    let newData = data.replacingChild(raw, at: 16, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
 
@@ -22954,9 +23156,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameter,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameter,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -22974,10 +23178,10 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
   /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
   ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
+  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return GenericParameterSyntax(newData)
   }
 
@@ -23000,23 +23204,24 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> GenericParameterSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return GenericParameterSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> GenericParameterSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> GenericParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return GenericParameterSyntax(newData)
   }
 
@@ -23034,10 +23239,10 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndName` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndName` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndName`, if present.
-  public func withUnexpectedBetweenAttributesAndName(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
+  public func withUnexpectedBetweenAttributesAndName(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return GenericParameterSyntax(newData)
   }
 
@@ -23054,10 +23259,10 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> GenericParameterSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withName(_ newChild: TokenSyntax?) -> GenericParameterSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return GenericParameterSyntax(newData)
   }
 
@@ -23075,10 +23280,10 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndEllipsis` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndEllipsis` to replace the node's
   ///                   current `unexpectedBetweenNameAndEllipsis`, if present.
-  public func withUnexpectedBetweenNameAndEllipsis(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
+  public func withUnexpectedBetweenNameAndEllipsis(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return GenericParameterSyntax(newData)
   }
 
@@ -23096,10 +23301,10 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `ellipsis` replaced.
   /// - param newChild: The new `ellipsis` to replace the node's
   ///                   current `ellipsis`, if present.
-  public func withEllipsis(
-    _ newChild: TokenSyntax?) -> GenericParameterSyntax {
+  public func withEllipsis(_ newChild: TokenSyntax?) -> GenericParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return GenericParameterSyntax(newData)
   }
 
@@ -23117,10 +23322,10 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenEllipsisAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenEllipsisAndColon` to replace the node's
   ///                   current `unexpectedBetweenEllipsisAndColon`, if present.
-  public func withUnexpectedBetweenEllipsisAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
+  public func withUnexpectedBetweenEllipsisAndColon(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return GenericParameterSyntax(newData)
   }
 
@@ -23138,10 +23343,10 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> GenericParameterSyntax {
+  public func withColon(_ newChild: TokenSyntax?) -> GenericParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return GenericParameterSyntax(newData)
   }
 
@@ -23159,10 +23364,10 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndInheritedType` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndInheritedType` to replace the node's
   ///                   current `unexpectedBetweenColonAndInheritedType`, if present.
-  public func withUnexpectedBetweenColonAndInheritedType(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
+  public func withUnexpectedBetweenColonAndInheritedType(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return GenericParameterSyntax(newData)
   }
 
@@ -23180,10 +23385,10 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `inheritedType` replaced.
   /// - param newChild: The new `inheritedType` to replace the node's
   ///                   current `inheritedType`, if present.
-  public func withInheritedType(
-    _ newChild: TypeSyntax?) -> GenericParameterSyntax {
+  public func withInheritedType(_ newChild: TypeSyntax?) -> GenericParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return GenericParameterSyntax(newData)
   }
 
@@ -23201,10 +23406,10 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInheritedTypeAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenInheritedTypeAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenInheritedTypeAndTrailingComma`, if present.
-  public func withUnexpectedBetweenInheritedTypeAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
+  public func withUnexpectedBetweenInheritedTypeAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return GenericParameterSyntax(newData)
   }
 
@@ -23222,10 +23427,10 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> GenericParameterSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> GenericParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return GenericParameterSyntax(newData)
   }
 
@@ -23243,10 +23448,10 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return GenericParameterSyntax(newData)
   }
 
@@ -23356,9 +23561,11 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -23376,10 +23583,10 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
   /// - param newChild: The new `unexpectedBeforeName` to replace the node's
   ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(
-    _ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeSyntax {
+  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PrimaryAssociatedTypeSyntax(newData)
   }
 
@@ -23396,10 +23603,10 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> PrimaryAssociatedTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withName(_ newChild: TokenSyntax?) -> PrimaryAssociatedTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PrimaryAssociatedTypeSyntax(newData)
   }
 
@@ -23417,10 +23624,10 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenNameAndTrailingComma`, if present.
-  public func withUnexpectedBetweenNameAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeSyntax {
+  public func withUnexpectedBetweenNameAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PrimaryAssociatedTypeSyntax(newData)
   }
 
@@ -23438,10 +23645,10 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> PrimaryAssociatedTypeSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> PrimaryAssociatedTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PrimaryAssociatedTypeSyntax(newData)
   }
 
@@ -23459,10 +23666,10 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PrimaryAssociatedTypeSyntax(newData)
   }
 
@@ -23548,9 +23755,11 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       rightAngleBracket.raw,
       unexpectedAfterRightAngleBracket?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterClause,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -23568,10 +23777,10 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftAngleBracket` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftAngleBracket` to replace the node's
   ///                   current `unexpectedBeforeLeftAngleBracket`, if present.
-  public func withUnexpectedBeforeLeftAngleBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
+  public func withUnexpectedBeforeLeftAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return GenericParameterClauseSyntax(newData)
   }
 
@@ -23588,10 +23797,10 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftAngleBracket` replaced.
   /// - param newChild: The new `leftAngleBracket` to replace the node's
   ///                   current `leftAngleBracket`, if present.
-  public func withLeftAngleBracket(
-    _ newChild: TokenSyntax?) -> GenericParameterClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftAngleBracket(_ newChild: TokenSyntax?) -> GenericParameterClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return GenericParameterClauseSyntax(newData)
   }
 
@@ -23609,10 +23818,10 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftAngleBracketAndGenericParameterList` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftAngleBracketAndGenericParameterList` to replace the node's
   ///                   current `unexpectedBetweenLeftAngleBracketAndGenericParameterList`, if present.
-  public func withUnexpectedBetweenLeftAngleBracketAndGenericParameterList(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
+  public func withUnexpectedBetweenLeftAngleBracketAndGenericParameterList(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return GenericParameterClauseSyntax(newData)
   }
 
@@ -23634,23 +23843,24 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `genericParameterList` collection.
   public func addGenericParameter(_ element: GenericParameterSyntax) -> GenericParameterClauseSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return GenericParameterClauseSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `genericParameterList` replaced.
   /// - param newChild: The new `genericParameterList` to replace the node's
   ///                   current `genericParameterList`, if present.
-  public func withGenericParameterList(
-    _ newChild: GenericParameterListSyntax?) -> GenericParameterClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericParameterList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withGenericParameterList(_ newChild: GenericParameterListSyntax?) -> GenericParameterClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericParameterList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return GenericParameterClauseSyntax(newData)
   }
 
@@ -23668,10 +23878,10 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterListAndGenericWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericParameterListAndGenericWhereClause` to replace the node's
   ///                   current `unexpectedBetweenGenericParameterListAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenGenericParameterListAndGenericWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
+  public func withUnexpectedBetweenGenericParameterListAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return GenericParameterClauseSyntax(newData)
   }
 
@@ -23689,10 +23899,10 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericWhereClause` replaced.
   /// - param newChild: The new `genericWhereClause` to replace the node's
   ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(
-    _ newChild: GenericWhereClauseSyntax?) -> GenericParameterClauseSyntax {
+  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> GenericParameterClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return GenericParameterClauseSyntax(newData)
   }
 
@@ -23710,10 +23920,10 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndRightAngleBracket` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndRightAngleBracket` to replace the node's
   ///                   current `unexpectedBetweenGenericWhereClauseAndRightAngleBracket`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndRightAngleBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
+  public func withUnexpectedBetweenGenericWhereClauseAndRightAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return GenericParameterClauseSyntax(newData)
   }
 
@@ -23730,10 +23940,10 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightAngleBracket` replaced.
   /// - param newChild: The new `rightAngleBracket` to replace the node's
   ///                   current `rightAngleBracket`, if present.
-  public func withRightAngleBracket(
-    _ newChild: TokenSyntax?) -> GenericParameterClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withRightAngleBracket(_ newChild: TokenSyntax?) -> GenericParameterClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return GenericParameterClauseSyntax(newData)
   }
 
@@ -23751,10 +23961,10 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightAngleBracket` replaced.
   /// - param newChild: The new `unexpectedAfterRightAngleBracket` to replace the node's
   ///                   current `unexpectedAfterRightAngleBracket`, if present.
-  public func withUnexpectedAfterRightAngleBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
+  public func withUnexpectedAfterRightAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return GenericParameterClauseSyntax(newData)
   }
 
@@ -23852,9 +24062,11 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       rightTypeIdentifier.raw,
       unexpectedAfterRightTypeIdentifier?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.conformanceRequirement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.conformanceRequirement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -23872,10 +24084,10 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftTypeIdentifier` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftTypeIdentifier` to replace the node's
   ///                   current `unexpectedBeforeLeftTypeIdentifier`, if present.
-  public func withUnexpectedBeforeLeftTypeIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
+  public func withUnexpectedBeforeLeftTypeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ConformanceRequirementSyntax(newData)
   }
 
@@ -23892,10 +24104,10 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftTypeIdentifier` replaced.
   /// - param newChild: The new `leftTypeIdentifier` to replace the node's
   ///                   current `leftTypeIdentifier`, if present.
-  public func withLeftTypeIdentifier(
-    _ newChild: TypeSyntax?) -> ConformanceRequirementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftTypeIdentifier(_ newChild: TypeSyntax?) -> ConformanceRequirementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ConformanceRequirementSyntax(newData)
   }
 
@@ -23913,10 +24125,10 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftTypeIdentifierAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftTypeIdentifierAndColon` to replace the node's
   ///                   current `unexpectedBetweenLeftTypeIdentifierAndColon`, if present.
-  public func withUnexpectedBetweenLeftTypeIdentifierAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
+  public func withUnexpectedBetweenLeftTypeIdentifierAndColon(_ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ConformanceRequirementSyntax(newData)
   }
 
@@ -23933,10 +24145,10 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> ConformanceRequirementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> ConformanceRequirementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ConformanceRequirementSyntax(newData)
   }
 
@@ -23954,10 +24166,10 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndRightTypeIdentifier` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndRightTypeIdentifier` to replace the node's
   ///                   current `unexpectedBetweenColonAndRightTypeIdentifier`, if present.
-  public func withUnexpectedBetweenColonAndRightTypeIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
+  public func withUnexpectedBetweenColonAndRightTypeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ConformanceRequirementSyntax(newData)
   }
 
@@ -23974,10 +24186,10 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightTypeIdentifier` replaced.
   /// - param newChild: The new `rightTypeIdentifier` to replace the node's
   ///                   current `rightTypeIdentifier`, if present.
-  public func withRightTypeIdentifier(
-    _ newChild: TypeSyntax?) -> ConformanceRequirementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightTypeIdentifier(_ newChild: TypeSyntax?) -> ConformanceRequirementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ConformanceRequirementSyntax(newData)
   }
 
@@ -23995,10 +24207,10 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightTypeIdentifier` replaced.
   /// - param newChild: The new `unexpectedAfterRightTypeIdentifier` to replace the node's
   ///                   current `unexpectedAfterRightTypeIdentifier`, if present.
-  public func withUnexpectedAfterRightTypeIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
+  public func withUnexpectedAfterRightTypeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ConformanceRequirementSyntax(newData)
   }
 
@@ -24088,9 +24300,11 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
       rightAngleBracket.raw,
       unexpectedAfterRightAngleBracket?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeClause,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -24108,10 +24322,10 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftAngleBracket` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftAngleBracket` to replace the node's
   ///                   current `unexpectedBeforeLeftAngleBracket`, if present.
-  public func withUnexpectedBeforeLeftAngleBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+  public func withUnexpectedBeforeLeftAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
@@ -24128,10 +24342,10 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `leftAngleBracket` replaced.
   /// - param newChild: The new `leftAngleBracket` to replace the node's
   ///                   current `leftAngleBracket`, if present.
-  public func withLeftAngleBracket(
-    _ newChild: TokenSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftAngleBracket(_ newChild: TokenSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
@@ -24149,10 +24363,10 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList` to replace the node's
   ///                   current `unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList`, if present.
-  public func withUnexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList(
-    _ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+  public func withUnexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList(_ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
@@ -24174,23 +24388,24 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   ///            appended to its `primaryAssociatedTypeList` collection.
   public func addPrimaryAssociatedType(_ element: PrimaryAssociatedTypeSyntax) -> PrimaryAssociatedTypeClauseSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `primaryAssociatedTypeList` replaced.
   /// - param newChild: The new `primaryAssociatedTypeList` to replace the node's
   ///                   current `primaryAssociatedTypeList`, if present.
-  public func withPrimaryAssociatedTypeList(
-    _ newChild: PrimaryAssociatedTypeListSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.primaryAssociatedTypeList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withPrimaryAssociatedTypeList(_ newChild: PrimaryAssociatedTypeListSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.primaryAssociatedTypeList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
@@ -24208,10 +24423,10 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket` replaced.
   /// - param newChild: The new `unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket` to replace the node's
   ///                   current `unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket`, if present.
-  public func withUnexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+  public func withUnexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
@@ -24228,10 +24443,10 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `rightAngleBracket` replaced.
   /// - param newChild: The new `rightAngleBracket` to replace the node's
   ///                   current `rightAngleBracket`, if present.
-  public func withRightAngleBracket(
-    _ newChild: TokenSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightAngleBracket(_ newChild: TokenSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
@@ -24249,10 +24464,10 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `unexpectedAfterRightAngleBracket` replaced.
   /// - param newChild: The new `unexpectedAfterRightAngleBracket` to replace the node's
   ///                   current `unexpectedAfterRightAngleBracket`, if present.
-  public func withUnexpectedAfterRightAngleBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+  public func withUnexpectedAfterRightAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
@@ -24338,9 +24553,11 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       ampersand?.raw,
       unexpectedAfterAmpersand?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -24358,10 +24575,10 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeType` replaced.
   /// - param newChild: The new `unexpectedBeforeType` to replace the node's
   ///                   current `unexpectedBeforeType`, if present.
-  public func withUnexpectedBeforeType(
-    _ newChild: UnexpectedNodesSyntax?) -> CompositionTypeElementSyntax {
+  public func withUnexpectedBeforeType(_ newChild: UnexpectedNodesSyntax?) -> CompositionTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return CompositionTypeElementSyntax(newData)
   }
 
@@ -24378,10 +24595,10 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `type` replaced.
   /// - param newChild: The new `type` to replace the node's
   ///                   current `type`, if present.
-  public func withType(
-    _ newChild: TypeSyntax?) -> CompositionTypeElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withType(_ newChild: TypeSyntax?) -> CompositionTypeElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return CompositionTypeElementSyntax(newData)
   }
 
@@ -24399,10 +24616,10 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTypeAndAmpersand` replaced.
   /// - param newChild: The new `unexpectedBetweenTypeAndAmpersand` to replace the node's
   ///                   current `unexpectedBetweenTypeAndAmpersand`, if present.
-  public func withUnexpectedBetweenTypeAndAmpersand(
-    _ newChild: UnexpectedNodesSyntax?) -> CompositionTypeElementSyntax {
+  public func withUnexpectedBetweenTypeAndAmpersand(_ newChild: UnexpectedNodesSyntax?) -> CompositionTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return CompositionTypeElementSyntax(newData)
   }
 
@@ -24420,10 +24637,10 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `ampersand` replaced.
   /// - param newChild: The new `ampersand` to replace the node's
   ///                   current `ampersand`, if present.
-  public func withAmpersand(
-    _ newChild: TokenSyntax?) -> CompositionTypeElementSyntax {
+  public func withAmpersand(_ newChild: TokenSyntax?) -> CompositionTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return CompositionTypeElementSyntax(newData)
   }
 
@@ -24441,10 +24658,10 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterAmpersand` replaced.
   /// - param newChild: The new `unexpectedAfterAmpersand` to replace the node's
   ///                   current `unexpectedAfterAmpersand`, if present.
-  public func withUnexpectedAfterAmpersand(
-    _ newChild: UnexpectedNodesSyntax?) -> CompositionTypeElementSyntax {
+  public func withUnexpectedAfterAmpersand(_ newChild: UnexpectedNodesSyntax?) -> CompositionTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return CompositionTypeElementSyntax(newData)
   }
 
@@ -24546,9 +24763,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -24566,10 +24785,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeInOut` replaced.
   /// - param newChild: The new `unexpectedBeforeInOut` to replace the node's
   ///                   current `unexpectedBeforeInOut`, if present.
-  public func withUnexpectedBeforeInOut(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+  public func withUnexpectedBeforeInOut(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24587,10 +24806,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `inOut` replaced.
   /// - param newChild: The new `inOut` to replace the node's
   ///                   current `inOut`, if present.
-  public func withInOut(
-    _ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
+  public func withInOut(_ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24608,10 +24827,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInOutAndName` replaced.
   /// - param newChild: The new `unexpectedBetweenInOutAndName` to replace the node's
   ///                   current `unexpectedBetweenInOutAndName`, if present.
-  public func withUnexpectedBetweenInOutAndName(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+  public func withUnexpectedBetweenInOutAndName(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24629,10 +24848,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
+  public func withName(_ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24650,10 +24869,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndSecondName` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndSecondName` to replace the node's
   ///                   current `unexpectedBetweenNameAndSecondName`, if present.
-  public func withUnexpectedBetweenNameAndSecondName(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+  public func withUnexpectedBetweenNameAndSecondName(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24671,10 +24890,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `secondName` replaced.
   /// - param newChild: The new `secondName` to replace the node's
   ///                   current `secondName`, if present.
-  public func withSecondName(
-    _ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
+  public func withSecondName(_ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24692,10 +24911,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenSecondNameAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenSecondNameAndColon` to replace the node's
   ///                   current `unexpectedBetweenSecondNameAndColon`, if present.
-  public func withUnexpectedBetweenSecondNameAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+  public func withUnexpectedBetweenSecondNameAndColon(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24713,10 +24932,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
+  public func withColon(_ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24734,10 +24953,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndType` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndType` to replace the node's
   ///                   current `unexpectedBetweenColonAndType`, if present.
-  public func withUnexpectedBetweenColonAndType(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+  public func withUnexpectedBetweenColonAndType(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24754,10 +24973,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `type` replaced.
   /// - param newChild: The new `type` to replace the node's
   ///                   current `type`, if present.
-  public func withType(
-    _ newChild: TypeSyntax?) -> TupleTypeElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 9)
+  public func withType(_ newChild: TypeSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24775,10 +24994,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTypeAndEllipsis` replaced.
   /// - param newChild: The new `unexpectedBetweenTypeAndEllipsis` to replace the node's
   ///                   current `unexpectedBetweenTypeAndEllipsis`, if present.
-  public func withUnexpectedBetweenTypeAndEllipsis(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+  public func withUnexpectedBetweenTypeAndEllipsis(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24796,10 +25015,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `ellipsis` replaced.
   /// - param newChild: The new `ellipsis` to replace the node's
   ///                   current `ellipsis`, if present.
-  public func withEllipsis(
-    _ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
+  public func withEllipsis(_ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24817,10 +25036,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenEllipsisAndInitializer` replaced.
   /// - param newChild: The new `unexpectedBetweenEllipsisAndInitializer` to replace the node's
   ///                   current `unexpectedBetweenEllipsisAndInitializer`, if present.
-  public func withUnexpectedBetweenEllipsisAndInitializer(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+  public func withUnexpectedBetweenEllipsisAndInitializer(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24838,10 +25057,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `initializer` replaced.
   /// - param newChild: The new `initializer` to replace the node's
   ///                   current `initializer`, if present.
-  public func withInitializer(
-    _ newChild: InitializerClauseSyntax?) -> TupleTypeElementSyntax {
+  public func withInitializer(_ newChild: InitializerClauseSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 13)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24859,10 +25078,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInitializerAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenInitializerAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenInitializerAndTrailingComma`, if present.
-  public func withUnexpectedBetweenInitializerAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+  public func withUnexpectedBetweenInitializerAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24880,10 +25099,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 15)
+    let newData = data.replacingChild(raw, at: 15, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -24901,10 +25120,10 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 16)
+    let newData = data.replacingChild(raw, at: 16, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
 
@@ -25030,9 +25249,11 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgument,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgument,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -25050,10 +25271,10 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeArgumentType` replaced.
   /// - param newChild: The new `unexpectedBeforeArgumentType` to replace the node's
   ///                   current `unexpectedBeforeArgumentType`, if present.
-  public func withUnexpectedBeforeArgumentType(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericArgumentSyntax {
+  public func withUnexpectedBeforeArgumentType(_ newChild: UnexpectedNodesSyntax?) -> GenericArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return GenericArgumentSyntax(newData)
   }
 
@@ -25070,10 +25291,10 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `argumentType` replaced.
   /// - param newChild: The new `argumentType` to replace the node's
   ///                   current `argumentType`, if present.
-  public func withArgumentType(
-    _ newChild: TypeSyntax?) -> GenericArgumentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withArgumentType(_ newChild: TypeSyntax?) -> GenericArgumentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return GenericArgumentSyntax(newData)
   }
 
@@ -25091,10 +25312,10 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenArgumentTypeAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenArgumentTypeAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenArgumentTypeAndTrailingComma`, if present.
-  public func withUnexpectedBetweenArgumentTypeAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericArgumentSyntax {
+  public func withUnexpectedBetweenArgumentTypeAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> GenericArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return GenericArgumentSyntax(newData)
   }
 
@@ -25112,10 +25333,10 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> GenericArgumentSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> GenericArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return GenericArgumentSyntax(newData)
   }
 
@@ -25133,10 +25354,10 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericArgumentSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> GenericArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return GenericArgumentSyntax(newData)
   }
 
@@ -25218,9 +25439,11 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
       rightAngleBracket.raw,
       unexpectedAfterRightAngleBracket?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentClause,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentClause,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -25238,10 +25461,10 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftAngleBracket` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftAngleBracket` to replace the node's
   ///                   current `unexpectedBeforeLeftAngleBracket`, if present.
-  public func withUnexpectedBeforeLeftAngleBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
+  public func withUnexpectedBeforeLeftAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return GenericArgumentClauseSyntax(newData)
   }
 
@@ -25258,10 +25481,10 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftAngleBracket` replaced.
   /// - param newChild: The new `leftAngleBracket` to replace the node's
   ///                   current `leftAngleBracket`, if present.
-  public func withLeftAngleBracket(
-    _ newChild: TokenSyntax?) -> GenericArgumentClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftAngleBracket(_ newChild: TokenSyntax?) -> GenericArgumentClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return GenericArgumentClauseSyntax(newData)
   }
 
@@ -25279,10 +25502,10 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftAngleBracketAndArguments` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftAngleBracketAndArguments` to replace the node's
   ///                   current `unexpectedBetweenLeftAngleBracketAndArguments`, if present.
-  public func withUnexpectedBetweenLeftAngleBracketAndArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
+  public func withUnexpectedBetweenLeftAngleBracketAndArguments(_ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return GenericArgumentClauseSyntax(newData)
   }
 
@@ -25304,23 +25527,24 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `arguments` collection.
   public func addArgument(_ element: GenericArgumentSyntax) -> GenericArgumentClauseSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return GenericArgumentClauseSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `arguments` replaced.
   /// - param newChild: The new `arguments` to replace the node's
   ///                   current `arguments`, if present.
-  public func withArguments(
-    _ newChild: GenericArgumentListSyntax?) -> GenericArgumentClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericArgumentList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withArguments(_ newChild: GenericArgumentListSyntax?) -> GenericArgumentClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericArgumentList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return GenericArgumentClauseSyntax(newData)
   }
 
@@ -25338,10 +25562,10 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenArgumentsAndRightAngleBracket` replaced.
   /// - param newChild: The new `unexpectedBetweenArgumentsAndRightAngleBracket` to replace the node's
   ///                   current `unexpectedBetweenArgumentsAndRightAngleBracket`, if present.
-  public func withUnexpectedBetweenArgumentsAndRightAngleBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
+  public func withUnexpectedBetweenArgumentsAndRightAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return GenericArgumentClauseSyntax(newData)
   }
 
@@ -25358,10 +25582,10 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightAngleBracket` replaced.
   /// - param newChild: The new `rightAngleBracket` to replace the node's
   ///                   current `rightAngleBracket`, if present.
-  public func withRightAngleBracket(
-    _ newChild: TokenSyntax?) -> GenericArgumentClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightAngleBracket(_ newChild: TokenSyntax?) -> GenericArgumentClauseSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return GenericArgumentClauseSyntax(newData)
   }
 
@@ -25379,10 +25603,10 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightAngleBracket` replaced.
   /// - param newChild: The new `unexpectedAfterRightAngleBracket` to replace the node's
   ///                   current `unexpectedAfterRightAngleBracket`, if present.
-  public func withUnexpectedAfterRightAngleBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
+  public func withUnexpectedAfterRightAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return GenericArgumentClauseSyntax(newData)
   }
 
@@ -25468,9 +25692,11 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
       type.raw,
       unexpectedAfterType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeAnnotation,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeAnnotation,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -25488,10 +25714,10 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeColon` replaced.
   /// - param newChild: The new `unexpectedBeforeColon` to replace the node's
   ///                   current `unexpectedBeforeColon`, if present.
-  public func withUnexpectedBeforeColon(
-    _ newChild: UnexpectedNodesSyntax?) -> TypeAnnotationSyntax {
+  public func withUnexpectedBeforeColon(_ newChild: UnexpectedNodesSyntax?) -> TypeAnnotationSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return TypeAnnotationSyntax(newData)
   }
 
@@ -25508,10 +25734,10 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> TypeAnnotationSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withColon(_ newChild: TokenSyntax?) -> TypeAnnotationSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return TypeAnnotationSyntax(newData)
   }
 
@@ -25529,10 +25755,10 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndType` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndType` to replace the node's
   ///                   current `unexpectedBetweenColonAndType`, if present.
-  public func withUnexpectedBetweenColonAndType(
-    _ newChild: UnexpectedNodesSyntax?) -> TypeAnnotationSyntax {
+  public func withUnexpectedBetweenColonAndType(_ newChild: UnexpectedNodesSyntax?) -> TypeAnnotationSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return TypeAnnotationSyntax(newData)
   }
 
@@ -25549,10 +25775,10 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `type` replaced.
   /// - param newChild: The new `type` to replace the node's
   ///                   current `type`, if present.
-  public func withType(
-    _ newChild: TypeSyntax?) -> TypeAnnotationSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withType(_ newChild: TypeSyntax?) -> TypeAnnotationSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return TypeAnnotationSyntax(newData)
   }
 
@@ -25570,10 +25796,10 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterType` replaced.
   /// - param newChild: The new `unexpectedAfterType` to replace the node's
   ///                   current `unexpectedAfterType`, if present.
-  public func withUnexpectedAfterType(
-    _ newChild: UnexpectedNodesSyntax?) -> TypeAnnotationSyntax {
+  public func withUnexpectedAfterType(_ newChild: UnexpectedNodesSyntax?) -> TypeAnnotationSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return TypeAnnotationSyntax(newData)
   }
 
@@ -25659,9 +25885,11 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElement,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElement,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -25679,10 +25907,10 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLabelName` replaced.
   /// - param newChild: The new `unexpectedBeforeLabelName` to replace the node's
   ///                   current `unexpectedBeforeLabelName`, if present.
-  public func withUnexpectedBeforeLabelName(
-    _ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
+  public func withUnexpectedBeforeLabelName(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return TuplePatternElementSyntax(newData)
   }
 
@@ -25700,10 +25928,10 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `labelName` replaced.
   /// - param newChild: The new `labelName` to replace the node's
   ///                   current `labelName`, if present.
-  public func withLabelName(
-    _ newChild: TokenSyntax?) -> TuplePatternElementSyntax {
+  public func withLabelName(_ newChild: TokenSyntax?) -> TuplePatternElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return TuplePatternElementSyntax(newData)
   }
 
@@ -25721,10 +25949,10 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLabelNameAndLabelColon` replaced.
   /// - param newChild: The new `unexpectedBetweenLabelNameAndLabelColon` to replace the node's
   ///                   current `unexpectedBetweenLabelNameAndLabelColon`, if present.
-  public func withUnexpectedBetweenLabelNameAndLabelColon(
-    _ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
+  public func withUnexpectedBetweenLabelNameAndLabelColon(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return TuplePatternElementSyntax(newData)
   }
 
@@ -25742,10 +25970,10 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `labelColon` replaced.
   /// - param newChild: The new `labelColon` to replace the node's
   ///                   current `labelColon`, if present.
-  public func withLabelColon(
-    _ newChild: TokenSyntax?) -> TuplePatternElementSyntax {
+  public func withLabelColon(_ newChild: TokenSyntax?) -> TuplePatternElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return TuplePatternElementSyntax(newData)
   }
 
@@ -25763,10 +25991,10 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLabelColonAndPattern` replaced.
   /// - param newChild: The new `unexpectedBetweenLabelColonAndPattern` to replace the node's
   ///                   current `unexpectedBetweenLabelColonAndPattern`, if present.
-  public func withUnexpectedBetweenLabelColonAndPattern(
-    _ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
+  public func withUnexpectedBetweenLabelColonAndPattern(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return TuplePatternElementSyntax(newData)
   }
 
@@ -25783,10 +26011,10 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(
-    _ newChild: PatternSyntax?) -> TuplePatternElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withPattern(_ newChild: PatternSyntax?) -> TuplePatternElementSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return TuplePatternElementSyntax(newData)
   }
 
@@ -25804,10 +26032,10 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPatternAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenPatternAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenPatternAndTrailingComma`, if present.
-  public func withUnexpectedBetweenPatternAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
+  public func withUnexpectedBetweenPatternAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return TuplePatternElementSyntax(newData)
   }
 
@@ -25825,10 +26053,10 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> TuplePatternElementSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> TuplePatternElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return TuplePatternElementSyntax(newData)
   }
 
@@ -25846,10 +26074,10 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return TuplePatternElementSyntax(newData)
   }
 
@@ -26003,9 +26231,11 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       trailingComma?.raw,
       unexpectedAfterTrailingComma?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityArgument,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityArgument,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -26023,10 +26253,10 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeEntry` replaced.
   /// - param newChild: The new `unexpectedBeforeEntry` to replace the node's
   ///                   current `unexpectedBeforeEntry`, if present.
-  public func withUnexpectedBeforeEntry(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityArgumentSyntax {
+  public func withUnexpectedBeforeEntry(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AvailabilityArgumentSyntax(newData)
   }
 
@@ -26044,10 +26274,10 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `entry` replaced.
   /// - param newChild: The new `entry` to replace the node's
   ///                   current `entry`, if present.
-  public func withEntry(
-    _ newChild: Entry?) -> AvailabilityArgumentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withEntry(_ newChild: Entry?) -> AvailabilityArgumentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AvailabilityArgumentSyntax(newData)
   }
 
@@ -26065,10 +26295,10 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenEntryAndTrailingComma` replaced.
   /// - param newChild: The new `unexpectedBetweenEntryAndTrailingComma` to replace the node's
   ///                   current `unexpectedBetweenEntryAndTrailingComma`, if present.
-  public func withUnexpectedBetweenEntryAndTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityArgumentSyntax {
+  public func withUnexpectedBetweenEntryAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AvailabilityArgumentSyntax(newData)
   }
 
@@ -26090,10 +26320,10 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `trailingComma` replaced.
   /// - param newChild: The new `trailingComma` to replace the node's
   ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> AvailabilityArgumentSyntax {
+  public func withTrailingComma(_ newChild: TokenSyntax?) -> AvailabilityArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AvailabilityArgumentSyntax(newData)
   }
 
@@ -26111,10 +26341,10 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
   /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
   ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityArgumentSyntax {
+  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AvailabilityArgumentSyntax(newData)
   }
 
@@ -26236,9 +26466,11 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
       value.raw,
       unexpectedAfterValue?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityLabeledArgument,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityLabeledArgument,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -26256,10 +26488,10 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `unexpectedBeforeLabel` replaced.
   /// - param newChild: The new `unexpectedBeforeLabel` to replace the node's
   ///                   current `unexpectedBeforeLabel`, if present.
-  public func withUnexpectedBeforeLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
+  public func withUnexpectedBeforeLabel(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
 
@@ -26277,10 +26509,10 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `label` replaced.
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
-  public func withLabel(
-    _ newChild: TokenSyntax?) -> AvailabilityLabeledArgumentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLabel(_ newChild: TokenSyntax?) -> AvailabilityLabeledArgumentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
 
@@ -26298,10 +26530,10 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `unexpectedBetweenLabelAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenLabelAndColon` to replace the node's
   ///                   current `unexpectedBetweenLabelAndColon`, if present.
-  public func withUnexpectedBetweenLabelAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
+  public func withUnexpectedBetweenLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
 
@@ -26319,10 +26551,10 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> AvailabilityLabeledArgumentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withColon(_ newChild: TokenSyntax?) -> AvailabilityLabeledArgumentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
 
@@ -26340,10 +26572,10 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndValue` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndValue` to replace the node's
   ///                   current `unexpectedBetweenColonAndValue`, if present.
-  public func withUnexpectedBetweenColonAndValue(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
+  public func withUnexpectedBetweenColonAndValue(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
 
@@ -26361,10 +26593,10 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `value` replaced.
   /// - param newChild: The new `value` to replace the node's
   ///                   current `value`, if present.
-  public func withValue(
-    _ newChild: Value?) -> AvailabilityLabeledArgumentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withValue(_ newChild: Value?) -> AvailabilityLabeledArgumentSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
 
@@ -26382,10 +26614,10 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `unexpectedAfterValue` replaced.
   /// - param newChild: The new `unexpectedAfterValue` to replace the node's
   ///                   current `unexpectedAfterValue`, if present.
-  public func withUnexpectedAfterValue(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
+  public func withUnexpectedAfterValue(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
 
@@ -26475,9 +26707,11 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
       version?.raw,
       unexpectedAfterVersion?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityVersionRestriction,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityVersionRestriction,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -26495,10 +26729,10 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `unexpectedBeforePlatform` replaced.
   /// - param newChild: The new `unexpectedBeforePlatform` to replace the node's
   ///                   current `unexpectedBeforePlatform`, if present.
-  public func withUnexpectedBeforePlatform(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityVersionRestrictionSyntax {
+  public func withUnexpectedBeforePlatform(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityVersionRestrictionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AvailabilityVersionRestrictionSyntax(newData)
   }
 
@@ -26520,10 +26754,10 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `platform` replaced.
   /// - param newChild: The new `platform` to replace the node's
   ///                   current `platform`, if present.
-  public func withPlatform(
-    _ newChild: TokenSyntax?) -> AvailabilityVersionRestrictionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPlatform(_ newChild: TokenSyntax?) -> AvailabilityVersionRestrictionSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AvailabilityVersionRestrictionSyntax(newData)
   }
 
@@ -26541,10 +26775,10 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `unexpectedBetweenPlatformAndVersion` replaced.
   /// - param newChild: The new `unexpectedBetweenPlatformAndVersion` to replace the node's
   ///                   current `unexpectedBetweenPlatformAndVersion`, if present.
-  public func withUnexpectedBetweenPlatformAndVersion(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityVersionRestrictionSyntax {
+  public func withUnexpectedBetweenPlatformAndVersion(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityVersionRestrictionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AvailabilityVersionRestrictionSyntax(newData)
   }
 
@@ -26562,10 +26796,10 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `version` replaced.
   /// - param newChild: The new `version` to replace the node's
   ///                   current `version`, if present.
-  public func withVersion(
-    _ newChild: VersionTupleSyntax?) -> AvailabilityVersionRestrictionSyntax {
+  public func withVersion(_ newChild: VersionTupleSyntax?) -> AvailabilityVersionRestrictionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AvailabilityVersionRestrictionSyntax(newData)
   }
 
@@ -26583,10 +26817,10 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `unexpectedAfterVersion` replaced.
   /// - param newChild: The new `unexpectedAfterVersion` to replace the node's
   ///                   current `unexpectedAfterVersion`, if present.
-  public func withUnexpectedAfterVersion(
-    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityVersionRestrictionSyntax {
+  public func withUnexpectedAfterVersion(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityVersionRestrictionSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AvailabilityVersionRestrictionSyntax(newData)
   }
 
@@ -26672,9 +26906,11 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
       patchVersion?.raw,
       unexpectedAfterPatchVersion?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.versionTuple,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.versionTuple,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -26692,10 +26928,10 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeMajorMinor` replaced.
   /// - param newChild: The new `unexpectedBeforeMajorMinor` to replace the node's
   ///                   current `unexpectedBeforeMajorMinor`, if present.
-  public func withUnexpectedBeforeMajorMinor(
-    _ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
+  public func withUnexpectedBeforeMajorMinor(_ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return VersionTupleSyntax(newData)
   }
 
@@ -26719,10 +26955,10 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `majorMinor` replaced.
   /// - param newChild: The new `majorMinor` to replace the node's
   ///                   current `majorMinor`, if present.
-  public func withMajorMinor(
-    _ newChild: TokenSyntax?) -> VersionTupleSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withMajorMinor(_ newChild: TokenSyntax?) -> VersionTupleSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return VersionTupleSyntax(newData)
   }
 
@@ -26740,10 +26976,10 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenMajorMinorAndPatchPeriod` replaced.
   /// - param newChild: The new `unexpectedBetweenMajorMinorAndPatchPeriod` to replace the node's
   ///                   current `unexpectedBetweenMajorMinorAndPatchPeriod`, if present.
-  public func withUnexpectedBetweenMajorMinorAndPatchPeriod(
-    _ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
+  public func withUnexpectedBetweenMajorMinorAndPatchPeriod(_ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return VersionTupleSyntax(newData)
   }
 
@@ -26765,10 +27001,10 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `patchPeriod` replaced.
   /// - param newChild: The new `patchPeriod` to replace the node's
   ///                   current `patchPeriod`, if present.
-  public func withPatchPeriod(
-    _ newChild: TokenSyntax?) -> VersionTupleSyntax {
+  public func withPatchPeriod(_ newChild: TokenSyntax?) -> VersionTupleSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return VersionTupleSyntax(newData)
   }
 
@@ -26786,10 +27022,10 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPatchPeriodAndPatchVersion` replaced.
   /// - param newChild: The new `unexpectedBetweenPatchPeriodAndPatchVersion` to replace the node's
   ///                   current `unexpectedBetweenPatchPeriodAndPatchVersion`, if present.
-  public func withUnexpectedBetweenPatchPeriodAndPatchVersion(
-    _ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
+  public func withUnexpectedBetweenPatchPeriodAndPatchVersion(_ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return VersionTupleSyntax(newData)
   }
 
@@ -26810,10 +27046,10 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `patchVersion` replaced.
   /// - param newChild: The new `patchVersion` to replace the node's
   ///                   current `patchVersion`, if present.
-  public func withPatchVersion(
-    _ newChild: TokenSyntax?) -> VersionTupleSyntax {
+  public func withPatchVersion(_ newChild: TokenSyntax?) -> VersionTupleSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return VersionTupleSyntax(newData)
   }
 
@@ -26831,10 +27067,10 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterPatchVersion` replaced.
   /// - param newChild: The new `unexpectedAfterPatchVersion` to replace the node's
   ///                   current `unexpectedAfterPatchVersion`, if present.
-  public func withUnexpectedAfterPatchVersion(
-    _ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
+  public func withUnexpectedAfterPatchVersion(_ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return VersionTupleSyntax(newData)
   }
 

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
@@ -37,9 +37,11 @@ public struct UnknownPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   ) {
     let layout: [RawSyntax?] = [
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unknownPattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unknownPattern,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -87,9 +89,11 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   ) {
     let layout: [RawSyntax?] = [
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingPattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingPattern,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -155,9 +159,11 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       associatedTuple?.raw,
       unexpectedAfterAssociatedTuple?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCasePattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCasePattern,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -175,10 +181,10 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeType` replaced.
   /// - param newChild: The new `unexpectedBeforeType` to replace the node's
   ///                   current `unexpectedBeforeType`, if present.
-  public func withUnexpectedBeforeType(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumCasePatternSyntax {
+  public func withUnexpectedBeforeType(_ newChild: UnexpectedNodesSyntax?) -> EnumCasePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return EnumCasePatternSyntax(newData)
   }
 
@@ -196,10 +202,10 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `type` replaced.
   /// - param newChild: The new `type` to replace the node's
   ///                   current `type`, if present.
-  public func withType(
-    _ newChild: TypeSyntax?) -> EnumCasePatternSyntax {
+  public func withType(_ newChild: TypeSyntax?) -> EnumCasePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return EnumCasePatternSyntax(newData)
   }
 
@@ -217,10 +223,10 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTypeAndPeriod` replaced.
   /// - param newChild: The new `unexpectedBetweenTypeAndPeriod` to replace the node's
   ///                   current `unexpectedBetweenTypeAndPeriod`, if present.
-  public func withUnexpectedBetweenTypeAndPeriod(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumCasePatternSyntax {
+  public func withUnexpectedBetweenTypeAndPeriod(_ newChild: UnexpectedNodesSyntax?) -> EnumCasePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return EnumCasePatternSyntax(newData)
   }
 
@@ -237,10 +243,10 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `period` replaced.
   /// - param newChild: The new `period` to replace the node's
   ///                   current `period`, if present.
-  public func withPeriod(
-    _ newChild: TokenSyntax?) -> EnumCasePatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withPeriod(_ newChild: TokenSyntax?) -> EnumCasePatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return EnumCasePatternSyntax(newData)
   }
 
@@ -258,10 +264,10 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPeriodAndCaseName` replaced.
   /// - param newChild: The new `unexpectedBetweenPeriodAndCaseName` to replace the node's
   ///                   current `unexpectedBetweenPeriodAndCaseName`, if present.
-  public func withUnexpectedBetweenPeriodAndCaseName(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumCasePatternSyntax {
+  public func withUnexpectedBetweenPeriodAndCaseName(_ newChild: UnexpectedNodesSyntax?) -> EnumCasePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return EnumCasePatternSyntax(newData)
   }
 
@@ -278,10 +284,10 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `caseName` replaced.
   /// - param newChild: The new `caseName` to replace the node's
   ///                   current `caseName`, if present.
-  public func withCaseName(
-    _ newChild: TokenSyntax?) -> EnumCasePatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withCaseName(_ newChild: TokenSyntax?) -> EnumCasePatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return EnumCasePatternSyntax(newData)
   }
 
@@ -299,10 +305,10 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCaseNameAndAssociatedTuple` replaced.
   /// - param newChild: The new `unexpectedBetweenCaseNameAndAssociatedTuple` to replace the node's
   ///                   current `unexpectedBetweenCaseNameAndAssociatedTuple`, if present.
-  public func withUnexpectedBetweenCaseNameAndAssociatedTuple(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumCasePatternSyntax {
+  public func withUnexpectedBetweenCaseNameAndAssociatedTuple(_ newChild: UnexpectedNodesSyntax?) -> EnumCasePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return EnumCasePatternSyntax(newData)
   }
 
@@ -320,10 +326,10 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `associatedTuple` replaced.
   /// - param newChild: The new `associatedTuple` to replace the node's
   ///                   current `associatedTuple`, if present.
-  public func withAssociatedTuple(
-    _ newChild: TuplePatternSyntax?) -> EnumCasePatternSyntax {
+  public func withAssociatedTuple(_ newChild: TuplePatternSyntax?) -> EnumCasePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return EnumCasePatternSyntax(newData)
   }
 
@@ -341,10 +347,10 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterAssociatedTuple` replaced.
   /// - param newChild: The new `unexpectedAfterAssociatedTuple` to replace the node's
   ///                   current `unexpectedAfterAssociatedTuple`, if present.
-  public func withUnexpectedAfterAssociatedTuple(
-    _ newChild: UnexpectedNodesSyntax?) -> EnumCasePatternSyntax {
+  public func withUnexpectedAfterAssociatedTuple(_ newChild: UnexpectedNodesSyntax?) -> EnumCasePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return EnumCasePatternSyntax(newData)
   }
 
@@ -438,9 +444,11 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       type.raw,
       unexpectedAfterType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.isTypePattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.isTypePattern,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -458,10 +466,10 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeIsKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeIsKeyword` to replace the node's
   ///                   current `unexpectedBeforeIsKeyword`, if present.
-  public func withUnexpectedBeforeIsKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> IsTypePatternSyntax {
+  public func withUnexpectedBeforeIsKeyword(_ newChild: UnexpectedNodesSyntax?) -> IsTypePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return IsTypePatternSyntax(newData)
   }
 
@@ -478,10 +486,10 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `isKeyword` replaced.
   /// - param newChild: The new `isKeyword` to replace the node's
   ///                   current `isKeyword`, if present.
-  public func withIsKeyword(
-    _ newChild: TokenSyntax?) -> IsTypePatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withIsKeyword(_ newChild: TokenSyntax?) -> IsTypePatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return IsTypePatternSyntax(newData)
   }
 
@@ -499,10 +507,10 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIsKeywordAndType` replaced.
   /// - param newChild: The new `unexpectedBetweenIsKeywordAndType` to replace the node's
   ///                   current `unexpectedBetweenIsKeywordAndType`, if present.
-  public func withUnexpectedBetweenIsKeywordAndType(
-    _ newChild: UnexpectedNodesSyntax?) -> IsTypePatternSyntax {
+  public func withUnexpectedBetweenIsKeywordAndType(_ newChild: UnexpectedNodesSyntax?) -> IsTypePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return IsTypePatternSyntax(newData)
   }
 
@@ -519,10 +527,10 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `type` replaced.
   /// - param newChild: The new `type` to replace the node's
   ///                   current `type`, if present.
-  public func withType(
-    _ newChild: TypeSyntax?) -> IsTypePatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withType(_ newChild: TypeSyntax?) -> IsTypePatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return IsTypePatternSyntax(newData)
   }
 
@@ -540,10 +548,10 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterType` replaced.
   /// - param newChild: The new `unexpectedAfterType` to replace the node's
   ///                   current `unexpectedAfterType`, if present.
-  public func withUnexpectedAfterType(
-    _ newChild: UnexpectedNodesSyntax?) -> IsTypePatternSyntax {
+  public func withUnexpectedAfterType(_ newChild: UnexpectedNodesSyntax?) -> IsTypePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return IsTypePatternSyntax(newData)
   }
 
@@ -621,9 +629,11 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       questionMark.raw,
       unexpectedAfterQuestionMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalPattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalPattern,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -641,10 +651,10 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeSubPattern` replaced.
   /// - param newChild: The new `unexpectedBeforeSubPattern` to replace the node's
   ///                   current `unexpectedBeforeSubPattern`, if present.
-  public func withUnexpectedBeforeSubPattern(
-    _ newChild: UnexpectedNodesSyntax?) -> OptionalPatternSyntax {
+  public func withUnexpectedBeforeSubPattern(_ newChild: UnexpectedNodesSyntax?) -> OptionalPatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return OptionalPatternSyntax(newData)
   }
 
@@ -661,10 +671,10 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `subPattern` replaced.
   /// - param newChild: The new `subPattern` to replace the node's
   ///                   current `subPattern`, if present.
-  public func withSubPattern(
-    _ newChild: PatternSyntax?) -> OptionalPatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withSubPattern(_ newChild: PatternSyntax?) -> OptionalPatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return OptionalPatternSyntax(newData)
   }
 
@@ -682,10 +692,10 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenSubPatternAndQuestionMark` replaced.
   /// - param newChild: The new `unexpectedBetweenSubPatternAndQuestionMark` to replace the node's
   ///                   current `unexpectedBetweenSubPatternAndQuestionMark`, if present.
-  public func withUnexpectedBetweenSubPatternAndQuestionMark(
-    _ newChild: UnexpectedNodesSyntax?) -> OptionalPatternSyntax {
+  public func withUnexpectedBetweenSubPatternAndQuestionMark(_ newChild: UnexpectedNodesSyntax?) -> OptionalPatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return OptionalPatternSyntax(newData)
   }
 
@@ -702,10 +712,10 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `questionMark` replaced.
   /// - param newChild: The new `questionMark` to replace the node's
   ///                   current `questionMark`, if present.
-  public func withQuestionMark(
-    _ newChild: TokenSyntax?) -> OptionalPatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withQuestionMark(_ newChild: TokenSyntax?) -> OptionalPatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return OptionalPatternSyntax(newData)
   }
 
@@ -723,10 +733,10 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterQuestionMark` replaced.
   /// - param newChild: The new `unexpectedAfterQuestionMark` to replace the node's
   ///                   current `unexpectedAfterQuestionMark`, if present.
-  public func withUnexpectedAfterQuestionMark(
-    _ newChild: UnexpectedNodesSyntax?) -> OptionalPatternSyntax {
+  public func withUnexpectedAfterQuestionMark(_ newChild: UnexpectedNodesSyntax?) -> OptionalPatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return OptionalPatternSyntax(newData)
   }
 
@@ -800,9 +810,11 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       identifier.raw,
       unexpectedAfterIdentifier?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.identifierPattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.identifierPattern,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -820,10 +832,10 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeIdentifier` replaced.
   /// - param newChild: The new `unexpectedBeforeIdentifier` to replace the node's
   ///                   current `unexpectedBeforeIdentifier`, if present.
-  public func withUnexpectedBeforeIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> IdentifierPatternSyntax {
+  public func withUnexpectedBeforeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> IdentifierPatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return IdentifierPatternSyntax(newData)
   }
 
@@ -840,10 +852,10 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(
-    _ newChild: TokenSyntax?) -> IdentifierPatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.selfKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withIdentifier(_ newChild: TokenSyntax?) -> IdentifierPatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.selfKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return IdentifierPatternSyntax(newData)
   }
 
@@ -861,10 +873,10 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterIdentifier` replaced.
   /// - param newChild: The new `unexpectedAfterIdentifier` to replace the node's
   ///                   current `unexpectedAfterIdentifier`, if present.
-  public func withUnexpectedAfterIdentifier(
-    _ newChild: UnexpectedNodesSyntax?) -> IdentifierPatternSyntax {
+  public func withUnexpectedAfterIdentifier(_ newChild: UnexpectedNodesSyntax?) -> IdentifierPatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return IdentifierPatternSyntax(newData)
   }
 
@@ -938,9 +950,11 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       type.raw,
       unexpectedAfterType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.asTypePattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.asTypePattern,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -958,10 +972,10 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePattern` replaced.
   /// - param newChild: The new `unexpectedBeforePattern` to replace the node's
   ///                   current `unexpectedBeforePattern`, if present.
-  public func withUnexpectedBeforePattern(
-    _ newChild: UnexpectedNodesSyntax?) -> AsTypePatternSyntax {
+  public func withUnexpectedBeforePattern(_ newChild: UnexpectedNodesSyntax?) -> AsTypePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AsTypePatternSyntax(newData)
   }
 
@@ -978,10 +992,10 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(
-    _ newChild: PatternSyntax?) -> AsTypePatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPattern(_ newChild: PatternSyntax?) -> AsTypePatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AsTypePatternSyntax(newData)
   }
 
@@ -999,10 +1013,10 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPatternAndAsKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenPatternAndAsKeyword` to replace the node's
   ///                   current `unexpectedBetweenPatternAndAsKeyword`, if present.
-  public func withUnexpectedBetweenPatternAndAsKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> AsTypePatternSyntax {
+  public func withUnexpectedBetweenPatternAndAsKeyword(_ newChild: UnexpectedNodesSyntax?) -> AsTypePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AsTypePatternSyntax(newData)
   }
 
@@ -1019,10 +1033,10 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `asKeyword` replaced.
   /// - param newChild: The new `asKeyword` to replace the node's
   ///                   current `asKeyword`, if present.
-  public func withAsKeyword(
-    _ newChild: TokenSyntax?) -> AsTypePatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withAsKeyword(_ newChild: TokenSyntax?) -> AsTypePatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AsTypePatternSyntax(newData)
   }
 
@@ -1040,10 +1054,10 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAsKeywordAndType` replaced.
   /// - param newChild: The new `unexpectedBetweenAsKeywordAndType` to replace the node's
   ///                   current `unexpectedBetweenAsKeywordAndType`, if present.
-  public func withUnexpectedBetweenAsKeywordAndType(
-    _ newChild: UnexpectedNodesSyntax?) -> AsTypePatternSyntax {
+  public func withUnexpectedBetweenAsKeywordAndType(_ newChild: UnexpectedNodesSyntax?) -> AsTypePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AsTypePatternSyntax(newData)
   }
 
@@ -1060,10 +1074,10 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `type` replaced.
   /// - param newChild: The new `type` to replace the node's
   ///                   current `type`, if present.
-  public func withType(
-    _ newChild: TypeSyntax?) -> AsTypePatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withType(_ newChild: TypeSyntax?) -> AsTypePatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return AsTypePatternSyntax(newData)
   }
 
@@ -1081,10 +1095,10 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterType` replaced.
   /// - param newChild: The new `unexpectedAfterType` to replace the node's
   ///                   current `unexpectedAfterType`, if present.
-  public func withUnexpectedAfterType(
-    _ newChild: UnexpectedNodesSyntax?) -> AsTypePatternSyntax {
+  public func withUnexpectedAfterType(_ newChild: UnexpectedNodesSyntax?) -> AsTypePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return AsTypePatternSyntax(newData)
   }
 
@@ -1174,9 +1188,11 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePattern,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1194,10 +1210,10 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
   ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
+  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return TuplePatternSyntax(newData)
   }
 
@@ -1214,10 +1230,10 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> TuplePatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> TuplePatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return TuplePatternSyntax(newData)
   }
 
@@ -1235,10 +1251,10 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndElements` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndElements` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndElements`, if present.
-  public func withUnexpectedBetweenLeftParenAndElements(
-    _ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
+  public func withUnexpectedBetweenLeftParenAndElements(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return TuplePatternSyntax(newData)
   }
 
@@ -1260,23 +1276,24 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   ///            appended to its `elements` collection.
   public func addElement(_ element: TuplePatternElementSyntax) -> TuplePatternSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return TuplePatternSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `elements` replaced.
   /// - param newChild: The new `elements` to replace the node's
   ///                   current `elements`, if present.
-  public func withElements(
-    _ newChild: TuplePatternElementListSyntax?) -> TuplePatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tuplePatternElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withElements(_ newChild: TuplePatternElementListSyntax?) -> TuplePatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tuplePatternElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return TuplePatternSyntax(newData)
   }
 
@@ -1294,10 +1311,10 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenElementsAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenElementsAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenElementsAndRightParen`, if present.
-  public func withUnexpectedBetweenElementsAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
+  public func withUnexpectedBetweenElementsAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return TuplePatternSyntax(newData)
   }
 
@@ -1314,10 +1331,10 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> TuplePatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightParen(_ newChild: TokenSyntax?) -> TuplePatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return TuplePatternSyntax(newData)
   }
 
@@ -1335,10 +1352,10 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return TuplePatternSyntax(newData)
   }
 
@@ -1424,9 +1441,11 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       typeAnnotation?.raw,
       unexpectedAfterTypeAnnotation?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.wildcardPattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.wildcardPattern,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1444,10 +1463,10 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeWildcard` replaced.
   /// - param newChild: The new `unexpectedBeforeWildcard` to replace the node's
   ///                   current `unexpectedBeforeWildcard`, if present.
-  public func withUnexpectedBeforeWildcard(
-    _ newChild: UnexpectedNodesSyntax?) -> WildcardPatternSyntax {
+  public func withUnexpectedBeforeWildcard(_ newChild: UnexpectedNodesSyntax?) -> WildcardPatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return WildcardPatternSyntax(newData)
   }
 
@@ -1464,10 +1483,10 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `wildcard` replaced.
   /// - param newChild: The new `wildcard` to replace the node's
   ///                   current `wildcard`, if present.
-  public func withWildcard(
-    _ newChild: TokenSyntax?) -> WildcardPatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.wildcardKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withWildcard(_ newChild: TokenSyntax?) -> WildcardPatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.wildcardKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return WildcardPatternSyntax(newData)
   }
 
@@ -1485,10 +1504,10 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenWildcardAndTypeAnnotation` replaced.
   /// - param newChild: The new `unexpectedBetweenWildcardAndTypeAnnotation` to replace the node's
   ///                   current `unexpectedBetweenWildcardAndTypeAnnotation`, if present.
-  public func withUnexpectedBetweenWildcardAndTypeAnnotation(
-    _ newChild: UnexpectedNodesSyntax?) -> WildcardPatternSyntax {
+  public func withUnexpectedBetweenWildcardAndTypeAnnotation(_ newChild: UnexpectedNodesSyntax?) -> WildcardPatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return WildcardPatternSyntax(newData)
   }
 
@@ -1506,10 +1525,10 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typeAnnotation` replaced.
   /// - param newChild: The new `typeAnnotation` to replace the node's
   ///                   current `typeAnnotation`, if present.
-  public func withTypeAnnotation(
-    _ newChild: TypeAnnotationSyntax?) -> WildcardPatternSyntax {
+  public func withTypeAnnotation(_ newChild: TypeAnnotationSyntax?) -> WildcardPatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return WildcardPatternSyntax(newData)
   }
 
@@ -1527,10 +1546,10 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTypeAnnotation` replaced.
   /// - param newChild: The new `unexpectedAfterTypeAnnotation` to replace the node's
   ///                   current `unexpectedAfterTypeAnnotation`, if present.
-  public func withUnexpectedAfterTypeAnnotation(
-    _ newChild: UnexpectedNodesSyntax?) -> WildcardPatternSyntax {
+  public func withUnexpectedAfterTypeAnnotation(_ newChild: UnexpectedNodesSyntax?) -> WildcardPatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return WildcardPatternSyntax(newData)
   }
 
@@ -1604,9 +1623,11 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionPattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionPattern,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1624,10 +1645,10 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
   /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
   ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> ExpressionPatternSyntax {
+  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> ExpressionPatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ExpressionPatternSyntax(newData)
   }
 
@@ -1644,10 +1665,10 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> ExpressionPatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withExpression(_ newChild: ExprSyntax?) -> ExpressionPatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ExpressionPatternSyntax(newData)
   }
 
@@ -1665,10 +1686,10 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
   /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
   ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> ExpressionPatternSyntax {
+  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> ExpressionPatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ExpressionPatternSyntax(newData)
   }
 
@@ -1738,9 +1759,11 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       valuePattern.raw,
       unexpectedAfterValuePattern?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.valueBindingPattern,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.valueBindingPattern,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1758,10 +1781,10 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLetOrVarKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeLetOrVarKeyword` to replace the node's
   ///                   current `unexpectedBeforeLetOrVarKeyword`, if present.
-  public func withUnexpectedBeforeLetOrVarKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ValueBindingPatternSyntax {
+  public func withUnexpectedBeforeLetOrVarKeyword(_ newChild: UnexpectedNodesSyntax?) -> ValueBindingPatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ValueBindingPatternSyntax(newData)
   }
 
@@ -1778,10 +1801,10 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `letOrVarKeyword` replaced.
   /// - param newChild: The new `letOrVarKeyword` to replace the node's
   ///                   current `letOrVarKeyword`, if present.
-  public func withLetOrVarKeyword(
-    _ newChild: TokenSyntax?) -> ValueBindingPatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLetOrVarKeyword(_ newChild: TokenSyntax?) -> ValueBindingPatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ValueBindingPatternSyntax(newData)
   }
 
@@ -1799,10 +1822,10 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLetOrVarKeywordAndValuePattern` replaced.
   /// - param newChild: The new `unexpectedBetweenLetOrVarKeywordAndValuePattern` to replace the node's
   ///                   current `unexpectedBetweenLetOrVarKeywordAndValuePattern`, if present.
-  public func withUnexpectedBetweenLetOrVarKeywordAndValuePattern(
-    _ newChild: UnexpectedNodesSyntax?) -> ValueBindingPatternSyntax {
+  public func withUnexpectedBetweenLetOrVarKeywordAndValuePattern(_ newChild: UnexpectedNodesSyntax?) -> ValueBindingPatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ValueBindingPatternSyntax(newData)
   }
 
@@ -1819,10 +1842,10 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `valuePattern` replaced.
   /// - param newChild: The new `valuePattern` to replace the node's
   ///                   current `valuePattern`, if present.
-  public func withValuePattern(
-    _ newChild: PatternSyntax?) -> ValueBindingPatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withValuePattern(_ newChild: PatternSyntax?) -> ValueBindingPatternSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ValueBindingPatternSyntax(newData)
   }
 
@@ -1840,10 +1863,10 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterValuePattern` replaced.
   /// - param newChild: The new `unexpectedAfterValuePattern` to replace the node's
   ///                   current `unexpectedAfterValuePattern`, if present.
-  public func withUnexpectedAfterValuePattern(
-    _ newChild: UnexpectedNodesSyntax?) -> ValueBindingPatternSyntax {
+  public func withUnexpectedAfterValuePattern(_ newChild: UnexpectedNodesSyntax?) -> ValueBindingPatternSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ValueBindingPatternSyntax(newData)
   }
 

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -37,9 +37,11 @@ public struct UnknownStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ) {
     let layout: [RawSyntax?] = [
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unknownStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unknownStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -87,9 +89,11 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ) {
     let layout: [RawSyntax?] = [
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -151,9 +155,11 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       statement.raw,
       unexpectedAfterStatement?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.labeledStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.labeledStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -171,10 +177,10 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLabelName` replaced.
   /// - param newChild: The new `unexpectedBeforeLabelName` to replace the node's
   ///                   current `unexpectedBeforeLabelName`, if present.
-  public func withUnexpectedBeforeLabelName(
-    _ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
+  public func withUnexpectedBeforeLabelName(_ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return LabeledStmtSyntax(newData)
   }
 
@@ -191,10 +197,10 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `labelName` replaced.
   /// - param newChild: The new `labelName` to replace the node's
   ///                   current `labelName`, if present.
-  public func withLabelName(
-    _ newChild: TokenSyntax?) -> LabeledStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLabelName(_ newChild: TokenSyntax?) -> LabeledStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return LabeledStmtSyntax(newData)
   }
 
@@ -212,10 +218,10 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLabelNameAndLabelColon` replaced.
   /// - param newChild: The new `unexpectedBetweenLabelNameAndLabelColon` to replace the node's
   ///                   current `unexpectedBetweenLabelNameAndLabelColon`, if present.
-  public func withUnexpectedBetweenLabelNameAndLabelColon(
-    _ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
+  public func withUnexpectedBetweenLabelNameAndLabelColon(_ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return LabeledStmtSyntax(newData)
   }
 
@@ -232,10 +238,10 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `labelColon` replaced.
   /// - param newChild: The new `labelColon` to replace the node's
   ///                   current `labelColon`, if present.
-  public func withLabelColon(
-    _ newChild: TokenSyntax?) -> LabeledStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withLabelColon(_ newChild: TokenSyntax?) -> LabeledStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return LabeledStmtSyntax(newData)
   }
 
@@ -253,10 +259,10 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLabelColonAndStatement` replaced.
   /// - param newChild: The new `unexpectedBetweenLabelColonAndStatement` to replace the node's
   ///                   current `unexpectedBetweenLabelColonAndStatement`, if present.
-  public func withUnexpectedBetweenLabelColonAndStatement(
-    _ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
+  public func withUnexpectedBetweenLabelColonAndStatement(_ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return LabeledStmtSyntax(newData)
   }
 
@@ -273,10 +279,10 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `statement` replaced.
   /// - param newChild: The new `statement` to replace the node's
   ///                   current `statement`, if present.
-  public func withStatement(
-    _ newChild: StmtSyntax?) -> LabeledStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingStmt, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withStatement(_ newChild: StmtSyntax?) -> LabeledStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingStmt, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return LabeledStmtSyntax(newData)
   }
 
@@ -294,10 +300,10 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterStatement` replaced.
   /// - param newChild: The new `unexpectedAfterStatement` to replace the node's
   ///                   current `unexpectedAfterStatement`, if present.
-  public func withUnexpectedAfterStatement(
-    _ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
+  public func withUnexpectedAfterStatement(_ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return LabeledStmtSyntax(newData)
   }
 
@@ -383,9 +389,11 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       label?.raw,
       unexpectedAfterLabel?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.continueStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.continueStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -403,10 +411,10 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeContinueKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeContinueKeyword` to replace the node's
   ///                   current `unexpectedBeforeContinueKeyword`, if present.
-  public func withUnexpectedBeforeContinueKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ContinueStmtSyntax {
+  public func withUnexpectedBeforeContinueKeyword(_ newChild: UnexpectedNodesSyntax?) -> ContinueStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ContinueStmtSyntax(newData)
   }
 
@@ -423,10 +431,10 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `continueKeyword` replaced.
   /// - param newChild: The new `continueKeyword` to replace the node's
   ///                   current `continueKeyword`, if present.
-  public func withContinueKeyword(
-    _ newChild: TokenSyntax?) -> ContinueStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.continueKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withContinueKeyword(_ newChild: TokenSyntax?) -> ContinueStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.continueKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ContinueStmtSyntax(newData)
   }
 
@@ -444,10 +452,10 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenContinueKeywordAndLabel` replaced.
   /// - param newChild: The new `unexpectedBetweenContinueKeywordAndLabel` to replace the node's
   ///                   current `unexpectedBetweenContinueKeywordAndLabel`, if present.
-  public func withUnexpectedBetweenContinueKeywordAndLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> ContinueStmtSyntax {
+  public func withUnexpectedBetweenContinueKeywordAndLabel(_ newChild: UnexpectedNodesSyntax?) -> ContinueStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ContinueStmtSyntax(newData)
   }
 
@@ -465,10 +473,10 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `label` replaced.
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
-  public func withLabel(
-    _ newChild: TokenSyntax?) -> ContinueStmtSyntax {
+  public func withLabel(_ newChild: TokenSyntax?) -> ContinueStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ContinueStmtSyntax(newData)
   }
 
@@ -486,10 +494,10 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterLabel` replaced.
   /// - param newChild: The new `unexpectedAfterLabel` to replace the node's
   ///                   current `unexpectedAfterLabel`, if present.
-  public func withUnexpectedAfterLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> ContinueStmtSyntax {
+  public func withUnexpectedAfterLabel(_ newChild: UnexpectedNodesSyntax?) -> ContinueStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ContinueStmtSyntax(newData)
   }
 
@@ -571,9 +579,11 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       body.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.whileStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.whileStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -591,10 +601,10 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeWhileKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeWhileKeyword` to replace the node's
   ///                   current `unexpectedBeforeWhileKeyword`, if present.
-  public func withUnexpectedBeforeWhileKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
+  public func withUnexpectedBeforeWhileKeyword(_ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return WhileStmtSyntax(newData)
   }
 
@@ -611,10 +621,10 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `whileKeyword` replaced.
   /// - param newChild: The new `whileKeyword` to replace the node's
   ///                   current `whileKeyword`, if present.
-  public func withWhileKeyword(
-    _ newChild: TokenSyntax?) -> WhileStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whileKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withWhileKeyword(_ newChild: TokenSyntax?) -> WhileStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whileKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return WhileStmtSyntax(newData)
   }
 
@@ -632,10 +642,10 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenWhileKeywordAndConditions` replaced.
   /// - param newChild: The new `unexpectedBetweenWhileKeywordAndConditions` to replace the node's
   ///                   current `unexpectedBetweenWhileKeywordAndConditions`, if present.
-  public func withUnexpectedBetweenWhileKeywordAndConditions(
-    _ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
+  public func withUnexpectedBetweenWhileKeywordAndConditions(_ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return WhileStmtSyntax(newData)
   }
 
@@ -657,23 +667,24 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///            appended to its `conditions` collection.
   public func addCondition(_ element: ConditionElementSyntax) -> WhileStmtSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.conditionElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return WhileStmtSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `conditions` replaced.
   /// - param newChild: The new `conditions` to replace the node's
   ///                   current `conditions`, if present.
-  public func withConditions(
-    _ newChild: ConditionElementListSyntax?) -> WhileStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withConditions(_ newChild: ConditionElementListSyntax?) -> WhileStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return WhileStmtSyntax(newData)
   }
 
@@ -691,10 +702,10 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenConditionsAndBody` replaced.
   /// - param newChild: The new `unexpectedBetweenConditionsAndBody` to replace the node's
   ///                   current `unexpectedBetweenConditionsAndBody`, if present.
-  public func withUnexpectedBetweenConditionsAndBody(
-    _ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
+  public func withUnexpectedBetweenConditionsAndBody(_ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return WhileStmtSyntax(newData)
   }
 
@@ -711,10 +722,10 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(
-    _ newChild: CodeBlockSyntax?) -> WhileStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withBody(_ newChild: CodeBlockSyntax?) -> WhileStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return WhileStmtSyntax(newData)
   }
 
@@ -732,10 +743,10 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
   /// - param newChild: The new `unexpectedAfterBody` to replace the node's
   ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(
-    _ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
+  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return WhileStmtSyntax(newData)
   }
 
@@ -821,9 +832,11 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       body.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.deferStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.deferStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -841,10 +854,10 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeDeferKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeDeferKeyword` to replace the node's
   ///                   current `unexpectedBeforeDeferKeyword`, if present.
-  public func withUnexpectedBeforeDeferKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> DeferStmtSyntax {
+  public func withUnexpectedBeforeDeferKeyword(_ newChild: UnexpectedNodesSyntax?) -> DeferStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DeferStmtSyntax(newData)
   }
 
@@ -861,10 +874,10 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `deferKeyword` replaced.
   /// - param newChild: The new `deferKeyword` to replace the node's
   ///                   current `deferKeyword`, if present.
-  public func withDeferKeyword(
-    _ newChild: TokenSyntax?) -> DeferStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.deferKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withDeferKeyword(_ newChild: TokenSyntax?) -> DeferStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.deferKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DeferStmtSyntax(newData)
   }
 
@@ -882,10 +895,10 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenDeferKeywordAndBody` replaced.
   /// - param newChild: The new `unexpectedBetweenDeferKeywordAndBody` to replace the node's
   ///                   current `unexpectedBetweenDeferKeywordAndBody`, if present.
-  public func withUnexpectedBetweenDeferKeywordAndBody(
-    _ newChild: UnexpectedNodesSyntax?) -> DeferStmtSyntax {
+  public func withUnexpectedBetweenDeferKeywordAndBody(_ newChild: UnexpectedNodesSyntax?) -> DeferStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DeferStmtSyntax(newData)
   }
 
@@ -902,10 +915,10 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(
-    _ newChild: CodeBlockSyntax?) -> DeferStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withBody(_ newChild: CodeBlockSyntax?) -> DeferStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DeferStmtSyntax(newData)
   }
 
@@ -923,10 +936,10 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
   /// - param newChild: The new `unexpectedAfterBody` to replace the node's
   ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(
-    _ newChild: UnexpectedNodesSyntax?) -> DeferStmtSyntax {
+  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> DeferStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DeferStmtSyntax(newData)
   }
 
@@ -1000,9 +1013,11 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1020,10 +1035,10 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
   /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
   ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> ExpressionStmtSyntax {
+  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> ExpressionStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ExpressionStmtSyntax(newData)
   }
 
@@ -1040,10 +1055,10 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> ExpressionStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withExpression(_ newChild: ExprSyntax?) -> ExpressionStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ExpressionStmtSyntax(newData)
   }
 
@@ -1061,10 +1076,10 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
   /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
   ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> ExpressionStmtSyntax {
+  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> ExpressionStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ExpressionStmtSyntax(newData)
   }
 
@@ -1142,9 +1157,11 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       condition.raw,
       unexpectedAfterCondition?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.repeatWhileStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.repeatWhileStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1162,10 +1179,10 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeRepeatKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeRepeatKeyword` to replace the node's
   ///                   current `unexpectedBeforeRepeatKeyword`, if present.
-  public func withUnexpectedBeforeRepeatKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
+  public func withUnexpectedBeforeRepeatKeyword(_ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return RepeatWhileStmtSyntax(newData)
   }
 
@@ -1182,10 +1199,10 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `repeatKeyword` replaced.
   /// - param newChild: The new `repeatKeyword` to replace the node's
   ///                   current `repeatKeyword`, if present.
-  public func withRepeatKeyword(
-    _ newChild: TokenSyntax?) -> RepeatWhileStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.repeatKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withRepeatKeyword(_ newChild: TokenSyntax?) -> RepeatWhileStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.repeatKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return RepeatWhileStmtSyntax(newData)
   }
 
@@ -1203,10 +1220,10 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenRepeatKeywordAndBody` replaced.
   /// - param newChild: The new `unexpectedBetweenRepeatKeywordAndBody` to replace the node's
   ///                   current `unexpectedBetweenRepeatKeywordAndBody`, if present.
-  public func withUnexpectedBetweenRepeatKeywordAndBody(
-    _ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
+  public func withUnexpectedBetweenRepeatKeywordAndBody(_ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return RepeatWhileStmtSyntax(newData)
   }
 
@@ -1223,10 +1240,10 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(
-    _ newChild: CodeBlockSyntax?) -> RepeatWhileStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withBody(_ newChild: CodeBlockSyntax?) -> RepeatWhileStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return RepeatWhileStmtSyntax(newData)
   }
 
@@ -1244,10 +1261,10 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenBodyAndWhileKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenBodyAndWhileKeyword` to replace the node's
   ///                   current `unexpectedBetweenBodyAndWhileKeyword`, if present.
-  public func withUnexpectedBetweenBodyAndWhileKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
+  public func withUnexpectedBetweenBodyAndWhileKeyword(_ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return RepeatWhileStmtSyntax(newData)
   }
 
@@ -1264,10 +1281,10 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `whileKeyword` replaced.
   /// - param newChild: The new `whileKeyword` to replace the node's
   ///                   current `whileKeyword`, if present.
-  public func withWhileKeyword(
-    _ newChild: TokenSyntax?) -> RepeatWhileStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whileKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withWhileKeyword(_ newChild: TokenSyntax?) -> RepeatWhileStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whileKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return RepeatWhileStmtSyntax(newData)
   }
 
@@ -1285,10 +1302,10 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenWhileKeywordAndCondition` replaced.
   /// - param newChild: The new `unexpectedBetweenWhileKeywordAndCondition` to replace the node's
   ///                   current `unexpectedBetweenWhileKeywordAndCondition`, if present.
-  public func withUnexpectedBetweenWhileKeywordAndCondition(
-    _ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
+  public func withUnexpectedBetweenWhileKeywordAndCondition(_ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return RepeatWhileStmtSyntax(newData)
   }
 
@@ -1305,10 +1322,10 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `condition` replaced.
   /// - param newChild: The new `condition` to replace the node's
   ///                   current `condition`, if present.
-  public func withCondition(
-    _ newChild: ExprSyntax?) -> RepeatWhileStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withCondition(_ newChild: ExprSyntax?) -> RepeatWhileStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return RepeatWhileStmtSyntax(newData)
   }
 
@@ -1326,10 +1343,10 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterCondition` replaced.
   /// - param newChild: The new `unexpectedAfterCondition` to replace the node's
   ///                   current `unexpectedAfterCondition`, if present.
-  public func withUnexpectedAfterCondition(
-    _ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
+  public func withUnexpectedAfterCondition(_ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return RepeatWhileStmtSyntax(newData)
   }
 
@@ -1431,9 +1448,11 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       body.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.guardStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.guardStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1451,10 +1470,10 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeGuardKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeGuardKeyword` to replace the node's
   ///                   current `unexpectedBeforeGuardKeyword`, if present.
-  public func withUnexpectedBeforeGuardKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
+  public func withUnexpectedBeforeGuardKeyword(_ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return GuardStmtSyntax(newData)
   }
 
@@ -1471,10 +1490,10 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `guardKeyword` replaced.
   /// - param newChild: The new `guardKeyword` to replace the node's
   ///                   current `guardKeyword`, if present.
-  public func withGuardKeyword(
-    _ newChild: TokenSyntax?) -> GuardStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.guardKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withGuardKeyword(_ newChild: TokenSyntax?) -> GuardStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.guardKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return GuardStmtSyntax(newData)
   }
 
@@ -1492,10 +1511,10 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGuardKeywordAndConditions` replaced.
   /// - param newChild: The new `unexpectedBetweenGuardKeywordAndConditions` to replace the node's
   ///                   current `unexpectedBetweenGuardKeywordAndConditions`, if present.
-  public func withUnexpectedBetweenGuardKeywordAndConditions(
-    _ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
+  public func withUnexpectedBetweenGuardKeywordAndConditions(_ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return GuardStmtSyntax(newData)
   }
 
@@ -1517,23 +1536,24 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///            appended to its `conditions` collection.
   public func addCondition(_ element: ConditionElementSyntax) -> GuardStmtSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.conditionElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return GuardStmtSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `conditions` replaced.
   /// - param newChild: The new `conditions` to replace the node's
   ///                   current `conditions`, if present.
-  public func withConditions(
-    _ newChild: ConditionElementListSyntax?) -> GuardStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withConditions(_ newChild: ConditionElementListSyntax?) -> GuardStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return GuardStmtSyntax(newData)
   }
 
@@ -1551,10 +1571,10 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenConditionsAndElseKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenConditionsAndElseKeyword` to replace the node's
   ///                   current `unexpectedBetweenConditionsAndElseKeyword`, if present.
-  public func withUnexpectedBetweenConditionsAndElseKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
+  public func withUnexpectedBetweenConditionsAndElseKeyword(_ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return GuardStmtSyntax(newData)
   }
 
@@ -1571,10 +1591,10 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `elseKeyword` replaced.
   /// - param newChild: The new `elseKeyword` to replace the node's
   ///                   current `elseKeyword`, if present.
-  public func withElseKeyword(
-    _ newChild: TokenSyntax?) -> GuardStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.elseKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withElseKeyword(_ newChild: TokenSyntax?) -> GuardStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.elseKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return GuardStmtSyntax(newData)
   }
 
@@ -1592,10 +1612,10 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenElseKeywordAndBody` replaced.
   /// - param newChild: The new `unexpectedBetweenElseKeywordAndBody` to replace the node's
   ///                   current `unexpectedBetweenElseKeywordAndBody`, if present.
-  public func withUnexpectedBetweenElseKeywordAndBody(
-    _ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
+  public func withUnexpectedBetweenElseKeywordAndBody(_ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return GuardStmtSyntax(newData)
   }
 
@@ -1612,10 +1632,10 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(
-    _ newChild: CodeBlockSyntax?) -> GuardStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withBody(_ newChild: CodeBlockSyntax?) -> GuardStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return GuardStmtSyntax(newData)
   }
 
@@ -1633,10 +1653,10 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
   /// - param newChild: The new `unexpectedAfterBody` to replace the node's
   ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(
-    _ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
+  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return GuardStmtSyntax(newData)
   }
 
@@ -1762,9 +1782,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       body.raw,
       unexpectedAfterBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.forInStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.forInStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1782,10 +1804,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeForKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeForKeyword` to replace the node's
   ///                   current `unexpectedBeforeForKeyword`, if present.
-  public func withUnexpectedBeforeForKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+  public func withUnexpectedBeforeForKeyword(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -1802,10 +1824,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `forKeyword` replaced.
   /// - param newChild: The new `forKeyword` to replace the node's
   ///                   current `forKeyword`, if present.
-  public func withForKeyword(
-    _ newChild: TokenSyntax?) -> ForInStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.forKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withForKeyword(_ newChild: TokenSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.forKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -1823,10 +1845,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenForKeywordAndTryKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenForKeywordAndTryKeyword` to replace the node's
   ///                   current `unexpectedBetweenForKeywordAndTryKeyword`, if present.
-  public func withUnexpectedBetweenForKeywordAndTryKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+  public func withUnexpectedBetweenForKeywordAndTryKeyword(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -1844,10 +1866,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `tryKeyword` replaced.
   /// - param newChild: The new `tryKeyword` to replace the node's
   ///                   current `tryKeyword`, if present.
-  public func withTryKeyword(
-    _ newChild: TokenSyntax?) -> ForInStmtSyntax {
+  public func withTryKeyword(_ newChild: TokenSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -1865,10 +1887,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTryKeywordAndAwaitKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenTryKeywordAndAwaitKeyword` to replace the node's
   ///                   current `unexpectedBetweenTryKeywordAndAwaitKeyword`, if present.
-  public func withUnexpectedBetweenTryKeywordAndAwaitKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+  public func withUnexpectedBetweenTryKeywordAndAwaitKeyword(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -1886,10 +1908,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `awaitKeyword` replaced.
   /// - param newChild: The new `awaitKeyword` to replace the node's
   ///                   current `awaitKeyword`, if present.
-  public func withAwaitKeyword(
-    _ newChild: TokenSyntax?) -> ForInStmtSyntax {
+  public func withAwaitKeyword(_ newChild: TokenSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -1907,10 +1929,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAwaitKeywordAndCaseKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenAwaitKeywordAndCaseKeyword` to replace the node's
   ///                   current `unexpectedBetweenAwaitKeywordAndCaseKeyword`, if present.
-  public func withUnexpectedBetweenAwaitKeywordAndCaseKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+  public func withUnexpectedBetweenAwaitKeywordAndCaseKeyword(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -1928,10 +1950,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `caseKeyword` replaced.
   /// - param newChild: The new `caseKeyword` to replace the node's
   ///                   current `caseKeyword`, if present.
-  public func withCaseKeyword(
-    _ newChild: TokenSyntax?) -> ForInStmtSyntax {
+  public func withCaseKeyword(_ newChild: TokenSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -1949,10 +1971,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCaseKeywordAndPattern` replaced.
   /// - param newChild: The new `unexpectedBetweenCaseKeywordAndPattern` to replace the node's
   ///                   current `unexpectedBetweenCaseKeywordAndPattern`, if present.
-  public func withUnexpectedBetweenCaseKeywordAndPattern(
-    _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+  public func withUnexpectedBetweenCaseKeywordAndPattern(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -1969,10 +1991,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(
-    _ newChild: PatternSyntax?) -> ForInStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: 9)
+  public func withPattern(_ newChild: PatternSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -1990,10 +2012,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPatternAndTypeAnnotation` replaced.
   /// - param newChild: The new `unexpectedBetweenPatternAndTypeAnnotation` to replace the node's
   ///                   current `unexpectedBetweenPatternAndTypeAnnotation`, if present.
-  public func withUnexpectedBetweenPatternAndTypeAnnotation(
-    _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+  public func withUnexpectedBetweenPatternAndTypeAnnotation(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -2011,10 +2033,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typeAnnotation` replaced.
   /// - param newChild: The new `typeAnnotation` to replace the node's
   ///                   current `typeAnnotation`, if present.
-  public func withTypeAnnotation(
-    _ newChild: TypeAnnotationSyntax?) -> ForInStmtSyntax {
+  public func withTypeAnnotation(_ newChild: TypeAnnotationSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 11)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -2032,10 +2054,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenTypeAnnotationAndInKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenTypeAnnotationAndInKeyword` to replace the node's
   ///                   current `unexpectedBetweenTypeAnnotationAndInKeyword`, if present.
-  public func withUnexpectedBetweenTypeAnnotationAndInKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+  public func withUnexpectedBetweenTypeAnnotationAndInKeyword(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -2052,10 +2074,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `inKeyword` replaced.
   /// - param newChild: The new `inKeyword` to replace the node's
   ///                   current `inKeyword`, if present.
-  public func withInKeyword(
-    _ newChild: TokenSyntax?) -> ForInStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.inKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 13)
+  public func withInKeyword(_ newChild: TokenSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.inKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -2073,10 +2095,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenInKeywordAndSequenceExpr` replaced.
   /// - param newChild: The new `unexpectedBetweenInKeywordAndSequenceExpr` to replace the node's
   ///                   current `unexpectedBetweenInKeywordAndSequenceExpr`, if present.
-  public func withUnexpectedBetweenInKeywordAndSequenceExpr(
-    _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+  public func withUnexpectedBetweenInKeywordAndSequenceExpr(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -2093,10 +2115,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `sequenceExpr` replaced.
   /// - param newChild: The new `sequenceExpr` to replace the node's
   ///                   current `sequenceExpr`, if present.
-  public func withSequenceExpr(
-    _ newChild: ExprSyntax?) -> ForInStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 15)
+  public func withSequenceExpr(_ newChild: ExprSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 15, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -2114,10 +2136,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenSequenceExprAndWhereClause` replaced.
   /// - param newChild: The new `unexpectedBetweenSequenceExprAndWhereClause` to replace the node's
   ///                   current `unexpectedBetweenSequenceExprAndWhereClause`, if present.
-  public func withUnexpectedBetweenSequenceExprAndWhereClause(
-    _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+  public func withUnexpectedBetweenSequenceExprAndWhereClause(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 16)
+    let newData = data.replacingChild(raw, at: 16, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -2135,10 +2157,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `whereClause` replaced.
   /// - param newChild: The new `whereClause` to replace the node's
   ///                   current `whereClause`, if present.
-  public func withWhereClause(
-    _ newChild: WhereClauseSyntax?) -> ForInStmtSyntax {
+  public func withWhereClause(_ newChild: WhereClauseSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 17)
+    let newData = data.replacingChild(raw, at: 17, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -2156,10 +2178,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenWhereClauseAndBody` replaced.
   /// - param newChild: The new `unexpectedBetweenWhereClauseAndBody` to replace the node's
   ///                   current `unexpectedBetweenWhereClauseAndBody`, if present.
-  public func withUnexpectedBetweenWhereClauseAndBody(
-    _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+  public func withUnexpectedBetweenWhereClauseAndBody(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 18)
+    let newData = data.replacingChild(raw, at: 18, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -2176,10 +2198,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(
-    _ newChild: CodeBlockSyntax?) -> ForInStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: 19)
+  public func withBody(_ newChild: CodeBlockSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let newData = data.replacingChild(raw, at: 19, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -2197,10 +2219,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
   /// - param newChild: The new `unexpectedAfterBody` to replace the node's
   ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(
-    _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 20)
+    let newData = data.replacingChild(raw, at: 20, arena: arena)
     return ForInStmtSyntax(newData)
   }
 
@@ -2354,9 +2376,11 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       rightBrace.raw,
       unexpectedAfterRightBrace?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2374,10 +2398,10 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeSwitchKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeSwitchKeyword` to replace the node's
   ///                   current `unexpectedBeforeSwitchKeyword`, if present.
-  public func withUnexpectedBeforeSwitchKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
+  public func withUnexpectedBeforeSwitchKeyword(_ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return SwitchStmtSyntax(newData)
   }
 
@@ -2394,10 +2418,10 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `switchKeyword` replaced.
   /// - param newChild: The new `switchKeyword` to replace the node's
   ///                   current `switchKeyword`, if present.
-  public func withSwitchKeyword(
-    _ newChild: TokenSyntax?) -> SwitchStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.switchKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withSwitchKeyword(_ newChild: TokenSyntax?) -> SwitchStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.switchKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return SwitchStmtSyntax(newData)
   }
 
@@ -2415,10 +2439,10 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenSwitchKeywordAndExpression` replaced.
   /// - param newChild: The new `unexpectedBetweenSwitchKeywordAndExpression` to replace the node's
   ///                   current `unexpectedBetweenSwitchKeywordAndExpression`, if present.
-  public func withUnexpectedBetweenSwitchKeywordAndExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
+  public func withUnexpectedBetweenSwitchKeywordAndExpression(_ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return SwitchStmtSyntax(newData)
   }
 
@@ -2435,10 +2459,10 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> SwitchStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withExpression(_ newChild: ExprSyntax?) -> SwitchStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return SwitchStmtSyntax(newData)
   }
 
@@ -2456,10 +2480,10 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndLeftBrace` replaced.
   /// - param newChild: The new `unexpectedBetweenExpressionAndLeftBrace` to replace the node's
   ///                   current `unexpectedBetweenExpressionAndLeftBrace`, if present.
-  public func withUnexpectedBetweenExpressionAndLeftBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
+  public func withUnexpectedBetweenExpressionAndLeftBrace(_ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return SwitchStmtSyntax(newData)
   }
 
@@ -2476,10 +2500,10 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBrace` replaced.
   /// - param newChild: The new `leftBrace` to replace the node's
   ///                   current `leftBrace`, if present.
-  public func withLeftBrace(
-    _ newChild: TokenSyntax?) -> SwitchStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withLeftBrace(_ newChild: TokenSyntax?) -> SwitchStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return SwitchStmtSyntax(newData)
   }
 
@@ -2497,10 +2521,10 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftBraceAndCases` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftBraceAndCases` to replace the node's
   ///                   current `unexpectedBetweenLeftBraceAndCases`, if present.
-  public func withUnexpectedBetweenLeftBraceAndCases(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
+  public func withUnexpectedBetweenLeftBraceAndCases(_ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return SwitchStmtSyntax(newData)
   }
 
@@ -2522,23 +2546,24 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///            appended to its `cases` collection.
   public func addCase(_ element: Syntax) -> SwitchStmtSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[7] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 7)
+    let newData = data.replacingChild(collection, at: 7, arena: arena)
     return SwitchStmtSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `cases` replaced.
   /// - param newChild: The new `cases` to replace the node's
   ///                   current `cases`, if present.
-  public func withCases(
-    _ newChild: SwitchCaseListSyntax?) -> SwitchStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.switchCaseList, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withCases(_ newChild: SwitchCaseListSyntax?) -> SwitchStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.switchCaseList, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return SwitchStmtSyntax(newData)
   }
 
@@ -2556,10 +2581,10 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCasesAndRightBrace` replaced.
   /// - param newChild: The new `unexpectedBetweenCasesAndRightBrace` to replace the node's
   ///                   current `unexpectedBetweenCasesAndRightBrace`, if present.
-  public func withUnexpectedBetweenCasesAndRightBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
+  public func withUnexpectedBetweenCasesAndRightBrace(_ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return SwitchStmtSyntax(newData)
   }
 
@@ -2576,10 +2601,10 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBrace` replaced.
   /// - param newChild: The new `rightBrace` to replace the node's
   ///                   current `rightBrace`, if present.
-  public func withRightBrace(
-    _ newChild: TokenSyntax?) -> SwitchStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: 9)
+  public func withRightBrace(_ newChild: TokenSyntax?) -> SwitchStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return SwitchStmtSyntax(newData)
   }
 
@@ -2597,10 +2622,10 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
   /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
   ///                   current `unexpectedAfterRightBrace`, if present.
-  public func withUnexpectedAfterRightBrace(
-    _ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
+  public func withUnexpectedAfterRightBrace(_ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return SwitchStmtSyntax(newData)
   }
 
@@ -2706,9 +2731,11 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       catchClauses?.raw,
       unexpectedAfterCatchClauses?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.doStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.doStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2726,10 +2753,10 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeDoKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeDoKeyword` to replace the node's
   ///                   current `unexpectedBeforeDoKeyword`, if present.
-  public func withUnexpectedBeforeDoKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
+  public func withUnexpectedBeforeDoKeyword(_ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DoStmtSyntax(newData)
   }
 
@@ -2746,10 +2773,10 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `doKeyword` replaced.
   /// - param newChild: The new `doKeyword` to replace the node's
   ///                   current `doKeyword`, if present.
-  public func withDoKeyword(
-    _ newChild: TokenSyntax?) -> DoStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.doKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withDoKeyword(_ newChild: TokenSyntax?) -> DoStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.doKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DoStmtSyntax(newData)
   }
 
@@ -2767,10 +2794,10 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenDoKeywordAndBody` replaced.
   /// - param newChild: The new `unexpectedBetweenDoKeywordAndBody` to replace the node's
   ///                   current `unexpectedBetweenDoKeywordAndBody`, if present.
-  public func withUnexpectedBetweenDoKeywordAndBody(
-    _ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
+  public func withUnexpectedBetweenDoKeywordAndBody(_ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DoStmtSyntax(newData)
   }
 
@@ -2787,10 +2814,10 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(
-    _ newChild: CodeBlockSyntax?) -> DoStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withBody(_ newChild: CodeBlockSyntax?) -> DoStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DoStmtSyntax(newData)
   }
 
@@ -2808,10 +2835,10 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenBodyAndCatchClauses` replaced.
   /// - param newChild: The new `unexpectedBetweenBodyAndCatchClauses` to replace the node's
   ///                   current `unexpectedBetweenBodyAndCatchClauses`, if present.
-  public func withUnexpectedBetweenBodyAndCatchClauses(
-    _ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
+  public func withUnexpectedBetweenBodyAndCatchClauses(_ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DoStmtSyntax(newData)
   }
 
@@ -2834,23 +2861,24 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///            appended to its `catchClauses` collection.
   public func addCatchClause(_ element: CatchClauseSyntax) -> DoStmtSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.catchClauseList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 5)
+    let newData = data.replacingChild(collection, at: 5, arena: arena)
     return DoStmtSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `catchClauses` replaced.
   /// - param newChild: The new `catchClauses` to replace the node's
   ///                   current `catchClauses`, if present.
-  public func withCatchClauses(
-    _ newChild: CatchClauseListSyntax?) -> DoStmtSyntax {
+  public func withCatchClauses(_ newChild: CatchClauseListSyntax?) -> DoStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return DoStmtSyntax(newData)
   }
 
@@ -2868,10 +2896,10 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterCatchClauses` replaced.
   /// - param newChild: The new `unexpectedAfterCatchClauses` to replace the node's
   ///                   current `unexpectedAfterCatchClauses`, if present.
-  public func withUnexpectedAfterCatchClauses(
-    _ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
+  public func withUnexpectedAfterCatchClauses(_ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return DoStmtSyntax(newData)
   }
 
@@ -2957,9 +2985,11 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       expression?.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.returnStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.returnStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2977,10 +3007,10 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeReturnKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeReturnKeyword` to replace the node's
   ///                   current `unexpectedBeforeReturnKeyword`, if present.
-  public func withUnexpectedBeforeReturnKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ReturnStmtSyntax {
+  public func withUnexpectedBeforeReturnKeyword(_ newChild: UnexpectedNodesSyntax?) -> ReturnStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ReturnStmtSyntax(newData)
   }
 
@@ -2997,10 +3027,10 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `returnKeyword` replaced.
   /// - param newChild: The new `returnKeyword` to replace the node's
   ///                   current `returnKeyword`, if present.
-  public func withReturnKeyword(
-    _ newChild: TokenSyntax?) -> ReturnStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.returnKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withReturnKeyword(_ newChild: TokenSyntax?) -> ReturnStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.returnKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ReturnStmtSyntax(newData)
   }
 
@@ -3018,10 +3048,10 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenReturnKeywordAndExpression` replaced.
   /// - param newChild: The new `unexpectedBetweenReturnKeywordAndExpression` to replace the node's
   ///                   current `unexpectedBetweenReturnKeywordAndExpression`, if present.
-  public func withUnexpectedBetweenReturnKeywordAndExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> ReturnStmtSyntax {
+  public func withUnexpectedBetweenReturnKeywordAndExpression(_ newChild: UnexpectedNodesSyntax?) -> ReturnStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ReturnStmtSyntax(newData)
   }
 
@@ -3039,10 +3069,10 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> ReturnStmtSyntax {
+  public func withExpression(_ newChild: ExprSyntax?) -> ReturnStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ReturnStmtSyntax(newData)
   }
 
@@ -3060,10 +3090,10 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
   /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
   ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> ReturnStmtSyntax {
+  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> ReturnStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ReturnStmtSyntax(newData)
   }
 
@@ -3177,9 +3207,11 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       yields.raw,
       unexpectedAfterYields?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3197,10 +3229,10 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeYieldKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeYieldKeyword` to replace the node's
   ///                   current `unexpectedBeforeYieldKeyword`, if present.
-  public func withUnexpectedBeforeYieldKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> YieldStmtSyntax {
+  public func withUnexpectedBeforeYieldKeyword(_ newChild: UnexpectedNodesSyntax?) -> YieldStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return YieldStmtSyntax(newData)
   }
 
@@ -3217,10 +3249,10 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `yieldKeyword` replaced.
   /// - param newChild: The new `yieldKeyword` to replace the node's
   ///                   current `yieldKeyword`, if present.
-  public func withYieldKeyword(
-    _ newChild: TokenSyntax?) -> YieldStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.yield, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withYieldKeyword(_ newChild: TokenSyntax?) -> YieldStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.yield, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return YieldStmtSyntax(newData)
   }
 
@@ -3238,10 +3270,10 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenYieldKeywordAndYields` replaced.
   /// - param newChild: The new `unexpectedBetweenYieldKeywordAndYields` to replace the node's
   ///                   current `unexpectedBetweenYieldKeywordAndYields`, if present.
-  public func withUnexpectedBetweenYieldKeywordAndYields(
-    _ newChild: UnexpectedNodesSyntax?) -> YieldStmtSyntax {
+  public func withUnexpectedBetweenYieldKeywordAndYields(_ newChild: UnexpectedNodesSyntax?) -> YieldStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return YieldStmtSyntax(newData)
   }
 
@@ -3258,10 +3290,10 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `yields` replaced.
   /// - param newChild: The new `yields` to replace the node's
   ///                   current `yields`, if present.
-  public func withYields(
-    _ newChild: Yields?) -> YieldStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withYields(_ newChild: Yields?) -> YieldStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return YieldStmtSyntax(newData)
   }
 
@@ -3279,10 +3311,10 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterYields` replaced.
   /// - param newChild: The new `unexpectedAfterYields` to replace the node's
   ///                   current `unexpectedAfterYields`, if present.
-  public func withUnexpectedAfterYields(
-    _ newChild: UnexpectedNodesSyntax?) -> YieldStmtSyntax {
+  public func withUnexpectedAfterYields(_ newChild: UnexpectedNodesSyntax?) -> YieldStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return YieldStmtSyntax(newData)
   }
 
@@ -3356,9 +3388,11 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       fallthroughKeyword.raw,
       unexpectedAfterFallthroughKeyword?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.fallthroughStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.fallthroughStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3376,10 +3410,10 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeFallthroughKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeFallthroughKeyword` to replace the node's
   ///                   current `unexpectedBeforeFallthroughKeyword`, if present.
-  public func withUnexpectedBeforeFallthroughKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> FallthroughStmtSyntax {
+  public func withUnexpectedBeforeFallthroughKeyword(_ newChild: UnexpectedNodesSyntax?) -> FallthroughStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return FallthroughStmtSyntax(newData)
   }
 
@@ -3396,10 +3430,10 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `fallthroughKeyword` replaced.
   /// - param newChild: The new `fallthroughKeyword` to replace the node's
   ///                   current `fallthroughKeyword`, if present.
-  public func withFallthroughKeyword(
-    _ newChild: TokenSyntax?) -> FallthroughStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.fallthroughKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withFallthroughKeyword(_ newChild: TokenSyntax?) -> FallthroughStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.fallthroughKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return FallthroughStmtSyntax(newData)
   }
 
@@ -3417,10 +3451,10 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterFallthroughKeyword` replaced.
   /// - param newChild: The new `unexpectedAfterFallthroughKeyword` to replace the node's
   ///                   current `unexpectedAfterFallthroughKeyword`, if present.
-  public func withUnexpectedAfterFallthroughKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> FallthroughStmtSyntax {
+  public func withUnexpectedAfterFallthroughKeyword(_ newChild: UnexpectedNodesSyntax?) -> FallthroughStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return FallthroughStmtSyntax(newData)
   }
 
@@ -3490,9 +3524,11 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       label?.raw,
       unexpectedAfterLabel?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.breakStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.breakStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3510,10 +3546,10 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeBreakKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeBreakKeyword` to replace the node's
   ///                   current `unexpectedBeforeBreakKeyword`, if present.
-  public func withUnexpectedBeforeBreakKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> BreakStmtSyntax {
+  public func withUnexpectedBeforeBreakKeyword(_ newChild: UnexpectedNodesSyntax?) -> BreakStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return BreakStmtSyntax(newData)
   }
 
@@ -3530,10 +3566,10 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `breakKeyword` replaced.
   /// - param newChild: The new `breakKeyword` to replace the node's
   ///                   current `breakKeyword`, if present.
-  public func withBreakKeyword(
-    _ newChild: TokenSyntax?) -> BreakStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.breakKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withBreakKeyword(_ newChild: TokenSyntax?) -> BreakStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.breakKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return BreakStmtSyntax(newData)
   }
 
@@ -3551,10 +3587,10 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenBreakKeywordAndLabel` replaced.
   /// - param newChild: The new `unexpectedBetweenBreakKeywordAndLabel` to replace the node's
   ///                   current `unexpectedBetweenBreakKeywordAndLabel`, if present.
-  public func withUnexpectedBetweenBreakKeywordAndLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> BreakStmtSyntax {
+  public func withUnexpectedBetweenBreakKeywordAndLabel(_ newChild: UnexpectedNodesSyntax?) -> BreakStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return BreakStmtSyntax(newData)
   }
 
@@ -3572,10 +3608,10 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `label` replaced.
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
-  public func withLabel(
-    _ newChild: TokenSyntax?) -> BreakStmtSyntax {
+  public func withLabel(_ newChild: TokenSyntax?) -> BreakStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return BreakStmtSyntax(newData)
   }
 
@@ -3593,10 +3629,10 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterLabel` replaced.
   /// - param newChild: The new `unexpectedAfterLabel` to replace the node's
   ///                   current `unexpectedAfterLabel`, if present.
-  public func withUnexpectedAfterLabel(
-    _ newChild: UnexpectedNodesSyntax?) -> BreakStmtSyntax {
+  public func withUnexpectedAfterLabel(_ newChild: UnexpectedNodesSyntax?) -> BreakStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return BreakStmtSyntax(newData)
   }
 
@@ -3670,9 +3706,11 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       declaration.raw,
       unexpectedAfterDeclaration?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.declarationStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declarationStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3690,10 +3728,10 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeDeclaration` replaced.
   /// - param newChild: The new `unexpectedBeforeDeclaration` to replace the node's
   ///                   current `unexpectedBeforeDeclaration`, if present.
-  public func withUnexpectedBeforeDeclaration(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclarationStmtSyntax {
+  public func withUnexpectedBeforeDeclaration(_ newChild: UnexpectedNodesSyntax?) -> DeclarationStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DeclarationStmtSyntax(newData)
   }
 
@@ -3710,10 +3748,10 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `declaration` replaced.
   /// - param newChild: The new `declaration` to replace the node's
   ///                   current `declaration`, if present.
-  public func withDeclaration(
-    _ newChild: DeclSyntax?) -> DeclarationStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingDecl, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withDeclaration(_ newChild: DeclSyntax?) -> DeclarationStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingDecl, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DeclarationStmtSyntax(newData)
   }
 
@@ -3731,10 +3769,10 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterDeclaration` replaced.
   /// - param newChild: The new `unexpectedAfterDeclaration` to replace the node's
   ///                   current `unexpectedAfterDeclaration`, if present.
-  public func withUnexpectedAfterDeclaration(
-    _ newChild: UnexpectedNodesSyntax?) -> DeclarationStmtSyntax {
+  public func withUnexpectedAfterDeclaration(_ newChild: UnexpectedNodesSyntax?) -> DeclarationStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DeclarationStmtSyntax(newData)
   }
 
@@ -3804,9 +3842,11 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       expression.raw,
       unexpectedAfterExpression?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.throwStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.throwStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3824,10 +3864,10 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeThrowKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeThrowKeyword` to replace the node's
   ///                   current `unexpectedBeforeThrowKeyword`, if present.
-  public func withUnexpectedBeforeThrowKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ThrowStmtSyntax {
+  public func withUnexpectedBeforeThrowKeyword(_ newChild: UnexpectedNodesSyntax?) -> ThrowStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ThrowStmtSyntax(newData)
   }
 
@@ -3844,10 +3884,10 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `throwKeyword` replaced.
   /// - param newChild: The new `throwKeyword` to replace the node's
   ///                   current `throwKeyword`, if present.
-  public func withThrowKeyword(
-    _ newChild: TokenSyntax?) -> ThrowStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.throwKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withThrowKeyword(_ newChild: TokenSyntax?) -> ThrowStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.throwKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ThrowStmtSyntax(newData)
   }
 
@@ -3865,10 +3905,10 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenThrowKeywordAndExpression` replaced.
   /// - param newChild: The new `unexpectedBetweenThrowKeywordAndExpression` to replace the node's
   ///                   current `unexpectedBetweenThrowKeywordAndExpression`, if present.
-  public func withUnexpectedBetweenThrowKeywordAndExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> ThrowStmtSyntax {
+  public func withUnexpectedBetweenThrowKeywordAndExpression(_ newChild: UnexpectedNodesSyntax?) -> ThrowStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ThrowStmtSyntax(newData)
   }
 
@@ -3885,10 +3925,10 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(
-    _ newChild: ExprSyntax?) -> ThrowStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withExpression(_ newChild: ExprSyntax?) -> ThrowStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ThrowStmtSyntax(newData)
   }
 
@@ -3906,10 +3946,10 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
   /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
   ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(
-    _ newChild: UnexpectedNodesSyntax?) -> ThrowStmtSyntax {
+  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> ThrowStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ThrowStmtSyntax(newData)
   }
 
@@ -4035,9 +4075,11 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       elseBody?.raw,
       unexpectedAfterElseBody?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4055,10 +4097,10 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeIfKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeIfKeyword` to replace the node's
   ///                   current `unexpectedBeforeIfKeyword`, if present.
-  public func withUnexpectedBeforeIfKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
+  public func withUnexpectedBeforeIfKeyword(_ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return IfStmtSyntax(newData)
   }
 
@@ -4075,10 +4117,10 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `ifKeyword` replaced.
   /// - param newChild: The new `ifKeyword` to replace the node's
   ///                   current `ifKeyword`, if present.
-  public func withIfKeyword(
-    _ newChild: TokenSyntax?) -> IfStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.ifKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withIfKeyword(_ newChild: TokenSyntax?) -> IfStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.ifKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return IfStmtSyntax(newData)
   }
 
@@ -4096,10 +4138,10 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenIfKeywordAndConditions` replaced.
   /// - param newChild: The new `unexpectedBetweenIfKeywordAndConditions` to replace the node's
   ///                   current `unexpectedBetweenIfKeywordAndConditions`, if present.
-  public func withUnexpectedBetweenIfKeywordAndConditions(
-    _ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
+  public func withUnexpectedBetweenIfKeywordAndConditions(_ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return IfStmtSyntax(newData)
   }
 
@@ -4121,23 +4163,24 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///            appended to its `conditions` collection.
   public func addCondition(_ element: ConditionElementSyntax) -> IfStmtSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.conditionElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return IfStmtSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `conditions` replaced.
   /// - param newChild: The new `conditions` to replace the node's
   ///                   current `conditions`, if present.
-  public func withConditions(
-    _ newChild: ConditionElementListSyntax?) -> IfStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withConditions(_ newChild: ConditionElementListSyntax?) -> IfStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return IfStmtSyntax(newData)
   }
 
@@ -4155,10 +4198,10 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenConditionsAndBody` replaced.
   /// - param newChild: The new `unexpectedBetweenConditionsAndBody` to replace the node's
   ///                   current `unexpectedBetweenConditionsAndBody`, if present.
-  public func withUnexpectedBetweenConditionsAndBody(
-    _ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
+  public func withUnexpectedBetweenConditionsAndBody(_ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return IfStmtSyntax(newData)
   }
 
@@ -4175,10 +4218,10 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(
-    _ newChild: CodeBlockSyntax?) -> IfStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withBody(_ newChild: CodeBlockSyntax?) -> IfStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return IfStmtSyntax(newData)
   }
 
@@ -4196,10 +4239,10 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenBodyAndElseKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenBodyAndElseKeyword` to replace the node's
   ///                   current `unexpectedBetweenBodyAndElseKeyword`, if present.
-  public func withUnexpectedBetweenBodyAndElseKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
+  public func withUnexpectedBetweenBodyAndElseKeyword(_ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return IfStmtSyntax(newData)
   }
 
@@ -4217,10 +4260,10 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `elseKeyword` replaced.
   /// - param newChild: The new `elseKeyword` to replace the node's
   ///                   current `elseKeyword`, if present.
-  public func withElseKeyword(
-    _ newChild: TokenSyntax?) -> IfStmtSyntax {
+  public func withElseKeyword(_ newChild: TokenSyntax?) -> IfStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return IfStmtSyntax(newData)
   }
 
@@ -4238,10 +4281,10 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenElseKeywordAndElseBody` replaced.
   /// - param newChild: The new `unexpectedBetweenElseKeywordAndElseBody` to replace the node's
   ///                   current `unexpectedBetweenElseKeywordAndElseBody`, if present.
-  public func withUnexpectedBetweenElseKeywordAndElseBody(
-    _ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
+  public func withUnexpectedBetweenElseKeywordAndElseBody(_ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return IfStmtSyntax(newData)
   }
 
@@ -4259,10 +4302,10 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `elseBody` replaced.
   /// - param newChild: The new `elseBody` to replace the node's
   ///                   current `elseBody`, if present.
-  public func withElseBody(
-    _ newChild: ElseBody?) -> IfStmtSyntax {
+  public func withElseBody(_ newChild: ElseBody?) -> IfStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return IfStmtSyntax(newData)
   }
 
@@ -4280,10 +4323,10 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterElseBody` replaced.
   /// - param newChild: The new `unexpectedAfterElseBody` to replace the node's
   ///                   current `unexpectedAfterElseBody`, if present.
-  public func withUnexpectedAfterElseBody(
-    _ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
+  public func withUnexpectedAfterElseBody(_ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return IfStmtSyntax(newData)
   }
 
@@ -4401,9 +4444,11 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundAssertStmt,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundAssertStmt,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -4421,10 +4466,10 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePoundAssert` replaced.
   /// - param newChild: The new `unexpectedBeforePoundAssert` to replace the node's
   ///                   current `unexpectedBeforePoundAssert`, if present.
-  public func withUnexpectedBeforePoundAssert(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
+  public func withUnexpectedBeforePoundAssert(_ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
 
@@ -4441,10 +4486,10 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundAssert` replaced.
   /// - param newChild: The new `poundAssert` to replace the node's
   ///                   current `poundAssert`, if present.
-  public func withPoundAssert(
-    _ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundAssertKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPoundAssert(_ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundAssertKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
 
@@ -4462,10 +4507,10 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPoundAssertAndLeftParen` replaced.
   /// - param newChild: The new `unexpectedBetweenPoundAssertAndLeftParen` to replace the node's
   ///                   current `unexpectedBetweenPoundAssertAndLeftParen`, if present.
-  public func withUnexpectedBetweenPoundAssertAndLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
+  public func withUnexpectedBetweenPoundAssertAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
 
@@ -4482,10 +4527,10 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
 
@@ -4503,10 +4548,10 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndCondition` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndCondition` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndCondition`, if present.
-  public func withUnexpectedBetweenLeftParenAndCondition(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
+  public func withUnexpectedBetweenLeftParenAndCondition(_ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
 
@@ -4524,10 +4569,10 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `condition` replaced.
   /// - param newChild: The new `condition` to replace the node's
   ///                   current `condition`, if present.
-  public func withCondition(
-    _ newChild: ExprSyntax?) -> PoundAssertStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withCondition(_ newChild: ExprSyntax?) -> PoundAssertStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
 
@@ -4545,10 +4590,10 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenConditionAndComma` replaced.
   /// - param newChild: The new `unexpectedBetweenConditionAndComma` to replace the node's
   ///                   current `unexpectedBetweenConditionAndComma`, if present.
-  public func withUnexpectedBetweenConditionAndComma(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
+  public func withUnexpectedBetweenConditionAndComma(_ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
 
@@ -4567,10 +4612,10 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `comma` replaced.
   /// - param newChild: The new `comma` to replace the node's
   ///                   current `comma`, if present.
-  public func withComma(
-    _ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
+  public func withComma(_ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
 
@@ -4588,10 +4633,10 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndMessage` replaced.
   /// - param newChild: The new `unexpectedBetweenCommaAndMessage` to replace the node's
   ///                   current `unexpectedBetweenCommaAndMessage`, if present.
-  public func withUnexpectedBetweenCommaAndMessage(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
+  public func withUnexpectedBetweenCommaAndMessage(_ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
 
@@ -4610,10 +4655,10 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `message` replaced.
   /// - param newChild: The new `message` to replace the node's
   ///                   current `message`, if present.
-  public func withMessage(
-    _ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
+  public func withMessage(_ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
 
@@ -4631,10 +4676,10 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenMessageAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenMessageAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenMessageAndRightParen`, if present.
-  public func withUnexpectedBetweenMessageAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
+  public func withUnexpectedBetweenMessageAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
 
@@ -4651,10 +4696,10 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 11)
+  public func withRightParen(_ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
 
@@ -4672,10 +4717,10 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
 

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -37,9 +37,11 @@ public struct UnknownTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ) {
     let layout: [RawSyntax?] = [
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.unknownType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unknownType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -87,9 +89,11 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ) {
     let layout: [RawSyntax?] = [
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -147,9 +151,11 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       genericArgumentClause?.raw,
       unexpectedAfterGenericArgumentClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.simpleTypeIdentifier,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.simpleTypeIdentifier,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -167,10 +173,10 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
   /// - param newChild: The new `unexpectedBeforeName` to replace the node's
   ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(
-    _ newChild: UnexpectedNodesSyntax?) -> SimpleTypeIdentifierSyntax {
+  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> SimpleTypeIdentifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return SimpleTypeIdentifierSyntax(newData)
   }
 
@@ -187,10 +193,10 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> SimpleTypeIdentifierSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withName(_ newChild: TokenSyntax?) -> SimpleTypeIdentifierSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return SimpleTypeIdentifierSyntax(newData)
   }
 
@@ -208,10 +214,10 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndGenericArgumentClause` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndGenericArgumentClause` to replace the node's
   ///                   current `unexpectedBetweenNameAndGenericArgumentClause`, if present.
-  public func withUnexpectedBetweenNameAndGenericArgumentClause(
-    _ newChild: UnexpectedNodesSyntax?) -> SimpleTypeIdentifierSyntax {
+  public func withUnexpectedBetweenNameAndGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> SimpleTypeIdentifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return SimpleTypeIdentifierSyntax(newData)
   }
 
@@ -229,10 +235,10 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericArgumentClause` replaced.
   /// - param newChild: The new `genericArgumentClause` to replace the node's
   ///                   current `genericArgumentClause`, if present.
-  public func withGenericArgumentClause(
-    _ newChild: GenericArgumentClauseSyntax?) -> SimpleTypeIdentifierSyntax {
+  public func withGenericArgumentClause(_ newChild: GenericArgumentClauseSyntax?) -> SimpleTypeIdentifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return SimpleTypeIdentifierSyntax(newData)
   }
 
@@ -250,10 +256,10 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterGenericArgumentClause` replaced.
   /// - param newChild: The new `unexpectedAfterGenericArgumentClause` to replace the node's
   ///                   current `unexpectedAfterGenericArgumentClause`, if present.
-  public func withUnexpectedAfterGenericArgumentClause(
-    _ newChild: UnexpectedNodesSyntax?) -> SimpleTypeIdentifierSyntax {
+  public func withUnexpectedAfterGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> SimpleTypeIdentifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return SimpleTypeIdentifierSyntax(newData)
   }
 
@@ -339,9 +345,11 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       genericArgumentClause?.raw,
       unexpectedAfterGenericArgumentClause?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberTypeIdentifier,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberTypeIdentifier,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -359,10 +367,10 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeBaseType` replaced.
   /// - param newChild: The new `unexpectedBeforeBaseType` to replace the node's
   ///                   current `unexpectedBeforeBaseType`, if present.
-  public func withUnexpectedBeforeBaseType(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
+  public func withUnexpectedBeforeBaseType(_ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return MemberTypeIdentifierSyntax(newData)
   }
 
@@ -379,10 +387,10 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `baseType` replaced.
   /// - param newChild: The new `baseType` to replace the node's
   ///                   current `baseType`, if present.
-  public func withBaseType(
-    _ newChild: TypeSyntax?) -> MemberTypeIdentifierSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withBaseType(_ newChild: TypeSyntax?) -> MemberTypeIdentifierSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return MemberTypeIdentifierSyntax(newData)
   }
 
@@ -400,10 +408,10 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenBaseTypeAndPeriod` replaced.
   /// - param newChild: The new `unexpectedBetweenBaseTypeAndPeriod` to replace the node's
   ///                   current `unexpectedBetweenBaseTypeAndPeriod`, if present.
-  public func withUnexpectedBetweenBaseTypeAndPeriod(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
+  public func withUnexpectedBetweenBaseTypeAndPeriod(_ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return MemberTypeIdentifierSyntax(newData)
   }
 
@@ -420,10 +428,10 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `period` replaced.
   /// - param newChild: The new `period` to replace the node's
   ///                   current `period`, if present.
-  public func withPeriod(
-    _ newChild: TokenSyntax?) -> MemberTypeIdentifierSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withPeriod(_ newChild: TokenSyntax?) -> MemberTypeIdentifierSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return MemberTypeIdentifierSyntax(newData)
   }
 
@@ -441,10 +449,10 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPeriodAndName` replaced.
   /// - param newChild: The new `unexpectedBetweenPeriodAndName` to replace the node's
   ///                   current `unexpectedBetweenPeriodAndName`, if present.
-  public func withUnexpectedBetweenPeriodAndName(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
+  public func withUnexpectedBetweenPeriodAndName(_ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return MemberTypeIdentifierSyntax(newData)
   }
 
@@ -461,10 +469,10 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(
-    _ newChild: TokenSyntax?) -> MemberTypeIdentifierSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withName(_ newChild: TokenSyntax?) -> MemberTypeIdentifierSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return MemberTypeIdentifierSyntax(newData)
   }
 
@@ -482,10 +490,10 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenNameAndGenericArgumentClause` replaced.
   /// - param newChild: The new `unexpectedBetweenNameAndGenericArgumentClause` to replace the node's
   ///                   current `unexpectedBetweenNameAndGenericArgumentClause`, if present.
-  public func withUnexpectedBetweenNameAndGenericArgumentClause(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
+  public func withUnexpectedBetweenNameAndGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return MemberTypeIdentifierSyntax(newData)
   }
 
@@ -503,10 +511,10 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericArgumentClause` replaced.
   /// - param newChild: The new `genericArgumentClause` to replace the node's
   ///                   current `genericArgumentClause`, if present.
-  public func withGenericArgumentClause(
-    _ newChild: GenericArgumentClauseSyntax?) -> MemberTypeIdentifierSyntax {
+  public func withGenericArgumentClause(_ newChild: GenericArgumentClauseSyntax?) -> MemberTypeIdentifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return MemberTypeIdentifierSyntax(newData)
   }
 
@@ -524,10 +532,10 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterGenericArgumentClause` replaced.
   /// - param newChild: The new `unexpectedAfterGenericArgumentClause` to replace the node's
   ///                   current `unexpectedAfterGenericArgumentClause`, if present.
-  public func withUnexpectedAfterGenericArgumentClause(
-    _ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
+  public func withUnexpectedAfterGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return MemberTypeIdentifierSyntax(newData)
   }
 
@@ -617,9 +625,11 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       classKeyword.raw,
       unexpectedAfterClassKeyword?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.classRestrictionType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.classRestrictionType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -637,10 +647,10 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeClassKeyword` replaced.
   /// - param newChild: The new `unexpectedBeforeClassKeyword` to replace the node's
   ///                   current `unexpectedBeforeClassKeyword`, if present.
-  public func withUnexpectedBeforeClassKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ClassRestrictionTypeSyntax {
+  public func withUnexpectedBeforeClassKeyword(_ newChild: UnexpectedNodesSyntax?) -> ClassRestrictionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ClassRestrictionTypeSyntax(newData)
   }
 
@@ -657,10 +667,10 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `classKeyword` replaced.
   /// - param newChild: The new `classKeyword` to replace the node's
   ///                   current `classKeyword`, if present.
-  public func withClassKeyword(
-    _ newChild: TokenSyntax?) -> ClassRestrictionTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.classKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withClassKeyword(_ newChild: TokenSyntax?) -> ClassRestrictionTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.classKeyword, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ClassRestrictionTypeSyntax(newData)
   }
 
@@ -678,10 +688,10 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterClassKeyword` replaced.
   /// - param newChild: The new `unexpectedAfterClassKeyword` to replace the node's
   ///                   current `unexpectedAfterClassKeyword`, if present.
-  public func withUnexpectedAfterClassKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> ClassRestrictionTypeSyntax {
+  public func withUnexpectedAfterClassKeyword(_ newChild: UnexpectedNodesSyntax?) -> ClassRestrictionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ClassRestrictionTypeSyntax(newData)
   }
 
@@ -755,9 +765,11 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       rightSquareBracket.raw,
       unexpectedAfterRightSquareBracket?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -775,10 +787,10 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftSquareBracket` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftSquareBracket` to replace the node's
   ///                   current `unexpectedBeforeLeftSquareBracket`, if present.
-  public func withUnexpectedBeforeLeftSquareBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
+  public func withUnexpectedBeforeLeftSquareBracket(_ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ArrayTypeSyntax(newData)
   }
 
@@ -795,10 +807,10 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftSquareBracket` replaced.
   /// - param newChild: The new `leftSquareBracket` to replace the node's
   ///                   current `leftSquareBracket`, if present.
-  public func withLeftSquareBracket(
-    _ newChild: TokenSyntax?) -> ArrayTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftSquareBracket(_ newChild: TokenSyntax?) -> ArrayTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ArrayTypeSyntax(newData)
   }
 
@@ -816,10 +828,10 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftSquareBracketAndElementType` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftSquareBracketAndElementType` to replace the node's
   ///                   current `unexpectedBetweenLeftSquareBracketAndElementType`, if present.
-  public func withUnexpectedBetweenLeftSquareBracketAndElementType(
-    _ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
+  public func withUnexpectedBetweenLeftSquareBracketAndElementType(_ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ArrayTypeSyntax(newData)
   }
 
@@ -836,10 +848,10 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `elementType` replaced.
   /// - param newChild: The new `elementType` to replace the node's
   ///                   current `elementType`, if present.
-  public func withElementType(
-    _ newChild: TypeSyntax?) -> ArrayTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withElementType(_ newChild: TypeSyntax?) -> ArrayTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ArrayTypeSyntax(newData)
   }
 
@@ -857,10 +869,10 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenElementTypeAndRightSquareBracket` replaced.
   /// - param newChild: The new `unexpectedBetweenElementTypeAndRightSquareBracket` to replace the node's
   ///                   current `unexpectedBetweenElementTypeAndRightSquareBracket`, if present.
-  public func withUnexpectedBetweenElementTypeAndRightSquareBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
+  public func withUnexpectedBetweenElementTypeAndRightSquareBracket(_ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ArrayTypeSyntax(newData)
   }
 
@@ -877,10 +889,10 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightSquareBracket` replaced.
   /// - param newChild: The new `rightSquareBracket` to replace the node's
   ///                   current `rightSquareBracket`, if present.
-  public func withRightSquareBracket(
-    _ newChild: TokenSyntax?) -> ArrayTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightSquareBracket(_ newChild: TokenSyntax?) -> ArrayTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return ArrayTypeSyntax(newData)
   }
 
@@ -898,10 +910,10 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightSquareBracket` replaced.
   /// - param newChild: The new `unexpectedAfterRightSquareBracket` to replace the node's
   ///                   current `unexpectedAfterRightSquareBracket`, if present.
-  public func withUnexpectedAfterRightSquareBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
+  public func withUnexpectedAfterRightSquareBracket(_ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return ArrayTypeSyntax(newData)
   }
 
@@ -999,9 +1011,11 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       rightSquareBracket.raw,
       unexpectedAfterRightSquareBracket?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1019,10 +1033,10 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftSquareBracket` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftSquareBracket` to replace the node's
   ///                   current `unexpectedBeforeLeftSquareBracket`, if present.
-  public func withUnexpectedBeforeLeftSquareBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
+  public func withUnexpectedBeforeLeftSquareBracket(_ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
 
@@ -1039,10 +1053,10 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftSquareBracket` replaced.
   /// - param newChild: The new `leftSquareBracket` to replace the node's
   ///                   current `leftSquareBracket`, if present.
-  public func withLeftSquareBracket(
-    _ newChild: TokenSyntax?) -> DictionaryTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftSquareBracket(_ newChild: TokenSyntax?) -> DictionaryTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
 
@@ -1060,10 +1074,10 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftSquareBracketAndKeyType` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftSquareBracketAndKeyType` to replace the node's
   ///                   current `unexpectedBetweenLeftSquareBracketAndKeyType`, if present.
-  public func withUnexpectedBetweenLeftSquareBracketAndKeyType(
-    _ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
+  public func withUnexpectedBetweenLeftSquareBracketAndKeyType(_ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
 
@@ -1080,10 +1094,10 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `keyType` replaced.
   /// - param newChild: The new `keyType` to replace the node's
   ///                   current `keyType`, if present.
-  public func withKeyType(
-    _ newChild: TypeSyntax?) -> DictionaryTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withKeyType(_ newChild: TypeSyntax?) -> DictionaryTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
 
@@ -1101,10 +1115,10 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenKeyTypeAndColon` replaced.
   /// - param newChild: The new `unexpectedBetweenKeyTypeAndColon` to replace the node's
   ///                   current `unexpectedBetweenKeyTypeAndColon`, if present.
-  public func withUnexpectedBetweenKeyTypeAndColon(
-    _ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
+  public func withUnexpectedBetweenKeyTypeAndColon(_ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
 
@@ -1121,10 +1135,10 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(
-    _ newChild: TokenSyntax?) -> DictionaryTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withColon(_ newChild: TokenSyntax?) -> DictionaryTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
 
@@ -1142,10 +1156,10 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenColonAndValueType` replaced.
   /// - param newChild: The new `unexpectedBetweenColonAndValueType` to replace the node's
   ///                   current `unexpectedBetweenColonAndValueType`, if present.
-  public func withUnexpectedBetweenColonAndValueType(
-    _ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
+  public func withUnexpectedBetweenColonAndValueType(_ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
 
@@ -1162,10 +1176,10 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `valueType` replaced.
   /// - param newChild: The new `valueType` to replace the node's
   ///                   current `valueType`, if present.
-  public func withValueType(
-    _ newChild: TypeSyntax?) -> DictionaryTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+  public func withValueType(_ newChild: TypeSyntax?) -> DictionaryTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
 
@@ -1183,10 +1197,10 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenValueTypeAndRightSquareBracket` replaced.
   /// - param newChild: The new `unexpectedBetweenValueTypeAndRightSquareBracket` to replace the node's
   ///                   current `unexpectedBetweenValueTypeAndRightSquareBracket`, if present.
-  public func withUnexpectedBetweenValueTypeAndRightSquareBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
+  public func withUnexpectedBetweenValueTypeAndRightSquareBracket(_ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
 
@@ -1203,10 +1217,10 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightSquareBracket` replaced.
   /// - param newChild: The new `rightSquareBracket` to replace the node's
   ///                   current `rightSquareBracket`, if present.
-  public func withRightSquareBracket(
-    _ newChild: TokenSyntax?) -> DictionaryTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: 9)
+  public func withRightSquareBracket(_ newChild: TokenSyntax?) -> DictionaryTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
 
@@ -1224,10 +1238,10 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightSquareBracket` replaced.
   /// - param newChild: The new `unexpectedAfterRightSquareBracket` to replace the node's
   ///                   current `unexpectedAfterRightSquareBracket`, if present.
-  public func withUnexpectedAfterRightSquareBracket(
-    _ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
+  public func withUnexpectedAfterRightSquareBracket(_ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
 
@@ -1333,9 +1347,11 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       typeOrProtocol.raw,
       unexpectedAfterTypeOrProtocol?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.metatypeType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.metatypeType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1353,10 +1369,10 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeBaseType` replaced.
   /// - param newChild: The new `unexpectedBeforeBaseType` to replace the node's
   ///                   current `unexpectedBeforeBaseType`, if present.
-  public func withUnexpectedBeforeBaseType(
-    _ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
+  public func withUnexpectedBeforeBaseType(_ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return MetatypeTypeSyntax(newData)
   }
 
@@ -1373,10 +1389,10 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `baseType` replaced.
   /// - param newChild: The new `baseType` to replace the node's
   ///                   current `baseType`, if present.
-  public func withBaseType(
-    _ newChild: TypeSyntax?) -> MetatypeTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withBaseType(_ newChild: TypeSyntax?) -> MetatypeTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return MetatypeTypeSyntax(newData)
   }
 
@@ -1394,10 +1410,10 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenBaseTypeAndPeriod` replaced.
   /// - param newChild: The new `unexpectedBetweenBaseTypeAndPeriod` to replace the node's
   ///                   current `unexpectedBetweenBaseTypeAndPeriod`, if present.
-  public func withUnexpectedBetweenBaseTypeAndPeriod(
-    _ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
+  public func withUnexpectedBetweenBaseTypeAndPeriod(_ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return MetatypeTypeSyntax(newData)
   }
 
@@ -1414,10 +1430,10 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `period` replaced.
   /// - param newChild: The new `period` to replace the node's
   ///                   current `period`, if present.
-  public func withPeriod(
-    _ newChild: TokenSyntax?) -> MetatypeTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withPeriod(_ newChild: TokenSyntax?) -> MetatypeTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return MetatypeTypeSyntax(newData)
   }
 
@@ -1435,10 +1451,10 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPeriodAndTypeOrProtocol` replaced.
   /// - param newChild: The new `unexpectedBetweenPeriodAndTypeOrProtocol` to replace the node's
   ///                   current `unexpectedBetweenPeriodAndTypeOrProtocol`, if present.
-  public func withUnexpectedBetweenPeriodAndTypeOrProtocol(
-    _ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
+  public func withUnexpectedBetweenPeriodAndTypeOrProtocol(_ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return MetatypeTypeSyntax(newData)
   }
 
@@ -1455,10 +1471,10 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typeOrProtocol` replaced.
   /// - param newChild: The new `typeOrProtocol` to replace the node's
   ///                   current `typeOrProtocol`, if present.
-  public func withTypeOrProtocol(
-    _ newChild: TokenSyntax?) -> MetatypeTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withTypeOrProtocol(_ newChild: TokenSyntax?) -> MetatypeTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return MetatypeTypeSyntax(newData)
   }
 
@@ -1476,10 +1492,10 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterTypeOrProtocol` replaced.
   /// - param newChild: The new `unexpectedAfterTypeOrProtocol` to replace the node's
   ///                   current `unexpectedAfterTypeOrProtocol`, if present.
-  public func withUnexpectedAfterTypeOrProtocol(
-    _ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
+  public func withUnexpectedAfterTypeOrProtocol(_ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return MetatypeTypeSyntax(newData)
   }
 
@@ -1565,9 +1581,11 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       questionMark.raw,
       unexpectedAfterQuestionMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1585,10 +1603,10 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeWrappedType` replaced.
   /// - param newChild: The new `unexpectedBeforeWrappedType` to replace the node's
   ///                   current `unexpectedBeforeWrappedType`, if present.
-  public func withUnexpectedBeforeWrappedType(
-    _ newChild: UnexpectedNodesSyntax?) -> OptionalTypeSyntax {
+  public func withUnexpectedBeforeWrappedType(_ newChild: UnexpectedNodesSyntax?) -> OptionalTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return OptionalTypeSyntax(newData)
   }
 
@@ -1605,10 +1623,10 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `wrappedType` replaced.
   /// - param newChild: The new `wrappedType` to replace the node's
   ///                   current `wrappedType`, if present.
-  public func withWrappedType(
-    _ newChild: TypeSyntax?) -> OptionalTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withWrappedType(_ newChild: TypeSyntax?) -> OptionalTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return OptionalTypeSyntax(newData)
   }
 
@@ -1626,10 +1644,10 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenWrappedTypeAndQuestionMark` replaced.
   /// - param newChild: The new `unexpectedBetweenWrappedTypeAndQuestionMark` to replace the node's
   ///                   current `unexpectedBetweenWrappedTypeAndQuestionMark`, if present.
-  public func withUnexpectedBetweenWrappedTypeAndQuestionMark(
-    _ newChild: UnexpectedNodesSyntax?) -> OptionalTypeSyntax {
+  public func withUnexpectedBetweenWrappedTypeAndQuestionMark(_ newChild: UnexpectedNodesSyntax?) -> OptionalTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return OptionalTypeSyntax(newData)
   }
 
@@ -1646,10 +1664,10 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `questionMark` replaced.
   /// - param newChild: The new `questionMark` to replace the node's
   ///                   current `questionMark`, if present.
-  public func withQuestionMark(
-    _ newChild: TokenSyntax?) -> OptionalTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withQuestionMark(_ newChild: TokenSyntax?) -> OptionalTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return OptionalTypeSyntax(newData)
   }
 
@@ -1667,10 +1685,10 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterQuestionMark` replaced.
   /// - param newChild: The new `unexpectedAfterQuestionMark` to replace the node's
   ///                   current `unexpectedAfterQuestionMark`, if present.
-  public func withUnexpectedAfterQuestionMark(
-    _ newChild: UnexpectedNodesSyntax?) -> OptionalTypeSyntax {
+  public func withUnexpectedAfterQuestionMark(_ newChild: UnexpectedNodesSyntax?) -> OptionalTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return OptionalTypeSyntax(newData)
   }
 
@@ -1748,9 +1766,11 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       baseType.raw,
       unexpectedAfterBaseType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.constrainedSugarType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.constrainedSugarType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1768,10 +1788,10 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeSomeOrAnySpecifier` replaced.
   /// - param newChild: The new `unexpectedBeforeSomeOrAnySpecifier` to replace the node's
   ///                   current `unexpectedBeforeSomeOrAnySpecifier`, if present.
-  public func withUnexpectedBeforeSomeOrAnySpecifier(
-    _ newChild: UnexpectedNodesSyntax?) -> ConstrainedSugarTypeSyntax {
+  public func withUnexpectedBeforeSomeOrAnySpecifier(_ newChild: UnexpectedNodesSyntax?) -> ConstrainedSugarTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ConstrainedSugarTypeSyntax(newData)
   }
 
@@ -1788,10 +1808,10 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `someOrAnySpecifier` replaced.
   /// - param newChild: The new `someOrAnySpecifier` to replace the node's
   ///                   current `someOrAnySpecifier`, if present.
-  public func withSomeOrAnySpecifier(
-    _ newChild: TokenSyntax?) -> ConstrainedSugarTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withSomeOrAnySpecifier(_ newChild: TokenSyntax?) -> ConstrainedSugarTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ConstrainedSugarTypeSyntax(newData)
   }
 
@@ -1809,10 +1829,10 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenSomeOrAnySpecifierAndBaseType` replaced.
   /// - param newChild: The new `unexpectedBetweenSomeOrAnySpecifierAndBaseType` to replace the node's
   ///                   current `unexpectedBetweenSomeOrAnySpecifierAndBaseType`, if present.
-  public func withUnexpectedBetweenSomeOrAnySpecifierAndBaseType(
-    _ newChild: UnexpectedNodesSyntax?) -> ConstrainedSugarTypeSyntax {
+  public func withUnexpectedBetweenSomeOrAnySpecifierAndBaseType(_ newChild: UnexpectedNodesSyntax?) -> ConstrainedSugarTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ConstrainedSugarTypeSyntax(newData)
   }
 
@@ -1829,10 +1849,10 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `baseType` replaced.
   /// - param newChild: The new `baseType` to replace the node's
   ///                   current `baseType`, if present.
-  public func withBaseType(
-    _ newChild: TypeSyntax?) -> ConstrainedSugarTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withBaseType(_ newChild: TypeSyntax?) -> ConstrainedSugarTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ConstrainedSugarTypeSyntax(newData)
   }
 
@@ -1850,10 +1870,10 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterBaseType` replaced.
   /// - param newChild: The new `unexpectedAfterBaseType` to replace the node's
   ///                   current `unexpectedAfterBaseType`, if present.
-  public func withUnexpectedAfterBaseType(
-    _ newChild: UnexpectedNodesSyntax?) -> ConstrainedSugarTypeSyntax {
+  public func withUnexpectedAfterBaseType(_ newChild: UnexpectedNodesSyntax?) -> ConstrainedSugarTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ConstrainedSugarTypeSyntax(newData)
   }
 
@@ -1931,9 +1951,11 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
       exclamationMark.raw,
       unexpectedAfterExclamationMark?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.implicitlyUnwrappedOptionalType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.implicitlyUnwrappedOptionalType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -1951,10 +1973,10 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
   /// Returns a copy of the receiver with its `unexpectedBeforeWrappedType` replaced.
   /// - param newChild: The new `unexpectedBeforeWrappedType` to replace the node's
   ///                   current `unexpectedBeforeWrappedType`, if present.
-  public func withUnexpectedBeforeWrappedType(
-    _ newChild: UnexpectedNodesSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
+  public func withUnexpectedBeforeWrappedType(_ newChild: UnexpectedNodesSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
 
@@ -1971,10 +1993,10 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
   /// Returns a copy of the receiver with its `wrappedType` replaced.
   /// - param newChild: The new `wrappedType` to replace the node's
   ///                   current `wrappedType`, if present.
-  public func withWrappedType(
-    _ newChild: TypeSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withWrappedType(_ newChild: TypeSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
 
@@ -1992,10 +2014,10 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
   /// Returns a copy of the receiver with its `unexpectedBetweenWrappedTypeAndExclamationMark` replaced.
   /// - param newChild: The new `unexpectedBetweenWrappedTypeAndExclamationMark` to replace the node's
   ///                   current `unexpectedBetweenWrappedTypeAndExclamationMark`, if present.
-  public func withUnexpectedBetweenWrappedTypeAndExclamationMark(
-    _ newChild: UnexpectedNodesSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
+  public func withUnexpectedBetweenWrappedTypeAndExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
 
@@ -2012,10 +2034,10 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
   /// Returns a copy of the receiver with its `exclamationMark` replaced.
   /// - param newChild: The new `exclamationMark` to replace the node's
   ///                   current `exclamationMark`, if present.
-  public func withExclamationMark(
-    _ newChild: TokenSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.exclamationMark, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withExclamationMark(_ newChild: TokenSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.exclamationMark, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
 
@@ -2033,10 +2055,10 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
   /// Returns a copy of the receiver with its `unexpectedAfterExclamationMark` replaced.
   /// - param newChild: The new `unexpectedAfterExclamationMark` to replace the node's
   ///                   current `unexpectedAfterExclamationMark`, if present.
-  public func withUnexpectedAfterExclamationMark(
-    _ newChild: UnexpectedNodesSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
+  public func withUnexpectedAfterExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
 
@@ -2110,9 +2132,11 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       elements.raw,
       unexpectedAfterElements?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2130,10 +2154,10 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeElements` replaced.
   /// - param newChild: The new `unexpectedBeforeElements` to replace the node's
   ///                   current `unexpectedBeforeElements`, if present.
-  public func withUnexpectedBeforeElements(
-    _ newChild: UnexpectedNodesSyntax?) -> CompositionTypeSyntax {
+  public func withUnexpectedBeforeElements(_ newChild: UnexpectedNodesSyntax?) -> CompositionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return CompositionTypeSyntax(newData)
   }
 
@@ -2155,23 +2179,24 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///            appended to its `elements` collection.
   public func addElement(_ element: CompositionTypeElementSyntax) -> CompositionTypeSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[1] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 1)
+    let newData = data.replacingChild(collection, at: 1, arena: arena)
     return CompositionTypeSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `elements` replaced.
   /// - param newChild: The new `elements` to replace the node's
   ///                   current `elements`, if present.
-  public func withElements(
-    _ newChild: CompositionTypeElementListSyntax?) -> CompositionTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.compositionTypeElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withElements(_ newChild: CompositionTypeElementListSyntax?) -> CompositionTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.compositionTypeElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return CompositionTypeSyntax(newData)
   }
 
@@ -2189,10 +2214,10 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterElements` replaced.
   /// - param newChild: The new `unexpectedAfterElements` to replace the node's
   ///                   current `unexpectedAfterElements`, if present.
-  public func withUnexpectedAfterElements(
-    _ newChild: UnexpectedNodesSyntax?) -> CompositionTypeSyntax {
+  public func withUnexpectedAfterElements(_ newChild: UnexpectedNodesSyntax?) -> CompositionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return CompositionTypeSyntax(newData)
   }
 
@@ -2262,9 +2287,11 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       ellipsis.raw,
       unexpectedAfterEllipsis?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.packExpansionType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.packExpansionType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2282,10 +2309,10 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforePatternType` replaced.
   /// - param newChild: The new `unexpectedBeforePatternType` to replace the node's
   ///                   current `unexpectedBeforePatternType`, if present.
-  public func withUnexpectedBeforePatternType(
-    _ newChild: UnexpectedNodesSyntax?) -> PackExpansionTypeSyntax {
+  public func withUnexpectedBeforePatternType(_ newChild: UnexpectedNodesSyntax?) -> PackExpansionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return PackExpansionTypeSyntax(newData)
   }
 
@@ -2302,10 +2329,10 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `patternType` replaced.
   /// - param newChild: The new `patternType` to replace the node's
   ///                   current `patternType`, if present.
-  public func withPatternType(
-    _ newChild: TypeSyntax?) -> PackExpansionTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withPatternType(_ newChild: TypeSyntax?) -> PackExpansionTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return PackExpansionTypeSyntax(newData)
   }
 
@@ -2323,10 +2350,10 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenPatternTypeAndEllipsis` replaced.
   /// - param newChild: The new `unexpectedBetweenPatternTypeAndEllipsis` to replace the node's
   ///                   current `unexpectedBetweenPatternTypeAndEllipsis`, if present.
-  public func withUnexpectedBetweenPatternTypeAndEllipsis(
-    _ newChild: UnexpectedNodesSyntax?) -> PackExpansionTypeSyntax {
+  public func withUnexpectedBetweenPatternTypeAndEllipsis(_ newChild: UnexpectedNodesSyntax?) -> PackExpansionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return PackExpansionTypeSyntax(newData)
   }
 
@@ -2343,10 +2370,10 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `ellipsis` replaced.
   /// - param newChild: The new `ellipsis` to replace the node's
   ///                   current `ellipsis`, if present.
-  public func withEllipsis(
-    _ newChild: TokenSyntax?) -> PackExpansionTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.ellipsis, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withEllipsis(_ newChild: TokenSyntax?) -> PackExpansionTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.ellipsis, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return PackExpansionTypeSyntax(newData)
   }
 
@@ -2364,10 +2391,10 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterEllipsis` replaced.
   /// - param newChild: The new `unexpectedAfterEllipsis` to replace the node's
   ///                   current `unexpectedAfterEllipsis`, if present.
-  public func withUnexpectedAfterEllipsis(
-    _ newChild: UnexpectedNodesSyntax?) -> PackExpansionTypeSyntax {
+  public func withUnexpectedAfterEllipsis(_ newChild: UnexpectedNodesSyntax?) -> PackExpansionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return PackExpansionTypeSyntax(newData)
   }
 
@@ -2449,9 +2476,11 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       rightParen.raw,
       unexpectedAfterRightParen?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2469,10 +2498,10 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
   ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
+  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return TupleTypeSyntax(newData)
   }
 
@@ -2489,10 +2518,10 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> TupleTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> TupleTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return TupleTypeSyntax(newData)
   }
 
@@ -2510,10 +2539,10 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndElements` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndElements` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndElements`, if present.
-  public func withUnexpectedBetweenLeftParenAndElements(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
+  public func withUnexpectedBetweenLeftParenAndElements(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return TupleTypeSyntax(newData)
   }
 
@@ -2535,23 +2564,24 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///            appended to its `elements` collection.
   public func addElement(_ element: TupleTypeElementSyntax) -> TupleTypeSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return TupleTypeSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `elements` replaced.
   /// - param newChild: The new `elements` to replace the node's
   ///                   current `elements`, if present.
-  public func withElements(
-    _ newChild: TupleTypeElementListSyntax?) -> TupleTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleTypeElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withElements(_ newChild: TupleTypeElementListSyntax?) -> TupleTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleTypeElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return TupleTypeSyntax(newData)
   }
 
@@ -2569,10 +2599,10 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenElementsAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenElementsAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenElementsAndRightParen`, if present.
-  public func withUnexpectedBetweenElementsAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
+  public func withUnexpectedBetweenElementsAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return TupleTypeSyntax(newData)
   }
 
@@ -2589,10 +2619,10 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> TupleTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightParen(_ newChild: TokenSyntax?) -> TupleTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return TupleTypeSyntax(newData)
   }
 
@@ -2610,10 +2640,10 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
   /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
   ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
+  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return TupleTypeSyntax(newData)
   }
 
@@ -2719,9 +2749,11 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       returnType.raw,
       unexpectedAfterReturnType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -2739,10 +2771,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
   /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
   ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
@@ -2759,10 +2791,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(
-    _ newChild: TokenSyntax?) -> FunctionTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withLeftParen(_ newChild: TokenSyntax?) -> FunctionTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
@@ -2780,10 +2812,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArguments` replaced.
   /// - param newChild: The new `unexpectedBetweenLeftParenAndArguments` to replace the node's
   ///                   current `unexpectedBetweenLeftParenAndArguments`, if present.
-  public func withUnexpectedBetweenLeftParenAndArguments(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+  public func withUnexpectedBetweenLeftParenAndArguments(_ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
@@ -2805,23 +2837,24 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///            appended to its `arguments` collection.
   public func addArgument(_ element: TupleTypeElementSyntax) -> FunctionTypeSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElementList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `arguments` replaced.
   /// - param newChild: The new `arguments` to replace the node's
   ///                   current `arguments`, if present.
-  public func withArguments(
-    _ newChild: TupleTypeElementListSyntax?) -> FunctionTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleTypeElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withArguments(_ newChild: TupleTypeElementListSyntax?) -> FunctionTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleTypeElementList, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
@@ -2839,10 +2872,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenArgumentsAndRightParen` replaced.
   /// - param newChild: The new `unexpectedBetweenArgumentsAndRightParen` to replace the node's
   ///                   current `unexpectedBetweenArgumentsAndRightParen`, if present.
-  public func withUnexpectedBetweenArgumentsAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+  public func withUnexpectedBetweenArgumentsAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
@@ -2859,10 +2892,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(
-    _ newChild: TokenSyntax?) -> FunctionTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withRightParen(_ newChild: TokenSyntax?) -> FunctionTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
@@ -2880,10 +2913,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenRightParenAndAsyncKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenRightParenAndAsyncKeyword` to replace the node's
   ///                   current `unexpectedBetweenRightParenAndAsyncKeyword`, if present.
-  public func withUnexpectedBetweenRightParenAndAsyncKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+  public func withUnexpectedBetweenRightParenAndAsyncKeyword(_ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
@@ -2901,10 +2934,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `asyncKeyword` replaced.
   /// - param newChild: The new `asyncKeyword` to replace the node's
   ///                   current `asyncKeyword`, if present.
-  public func withAsyncKeyword(
-    _ newChild: TokenSyntax?) -> FunctionTypeSyntax {
+  public func withAsyncKeyword(_ newChild: TokenSyntax?) -> FunctionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 7, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
@@ -2922,10 +2955,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword` replaced.
   /// - param newChild: The new `unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword` to replace the node's
   ///                   current `unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword`, if present.
-  public func withUnexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+  public func withUnexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword(_ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 8)
+    let newData = data.replacingChild(raw, at: 8, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
@@ -2943,10 +2976,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `throwsOrRethrowsKeyword` replaced.
   /// - param newChild: The new `throwsOrRethrowsKeyword` to replace the node's
   ///                   current `throwsOrRethrowsKeyword`, if present.
-  public func withThrowsOrRethrowsKeyword(
-    _ newChild: TokenSyntax?) -> FunctionTypeSyntax {
+  public func withThrowsOrRethrowsKeyword(_ newChild: TokenSyntax?) -> FunctionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 9)
+    let newData = data.replacingChild(raw, at: 9, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
@@ -2964,10 +2997,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenThrowsOrRethrowsKeywordAndArrow` replaced.
   /// - param newChild: The new `unexpectedBetweenThrowsOrRethrowsKeywordAndArrow` to replace the node's
   ///                   current `unexpectedBetweenThrowsOrRethrowsKeywordAndArrow`, if present.
-  public func withUnexpectedBetweenThrowsOrRethrowsKeywordAndArrow(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+  public func withUnexpectedBetweenThrowsOrRethrowsKeywordAndArrow(_ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 10)
+    let newData = data.replacingChild(raw, at: 10, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
@@ -2984,10 +3017,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `arrow` replaced.
   /// - param newChild: The new `arrow` to replace the node's
   ///                   current `arrow`, if present.
-  public func withArrow(
-    _ newChild: TokenSyntax?) -> FunctionTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: .default)
-    let newData = data.replacingChild(raw, at: 11)
+  public func withArrow(_ newChild: TokenSyntax?) -> FunctionTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: arena)
+    let newData = data.replacingChild(raw, at: 11, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
@@ -3005,10 +3038,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenArrowAndReturnType` replaced.
   /// - param newChild: The new `unexpectedBetweenArrowAndReturnType` to replace the node's
   ///                   current `unexpectedBetweenArrowAndReturnType`, if present.
-  public func withUnexpectedBetweenArrowAndReturnType(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+  public func withUnexpectedBetweenArrowAndReturnType(_ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 12)
+    let newData = data.replacingChild(raw, at: 12, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
@@ -3025,10 +3058,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `returnType` replaced.
   /// - param newChild: The new `returnType` to replace the node's
   ///                   current `returnType`, if present.
-  public func withReturnType(
-    _ newChild: TypeSyntax?) -> FunctionTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 13)
+  public func withReturnType(_ newChild: TypeSyntax?) -> FunctionTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 13, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
@@ -3046,10 +3079,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterReturnType` replaced.
   /// - param newChild: The new `unexpectedAfterReturnType` to replace the node's
   ///                   current `unexpectedAfterReturnType`, if present.
-  public func withUnexpectedAfterReturnType(
-    _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+  public func withUnexpectedAfterReturnType(_ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 14)
+    let newData = data.replacingChild(raw, at: 14, arena: arena)
     return FunctionTypeSyntax(newData)
   }
 
@@ -3171,9 +3204,11 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       baseType.raw,
       unexpectedAfterBaseType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.attributedType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.attributedType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3191,10 +3226,10 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeSpecifier` replaced.
   /// - param newChild: The new `unexpectedBeforeSpecifier` to replace the node's
   ///                   current `unexpectedBeforeSpecifier`, if present.
-  public func withUnexpectedBeforeSpecifier(
-    _ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
+  public func withUnexpectedBeforeSpecifier(_ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return AttributedTypeSyntax(newData)
   }
 
@@ -3212,10 +3247,10 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `specifier` replaced.
   /// - param newChild: The new `specifier` to replace the node's
   ///                   current `specifier`, if present.
-  public func withSpecifier(
-    _ newChild: TokenSyntax?) -> AttributedTypeSyntax {
+  public func withSpecifier(_ newChild: TokenSyntax?) -> AttributedTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 1)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return AttributedTypeSyntax(newData)
   }
 
@@ -3233,10 +3268,10 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenSpecifierAndAttributes` replaced.
   /// - param newChild: The new `unexpectedBetweenSpecifierAndAttributes` to replace the node's
   ///                   current `unexpectedBetweenSpecifierAndAttributes`, if present.
-  public func withUnexpectedBetweenSpecifierAndAttributes(
-    _ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
+  public func withUnexpectedBetweenSpecifierAndAttributes(_ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return AttributedTypeSyntax(newData)
   }
 
@@ -3259,23 +3294,24 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> AttributedTypeSyntax {
     var collection: RawSyntax
+    let arena = SyntaxArena()
     if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
+      collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
-        from: [element.raw], arena: .default)
+        from: [element.raw], arena: arena)
     }
-    let newData = data.replacingChild(collection, at: 3)
+    let newData = data.replacingChild(collection, at: 3, arena: arena)
     return AttributedTypeSyntax(newData)
   }
 
   /// Returns a copy of the receiver with its `attributes` replaced.
   /// - param newChild: The new `attributes` to replace the node's
   ///                   current `attributes`, if present.
-  public func withAttributes(
-    _ newChild: AttributeListSyntax?) -> AttributedTypeSyntax {
+  public func withAttributes(_ newChild: AttributeListSyntax?) -> AttributedTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 3)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return AttributedTypeSyntax(newData)
   }
 
@@ -3293,10 +3329,10 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndBaseType` replaced.
   /// - param newChild: The new `unexpectedBetweenAttributesAndBaseType` to replace the node's
   ///                   current `unexpectedBetweenAttributesAndBaseType`, if present.
-  public func withUnexpectedBetweenAttributesAndBaseType(
-    _ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
+  public func withUnexpectedBetweenAttributesAndBaseType(_ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return AttributedTypeSyntax(newData)
   }
 
@@ -3313,10 +3349,10 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `baseType` replaced.
   /// - param newChild: The new `baseType` to replace the node's
   ///                   current `baseType`, if present.
-  public func withBaseType(
-    _ newChild: TypeSyntax?) -> AttributedTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 5)
+  public func withBaseType(_ newChild: TypeSyntax?) -> AttributedTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 5, arena: arena)
     return AttributedTypeSyntax(newData)
   }
 
@@ -3334,10 +3370,10 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterBaseType` replaced.
   /// - param newChild: The new `unexpectedAfterBaseType` to replace the node's
   ///                   current `unexpectedAfterBaseType`, if present.
-  public func withUnexpectedAfterBaseType(
-    _ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
+  public func withUnexpectedAfterBaseType(_ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
+    let newData = data.replacingChild(raw, at: 6, arena: arena)
     return AttributedTypeSyntax(newData)
   }
 
@@ -3423,9 +3459,11 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       baseType.raw,
       unexpectedAfterBaseType?.raw,
     ]
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.namedOpaqueReturnType,
-      from: layout, arena: .default)
-    let data = SyntaxData.forRoot(raw)
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.namedOpaqueReturnType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
     self.init(data)
   }
 
@@ -3443,10 +3481,10 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBeforeGenericParameters` replaced.
   /// - param newChild: The new `unexpectedBeforeGenericParameters` to replace the node's
   ///                   current `unexpectedBeforeGenericParameters`, if present.
-  public func withUnexpectedBeforeGenericParameters(
-    _ newChild: UnexpectedNodesSyntax?) -> NamedOpaqueReturnTypeSyntax {
+  public func withUnexpectedBeforeGenericParameters(_ newChild: UnexpectedNodesSyntax?) -> NamedOpaqueReturnTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 0)
+    let newData = data.replacingChild(raw, at: 0, arena: arena)
     return NamedOpaqueReturnTypeSyntax(newData)
   }
 
@@ -3463,10 +3501,10 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericParameters` replaced.
   /// - param newChild: The new `genericParameters` to replace the node's
   ///                   current `genericParameters`, if present.
-  public func withGenericParameters(
-    _ newChild: GenericParameterClauseSyntax?) -> NamedOpaqueReturnTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericParameterClause, arena: .default)
-    let newData = data.replacingChild(raw, at: 1)
+  public func withGenericParameters(_ newChild: GenericParameterClauseSyntax?) -> NamedOpaqueReturnTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericParameterClause, arena: arena)
+    let newData = data.replacingChild(raw, at: 1, arena: arena)
     return NamedOpaqueReturnTypeSyntax(newData)
   }
 
@@ -3484,10 +3522,10 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedBetweenGenericParametersAndBaseType` replaced.
   /// - param newChild: The new `unexpectedBetweenGenericParametersAndBaseType` to replace the node's
   ///                   current `unexpectedBetweenGenericParametersAndBaseType`, if present.
-  public func withUnexpectedBetweenGenericParametersAndBaseType(
-    _ newChild: UnexpectedNodesSyntax?) -> NamedOpaqueReturnTypeSyntax {
+  public func withUnexpectedBetweenGenericParametersAndBaseType(_ newChild: UnexpectedNodesSyntax?) -> NamedOpaqueReturnTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 2)
+    let newData = data.replacingChild(raw, at: 2, arena: arena)
     return NamedOpaqueReturnTypeSyntax(newData)
   }
 
@@ -3504,10 +3542,10 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `baseType` replaced.
   /// - param newChild: The new `baseType` to replace the node's
   ///                   current `baseType`, if present.
-  public func withBaseType(
-    _ newChild: TypeSyntax?) -> NamedOpaqueReturnTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public func withBaseType(_ newChild: TypeSyntax?) -> NamedOpaqueReturnTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(raw, at: 3, arena: arena)
     return NamedOpaqueReturnTypeSyntax(newData)
   }
 
@@ -3525,10 +3563,10 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `unexpectedAfterBaseType` replaced.
   /// - param newChild: The new `unexpectedAfterBaseType` to replace the node's
   ///                   current `unexpectedAfterBaseType`, if present.
-  public func withUnexpectedAfterBaseType(
-    _ newChild: UnexpectedNodesSyntax?) -> NamedOpaqueReturnTypeSyntax {
+  public func withUnexpectedAfterBaseType(_ newChild: UnexpectedNodesSyntax?) -> NamedOpaqueReturnTypeSyntax {
+    let arena = SyntaxArena()
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 4)
+    let newData = data.replacingChild(raw, at: 4, arena: arena)
     return NamedOpaqueReturnTypeSyntax(newData)
   }
 

--- a/gyb_syntax_support/__init__.py
+++ b/gyb_syntax_support/__init__.py
@@ -124,7 +124,7 @@ def make_missing_swift_child(child):
         if not token or not token.text:
             tok_kind += '("")'
         return f'RawSyntax.makeMissingToken(kind: TokenKind.{tok_kind}, ' + \
-            'arena: .default)'
+            'arena: arena)'
     else:
         if child.syntax_kind == "Syntax":
             missing_kind = "unknown"
@@ -133,7 +133,7 @@ def make_missing_swift_child(child):
         else:
             missing_kind = child.swift_syntax_kind
         return f'RawSyntax.makeEmptyLayout(kind: SyntaxKind.{missing_kind}, ' + \
-            'arena: .default)'
+            'arena: arena)'
 
 
 def create_node_map():


### PR DESCRIPTION
SyntaxArena.default was a global arena which just leaked. Eliminate it, and make all Syntax factory/modifier API use a new arena.

rdar://101894396