### PR TITLE
Add CMakeLists.txt to ignored files for IDEUtils (NFC)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -103,6 +103,7 @@ let package = Package(
       name: "IDEUtils",
       dependencies: ["SwiftSyntax"],
       exclude: [
+        "CMakeLists.txt",
         "SyntaxClassification.swift.gyb",
       ]
     ),


### PR DESCRIPTION
Fixes this warning `warning: 'swift-syntax': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target`