### PR TITLE
Add an Editor Extension for Testing Refactorings 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 *.xcodeproj
 # Ignore Data Xcode stores when opening the project directly
 /.swiftpm/xcode
+# Ignore user state in Xcode Projects
+*.xcuserdatad
+UserInterfaceState.xcuserstate
+xcuserdata/
 
 # We always build swiftSyntax of trunk dependencies. Ignore any fixed 
 # dependency versions.

--- a/EditorExtension/Host/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/EditorExtension/Host/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/EditorExtension/Host/HostApp.swift
+++ b/EditorExtension/Host/HostApp.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftUI
+
+@main struct HostApp: App {
+  var body: some Scene {
+    WindowGroup {
+      Text("I am a stub! Please build and run the 'SwiftRefactorExtension' scheme instead.")
+    }
+  }
+}

--- a/EditorExtension/Host/Info.plist
+++ b/EditorExtension/Host/Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2022 Apple Inc. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/EditorExtension/README.md
+++ b/EditorExtension/README.md
@@ -1,0 +1,107 @@
+# SwiftRefactor Source Editor Extension
+
+This directory contains an Xcode project that can be used for rapidly iterating
+on refactorings built with the SwiftRefactor library.
+
+## Project Structure
+
+The attached project contains two build schemes:
+
+- A host application
+- A [Source Editor Extension](https://developer.apple.com/documentation/xcodekit/creating_a_source_editor_extension)
+
+The Source Editor Extension is the only target of interest - the host
+application is vestigial and merely exists to provide a container application we
+can host the editor extension in.
+
+## Adding Refactoring Actions
+
+This extension automatically discovers refactoring actions present in the
+[SwiftRefactor](../Sources/SwiftRefactor) library in the SwiftSyntax package. To add a new refactoring
+action, add the corresponding conformance to `RefactoringProvider` and ensure
+that it is `public`. Rebuilding and relaunching the extension will pick up your
+changes and make them available in Xcode.
+
+## Testing Refactoring Actions in Xcode
+
+Because of code signature requirements, there is some one-time bookkeeping 
+to perform before Xcode will accept the plugin:
+
+### Code Signing
+
+- Open SwiftRefactorExtension.xcodeproj in Xcode 14+
+- Select the SwiftRefactorExtension project in the project navigator
+- Select the 'Host' Target
+- Navigate to the 'Signing & Capabilities' tab
+- Change the 'Team' field to your development team
+- Change the 'Signing Certificate' field to an appropriate Development certificate
+- Select the 'SwiftRefactorExtension' Target
+- Navigate to the 'Signing & Capabilities' tab
+- Change the 'Team' field to your development team
+- Change the 'Signing Certificate' field to an appropriate Development certificate
+
+### Running The Editor Extension
+
+- Select the 'SwiftRefactorExtension' scheme
+- Select 'My Mac' as the run destination
+- Select Product > Run
+- When prompted, select 'Xcode' as the app to run
+- Click 'Run'
+
+### Executing the Refactoring Action
+
+By now, there should be two copies of Xcode running: The Xcode you used to open 
+this project, and a new Xcode that has a gray dock icon. This gray Xcode is
+called the "inferior". The inferior is where the plugin runs both for security
+and debuggability. It is a full copy of Xcode, so you can open projects,
+edit and run code, and use all of the IDE's normal functionalities.
+
+To run the refactoring actions provided by SwiftRefactorExtension, open
+a project or package and select a Swift file in the file navigator. Select
+the `Editor` menu. At the very bottom of this menu, an entry called "Swift
+Refactoring" should now be visible. Each refactoring action is listed as a
+sub-menu, so mousing over it will reveal all of the actions that the editor
+extension detected at start up.
+
+Selecting a refactoring action will run it over the entire file. The plugin
+executes the corresponding `RefactoringProvider` and, whenever it recieves a
+non-`nil` response, it performs a structured edit of the syntax of the code.
+
+## Troubleshooting
+
+Here are some common issues you might encounter when using this project
+
+### The Code Doesn't Build
+
+You may be using a version of Xcode that is too old and does not contain Swift
+5.7 tools. Please ensure that you have the latest available tools from
+the Apple developer portal or Mac App Store.
+
+### I Don't See 'Swift Refactoring' in the Editor Menu
+
+This is usually caused by a code signing issue. Please ensure that you are
+signing *both* the Host application and the SwiftRefactorExtension products
+with a valid development team and are using a Development signing certificate.
+Xcode will refuse to load any improperly signed plugins.
+
+### I Don't See My Refactoring in the 'Swift Refactoring' Menu
+
+SwiftRefactoring relies on type metadata in the SwiftRefactor library to
+automatically ingest refactoring actions. To ensure that this metadata is
+available, make sure that any instances of `RefactoringProvider ` are declared
+`public`. Then rebuild the extension and relaunch the inferior Xcode.
+
+### I Still Don't See My Refactoring in the 'Swift Refactoring' Menu
+
+There is a known limitation of the automatic refactoring action discovery
+mechanism where it will not detect refactorings with `Context`s that are
+not Void. This is because the plugin has no way of knowing how to build custom
+`Context` instances. We hope to lift this restriction soon.
+
+## Requirements
+
+This project uses modern Swift features included with the Swift 5.7 release. As
+such, Xcode 14 is required to build this project. Additionally, source editor
+extensions are required to be code signed and associated with a development
+team. This extension *will not* be run if it is ad-hoc signed.
+

--- a/EditorExtension/SwiftRefactorExtension.xcodeproj/project.pbxproj
+++ b/EditorExtension/SwiftRefactorExtension.xcodeproj/project.pbxproj
@@ -1,0 +1,617 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 52;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		25F743FF1DA97E9000CCD5AD /* HostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F743FE1DA97E9000CCD5AD /* HostApp.swift */; };
+		25F744031DA97E9000CCD5AD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 25F744021DA97E9000CCD5AD /* Assets.xcassets */; };
+		25F744141DA97ED800CCD5AD /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25F744131DA97ED800CCD5AD /* Cocoa.framework */; };
+		25F744191DA97ED800CCD5AD /* SourceEditorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F744181DA97ED800CCD5AD /* SourceEditorExtension.swift */; };
+		25F7441B1DA97ED800CCD5AD /* SourceEditorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F7441A1DA97ED800CCD5AD /* SourceEditorCommand.swift */; };
+		25F7441F1DA97ED800CCD5AD /* Swift Refactor.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 25F744111DA97ED800CCD5AD /* Swift Refactor.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		999BA0FC2914963100706E88 /* XcodeKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 999BA0F42914952D00706E88 /* XcodeKit.framework */; };
+		999BA0FD2914963100706E88 /* XcodeKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 999BA0F42914952D00706E88 /* XcodeKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		999BA10B291497D300706E88 /* SwiftOperators in Frameworks */ = {isa = PBXBuildFile; productRef = 999BA10A291497D300706E88 /* SwiftOperators */; };
+		999BA10D291497D300706E88 /* SwiftParser in Frameworks */ = {isa = PBXBuildFile; productRef = 999BA10C291497D300706E88 /* SwiftParser */; };
+		999BA10F291497D300706E88 /* SwiftRefactor in Frameworks */ = {isa = PBXBuildFile; productRef = 999BA10E291497D300706E88 /* SwiftRefactor */; };
+		999BA111291497D300706E88 /* SwiftSyntax in Frameworks */ = {isa = PBXBuildFile; productRef = 999BA110291497D300706E88 /* SwiftSyntax */; };
+		999BA113291497D300706E88 /* SwiftSyntaxBuilder in Frameworks */ = {isa = PBXBuildFile; productRef = 999BA112291497D300706E88 /* SwiftSyntaxBuilder */; };
+		999BA11529149D8500706E88 /* CommandDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999BA11429149D8500706E88 /* CommandDiscovery.swift */; };
+		999BA11729149F4200706E88 /* Bridge.h in Sources */ = {isa = PBXBuildFile; fileRef = 999BA11629149F4200706E88 /* Bridge.h */; };
+		999BA11B2914B25900706E88 /* RefactoringRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999BA11A2914B25900706E88 /* RefactoringRegistry.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		25F7441D1DA97ED800CCD5AD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 25F743F31DA97E9000CCD5AD /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 25F744101DA97ED800CCD5AD;
+			remoteInfo = SwiftRefactorExtension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		25F744231DA97ED800CCD5AD /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				25F7441F1DA97ED800CCD5AD /* Swift Refactor.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		999BA0FE2914963100706E88 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				999BA0FD2914963100706E88 /* XcodeKit.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		25F743FB1DA97E9000CCD5AD /* Host.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Host.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		25F743FE1DA97E9000CCD5AD /* HostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostApp.swift; sourceTree = "<group>"; };
+		25F744021DA97E9000CCD5AD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		25F744071DA97E9000CCD5AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		25F744111DA97ED800CCD5AD /* Swift Refactor.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Swift Refactor.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		25F744131DA97ED800CCD5AD /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		25F744181DA97ED800CCD5AD /* SourceEditorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceEditorExtension.swift; sourceTree = "<group>"; };
+		25F7441A1DA97ED800CCD5AD /* SourceEditorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceEditorCommand.swift; sourceTree = "<group>"; };
+		25F7441C1DA97ED800CCD5AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		999BA0F42914952D00706E88 /* XcodeKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XcodeKit.framework; path = Library/Frameworks/XcodeKit.framework; sourceTree = DEVELOPER_DIR; };
+		999BA0F8291495FC00706E88 /* SwiftRefactorExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftRefactorExtension.entitlements; sourceTree = "<group>"; };
+		999BA0FF291497AD00706E88 /* swift-syntax */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "swift-syntax"; path = ..; sourceTree = "<group>"; };
+		999BA11429149D8500706E88 /* CommandDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandDiscovery.swift; sourceTree = "<group>"; };
+		999BA11629149F4200706E88 /* Bridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Bridge.h; sourceTree = "<group>"; };
+		999BA11A2914B25900706E88 /* RefactoringRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefactoringRegistry.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		25F743F81DA97E9000CCD5AD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		25F7440E1DA97ED800CCD5AD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				999BA10B291497D300706E88 /* SwiftOperators in Frameworks */,
+				999BA111291497D300706E88 /* SwiftSyntax in Frameworks */,
+				999BA10D291497D300706E88 /* SwiftParser in Frameworks */,
+				25F744141DA97ED800CCD5AD /* Cocoa.framework in Frameworks */,
+				999BA113291497D300706E88 /* SwiftSyntaxBuilder in Frameworks */,
+				999BA10F291497D300706E88 /* SwiftRefactor in Frameworks */,
+				999BA0FC2914963100706E88 /* XcodeKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		25F743F21DA97E9000CCD5AD = {
+			isa = PBXGroup;
+			children = (
+				999BA0FF291497AD00706E88 /* swift-syntax */,
+				25F743FD1DA97E9000CCD5AD /* Host */,
+				25F744151DA97ED800CCD5AD /* SwiftRefactorExtension */,
+				25F744121DA97ED800CCD5AD /* Frameworks */,
+				25F743FC1DA97E9000CCD5AD /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		25F743FC1DA97E9000CCD5AD /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				25F743FB1DA97E9000CCD5AD /* Host.app */,
+				25F744111DA97ED800CCD5AD /* Swift Refactor.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		25F743FD1DA97E9000CCD5AD /* Host */ = {
+			isa = PBXGroup;
+			children = (
+				25F743FE1DA97E9000CCD5AD /* HostApp.swift */,
+				25F744021DA97E9000CCD5AD /* Assets.xcassets */,
+				25F744071DA97E9000CCD5AD /* Info.plist */,
+			);
+			path = Host;
+			sourceTree = "<group>";
+		};
+		25F744121DA97ED800CCD5AD /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				999BA0F42914952D00706E88 /* XcodeKit.framework */,
+				25F744131DA97ED800CCD5AD /* Cocoa.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		25F744151DA97ED800CCD5AD /* SwiftRefactorExtension */ = {
+			isa = PBXGroup;
+			children = (
+				25F744181DA97ED800CCD5AD /* SourceEditorExtension.swift */,
+				25F7441A1DA97ED800CCD5AD /* SourceEditorCommand.swift */,
+				999BA11A2914B25900706E88 /* RefactoringRegistry.swift */,
+				999BA11429149D8500706E88 /* CommandDiscovery.swift */,
+				999BA11629149F4200706E88 /* Bridge.h */,
+				25F7441C1DA97ED800CCD5AD /* Info.plist */,
+				25F744161DA97ED800CCD5AD /* Supporting Files */,
+			);
+			path = SwiftRefactorExtension;
+			sourceTree = "<group>";
+		};
+		25F744161DA97ED800CCD5AD /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				999BA0F8291495FC00706E88 /* SwiftRefactorExtension.entitlements */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		25F743FA1DA97E9000CCD5AD /* Host */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 25F7440A1DA97E9000CCD5AD /* Build configuration list for PBXNativeTarget "Host" */;
+			buildPhases = (
+				25F743F71DA97E9000CCD5AD /* Sources */,
+				25F743F81DA97E9000CCD5AD /* Frameworks */,
+				25F743F91DA97E9000CCD5AD /* Resources */,
+				25F744231DA97ED800CCD5AD /* Embed Foundation Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				25F7441E1DA97ED800CCD5AD /* PBXTargetDependency */,
+			);
+			name = Host;
+			productName = Host;
+			productReference = 25F743FB1DA97E9000CCD5AD /* Host.app */;
+			productType = "com.apple.product-type.application";
+		};
+		25F744101DA97ED800CCD5AD /* SwiftRefactorExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 25F744201DA97ED800CCD5AD /* Build configuration list for PBXNativeTarget "SwiftRefactorExtension" */;
+			buildPhases = (
+				25F7440D1DA97ED800CCD5AD /* Sources */,
+				25F7440E1DA97ED800CCD5AD /* Frameworks */,
+				25F7440F1DA97ED800CCD5AD /* Resources */,
+				999BA0FE2914963100706E88 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				999BA101291497C700706E88 /* PBXTargetDependency */,
+				999BA103291497C700706E88 /* PBXTargetDependency */,
+				999BA105291497C700706E88 /* PBXTargetDependency */,
+				999BA107291497C700706E88 /* PBXTargetDependency */,
+				999BA109291497C700706E88 /* PBXTargetDependency */,
+			);
+			name = SwiftRefactorExtension;
+			packageProductDependencies = (
+				999BA10A291497D300706E88 /* SwiftOperators */,
+				999BA10C291497D300706E88 /* SwiftParser */,
+				999BA10E291497D300706E88 /* SwiftRefactor */,
+				999BA110291497D300706E88 /* SwiftSyntax */,
+				999BA112291497D300706E88 /* SwiftSyntaxBuilder */,
+			);
+			productName = SwiftRefactorExtension;
+			productReference = 25F744111DA97ED800CCD5AD /* Swift Refactor.appex */;
+			productType = "com.apple.product-type.xcode-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		25F743F31DA97E9000CCD5AD /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0800;
+				LastUpgradeCheck = 1430;
+				ORGANIZATIONNAME = sergdort;
+				TargetAttributes = {
+					25F743FA1DA97E9000CCD5AD = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+					};
+					25F744101DA97ED800CCD5AD = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 25F743F61DA97E9000CCD5AD /* Build configuration list for PBXProject "SwiftRefactorExtension" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 25F743F21DA97E9000CCD5AD;
+			productRefGroup = 25F743FC1DA97E9000CCD5AD /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				25F743FA1DA97E9000CCD5AD /* Host */,
+				25F744101DA97ED800CCD5AD /* SwiftRefactorExtension */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		25F743F91DA97E9000CCD5AD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				25F744031DA97E9000CCD5AD /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		25F7440F1DA97ED800CCD5AD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		25F743F71DA97E9000CCD5AD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				25F743FF1DA97E9000CCD5AD /* HostApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		25F7440D1DA97ED800CCD5AD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				999BA11729149F4200706E88 /* Bridge.h in Sources */,
+				999BA11B2914B25900706E88 /* RefactoringRegistry.swift in Sources */,
+				999BA11529149D8500706E88 /* CommandDiscovery.swift in Sources */,
+				25F744191DA97ED800CCD5AD /* SourceEditorExtension.swift in Sources */,
+				25F7441B1DA97ED800CCD5AD /* SourceEditorCommand.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		25F7441E1DA97ED800CCD5AD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 25F744101DA97ED800CCD5AD /* SwiftRefactorExtension */;
+			targetProxy = 25F7441D1DA97ED800CCD5AD /* PBXContainerItemProxy */;
+		};
+		999BA101291497C700706E88 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 999BA100291497C700706E88 /* SwiftOperators */;
+		};
+		999BA103291497C700706E88 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 999BA102291497C700706E88 /* SwiftParser */;
+		};
+		999BA105291497C700706E88 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 999BA104291497C700706E88 /* SwiftRefactor */;
+		};
+		999BA107291497C700706E88 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 999BA106291497C700706E88 /* SwiftSyntax */;
+		};
+		999BA109291497C700706E88 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 999BA108291497C700706E88 /* SwiftSyntaxBuilder */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		25F744081DA97E9000CCD5AD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		25F744091DA97E9000CCD5AD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		25F7440B1DA97E9000CCD5AD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Host/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.apple.dt.swift.swift-syntax.swift-refactor.host";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		25F7440C1DA97E9000CCD5AD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Host/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.apple.dt.swift.swift-syntax.swift-refactor.host";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		25F744211DA97ED800CCD5AD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = SwiftRefactorExtension/SwiftRefactorExtension.entitlements;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				INFOPLIST_FILE = SwiftRefactorExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.apple.dt.swift.swift-syntax.swift-refactor.extension";
+				PRODUCT_NAME = "Swift Refactor";
+				SKIP_INSTALL = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/SwiftRefactorExtension/Bridge.h";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_PRECOMPILE_BRIDGING_HEADER = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		25F744221DA97ED800CCD5AD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = SwiftRefactorExtension/SwiftRefactorExtension.entitlements;
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_HARDENED_RUNTIME = YES;
+				INFOPLIST_FILE = SwiftRefactorExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.apple.dt.swift.swift-syntax.swift-refactor.extension";
+				PRODUCT_NAME = "Swift Refactor";
+				SKIP_INSTALL = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/SwiftRefactorExtension/Bridge.h";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_PRECOMPILE_BRIDGING_HEADER = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		25F743F61DA97E9000CCD5AD /* Build configuration list for PBXProject "SwiftRefactorExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				25F744081DA97E9000CCD5AD /* Debug */,
+				25F744091DA97E9000CCD5AD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		25F7440A1DA97E9000CCD5AD /* Build configuration list for PBXNativeTarget "Host" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				25F7440B1DA97E9000CCD5AD /* Debug */,
+				25F7440C1DA97E9000CCD5AD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		25F744201DA97ED800CCD5AD /* Build configuration list for PBXNativeTarget "SwiftRefactorExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				25F744211DA97ED800CCD5AD /* Debug */,
+				25F744221DA97ED800CCD5AD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		999BA100291497C700706E88 /* SwiftOperators */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SwiftOperators;
+		};
+		999BA102291497C700706E88 /* SwiftParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SwiftParser;
+		};
+		999BA104291497C700706E88 /* SwiftRefactor */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SwiftRefactor;
+		};
+		999BA106291497C700706E88 /* SwiftSyntax */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SwiftSyntax;
+		};
+		999BA108291497C700706E88 /* SwiftSyntaxBuilder */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SwiftSyntaxBuilder;
+		};
+		999BA10A291497D300706E88 /* SwiftOperators */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SwiftOperators;
+		};
+		999BA10C291497D300706E88 /* SwiftParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SwiftParser;
+		};
+		999BA10E291497D300706E88 /* SwiftRefactor */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SwiftRefactor;
+		};
+		999BA110291497D300706E88 /* SwiftSyntax */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SwiftSyntax;
+		};
+		999BA112291497D300706E88 /* SwiftSyntaxBuilder */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SwiftSyntaxBuilder;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 25F743F31DA97E9000CCD5AD /* Project object */;
+}

--- a/EditorExtension/SwiftRefactorExtension.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/EditorExtension/SwiftRefactorExtension.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/EditorExtension/SwiftRefactorExtension.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/EditorExtension/SwiftRefactorExtension.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/EditorExtension/SwiftRefactorExtension.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EditorExtension/SwiftRefactorExtension.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+        "state": {
+          "branch": null,
+          "revision": "9f39744e025c7d377987f30b03770805dcb0bcd1",
+          "version": "1.1.4"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/EditorExtension/SwiftRefactorExtension.xcodeproj/xcshareddata/xcschemes/SwiftRefactorExtension.xcscheme
+++ b/EditorExtension/SwiftRefactorExtension.xcodeproj/xcshareddata/xcschemes/SwiftRefactorExtension.xcscheme
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "25F744101DA97ED800CCD5AD"
+               BuildableName = "Swift Refactor.appex"
+               BlueprintName = "SwiftRefactorExtension"
+               ReferencedContainer = "container:SwiftRefactorExtension.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "25F743FA1DA97E9000CCD5AD"
+               BuildableName = "Host.app"
+               BlueprintName = "Host"
+               ReferencedContainer = "container:SwiftRefactorExtension.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <RemoteRunnable
+         runnableDebuggingMode = "0"
+         BundleIdentifier = "com.apple.dt.Xcode"
+         RemotePath = "/Applications/Xcode-Summit.app">
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "25F743FA1DA97E9000CCD5AD"
+            BuildableName = "Host.app"
+            BlueprintName = "Host"
+            ReferencedContainer = "container:SwiftRefactorExtension.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "25F743FA1DA97E9000CCD5AD"
+            BuildableName = "Host.app"
+            BlueprintName = "Host"
+            ReferencedContainer = "container:SwiftRefactorExtension.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+   <InstallAction
+      buildConfiguration = "Release">
+   </InstallAction>
+</Scheme>

--- a/EditorExtension/SwiftRefactorExtension/Bridge.h
+++ b/EditorExtension/SwiftRefactorExtension/Bridge.h
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "stdint.h"
+
+struct ConformanceDescriptor {
+  int32_t protocol;
+  int32_t typeRef;
+  int32_t witnessTablePattern;
+  uint32_t flags;
+};
+
+struct ContextDescriptor {
+  uint32_t flags;
+  int32_t parent;
+};
+
+struct ModuleContextDescriptor {
+  uint32_t flags;
+  int32_t parent;
+  int32_t name;
+};
+
+struct TypeContextDescriptor {
+  uint32_t flags;
+  int32_t parent;
+  int32_t name;
+  int32_t accessor;
+};

--- a/EditorExtension/SwiftRefactorExtension/CommandDiscovery.swift
+++ b/EditorExtension/SwiftRefactorExtension/CommandDiscovery.swift
@@ -1,0 +1,184 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Darwin
+import MachO
+import Foundation
+import SwiftRefactor
+
+extension SourceEditorExtension {
+  static func forEachRefactoringProvider(_ action: (any RefactoringProvider.Type) -> Void) {
+    guard let header = _dyld_get_image_header(0) else {
+      return
+    }
+
+    var size: UInt = 0
+    let section = header.withMemoryRebound(to: mach_header_64.self, capacity: 1) { pointer in
+      getsectiondata(pointer, "__TEXT", "__swift5_proto", &size)
+    }
+
+    guard let section = section else {
+      return
+    }
+
+    let rawSection = UnsafeRawPointer(section)
+    for start in stride(from: rawSection, to: rawSection + Int(size), by: MemoryLayout<Int32>.stride) {
+      let address = start.load(as: RelativeDirectPointer<ConformanceDescriptor>.self).address(from: start)
+      let conformance = Conformance(raw: address)
+
+      guard let context = conformance.context, context.moduleDescriptor.isSwiftRefactorModule else {
+        continue
+      }
+      
+      guard let typeMetadata = context.metadata(), let provider = typeMetadata as? any RefactoringProvider.Type else {
+        continue
+      }
+
+      action(provider)
+    }
+  }
+}
+
+struct Conformance {
+  enum Kind: UInt16 {
+    case direct = 0x0
+    case indirect = 0x1
+  }
+
+  var raw: UnsafeRawPointer
+
+  var `protocol`: Context {
+    let maybeProtocol = RelativeIndirectablePointer<ContextDescriptor>(offset: self.raw.load(as: ConformanceDescriptor.self).protocol)
+    return Context(raw: maybeProtocol.address(from: self.raw))
+  }
+
+  var context: Context? {
+    let start = self.raw + MemoryLayout<Int32>.size
+    let offset = start.load(as: Int32.self)
+    let addr = start + Int(offset)
+    let kind = UInt16(self.raw.load(as: ConformanceDescriptor.self).flags & (0x7 << 3)) >> 3
+    switch Conformance.Kind(rawValue: kind) {
+    case .direct:
+      return Context(raw: addr)
+    case .indirect:
+      return addr.load(as: Context.self)
+    case nil:
+      return nil
+    }
+  }
+}
+
+struct Context: Hashable {
+  struct Flags: OptionSet {
+    var rawValue: UInt32
+
+    var kind: Context.Kind? {
+      return Context.Kind(rawValue: UInt8(self.rawValue & 0x1F))
+    }
+  }
+
+  enum Kind: UInt8 {
+    case `class` = 0x11
+    case `struct` = 0x12
+    case `enum` = 0x13
+  }
+
+  var raw: UnsafeRawPointer
+
+  var parent: Context? {
+    let parent = RelativeIndirectablePointer<ContextDescriptor>(offset: self.raw.load(as: ContextDescriptor.self).parent)
+
+    guard parent.offset != 0 else {
+      return nil
+    }
+
+    let start = self.raw + MemoryLayout<Int32>.size
+    return Context(raw: parent.address(from: start))
+  }
+
+  var moduleDescriptor: ModuleContext {
+    var result = self
+
+    while let parent = result.parent {
+      result = parent
+    }
+
+    return ModuleContext(raw: result.raw)
+  }
+
+  func metadata() -> Any.Type? {
+    guard Context.Flags(rawValue: self.raw.load(as: ContextDescriptor.self).flags).kind != nil else {
+      return nil
+    }
+
+    let typeDescriptor = self.raw.load(as: TypeContextDescriptor.self)
+    let start = self.raw + MemoryLayout<TypeContextDescriptor>.offset(of: \.accessor)!
+    let accessor = RelativeDirectPointer<Void>(offset: typeDescriptor.accessor)
+    let access = MetadataAccessor(raw: accessor.address(from: start))
+    let fn = unsafeBitCast(access.raw, to: (@convention(thin) (Int) -> MetadataResponse).self)
+    return fn(0).type
+  }
+}
+
+struct MetadataAccessor {
+  var raw: UnsafeRawPointer
+}
+
+struct MetadataResponse {
+  let type: Any.Type
+  let state: Int
+}
+
+struct ModuleContext {
+  var raw: UnsafeRawPointer
+
+  var name: String {
+    let typeDescriptor = self.raw.load(as: ModuleContextDescriptor.self)
+    let start = self.raw + MemoryLayout<ModuleContextDescriptor>.offset(of: \.name)!
+    let name = RelativeDirectPointer<CChar>(offset: typeDescriptor.name)
+    return name
+      .address(from: start)
+      .withMemoryRebound(to: CChar.self, capacity: 1) { pointer in
+      return String(cString: pointer)
+    }
+  }
+}
+
+extension ModuleContext {
+  var isSwiftRefactorModule: Bool {
+    return self.name == "SwiftRefactor"
+  }
+}
+
+struct RelativeDirectPointer<Pointee> {
+  var offset: Int32
+
+  func address(from pointer: UnsafeRawPointer) -> UnsafeRawPointer {
+    return pointer + UnsafeRawPointer.Stride(self.offset)
+  }
+}
+
+struct RelativeIndirectablePointer<Pointee> {
+  var offset: Int32
+
+  func address(from pointer: UnsafeRawPointer) -> UnsafeRawPointer {
+    let dest = pointer + Int(self.offset & ~1)
+
+    // If the low bit is set, then this is an indirect address. Otherwise,
+    // it's direct.
+    if Int(offset) & 1 == 1 {
+      return dest.load(as: UnsafeRawPointer.self)
+    } else {
+      return dest
+    }
+  }
+}

--- a/EditorExtension/SwiftRefactorExtension/Info.plist
+++ b/EditorExtension/SwiftRefactorExtension/Info.plist
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>SwiftRefactorExtension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>XCSourceEditorCommandDefinitions</key>
+			<array>
+				<dict>
+					<key>XCSourceEditorCommandClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SourceEditorCommand</string>
+					<key>XCSourceEditorCommandIdentifier</key>
+					<string>$(PRODUCT_BUNDLE_IDENTIFIER).SourceEditorCommand</string>
+					<key>XCSourceEditorCommandName</key>
+					<string>Swift Refactoring</string>
+				</dict>
+			</array>
+			<key>XCSourceEditorExtensionPrincipalClass</key>
+			<string>$(PRODUCT_MODULE_NAME).SourceEditorExtension</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.dt.Xcode.extension.source-editor</string>
+	</dict>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2022 Apple Inc. All rights reserved.</string>
+</dict>
+</plist>

--- a/EditorExtension/SwiftRefactorExtension/RefactoringRegistry.swift
+++ b/EditorExtension/SwiftRefactorExtension/RefactoringRegistry.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftRefactor
+
+final class RefactoringRegistry {
+  public static let shared = RefactoringRegistry()
+
+  public private(set) var providers = [any RefactoringProvider.Type]()
+  private var providersByName = [String: any RefactoringProvider.Type]()
+
+  func register(_ provider: any RefactoringProvider.Type) {
+    self.providers.append(provider)
+    self.providersByName[String(describing: provider)] = provider
+  }
+
+  subscript(identifier: String) -> (any RefactoringProvider.Type)? {
+    _read { yield self.providersByName[identifier] }
+  }
+
+  private init() {}
+}

--- a/EditorExtension/SwiftRefactorExtension/SourceEditorCommand.swift
+++ b/EditorExtension/SwiftRefactorExtension/SourceEditorCommand.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XcodeKit
+import SwiftParser
+import SwiftRefactor
+import SwiftSyntax
+
+enum ExtensionError: Error {
+  case unsupportedContentType
+  case unknownRefactoring(String)
+}
+
+final class SourceEditorCommand: NSObject, XCSourceEditorCommand {
+  func perform(with invocation: XCSourceEditorCommandInvocation) async throws {
+    guard invocation.buffer.contentUTI == "public.swift-source" else {
+      throw ExtensionError.unsupportedContentType
+    }
+
+    guard let provider = RefactoringRegistry.shared[invocation.commandIdentifier] else {
+      throw ExtensionError.unknownRefactoring(invocation.commandIdentifier)
+    }
+
+    class Rewriter: SyntaxRewriter {
+      private let provider: any RefactoringProvider.Type
+
+      init(provider: any RefactoringProvider.Type) {
+        self.provider = provider
+      }
+
+      override func visitAny(_ node: Syntax) -> Syntax? {
+        func withOpenedRefactoringProvider<T: RefactoringProvider>(_ providerType: T.Type) -> Syntax? {
+          guard
+            let input = node.as(providerType.Input.self),
+            providerType.Context.self == Void.self
+          else {
+            return nil
+          }
+          let context = unsafeBitCast(Void(), to: providerType.Context.self)
+          return providerType.refactor(syntax: input, in: context).map { Syntax($0) }
+        }
+
+        return _openExistential(self.provider, do: withOpenedRefactoringProvider)
+      }
+    }
+
+    let source = Parser.parse(source: invocation.buffer.completeBuffer)
+    let transformedSource = Rewriter(provider: provider).visit(source)
+    invocation.buffer.completeBuffer = transformedSource.description
+  }
+}
+

--- a/EditorExtension/SwiftRefactorExtension/SourceEditorExtension.swift
+++ b/EditorExtension/SwiftRefactorExtension/SourceEditorExtension.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XcodeKit
+import SwiftRefactor
+
+final class SourceEditorExtension: NSObject, XCSourceEditorExtension {
+  func extensionDidFinishLaunching() {
+    Self.forEachRefactoringProvider { provider in
+      RefactoringRegistry.shared.register(provider)
+    }
+  }
+
+  var commandDefinitions: [[XCSourceEditorCommandDefinitionKey : Any]] {
+    return RefactoringRegistry.shared.providers.map { provider in
+      return [
+        .classNameKey: SourceEditorCommand.className(),
+        .identifierKey: String(describing: provider),
+        .nameKey: String(describing: provider),
+      ]
+    }
+  }
+}

--- a/EditorExtension/SwiftRefactorExtension/SwiftRefactorExtension.entitlements
+++ b/EditorExtension/SwiftRefactorExtension/SwiftRefactorExtension.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/SwiftRefactor/MigrateToNewIfLetSyntax.swift
+++ b/Sources/SwiftRefactor/MigrateToNewIfLetSyntax.swift
@@ -24,7 +24,7 @@ import SwiftParser
 public struct MigrateToNewIfLetSyntax: RefactoringProvider {
   public static func refactor(syntax node: IfStmtSyntax, in context: ()) -> StmtSyntax? {
     // Visit all conditions in the node.
-    let newConditions = node.conditions.enumerated().map { (index, condition) in
+    let newConditions = node.conditions.enumerated().map { (index, condition) -> ConditionElementListSyntax.Element in
       var conditionCopy = condition
       // Check if the condition is an optional binding ...
       if var binding = condition.condition.as(OptionalBindingConditionSyntax.self),


### PR DESCRIPTION
Add an editor extension that scans itself for refactoring actions and
translates them into a form that Xcode can ingest via a source editor
plugin. At the moment this applies the selected transformation to every
input instance in the entire buffer.