### PR TITLE
Use generic SyntaxProtocol initializer

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -71,12 +71,6 @@ public struct Syntax: SyntaxProtocol, SyntaxHashable {
   public init<S: SyntaxProtocol>(_ syntax: S) {
     self = syntax._syntaxNode
   }
-
-  /// Create a `Syntax` node from a specialized optional syntax node.
-  public init?<S: SyntaxProtocol>(_ syntax: S?) {
-    guard let syntax = syntax else { return nil }
-    self = syntax._syntaxNode
-  }
   
   public init(fromProtocol syntax: SyntaxProtocol) {
     self = syntax._syntaxNode
@@ -111,21 +105,6 @@ public struct Syntax: SyntaxProtocol, SyntaxHashable {
 
   public static func ==(lhs: Syntax, rhs: Syntax) -> Bool {
     return lhs.data.nodeId == rhs.data.nodeId
-  }
-}
-
-// Casting functions to specialized syntax nodes.
-extension SyntaxProtocol {
-  public func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
-    return self.as(syntaxType) != nil
-  }
-
-  public func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
-    return S.init(self._syntaxNode)
-  }
-
-  func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
-    return self.as(S.self)!
   }
 }
 
@@ -188,9 +167,9 @@ public protocol SyntaxProtocol: CustomStringConvertible,
   /// Do not retrieve this property directly. Use `Syntax(self)` instead.
   var _syntaxNode: Syntax { get }
 
-  /// Converts the given `Syntax` node to this type. Returns `nil` if the
+  /// Converts the given specialized node to this type. Returns `nil` if the
   /// conversion is not possible.
-  init?(_ syntaxNode: Syntax)
+  init?<S: SyntaxProtocol>(_ node: S)
 
   /// The statically allowed structure of the syntax node.
   static var structure: SyntaxNodeStructure { get }
@@ -200,6 +179,30 @@ public protocol SyntaxProtocol: CustomStringConvertible,
   /// Typically, you want to use `childNameInParent` on the child instead of
   /// calling this method on the parent.
   func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String?
+}
+
+// Casting functions to specialized syntax nodes.
+public extension SyntaxProtocol {
+  /// Converts the given specialized node to this type. Returns `nil` if the
+  /// conversion is not possible or the given node was `nil`.
+  init?<S: SyntaxProtocol>(_ node: S?) {
+    guard let node = node else {
+      return nil
+    }
+    self.init(node)
+  }
+
+  func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return self.as(syntaxType) != nil
+  }
+
+  func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return S.init(self)
+  }
+
+  func cast<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S {
+    return self.as(S.self)!
+  }
 }
 
 public extension SyntaxProtocol {

--- a/Sources/SwiftSyntax/SyntaxBaseNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxBaseNodes.swift.gyb
@@ -78,15 +78,13 @@ public struct ${node.name}: ${node.name}Protocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
 
-  /// Converts the given `Syntax` node to a `${node.name}` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    switch syntax.raw.kind {
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    switch node.raw.kind {
 %     castable_kinds = ['.' + child_node.swift_syntax_kind for child_node \
 %                       in SYNTAX_NODES \
 %                       if child_node.base_kind == node.syntax_kind]
     case ${', '.join(castable_kinds)}:
-      self._syntaxNode = syntax
+      self._syntaxNode = node._syntaxNode
     default:
       return nil
     }
@@ -117,7 +115,7 @@ public struct ${node.name}: ${node.name}Protocol, SyntaxHashable {
   }
 
   public func `as`<S: ${node.name}Protocol>(_ syntaxType: S.Type) -> S? {
-    return S.init(_syntaxNode)
+    return S.init(self)
   }
 
   public func cast<S: ${node.name}Protocol>(_ syntaxType: S.Type) -> S {

--- a/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -71,10 +71,10 @@ public struct ${node.name}: SyntaxCollection, SyntaxHashable {
     }
 %     end
 %   end
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
 %   for choice_name in node.collection_element_choices:
 %     choice = NODE_MAP[choice_name]
-      if let node = syntaxNode.as(${choice.name}.self) {
+      if let node = node.as(${choice.name}.self) {
         self = .${choice.swift_syntax_kind}(node)
         return
       }
@@ -102,11 +102,9 @@ public struct ${node.name}: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `${node.name}` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .${node.swift_syntax_kind} else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .${node.swift_syntax_kind} else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
@@ -73,9 +73,9 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
     }
 %           end
 %         end
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
 %         for choice in child.node_choices:
-      if let node = syntaxNode.as(${choice.type_name}.self) {
+      if let node = node.as(${choice.type_name}.self) {
         self = .${choice.swift_name}(node)
         return
       }
@@ -100,11 +100,9 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
 %
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `${node.name}` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .${node.swift_syntax_kind} else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .${node.swift_syntax_kind} else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `${node.name}` node from the given `SyntaxData`. This assumes

--- a/Sources/SwiftSyntax/SyntaxOtherNodes.swift
+++ b/Sources/SwiftSyntax/SyntaxOtherNodes.swift
@@ -16,11 +16,9 @@
 public struct UnknownSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Convert the given `Syntax` node to an `UnknownSyntax` if possible. Return
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .unknown else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .unknown else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates an `UnknownSyntax` node from the given `SyntaxData`. This assumes
@@ -66,11 +64,9 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
     return raw.tokenView!
   }
 
-  /// Converts the given `Syntax` node to a `TokenSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .token else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .token else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the given `SyntaxData`. This assumes

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
@@ -65,12 +65,10 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
 
-  /// Converts the given `Syntax` node to a `DeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    switch syntax.raw.kind {
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    switch node.raw.kind {
     case .unknownDecl, .missingDecl, .typealiasDecl, .associatedtypeDecl, .ifConfigDecl, .poundErrorDecl, .poundWarningDecl, .poundSourceLocation, .classDecl, .actorDecl, .structDecl, .protocolDecl, .extensionDecl, .functionDecl, .initializerDecl, .deinitializerDecl, .subscriptDecl, .importDecl, .accessorDecl, .variableDecl, .enumCaseDecl, .enumDecl, .operatorDecl, .precedenceGroupDecl, .macroExpansionDecl:
-      self._syntaxNode = syntax
+      self._syntaxNode = node._syntaxNode
     default:
       return nil
     }
@@ -98,7 +96,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public func `as`<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
-    return S.init(_syntaxNode)
+    return S.init(self)
   }
 
   public func cast<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> S {
@@ -215,12 +213,10 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
 
-  /// Converts the given `Syntax` node to a `ExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    switch syntax.raw.kind {
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    switch node.raw.kind {
     case .unknownExpr, .missingExpr, .inOutExpr, .poundColumnExpr, .tryExpr, .awaitExpr, .moveExpr, .identifierExpr, .superRefExpr, .nilLiteralExpr, .discardAssignmentExpr, .assignmentExpr, .sequenceExpr, .poundLineExpr, .poundFileExpr, .poundFileIDExpr, .poundFilePathExpr, .poundFunctionExpr, .poundDsohandleExpr, .symbolicReferenceExpr, .prefixOperatorExpr, .binaryOperatorExpr, .arrowExpr, .infixOperatorExpr, .floatLiteralExpr, .tupleExpr, .arrayExpr, .dictionaryExpr, .integerLiteralExpr, .booleanLiteralExpr, .unresolvedTernaryExpr, .ternaryExpr, .memberAccessExpr, .unresolvedIsExpr, .isExpr, .unresolvedAsExpr, .asExpr, .typeExpr, .closureExpr, .unresolvedPatternExpr, .functionCallExpr, .subscriptExpr, .optionalChainingExpr, .forcedValueExpr, .postfixUnaryExpr, .specializeExpr, .stringLiteralExpr, .regexLiteralExpr, .keyPathExpr, .oldKeyPathExpr, .keyPathBaseExpr, .objcKeyPathExpr, .objcSelectorExpr, .macroExpansionExpr, .postfixIfConfigExpr, .editorPlaceholderExpr, .objectLiteralExpr:
-      self._syntaxNode = syntax
+      self._syntaxNode = node._syntaxNode
     default:
       return nil
     }
@@ -248,7 +244,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public func `as`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
-    return S.init(_syntaxNode)
+    return S.init(self)
   }
 
   public func cast<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S {
@@ -397,12 +393,10 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
 
-  /// Converts the given `Syntax` node to a `StmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    switch syntax.raw.kind {
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    switch node.raw.kind {
     case .unknownStmt, .missingStmt, .labeledStmt, .continueStmt, .whileStmt, .deferStmt, .expressionStmt, .repeatWhileStmt, .guardStmt, .forInStmt, .switchStmt, .doStmt, .returnStmt, .yieldStmt, .fallthroughStmt, .breakStmt, .declarationStmt, .throwStmt, .ifStmt, .poundAssertStmt:
-      self._syntaxNode = syntax
+      self._syntaxNode = node._syntaxNode
     default:
       return nil
     }
@@ -430,7 +424,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
 
   public func `as`<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
-    return S.init(_syntaxNode)
+    return S.init(self)
   }
 
   public func cast<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> S {
@@ -542,12 +536,10 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
 
-  /// Converts the given `Syntax` node to a `TypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    switch syntax.raw.kind {
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    switch node.raw.kind {
     case .unknownType, .missingType, .simpleTypeIdentifier, .memberTypeIdentifier, .classRestrictionType, .arrayType, .dictionaryType, .metatypeType, .optionalType, .constrainedSugarType, .implicitlyUnwrappedOptionalType, .compositionType, .packExpansionType, .tupleType, .functionType, .attributedType, .namedOpaqueReturnType:
-      self._syntaxNode = syntax
+      self._syntaxNode = node._syntaxNode
     default:
       return nil
     }
@@ -575,7 +567,7 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   }
 
   public func `as`<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
-    return S.init(_syntaxNode)
+    return S.init(self)
   }
 
   public func cast<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> S {
@@ -684,12 +676,10 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
 
-  /// Converts the given `Syntax` node to a `PatternSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    switch syntax.raw.kind {
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    switch node.raw.kind {
     case .unknownPattern, .missingPattern, .enumCasePattern, .isTypePattern, .optionalPattern, .identifierPattern, .asTypePattern, .tuplePattern, .wildcardPattern, .expressionPattern, .valueBindingPattern:
-      self._syntaxNode = syntax
+      self._syntaxNode = node._syntaxNode
     default:
       return nil
     }
@@ -717,7 +707,7 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   }
 
   public func `as`<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
-    return S.init(_syntaxNode)
+    return S.init(self)
   }
 
   public func cast<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> S {

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
@@ -38,11 +38,9 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `CodeBlockItemListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .codeBlockItemList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .codeBlockItemList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -292,11 +290,9 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `UnexpectedNodesSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .unexpectedNodes else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .unexpectedNodes else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -546,11 +542,9 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `TupleExprElementListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .tupleExprElementList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .tupleExprElementList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -800,11 +794,9 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `ArrayElementListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .arrayElementList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .arrayElementList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -1054,11 +1046,9 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `DictionaryElementListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .dictionaryElementList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .dictionaryElementList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -1315,12 +1305,12 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
     public init(_ node: ExpressionSegmentSyntax) {
       self = .expressionSegment(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(StringSegmentSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(StringSegmentSyntax.self) {
         self = .stringSegment(node)
         return
       }
-      if let node = syntaxNode.as(ExpressionSegmentSyntax.self) {
+      if let node = node.as(ExpressionSegmentSyntax.self) {
         self = .expressionSegment(node)
         return
       }
@@ -1342,11 +1332,9 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `StringLiteralSegmentsSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .stringLiteralSegments else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .stringLiteralSegments else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -1596,11 +1584,9 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `DeclNameArgumentListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .declNameArgumentList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .declNameArgumentList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -1850,11 +1836,9 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `ExprListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .exprList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .exprList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -2104,11 +2088,9 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `ClosureCaptureItemListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .closureCaptureItemList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .closureCaptureItemList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -2358,11 +2340,9 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `ClosureParamListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .closureParamList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .closureParamList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -2612,11 +2592,9 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `MultipleTrailingClosureElementListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .multipleTrailingClosureElementList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .multipleTrailingClosureElementList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -2866,11 +2844,9 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `KeyPathComponentListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .keyPathComponentList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .keyPathComponentList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -3120,11 +3096,9 @@ public struct ObjcNameSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `ObjcNameSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .objcName else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .objcName else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -3374,11 +3348,9 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `YieldExprListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .yieldExprList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .yieldExprList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -3628,11 +3600,9 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `FunctionParameterListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .functionParameterList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .functionParameterList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -3882,11 +3852,9 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `IfConfigClauseListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .ifConfigClauseList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .ifConfigClauseList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -4136,11 +4104,9 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `InheritedTypeListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .inheritedTypeList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .inheritedTypeList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -4390,11 +4356,9 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `MemberDeclListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .memberDeclList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .memberDeclList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -4644,11 +4608,9 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `ModifierListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .modifierList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .modifierList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -4898,11 +4860,9 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `AccessPathSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .accessPath else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .accessPath else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -5152,11 +5112,9 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `AccessorListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .accessorList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .accessorList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -5406,11 +5364,9 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `PatternBindingListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .patternBindingList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .patternBindingList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -5657,11 +5613,9 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `EnumCaseElementListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .enumCaseElementList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .enumCaseElementList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -5911,11 +5865,9 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `DesignatedTypeListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .designatedTypeList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .designatedTypeList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -6177,16 +6129,16 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
     public init(_ node: PrecedenceGroupAssociativitySyntax) {
       self = .precedenceGroupAssociativity(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(PrecedenceGroupRelationSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(PrecedenceGroupRelationSyntax.self) {
         self = .precedenceGroupRelation(node)
         return
       }
-      if let node = syntaxNode.as(PrecedenceGroupAssignmentSyntax.self) {
+      if let node = node.as(PrecedenceGroupAssignmentSyntax.self) {
         self = .precedenceGroupAssignment(node)
         return
       }
-      if let node = syntaxNode.as(PrecedenceGroupAssociativitySyntax.self) {
+      if let node = node.as(PrecedenceGroupAssociativitySyntax.self) {
         self = .precedenceGroupAssociativity(node)
         return
       }
@@ -6209,11 +6161,9 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `PrecedenceGroupAttributeListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .precedenceGroupAttributeList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .precedenceGroupAttributeList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -6463,11 +6413,9 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `PrecedenceGroupNameListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .precedenceGroupNameList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .precedenceGroupNameList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -6717,11 +6665,9 @@ public struct TokenListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `TokenListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .tokenList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .tokenList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -6971,11 +6917,9 @@ public struct NonEmptyTokenListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `NonEmptyTokenListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .nonEmptyTokenList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .nonEmptyTokenList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -7237,16 +7181,16 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
     public init(_ node: IfConfigDeclSyntax) {
       self = .ifConfigDecl(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(AttributeSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(AttributeSyntax.self) {
         self = .attribute(node)
         return
       }
-      if let node = syntaxNode.as(CustomAttributeSyntax.self) {
+      if let node = node.as(CustomAttributeSyntax.self) {
         self = .customAttribute(node)
         return
       }
-      if let node = syntaxNode.as(IfConfigDeclSyntax.self) {
+      if let node = node.as(IfConfigDeclSyntax.self) {
         self = .ifConfigDecl(node)
         return
       }
@@ -7269,11 +7213,9 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `AttributeListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .attributeList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .attributeList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -7539,20 +7481,20 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
     public init(_ node: GenericWhereClauseSyntax) {
       self = .genericWhereClause(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(LabeledSpecializeEntrySyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(LabeledSpecializeEntrySyntax.self) {
         self = .labeledSpecializeEntry(node)
         return
       }
-      if let node = syntaxNode.as(AvailabilityEntrySyntax.self) {
+      if let node = node.as(AvailabilityEntrySyntax.self) {
         self = .availabilityEntry(node)
         return
       }
-      if let node = syntaxNode.as(TargetFunctionEntrySyntax.self) {
+      if let node = node.as(TargetFunctionEntrySyntax.self) {
         self = .targetFunctionEntry(node)
         return
       }
-      if let node = syntaxNode.as(GenericWhereClauseSyntax.self) {
+      if let node = node.as(GenericWhereClauseSyntax.self) {
         self = .genericWhereClause(node)
         return
       }
@@ -7576,11 +7518,9 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `SpecializeAttributeSpecListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .specializeAttributeSpecList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .specializeAttributeSpecList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -7830,11 +7770,9 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `ObjCSelectorSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .objCSelector else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .objCSelector else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -8084,11 +8022,9 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `DifferentiabilityParamListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .differentiabilityParamList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .differentiabilityParamList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -8338,11 +8274,9 @@ public struct BackDeployVersionListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `BackDeployVersionListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .backDeployVersionList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .backDeployVersionList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -8599,12 +8533,12 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
     public init(_ node: IfConfigDeclSyntax) {
       self = .ifConfigDecl(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(SwitchCaseSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(SwitchCaseSyntax.self) {
         self = .switchCase(node)
         return
       }
-      if let node = syntaxNode.as(IfConfigDeclSyntax.self) {
+      if let node = node.as(IfConfigDeclSyntax.self) {
         self = .ifConfigDecl(node)
         return
       }
@@ -8626,11 +8560,9 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `SwitchCaseListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .switchCaseList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .switchCaseList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -8880,11 +8812,9 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `CatchClauseListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .catchClauseList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .catchClauseList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -9134,11 +9064,9 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `CaseItemListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .caseItemList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .caseItemList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -9388,11 +9316,9 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `CatchItemListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .catchItemList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .catchItemList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -9642,11 +9568,9 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `ConditionElementListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .conditionElementList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .conditionElementList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -9896,11 +9820,9 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `GenericRequirementListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .genericRequirementList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .genericRequirementList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -10150,11 +10072,9 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `GenericParameterListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .genericParameterList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .genericParameterList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -10404,11 +10324,9 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `PrimaryAssociatedTypeListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .primaryAssociatedTypeList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .primaryAssociatedTypeList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -10658,11 +10576,9 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `CompositionTypeElementListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .compositionTypeElementList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .compositionTypeElementList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -10912,11 +10828,9 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `TupleTypeElementListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .tupleTypeElementList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .tupleTypeElementList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -11166,11 +11080,9 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `GenericArgumentListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .genericArgumentList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .genericArgumentList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -11420,11 +11332,9 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `TuplePatternElementListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .tuplePatternElementList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .tuplePatternElementList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 
@@ -11674,11 +11584,9 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `AvailabilitySpecListSyntax` if possible. Returns 
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .availabilitySpecList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .availabilitySpecList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a Syntax node from the provided root and data. This assumes 

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -18,11 +18,9 @@
 public struct UnknownDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `UnknownDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .unknownDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .unknownDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `UnknownDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -70,11 +68,9 @@ extension UnknownDeclSyntax: CustomReflectable {
 public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MissingDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .missingDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .missingDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MissingDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -295,11 +291,9 @@ extension MissingDeclSyntax: CustomReflectable {
 public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `TypealiasDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .typealiasDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .typealiasDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `TypealiasDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -787,11 +781,9 @@ extension TypealiasDeclSyntax: CustomReflectable {
 public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AssociatedtypeDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .associatedtypeDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .associatedtypeDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AssociatedtypeDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -1280,11 +1272,9 @@ extension AssociatedtypeDeclSyntax: CustomReflectable {
 public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `IfConfigDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .ifConfigDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .ifConfigDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `IfConfigDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -1484,11 +1474,9 @@ extension IfConfigDeclSyntax: CustomReflectable {
 public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PoundErrorDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .poundErrorDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .poundErrorDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PoundErrorDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -1775,11 +1763,9 @@ extension PoundErrorDeclSyntax: CustomReflectable {
 public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PoundWarningDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .poundWarningDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .poundWarningDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PoundWarningDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -2066,11 +2052,9 @@ extension PoundWarningDeclSyntax: CustomReflectable {
 public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PoundSourceLocationSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .poundSourceLocation else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .poundSourceLocation else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PoundSourceLocationSyntax` node from the given `SyntaxData`. This assumes
@@ -2358,11 +2342,9 @@ extension PoundSourceLocationSyntax: CustomReflectable {
 public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ClassDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .classDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .classDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ClassDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -2904,11 +2886,9 @@ extension ClassDeclSyntax: CustomReflectable {
 public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ActorDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .actorDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .actorDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ActorDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -3450,11 +3430,9 @@ extension ActorDeclSyntax: CustomReflectable {
 public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `StructDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .structDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .structDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `StructDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -3996,11 +3974,9 @@ extension StructDeclSyntax: CustomReflectable {
 public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ProtocolDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .protocolDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .protocolDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ProtocolDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -4542,11 +4518,9 @@ extension ProtocolDeclSyntax: CustomReflectable {
 public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ExtensionDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .extensionDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .extensionDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ExtensionDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -5034,11 +5008,9 @@ extension ExtensionDeclSyntax: CustomReflectable {
 public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `FunctionDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .functionDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .functionDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `FunctionDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -5580,11 +5552,9 @@ extension FunctionDeclSyntax: CustomReflectable {
 public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `InitializerDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .initializerDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .initializerDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `InitializerDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -6127,11 +6097,9 @@ extension InitializerDeclSyntax: CustomReflectable {
 public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DeinitializerDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .deinitializerDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .deinitializerDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DeinitializerDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -6473,12 +6441,12 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     public init(_ node: CodeBlockSyntax) {
       self = .getter(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(AccessorBlockSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(AccessorBlockSyntax.self) {
         self = .accessors(node)
         return
       }
-      if let node = syntaxNode.as(CodeBlockSyntax.self) {
+      if let node = node.as(CodeBlockSyntax.self) {
         self = .getter(node)
         return
       }
@@ -6495,11 +6463,9 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `SubscriptDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .subscriptDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .subscriptDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `SubscriptDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -7041,11 +7007,9 @@ extension SubscriptDeclSyntax: CustomReflectable {
 public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ImportDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .importDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .importDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ImportDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -7445,11 +7409,9 @@ extension ImportDeclSyntax: CustomReflectable {
 public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AccessorDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .accessorDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .accessorDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AccessorDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -7920,11 +7882,9 @@ extension AccessorDeclSyntax: CustomReflectable {
 public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `VariableDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .variableDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .variableDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `VariableDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -8275,11 +8235,9 @@ extension VariableDeclSyntax: CustomReflectable {
 public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `EnumCaseDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .enumCaseDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .enumCaseDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `EnumCaseDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -8634,11 +8592,9 @@ extension EnumCaseDeclSyntax: CustomReflectable {
 public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `EnumDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .enumDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .enumDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `EnumDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -9207,11 +9163,9 @@ extension EnumDeclSyntax: CustomReflectable {
 public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `OperatorDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .operatorDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .operatorDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `OperatorDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -9603,11 +9557,9 @@ extension OperatorDeclSyntax: CustomReflectable {
 public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PrecedenceGroupDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .precedenceGroupDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .precedenceGroupDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PrecedenceGroupDeclSyntax` node from the given `SyntaxData`. This assumes
@@ -10125,11 +10077,9 @@ extension PrecedenceGroupDeclSyntax: CustomReflectable {
 public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MacroExpansionDeclSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .macroExpansionDecl else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .macroExpansionDecl else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MacroExpansionDeclSyntax` node from the given `SyntaxData`. This assumes

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -18,11 +18,9 @@
 public struct UnknownExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `UnknownExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .unknownExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .unknownExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `UnknownExprSyntax` node from the given `SyntaxData`. This assumes
@@ -70,11 +68,9 @@ extension UnknownExprSyntax: CustomReflectable {
 public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MissingExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .missingExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .missingExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MissingExprSyntax` node from the given `SyntaxData`. This assumes
@@ -122,11 +118,9 @@ extension MissingExprSyntax: CustomReflectable {
 public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `InOutExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .inOutExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .inOutExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `InOutExprSyntax` node from the given `SyntaxData`. This assumes
@@ -307,11 +301,9 @@ extension InOutExprSyntax: CustomReflectable {
 public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PoundColumnExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .poundColumnExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .poundColumnExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PoundColumnExprSyntax` node from the given `SyntaxData`. This assumes
@@ -439,11 +431,9 @@ extension PoundColumnExprSyntax: CustomReflectable {
 public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `TryExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .tryExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .tryExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `TryExprSyntax` node from the given `SyntaxData`. This assumes
@@ -678,11 +668,9 @@ extension TryExprSyntax: CustomReflectable {
 public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AwaitExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .awaitExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .awaitExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AwaitExprSyntax` node from the given `SyntaxData`. This assumes
@@ -863,11 +851,9 @@ extension AwaitExprSyntax: CustomReflectable {
 public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MoveExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .moveExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .moveExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MoveExprSyntax` node from the given `SyntaxData`. This assumes
@@ -1048,11 +1034,9 @@ extension MoveExprSyntax: CustomReflectable {
 public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `IdentifierExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .identifierExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .identifierExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `IdentifierExprSyntax` node from the given `SyntaxData`. This assumes
@@ -1234,11 +1218,9 @@ extension IdentifierExprSyntax: CustomReflectable {
 public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `SuperRefExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .superRefExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .superRefExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `SuperRefExprSyntax` node from the given `SyntaxData`. This assumes
@@ -1366,11 +1348,9 @@ extension SuperRefExprSyntax: CustomReflectable {
 public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `NilLiteralExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .nilLiteralExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .nilLiteralExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `NilLiteralExprSyntax` node from the given `SyntaxData`. This assumes
@@ -1498,11 +1478,9 @@ extension NilLiteralExprSyntax: CustomReflectable {
 public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DiscardAssignmentExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .discardAssignmentExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .discardAssignmentExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DiscardAssignmentExprSyntax` node from the given `SyntaxData`. This assumes
@@ -1630,11 +1608,9 @@ extension DiscardAssignmentExprSyntax: CustomReflectable {
 public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AssignmentExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .assignmentExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .assignmentExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AssignmentExprSyntax` node from the given `SyntaxData`. This assumes
@@ -1762,11 +1738,9 @@ extension AssignmentExprSyntax: CustomReflectable {
 public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `SequenceExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .sequenceExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .sequenceExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `SequenceExprSyntax` node from the given `SyntaxData`. This assumes
@@ -1913,11 +1887,9 @@ extension SequenceExprSyntax: CustomReflectable {
 public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PoundLineExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .poundLineExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .poundLineExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PoundLineExprSyntax` node from the given `SyntaxData`. This assumes
@@ -2045,11 +2017,9 @@ extension PoundLineExprSyntax: CustomReflectable {
 public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PoundFileExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .poundFileExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .poundFileExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PoundFileExprSyntax` node from the given `SyntaxData`. This assumes
@@ -2177,11 +2147,9 @@ extension PoundFileExprSyntax: CustomReflectable {
 public struct PoundFileIDExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PoundFileIDExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .poundFileIDExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .poundFileIDExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PoundFileIDExprSyntax` node from the given `SyntaxData`. This assumes
@@ -2309,11 +2277,9 @@ extension PoundFileIDExprSyntax: CustomReflectable {
 public struct PoundFilePathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PoundFilePathExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .poundFilePathExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .poundFilePathExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PoundFilePathExprSyntax` node from the given `SyntaxData`. This assumes
@@ -2441,11 +2407,9 @@ extension PoundFilePathExprSyntax: CustomReflectable {
 public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PoundFunctionExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .poundFunctionExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .poundFunctionExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PoundFunctionExprSyntax` node from the given `SyntaxData`. This assumes
@@ -2573,11 +2537,9 @@ extension PoundFunctionExprSyntax: CustomReflectable {
 public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PoundDsohandleExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .poundDsohandleExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .poundDsohandleExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PoundDsohandleExprSyntax` node from the given `SyntaxData`. This assumes
@@ -2705,11 +2667,9 @@ extension PoundDsohandleExprSyntax: CustomReflectable {
 public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `SymbolicReferenceExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .symbolicReferenceExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .symbolicReferenceExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `SymbolicReferenceExprSyntax` node from the given `SyntaxData`. This assumes
@@ -2891,11 +2851,9 @@ extension SymbolicReferenceExprSyntax: CustomReflectable {
 public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PrefixOperatorExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .prefixOperatorExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .prefixOperatorExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PrefixOperatorExprSyntax` node from the given `SyntaxData`. This assumes
@@ -3077,11 +3035,9 @@ extension PrefixOperatorExprSyntax: CustomReflectable {
 public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `BinaryOperatorExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .binaryOperatorExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .binaryOperatorExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `BinaryOperatorExprSyntax` node from the given `SyntaxData`. This assumes
@@ -3209,11 +3165,9 @@ extension BinaryOperatorExprSyntax: CustomReflectable {
 public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ArrowExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .arrowExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .arrowExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ArrowExprSyntax` node from the given `SyntaxData`. This assumes
@@ -3449,11 +3403,9 @@ extension ArrowExprSyntax: CustomReflectable {
 public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `InfixOperatorExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .infixOperatorExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .infixOperatorExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `InfixOperatorExprSyntax` node from the given `SyntaxData`. This assumes
@@ -3687,11 +3639,9 @@ extension InfixOperatorExprSyntax: CustomReflectable {
 public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `FloatLiteralExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .floatLiteralExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .floatLiteralExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `FloatLiteralExprSyntax` node from the given `SyntaxData`. This assumes
@@ -3819,11 +3769,9 @@ extension FloatLiteralExprSyntax: CustomReflectable {
 public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `TupleExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .tupleExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .tupleExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `TupleExprSyntax` node from the given `SyntaxData`. This assumes
@@ -4076,11 +4024,9 @@ extension TupleExprSyntax: CustomReflectable {
 public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ArrayExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .arrayExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .arrayExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ArrayExprSyntax` node from the given `SyntaxData`. This assumes
@@ -4347,12 +4293,12 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     public init(_ node: DictionaryElementListSyntax) {
       self = .elements(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(TokenSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(TokenSyntax.self) {
         self = .colon(node)
         return
       }
-      if let node = syntaxNode.as(DictionaryElementListSyntax.self) {
+      if let node = node.as(DictionaryElementListSyntax.self) {
         self = .elements(node)
         return
       }
@@ -4369,11 +4315,9 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DictionaryExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .dictionaryExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .dictionaryExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DictionaryExprSyntax` node from the given `SyntaxData`. This assumes
@@ -4607,11 +4551,9 @@ extension DictionaryExprSyntax: CustomReflectable {
 public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `IntegerLiteralExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .integerLiteralExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .integerLiteralExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `IntegerLiteralExprSyntax` node from the given `SyntaxData`. This assumes
@@ -4739,11 +4681,9 @@ extension IntegerLiteralExprSyntax: CustomReflectable {
 public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `BooleanLiteralExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .booleanLiteralExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .booleanLiteralExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `BooleanLiteralExprSyntax` node from the given `SyntaxData`. This assumes
@@ -4871,11 +4811,9 @@ extension BooleanLiteralExprSyntax: CustomReflectable {
 public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `UnresolvedTernaryExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .unresolvedTernaryExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .unresolvedTernaryExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `UnresolvedTernaryExprSyntax` node from the given `SyntaxData`. This assumes
@@ -5109,11 +5047,9 @@ extension UnresolvedTernaryExprSyntax: CustomReflectable {
 public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `TernaryExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .ternaryExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .ternaryExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `TernaryExprSyntax` node from the given `SyntaxData`. This assumes
@@ -5453,11 +5389,9 @@ extension TernaryExprSyntax: CustomReflectable {
 public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MemberAccessExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .memberAccessExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .memberAccessExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MemberAccessExprSyntax` node from the given `SyntaxData`. This assumes
@@ -5746,11 +5680,9 @@ extension MemberAccessExprSyntax: CustomReflectable {
 public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `UnresolvedIsExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .unresolvedIsExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .unresolvedIsExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `UnresolvedIsExprSyntax` node from the given `SyntaxData`. This assumes
@@ -5878,11 +5810,9 @@ extension UnresolvedIsExprSyntax: CustomReflectable {
 public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `IsExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .isExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .isExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `IsExprSyntax` node from the given `SyntaxData`. This assumes
@@ -6116,11 +6046,9 @@ extension IsExprSyntax: CustomReflectable {
 public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `UnresolvedAsExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .unresolvedAsExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .unresolvedAsExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `UnresolvedAsExprSyntax` node from the given `SyntaxData`. This assumes
@@ -6302,11 +6230,9 @@ extension UnresolvedAsExprSyntax: CustomReflectable {
 public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AsExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .asExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .asExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AsExprSyntax` node from the given `SyntaxData`. This assumes
@@ -6594,11 +6520,9 @@ extension AsExprSyntax: CustomReflectable {
 public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `TypeExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .typeExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .typeExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `TypeExprSyntax` node from the given `SyntaxData`. This assumes
@@ -6726,11 +6650,9 @@ extension TypeExprSyntax: CustomReflectable {
 public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ClosureExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .closureExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .closureExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ClosureExprSyntax` node from the given `SyntaxData`. This assumes
@@ -7037,11 +6959,9 @@ extension ClosureExprSyntax: CustomReflectable {
 public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `UnresolvedPatternExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .unresolvedPatternExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .unresolvedPatternExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `UnresolvedPatternExprSyntax` node from the given `SyntaxData`. This assumes
@@ -7169,11 +7089,9 @@ extension UnresolvedPatternExprSyntax: CustomReflectable {
 public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `FunctionCallExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .functionCallExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .functionCallExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `FunctionCallExprSyntax` node from the given `SyntaxData`. This assumes
@@ -7608,11 +7526,9 @@ extension FunctionCallExprSyntax: CustomReflectable {
 public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `SubscriptExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .subscriptExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .subscriptExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `SubscriptExprSyntax` node from the given `SyntaxData`. This assumes
@@ -8045,11 +7961,9 @@ extension SubscriptExprSyntax: CustomReflectable {
 public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `OptionalChainingExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .optionalChainingExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .optionalChainingExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `OptionalChainingExprSyntax` node from the given `SyntaxData`. This assumes
@@ -8230,11 +8144,9 @@ extension OptionalChainingExprSyntax: CustomReflectable {
 public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ForcedValueExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .forcedValueExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .forcedValueExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ForcedValueExprSyntax` node from the given `SyntaxData`. This assumes
@@ -8415,11 +8327,9 @@ extension ForcedValueExprSyntax: CustomReflectable {
 public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PostfixUnaryExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .postfixUnaryExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .postfixUnaryExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PostfixUnaryExprSyntax` node from the given `SyntaxData`. This assumes
@@ -8600,11 +8510,9 @@ extension PostfixUnaryExprSyntax: CustomReflectable {
 public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `SpecializeExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .specializeExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .specializeExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `SpecializeExprSyntax` node from the given `SyntaxData`. This assumes
@@ -8785,11 +8693,9 @@ extension SpecializeExprSyntax: CustomReflectable {
 public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `StringLiteralExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .stringLiteralExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .stringLiteralExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `StringLiteralExprSyntax` node from the given `SyntaxData`. This assumes
@@ -9150,11 +9056,9 @@ extension StringLiteralExprSyntax: CustomReflectable {
 public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `RegexLiteralExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .regexLiteralExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .regexLiteralExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `RegexLiteralExprSyntax` node from the given `SyntaxData`. This assumes
@@ -9282,11 +9186,9 @@ extension RegexLiteralExprSyntax: CustomReflectable {
 public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `KeyPathExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .keyPathExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .keyPathExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `KeyPathExprSyntax` node from the given `SyntaxData`. This assumes
@@ -9559,16 +9461,16 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     public init(_ node: OptionalChainingExprSyntax) {
       self = .optionalChainingExpr(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(IdentifierExprSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(IdentifierExprSyntax.self) {
         self = .identifierExpr(node)
         return
       }
-      if let node = syntaxNode.as(SpecializeExprSyntax.self) {
+      if let node = node.as(SpecializeExprSyntax.self) {
         self = .specializeExpr(node)
         return
       }
-      if let node = syntaxNode.as(OptionalChainingExprSyntax.self) {
+      if let node = node.as(OptionalChainingExprSyntax.self) {
         self = .optionalChainingExpr(node)
         return
       }
@@ -9586,11 +9488,9 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `OldKeyPathExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .oldKeyPathExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .oldKeyPathExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `OldKeyPathExprSyntax` node from the given `SyntaxData`. This assumes
@@ -9825,11 +9725,9 @@ extension OldKeyPathExprSyntax: CustomReflectable {
 public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `KeyPathBaseExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .keyPathBaseExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .keyPathBaseExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `KeyPathBaseExprSyntax` node from the given `SyntaxData`. This assumes
@@ -9957,11 +9855,9 @@ extension KeyPathBaseExprSyntax: CustomReflectable {
 public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ObjcKeyPathExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .objcKeyPathExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .objcKeyPathExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ObjcKeyPathExprSyntax` node from the given `SyntaxData`. This assumes
@@ -10267,11 +10163,9 @@ extension ObjcKeyPathExprSyntax: CustomReflectable {
 public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ObjcSelectorExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .objcSelectorExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .objcSelectorExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ObjcSelectorExprSyntax` node from the given `SyntaxData`. This assumes
@@ -10666,11 +10560,9 @@ extension ObjcSelectorExprSyntax: CustomReflectable {
 public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MacroExpansionExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .macroExpansionExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .macroExpansionExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MacroExpansionExprSyntax` node from the given `SyntaxData`. This assumes
@@ -11159,11 +11051,9 @@ extension MacroExpansionExprSyntax: CustomReflectable {
 public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PostfixIfConfigExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .postfixIfConfigExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .postfixIfConfigExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PostfixIfConfigExprSyntax` node from the given `SyntaxData`. This assumes
@@ -11345,11 +11235,9 @@ extension PostfixIfConfigExprSyntax: CustomReflectable {
 public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `EditorPlaceholderExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .editorPlaceholderExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .editorPlaceholderExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `EditorPlaceholderExprSyntax` node from the given `SyntaxData`. This assumes
@@ -11477,11 +11365,9 @@ extension EditorPlaceholderExprSyntax: CustomReflectable {
 public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ObjectLiteralExprSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .objectLiteralExpr else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .objectLiteralExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ObjectLiteralExprSyntax` node from the given `SyntaxData`. This assumes

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -18,11 +18,9 @@
 public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MissingSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .missing else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .missing else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MissingSyntax` node from the given `SyntaxData`. This assumes
@@ -103,24 +101,24 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
     public init(_ node: NonEmptyTokenListSyntax) {
       self = .nonEmptyTokenList(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(DeclSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(DeclSyntax.self) {
         self = .decl(node)
         return
       }
-      if let node = syntaxNode.as(StmtSyntax.self) {
+      if let node = node.as(StmtSyntax.self) {
         self = .stmt(node)
         return
       }
-      if let node = syntaxNode.as(ExprSyntax.self) {
+      if let node = node.as(ExprSyntax.self) {
         self = .expr(node)
         return
       }
-      if let node = syntaxNode.as(TokenListSyntax.self) {
+      if let node = node.as(TokenListSyntax.self) {
         self = .tokenList(node)
         return
       }
-      if let node = syntaxNode.as(NonEmptyTokenListSyntax.self) {
+      if let node = node.as(NonEmptyTokenListSyntax.self) {
         self = .nonEmptyTokenList(node)
         return
       }
@@ -140,11 +138,9 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `CodeBlockItemSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .codeBlockItem else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .codeBlockItem else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `CodeBlockItemSyntax` node from the given `SyntaxData`. This assumes
@@ -384,11 +380,9 @@ extension CodeBlockItemSyntax: CustomReflectable {
 public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `CodeBlockSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .codeBlock else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .codeBlock else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `CodeBlockSyntax` node from the given `SyntaxData`. This assumes
@@ -641,11 +635,9 @@ extension CodeBlockSyntax: CustomReflectable {
 public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DeclNameArgumentSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .declNameArgument else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .declNameArgument else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DeclNameArgumentSyntax` node from the given `SyntaxData`. This assumes
@@ -826,11 +818,9 @@ extension DeclNameArgumentSyntax: CustomReflectable {
 public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DeclNameArgumentsSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .declNameArguments else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .declNameArguments else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DeclNameArgumentsSyntax` node from the given `SyntaxData`. This assumes
@@ -1083,11 +1073,9 @@ extension DeclNameArgumentsSyntax: CustomReflectable {
 public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `TupleExprElementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .tupleExprElement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .tupleExprElement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `TupleExprElementSyntax` node from the given `SyntaxData`. This assumes
@@ -1377,11 +1365,9 @@ extension TupleExprElementSyntax: CustomReflectable {
 public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ArrayElementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .arrayElement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .arrayElement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ArrayElementSyntax` node from the given `SyntaxData`. This assumes
@@ -1563,11 +1549,9 @@ extension ArrayElementSyntax: CustomReflectable {
 public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DictionaryElementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .dictionaryElement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .dictionaryElement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DictionaryElementSyntax` node from the given `SyntaxData`. This assumes
@@ -1855,11 +1839,9 @@ extension DictionaryElementSyntax: CustomReflectable {
 public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ClosureCaptureItemSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .closureCaptureItem else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .closureCaptureItem else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ClosureCaptureItemSyntax` node from the given `SyntaxData`. This assumes
@@ -2222,11 +2204,9 @@ extension ClosureCaptureItemSyntax: CustomReflectable {
 public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ClosureCaptureSignatureSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .closureCaptureSignature else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .closureCaptureSignature else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ClosureCaptureSignatureSyntax` node from the given `SyntaxData`. This assumes
@@ -2480,11 +2460,9 @@ extension ClosureCaptureSignatureSyntax: CustomReflectable {
 public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ClosureParamSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .closureParam else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .closureParam else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ClosureParamSyntax` node from the given `SyntaxData`. This assumes
@@ -2680,12 +2658,12 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     public init(_ node: ParameterClauseSyntax) {
       self = .input(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(ClosureParamListSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(ClosureParamListSyntax.self) {
         self = .simpleInput(node)
         return
       }
-      if let node = syntaxNode.as(ParameterClauseSyntax.self) {
+      if let node = node.as(ParameterClauseSyntax.self) {
         self = .input(node)
         return
       }
@@ -2702,11 +2680,9 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ClosureSignatureSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .closureSignature else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .closureSignature else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ClosureSignatureSyntax` node from the given `SyntaxData`. This assumes
@@ -3177,11 +3153,9 @@ extension ClosureSignatureSyntax: CustomReflectable {
 public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MultipleTrailingClosureElementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .multipleTrailingClosureElement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .multipleTrailingClosureElement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MultipleTrailingClosureElementSyntax` node from the given `SyntaxData`. This assumes
@@ -3415,11 +3389,9 @@ extension MultipleTrailingClosureElementSyntax: CustomReflectable {
 public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `StringSegmentSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .stringSegment else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .stringSegment else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `StringSegmentSyntax` node from the given `SyntaxData`. This assumes
@@ -3547,11 +3519,9 @@ extension StringSegmentSyntax: CustomReflectable {
 public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ExpressionSegmentSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .expressionSegment else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .expressionSegment else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ExpressionSegmentSyntax` node from the given `SyntaxData`. This assumes
@@ -3930,16 +3900,16 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
     public init(_ node: KeyPathOptionalComponentSyntax) {
       self = .optional(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(KeyPathPropertyComponentSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(KeyPathPropertyComponentSyntax.self) {
         self = .property(node)
         return
       }
-      if let node = syntaxNode.as(KeyPathSubscriptComponentSyntax.self) {
+      if let node = node.as(KeyPathSubscriptComponentSyntax.self) {
         self = .subscript(node)
         return
       }
-      if let node = syntaxNode.as(KeyPathOptionalComponentSyntax.self) {
+      if let node = node.as(KeyPathOptionalComponentSyntax.self) {
         self = .optional(node)
         return
       }
@@ -3957,11 +3927,9 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `KeyPathComponentSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .keyPathComponent else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .keyPathComponent else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `KeyPathComponentSyntax` node from the given `SyntaxData`. This assumes
@@ -4143,11 +4111,9 @@ extension KeyPathComponentSyntax: CustomReflectable {
 public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `KeyPathPropertyComponentSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .keyPathPropertyComponent else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .keyPathPropertyComponent else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `KeyPathPropertyComponentSyntax` node from the given `SyntaxData`. This assumes
@@ -4383,11 +4349,9 @@ extension KeyPathPropertyComponentSyntax: CustomReflectable {
 public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `KeyPathSubscriptComponentSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .keyPathSubscriptComponent else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .keyPathSubscriptComponent else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `KeyPathSubscriptComponentSyntax` node from the given `SyntaxData`. This assumes
@@ -4640,11 +4604,9 @@ extension KeyPathSubscriptComponentSyntax: CustomReflectable {
 public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `KeyPathOptionalComponentSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .keyPathOptionalComponent else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .keyPathOptionalComponent else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `KeyPathOptionalComponentSyntax` node from the given `SyntaxData`. This assumes
@@ -4772,11 +4734,9 @@ extension KeyPathOptionalComponentSyntax: CustomReflectable {
 public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ObjcNamePieceSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .objcNamePiece else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .objcNamePiece else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ObjcNamePieceSyntax` node from the given `SyntaxData`. This assumes
@@ -4958,11 +4918,9 @@ extension ObjcNamePieceSyntax: CustomReflectable {
 public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `YieldExprListElementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .yieldExprListElement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .yieldExprListElement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `YieldExprListElementSyntax` node from the given `SyntaxData`. This assumes
@@ -5144,11 +5102,9 @@ extension YieldExprListElementSyntax: CustomReflectable {
 public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `TypeInitializerClauseSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .typeInitializerClause else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .typeInitializerClause else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `TypeInitializerClauseSyntax` node from the given `SyntaxData`. This assumes
@@ -5329,11 +5285,9 @@ extension TypeInitializerClauseSyntax: CustomReflectable {
 public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ParameterClauseSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .parameterClause else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .parameterClause else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ParameterClauseSyntax` node from the given `SyntaxData`. This assumes
@@ -5586,11 +5540,9 @@ extension ParameterClauseSyntax: CustomReflectable {
 public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ReturnClauseSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .returnClause else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .returnClause else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ReturnClauseSyntax` node from the given `SyntaxData`. This assumes
@@ -5771,11 +5723,9 @@ extension ReturnClauseSyntax: CustomReflectable {
 public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `FunctionSignatureSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .functionSignature else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .functionSignature else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `FunctionSignatureSyntax` node from the given `SyntaxData`. This assumes
@@ -6094,24 +6044,24 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
     public init(_ node: AttributeListSyntax) {
       self = .attributes(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(CodeBlockItemListSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(CodeBlockItemListSyntax.self) {
         self = .statements(node)
         return
       }
-      if let node = syntaxNode.as(SwitchCaseListSyntax.self) {
+      if let node = node.as(SwitchCaseListSyntax.self) {
         self = .switchCases(node)
         return
       }
-      if let node = syntaxNode.as(MemberDeclListSyntax.self) {
+      if let node = node.as(MemberDeclListSyntax.self) {
         self = .decls(node)
         return
       }
-      if let node = syntaxNode.as(ExprSyntax.self) {
+      if let node = node.as(ExprSyntax.self) {
         self = .postfixExpression(node)
         return
       }
-      if let node = syntaxNode.as(AttributeListSyntax.self) {
+      if let node = node.as(AttributeListSyntax.self) {
         self = .attributes(node)
         return
       }
@@ -6131,11 +6081,9 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `IfConfigClauseSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .ifConfigClause else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .ifConfigClause else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `IfConfigClauseSyntax` node from the given `SyntaxData`. This assumes
@@ -6371,11 +6319,9 @@ extension IfConfigClauseSyntax: CustomReflectable {
 public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PoundSourceLocationArgsSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .poundSourceLocationArgs else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .poundSourceLocationArgs else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PoundSourceLocationArgsSyntax` node from the given `SyntaxData`. This assumes
@@ -6821,11 +6767,9 @@ extension PoundSourceLocationArgsSyntax: CustomReflectable {
 public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DeclModifierDetailSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .declModifierDetail else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .declModifierDetail else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DeclModifierDetailSyntax` node from the given `SyntaxData`. This assumes
@@ -7059,11 +7003,9 @@ extension DeclModifierDetailSyntax: CustomReflectable {
 public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DeclModifierSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .declModifier else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .declModifier else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DeclModifierSyntax` node from the given `SyntaxData`. This assumes
@@ -7245,11 +7187,9 @@ extension DeclModifierSyntax: CustomReflectable {
 public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `InheritedTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .inheritedType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .inheritedType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `InheritedTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -7431,11 +7371,9 @@ extension InheritedTypeSyntax: CustomReflectable {
 public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `TypeInheritanceClauseSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .typeInheritanceClause else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .typeInheritanceClause else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `TypeInheritanceClauseSyntax` node from the given `SyntaxData`. This assumes
@@ -7635,11 +7573,9 @@ extension TypeInheritanceClauseSyntax: CustomReflectable {
 public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MemberDeclBlockSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .memberDeclBlock else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .memberDeclBlock else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MemberDeclBlockSyntax` node from the given `SyntaxData`. This assumes
@@ -7896,11 +7832,9 @@ extension MemberDeclBlockSyntax: CustomReflectable {
 public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MemberDeclListItemSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .memberDeclListItem else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .memberDeclListItem else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MemberDeclListItemSyntax` node from the given `SyntaxData`. This assumes
@@ -8084,11 +8018,9 @@ extension MemberDeclListItemSyntax: CustomReflectable {
 public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `SourceFileSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .sourceFile else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .sourceFile else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `SourceFileSyntax` node from the given `SyntaxData`. This assumes
@@ -8288,11 +8220,9 @@ extension SourceFileSyntax: CustomReflectable {
 public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `InitializerClauseSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .initializerClause else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .initializerClause else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `InitializerClauseSyntax` node from the given `SyntaxData`. This assumes
@@ -8473,11 +8403,9 @@ extension InitializerClauseSyntax: CustomReflectable {
 public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `FunctionParameterSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .functionParameter else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .functionParameter else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `FunctionParameterSyntax` node from the given `SyntaxData`. This assumes
@@ -9076,11 +9004,9 @@ extension FunctionParameterSyntax: CustomReflectable {
 public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AccessLevelModifierSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .accessLevelModifier else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .accessLevelModifier else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AccessLevelModifierSyntax` node from the given `SyntaxData`. This assumes
@@ -9262,11 +9188,9 @@ extension AccessLevelModifierSyntax: CustomReflectable {
 public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AccessPathComponentSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .accessPathComponent else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .accessPathComponent else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AccessPathComponentSyntax` node from the given `SyntaxData`. This assumes
@@ -9448,11 +9372,9 @@ extension AccessPathComponentSyntax: CustomReflectable {
 public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AccessorParameterSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .accessorParameter else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .accessorParameter else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AccessorParameterSyntax` node from the given `SyntaxData`. This assumes
@@ -9686,11 +9608,9 @@ extension AccessorParameterSyntax: CustomReflectable {
 public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AccessorBlockSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .accessorBlock else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .accessorBlock else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AccessorBlockSyntax` node from the given `SyntaxData`. This assumes
@@ -9957,12 +9877,12 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
     public init(_ node: CodeBlockSyntax) {
       self = .getter(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(AccessorBlockSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(AccessorBlockSyntax.self) {
         self = .accessors(node)
         return
       }
-      if let node = syntaxNode.as(CodeBlockSyntax.self) {
+      if let node = node.as(CodeBlockSyntax.self) {
         self = .getter(node)
         return
       }
@@ -9979,11 +9899,9 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PatternBindingSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .patternBinding else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .patternBinding else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PatternBindingSyntax` node from the given `SyntaxData`. This assumes
@@ -10331,11 +10249,9 @@ extension PatternBindingSyntax: CustomReflectable {
 public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `EnumCaseElementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .enumCaseElement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .enumCaseElement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `EnumCaseElementSyntax` node from the given `SyntaxData`. This assumes
@@ -10634,11 +10550,9 @@ extension EnumCaseElementSyntax: CustomReflectable {
 public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DesignatedTypeElementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .designatedTypeElement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .designatedTypeElement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DesignatedTypeElementSyntax` node from the given `SyntaxData`. This assumes
@@ -10822,11 +10736,9 @@ extension DesignatedTypeElementSyntax: CustomReflectable {
 public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `OperatorPrecedenceAndTypesSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .operatorPrecedenceAndTypes else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .operatorPrecedenceAndTypes else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `OperatorPrecedenceAndTypesSyntax` node from the given `SyntaxData`. This assumes
@@ -11089,11 +11001,9 @@ extension OperatorPrecedenceAndTypesSyntax: CustomReflectable {
 public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PrecedenceGroupRelationSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .precedenceGroupRelation else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .precedenceGroupRelation else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PrecedenceGroupRelationSyntax` node from the given `SyntaxData`. This assumes
@@ -11353,11 +11263,9 @@ extension PrecedenceGroupRelationSyntax: CustomReflectable {
 public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PrecedenceGroupNameElementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .precedenceGroupNameElement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .precedenceGroupNameElement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PrecedenceGroupNameElementSyntax` node from the given `SyntaxData`. This assumes
@@ -11543,11 +11451,9 @@ extension PrecedenceGroupNameElementSyntax: CustomReflectable {
 public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PrecedenceGroupAssignmentSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .precedenceGroupAssignment else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .precedenceGroupAssignment else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PrecedenceGroupAssignmentSyntax` node from the given `SyntaxData`. This assumes
@@ -11792,11 +11698,9 @@ extension PrecedenceGroupAssignmentSyntax: CustomReflectable {
 public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PrecedenceGroupAssociativitySyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .precedenceGroupAssociativity else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .precedenceGroupAssociativity else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PrecedenceGroupAssociativitySyntax` node from the given `SyntaxData`. This assumes
@@ -12039,11 +11943,9 @@ extension PrecedenceGroupAssociativitySyntax: CustomReflectable {
 public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `CustomAttributeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .customAttribute else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .customAttribute else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `CustomAttributeSyntax` node from the given `SyntaxData`. This assumes
@@ -12484,60 +12386,60 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
     public init(_ node: TokenListSyntax) {
       self = .tokenList(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(TokenSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(TokenSyntax.self) {
         self = .token(node)
         return
       }
-      if let node = syntaxNode.as(StringLiteralExprSyntax.self) {
+      if let node = node.as(StringLiteralExprSyntax.self) {
         self = .stringExpr(node)
         return
       }
-      if let node = syntaxNode.as(AvailabilitySpecListSyntax.self) {
+      if let node = node.as(AvailabilitySpecListSyntax.self) {
         self = .availability(node)
         return
       }
-      if let node = syntaxNode.as(SpecializeAttributeSpecListSyntax.self) {
+      if let node = node.as(SpecializeAttributeSpecListSyntax.self) {
         self = .specializeArguments(node)
         return
       }
-      if let node = syntaxNode.as(ObjCSelectorSyntax.self) {
+      if let node = node.as(ObjCSelectorSyntax.self) {
         self = .objCName(node)
         return
       }
-      if let node = syntaxNode.as(ImplementsAttributeArgumentsSyntax.self) {
+      if let node = node.as(ImplementsAttributeArgumentsSyntax.self) {
         self = .implementsArguments(node)
         return
       }
-      if let node = syntaxNode.as(DifferentiableAttributeArgumentsSyntax.self) {
+      if let node = node.as(DifferentiableAttributeArgumentsSyntax.self) {
         self = .differentiableArguments(node)
         return
       }
-      if let node = syntaxNode.as(DerivativeRegistrationAttributeArgumentsSyntax.self) {
+      if let node = node.as(DerivativeRegistrationAttributeArgumentsSyntax.self) {
         self = .derivativeRegistrationArguments(node)
         return
       }
-      if let node = syntaxNode.as(NamedAttributeStringArgumentSyntax.self) {
+      if let node = node.as(NamedAttributeStringArgumentSyntax.self) {
         self = .namedAttributeString(node)
         return
       }
-      if let node = syntaxNode.as(BackDeployAttributeSpecListSyntax.self) {
+      if let node = node.as(BackDeployAttributeSpecListSyntax.self) {
         self = .backDeployArguments(node)
         return
       }
-      if let node = syntaxNode.as(ConventionAttributeArgumentsSyntax.self) {
+      if let node = node.as(ConventionAttributeArgumentsSyntax.self) {
         self = .conventionArguments(node)
         return
       }
-      if let node = syntaxNode.as(ConventionWitnessMethodAttributeArgumentsSyntax.self) {
+      if let node = node.as(ConventionWitnessMethodAttributeArgumentsSyntax.self) {
         self = .conventionWitnessMethodArguments(node)
         return
       }
-      if let node = syntaxNode.as(OpaqueReturnTypeOfAttributeArgumentsSyntax.self) {
+      if let node = node.as(OpaqueReturnTypeOfAttributeArgumentsSyntax.self) {
         self = .opaqueReturnTypeOfAttributeArguments(node)
         return
       }
-      if let node = syntaxNode.as(TokenListSyntax.self) {
+      if let node = node.as(TokenListSyntax.self) {
         self = .tokenList(node)
         return
       }
@@ -12566,11 +12468,9 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AttributeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .attribute else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .attribute else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AttributeSyntax` node from the given `SyntaxData`. This assumes
@@ -13002,11 +12902,9 @@ extension AttributeSyntax: CustomReflectable {
 public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AvailabilityEntrySyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .availabilityEntry else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .availabilityEntry else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AvailabilityEntrySyntax` node from the given `SyntaxData`. This assumes
@@ -13318,11 +13216,9 @@ extension AvailabilityEntrySyntax: CustomReflectable {
 public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `LabeledSpecializeEntrySyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .labeledSpecializeEntry else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .labeledSpecializeEntry else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `LabeledSpecializeEntrySyntax` node from the given `SyntaxData`. This assumes
@@ -13621,11 +13517,9 @@ extension LabeledSpecializeEntrySyntax: CustomReflectable {
 public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `TargetFunctionEntrySyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .targetFunctionEntry else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .targetFunctionEntry else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `TargetFunctionEntrySyntax` node from the given `SyntaxData`. This assumes
@@ -13938,12 +13832,12 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
     public init(_ node: DeclNameSyntax) {
       self = .declname(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(TokenSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(TokenSyntax.self) {
         self = .string(node)
         return
       }
-      if let node = syntaxNode.as(DeclNameSyntax.self) {
+      if let node = node.as(DeclNameSyntax.self) {
         self = .declname(node)
         return
       }
@@ -13960,11 +13854,9 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `NamedAttributeStringArgumentSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .namedAttributeStringArgument else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .namedAttributeStringArgument else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `NamedAttributeStringArgumentSyntax` node from the given `SyntaxData`. This assumes
@@ -14200,11 +14092,9 @@ extension NamedAttributeStringArgumentSyntax: CustomReflectable {
 public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DeclNameSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .declName else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .declName else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DeclNameSyntax` node from the given `SyntaxData`. This assumes
@@ -14397,11 +14287,9 @@ extension DeclNameSyntax: CustomReflectable {
 public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ImplementsAttributeArgumentsSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .implementsAttributeArguments else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .implementsAttributeArguments else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ImplementsAttributeArgumentsSyntax` node from the given `SyntaxData`. This assumes
@@ -14708,11 +14596,9 @@ extension ImplementsAttributeArgumentsSyntax: CustomReflectable {
 public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ObjCSelectorPieceSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .objCSelectorPiece else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .objCSelectorPiece else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ObjCSelectorPieceSyntax` node from the given `SyntaxData`. This assumes
@@ -14900,11 +14786,9 @@ extension ObjCSelectorPieceSyntax: CustomReflectable {
 public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DifferentiableAttributeArgumentsSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .differentiableAttributeArguments else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .differentiableAttributeArguments else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DifferentiableAttributeArgumentsSyntax` node from the given `SyntaxData`. This assumes
@@ -15271,12 +15155,12 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
     public init(_ node: DifferentiabilityParamsSyntax) {
       self = .parameterList(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(DifferentiabilityParamSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(DifferentiabilityParamSyntax.self) {
         self = .parameter(node)
         return
       }
-      if let node = syntaxNode.as(DifferentiabilityParamsSyntax.self) {
+      if let node = node.as(DifferentiabilityParamsSyntax.self) {
         self = .parameterList(node)
         return
       }
@@ -15293,11 +15177,9 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DifferentiabilityParamsClauseSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .differentiabilityParamsClause else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .differentiabilityParamsClause else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DifferentiabilityParamsClauseSyntax` node from the given `SyntaxData`. This assumes
@@ -15536,11 +15418,9 @@ extension DifferentiabilityParamsClauseSyntax: CustomReflectable {
 public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DifferentiabilityParamsSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .differentiabilityParams else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .differentiabilityParams else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DifferentiabilityParamsSyntax` node from the given `SyntaxData`. This assumes
@@ -15798,11 +15678,9 @@ extension DifferentiabilityParamsSyntax: CustomReflectable {
 public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DifferentiabilityParamSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .differentiabilityParam else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .differentiabilityParam else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DifferentiabilityParamSyntax` node from the given `SyntaxData`. This assumes
@@ -15989,11 +15867,9 @@ extension DifferentiabilityParamSyntax: CustomReflectable {
 public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DerivativeRegistrationAttributeArgumentsSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .derivativeRegistrationAttributeArguments else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .derivativeRegistrationAttributeArguments else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DerivativeRegistrationAttributeArgumentsSyntax` node from the given `SyntaxData`. This assumes
@@ -16458,11 +16334,9 @@ extension DerivativeRegistrationAttributeArgumentsSyntax: CustomReflectable {
 public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `QualifiedDeclNameSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .qualifiedDeclName else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .qualifiedDeclName else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `QualifiedDeclNameSyntax` node from the given `SyntaxData`. This assumes
@@ -16763,11 +16637,9 @@ extension QualifiedDeclNameSyntax: CustomReflectable {
 public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `FunctionDeclNameSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .functionDeclName else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .functionDeclName else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `FunctionDeclNameSyntax` node from the given `SyntaxData`. This assumes
@@ -16959,11 +16831,9 @@ extension FunctionDeclNameSyntax: CustomReflectable {
 public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `BackDeployAttributeSpecListSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .backDeployAttributeSpecList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .backDeployAttributeSpecList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `BackDeployAttributeSpecListSyntax` node from the given `SyntaxData`. This assumes
@@ -17228,11 +17098,9 @@ extension BackDeployAttributeSpecListSyntax: CustomReflectable {
 public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `BackDeployVersionArgumentSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .backDeployVersionArgument else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .backDeployVersionArgument else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `BackDeployVersionArgumentSyntax` node from the given `SyntaxData`. This assumes
@@ -17421,11 +17289,9 @@ extension BackDeployVersionArgumentSyntax: CustomReflectable {
 public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `OpaqueReturnTypeOfAttributeArgumentsSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .opaqueReturnTypeOfAttributeArguments else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .opaqueReturnTypeOfAttributeArguments else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `OpaqueReturnTypeOfAttributeArgumentsSyntax` node from the given `SyntaxData`. This assumes
@@ -17664,11 +17530,9 @@ extension OpaqueReturnTypeOfAttributeArgumentsSyntax: CustomReflectable {
 public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ConventionAttributeArgumentsSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .conventionAttributeArguments else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .conventionAttributeArguments else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ConventionAttributeArgumentsSyntax` node from the given `SyntaxData`. This assumes
@@ -18016,11 +17880,9 @@ extension ConventionAttributeArgumentsSyntax: CustomReflectable {
 public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ConventionWitnessMethodAttributeArgumentsSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .conventionWitnessMethodAttributeArguments else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .conventionWitnessMethodAttributeArguments else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ConventionWitnessMethodAttributeArgumentsSyntax` node from the given `SyntaxData`. This assumes
@@ -18254,11 +18116,9 @@ extension ConventionWitnessMethodAttributeArgumentsSyntax: CustomReflectable {
 public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `WhereClauseSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .whereClause else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .whereClause else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `WhereClauseSyntax` node from the given `SyntaxData`. This assumes
@@ -18439,11 +18299,9 @@ extension WhereClauseSyntax: CustomReflectable {
 public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `YieldListSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .yieldList else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .yieldList else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `YieldListSyntax` node from the given `SyntaxData`. This assumes
@@ -18730,28 +18588,28 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
     public init(_ node: HasSymbolConditionSyntax) {
       self = .hasSymbol(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(ExprSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(ExprSyntax.self) {
         self = .expression(node)
         return
       }
-      if let node = syntaxNode.as(AvailabilityConditionSyntax.self) {
+      if let node = node.as(AvailabilityConditionSyntax.self) {
         self = .availability(node)
         return
       }
-      if let node = syntaxNode.as(UnavailabilityConditionSyntax.self) {
+      if let node = node.as(UnavailabilityConditionSyntax.self) {
         self = .unavailability(node)
         return
       }
-      if let node = syntaxNode.as(MatchingPatternConditionSyntax.self) {
+      if let node = node.as(MatchingPatternConditionSyntax.self) {
         self = .matchingPattern(node)
         return
       }
-      if let node = syntaxNode.as(OptionalBindingConditionSyntax.self) {
+      if let node = node.as(OptionalBindingConditionSyntax.self) {
         self = .optionalBinding(node)
         return
       }
-      if let node = syntaxNode.as(HasSymbolConditionSyntax.self) {
+      if let node = node.as(HasSymbolConditionSyntax.self) {
         self = .hasSymbol(node)
         return
       }
@@ -18772,11 +18630,9 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ConditionElementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .conditionElement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .conditionElement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ConditionElementSyntax` node from the given `SyntaxData`. This assumes
@@ -18958,11 +18814,9 @@ extension ConditionElementSyntax: CustomReflectable {
 public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AvailabilityConditionSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .availabilityCondition else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .availabilityCondition else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AvailabilityConditionSyntax` node from the given `SyntaxData`. This assumes
@@ -19268,11 +19122,9 @@ extension AvailabilityConditionSyntax: CustomReflectable {
 public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MatchingPatternConditionSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .matchingPatternCondition else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .matchingPatternCondition else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MatchingPatternConditionSyntax` node from the given `SyntaxData`. This assumes
@@ -19560,11 +19412,9 @@ extension MatchingPatternConditionSyntax: CustomReflectable {
 public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `OptionalBindingConditionSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .optionalBindingCondition else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .optionalBindingCondition else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `OptionalBindingConditionSyntax` node from the given `SyntaxData`. This assumes
@@ -19853,11 +19703,9 @@ extension OptionalBindingConditionSyntax: CustomReflectable {
 public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `UnavailabilityConditionSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .unavailabilityCondition else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .unavailabilityCondition else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `UnavailabilityConditionSyntax` node from the given `SyntaxData`. This assumes
@@ -20163,11 +20011,9 @@ extension UnavailabilityConditionSyntax: CustomReflectable {
 public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `HasSymbolConditionSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .hasSymbolCondition else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .hasSymbolCondition else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `HasSymbolConditionSyntax` node from the given `SyntaxData`. This assumes
@@ -20468,12 +20314,12 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
     public init(_ node: SwitchCaseLabelSyntax) {
       self = .case(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(SwitchDefaultLabelSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(SwitchDefaultLabelSyntax.self) {
         self = .default(node)
         return
       }
-      if let node = syntaxNode.as(SwitchCaseLabelSyntax.self) {
+      if let node = node.as(SwitchCaseLabelSyntax.self) {
         self = .case(node)
         return
       }
@@ -20490,11 +20336,9 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `SwitchCaseSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .switchCase else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .switchCase else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `SwitchCaseSyntax` node from the given `SyntaxData`. This assumes
@@ -20748,11 +20592,9 @@ extension SwitchCaseSyntax: CustomReflectable {
 public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `SwitchDefaultLabelSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .switchDefaultLabel else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .switchDefaultLabel else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `SwitchDefaultLabelSyntax` node from the given `SyntaxData`. This assumes
@@ -20933,11 +20775,9 @@ extension SwitchDefaultLabelSyntax: CustomReflectable {
 public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `CaseItemSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .caseItem else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .caseItem else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `CaseItemSyntax` node from the given `SyntaxData`. This assumes
@@ -21173,11 +21013,9 @@ extension CaseItemSyntax: CustomReflectable {
 public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `CatchItemSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .catchItem else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .catchItem else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `CatchItemSyntax` node from the given `SyntaxData`. This assumes
@@ -21414,11 +21252,9 @@ extension CatchItemSyntax: CustomReflectable {
 public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `SwitchCaseLabelSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .switchCaseLabel else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .switchCaseLabel else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `SwitchCaseLabelSyntax` node from the given `SyntaxData`. This assumes
@@ -21671,11 +21507,9 @@ extension SwitchCaseLabelSyntax: CustomReflectable {
 public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `CatchClauseSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .catchClause else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .catchClause else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `CatchClauseSyntax` node from the given `SyntaxData`. This assumes
@@ -21929,11 +21763,9 @@ extension CatchClauseSyntax: CustomReflectable {
 public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `GenericWhereClauseSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .genericWhereClause else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .genericWhereClause else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `GenericWhereClauseSyntax` node from the given `SyntaxData`. This assumes
@@ -22152,16 +21984,16 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     public init(_ node: LayoutRequirementSyntax) {
       self = .layoutRequirement(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(SameTypeRequirementSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(SameTypeRequirementSyntax.self) {
         self = .sameTypeRequirement(node)
         return
       }
-      if let node = syntaxNode.as(ConformanceRequirementSyntax.self) {
+      if let node = node.as(ConformanceRequirementSyntax.self) {
         self = .conformanceRequirement(node)
         return
       }
-      if let node = syntaxNode.as(LayoutRequirementSyntax.self) {
+      if let node = node.as(LayoutRequirementSyntax.self) {
         self = .layoutRequirement(node)
         return
       }
@@ -22179,11 +22011,9 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `GenericRequirementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .genericRequirement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .genericRequirement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `GenericRequirementSyntax` node from the given `SyntaxData`. This assumes
@@ -22365,11 +22195,9 @@ extension GenericRequirementSyntax: CustomReflectable {
 public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `SameTypeRequirementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .sameTypeRequirement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .sameTypeRequirement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `SameTypeRequirementSyntax` node from the given `SyntaxData`. This assumes
@@ -22603,11 +22431,9 @@ extension SameTypeRequirementSyntax: CustomReflectable {
 public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `LayoutRequirementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .layoutRequirement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .layoutRequirement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `LayoutRequirementSyntax` node from the given `SyntaxData`. This assumes
@@ -23111,11 +22937,9 @@ extension LayoutRequirementSyntax: CustomReflectable {
 public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `GenericParameterSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .genericParameter else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .genericParameter else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `GenericParameterSyntax` node from the given `SyntaxData`. This assumes
@@ -23532,11 +23356,9 @@ extension GenericParameterSyntax: CustomReflectable {
 public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PrimaryAssociatedTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .primaryAssociatedType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .primaryAssociatedType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PrimaryAssociatedTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -23718,11 +23540,9 @@ extension PrimaryAssociatedTypeSyntax: CustomReflectable {
 public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `GenericParameterClauseSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .genericParameterClause else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .genericParameterClause else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `GenericParameterClauseSyntax` node from the given `SyntaxData`. This assumes
@@ -24029,11 +23849,9 @@ extension GenericParameterClauseSyntax: CustomReflectable {
 public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ConformanceRequirementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .conformanceRequirement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .conformanceRequirement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ConformanceRequirementSyntax` node from the given `SyntaxData`. This assumes
@@ -24267,11 +24085,9 @@ extension ConformanceRequirementSyntax: CustomReflectable {
 public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PrimaryAssociatedTypeClauseSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .primaryAssociatedTypeClause else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .primaryAssociatedTypeClause else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PrimaryAssociatedTypeClauseSyntax` node from the given `SyntaxData`. This assumes
@@ -24524,11 +24340,9 @@ extension PrimaryAssociatedTypeClauseSyntax: CustomReflectable {
 public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `CompositionTypeElementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .compositionTypeElement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .compositionTypeElement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `CompositionTypeElementSyntax` node from the given `SyntaxData`. This assumes
@@ -24710,11 +24524,9 @@ extension CompositionTypeElementSyntax: CustomReflectable {
 public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `TupleTypeElementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .tupleTypeElement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .tupleTypeElement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `TupleTypeElementSyntax` node from the given `SyntaxData`. This assumes
@@ -25220,11 +25032,9 @@ extension TupleTypeElementSyntax: CustomReflectable {
 public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `GenericArgumentSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .genericArgument else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .genericArgument else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `GenericArgumentSyntax` node from the given `SyntaxData`. This assumes
@@ -25406,11 +25216,9 @@ extension GenericArgumentSyntax: CustomReflectable {
 public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `GenericArgumentClauseSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .genericArgumentClause else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .genericArgumentClause else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `GenericArgumentClauseSyntax` node from the given `SyntaxData`. This assumes
@@ -25663,11 +25471,9 @@ extension GenericArgumentClauseSyntax: CustomReflectable {
 public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `TypeAnnotationSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .typeAnnotation else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .typeAnnotation else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `TypeAnnotationSyntax` node from the given `SyntaxData`. This assumes
@@ -25848,11 +25654,9 @@ extension TypeAnnotationSyntax: CustomReflectable {
 public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `TuplePatternElementSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .tuplePatternElement else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .tuplePatternElement else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `TuplePatternElementSyntax` node from the given `SyntaxData`. This assumes
@@ -26170,20 +25974,20 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     public init(_ node: TokenListSyntax) {
       self = .tokenList(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(TokenSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(TokenSyntax.self) {
         self = .token(node)
         return
       }
-      if let node = syntaxNode.as(AvailabilityVersionRestrictionSyntax.self) {
+      if let node = node.as(AvailabilityVersionRestrictionSyntax.self) {
         self = .availabilityVersionRestriction(node)
         return
       }
-      if let node = syntaxNode.as(AvailabilityLabeledArgumentSyntax.self) {
+      if let node = node.as(AvailabilityLabeledArgumentSyntax.self) {
         self = .availabilityLabeledArgument(node)
         return
       }
-      if let node = syntaxNode.as(TokenListSyntax.self) {
+      if let node = node.as(TokenListSyntax.self) {
         self = .tokenList(node)
         return
       }
@@ -26202,11 +26006,9 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AvailabilityArgumentSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .availabilityArgument else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .availabilityArgument else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AvailabilityArgumentSyntax` node from the given `SyntaxData`. This assumes
@@ -26411,12 +26213,12 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
     public init(_ node: VersionTupleSyntax) {
       self = .version(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(TokenSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(TokenSyntax.self) {
         self = .string(node)
         return
       }
-      if let node = syntaxNode.as(VersionTupleSyntax.self) {
+      if let node = node.as(VersionTupleSyntax.self) {
         self = .version(node)
         return
       }
@@ -26433,11 +26235,9 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AvailabilityLabeledArgumentSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .availabilityLabeledArgument else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .availabilityLabeledArgument else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AvailabilityLabeledArgumentSyntax` node from the given `SyntaxData`. This assumes
@@ -26678,11 +26478,9 @@ extension AvailabilityLabeledArgumentSyntax: CustomReflectable {
 public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AvailabilityVersionRestrictionSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .availabilityVersionRestriction else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .availabilityVersionRestriction else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AvailabilityVersionRestrictionSyntax` node from the given `SyntaxData`. This assumes
@@ -26873,11 +26671,9 @@ extension AvailabilityVersionRestrictionSyntax: CustomReflectable {
 public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `VersionTupleSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .versionTuple else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .versionTuple else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `VersionTupleSyntax` node from the given `SyntaxData`. This assumes

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
@@ -18,11 +18,9 @@
 public struct UnknownPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `UnknownPatternSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .unknownPattern else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .unknownPattern else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `UnknownPatternSyntax` node from the given `SyntaxData`. This assumes
@@ -70,11 +68,9 @@ extension UnknownPatternSyntax: CustomReflectable {
 public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MissingPatternSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .missingPattern else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .missingPattern else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MissingPatternSyntax` node from the given `SyntaxData`. This assumes
@@ -122,11 +118,9 @@ extension MissingPatternSyntax: CustomReflectable {
 public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `EnumCasePatternSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .enumCasePattern else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .enumCasePattern else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `EnumCasePatternSyntax` node from the given `SyntaxData`. This assumes
@@ -415,11 +409,9 @@ extension EnumCasePatternSyntax: CustomReflectable {
 public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `IsTypePatternSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .isTypePattern else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .isTypePattern else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `IsTypePatternSyntax` node from the given `SyntaxData`. This assumes
@@ -600,11 +592,9 @@ extension IsTypePatternSyntax: CustomReflectable {
 public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `OptionalPatternSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .optionalPattern else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .optionalPattern else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `OptionalPatternSyntax` node from the given `SyntaxData`. This assumes
@@ -785,11 +775,9 @@ extension OptionalPatternSyntax: CustomReflectable {
 public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `IdentifierPatternSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .identifierPattern else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .identifierPattern else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `IdentifierPatternSyntax` node from the given `SyntaxData`. This assumes
@@ -917,11 +905,9 @@ extension IdentifierPatternSyntax: CustomReflectable {
 public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AsTypePatternSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .asTypePattern else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .asTypePattern else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AsTypePatternSyntax` node from the given `SyntaxData`. This assumes
@@ -1155,11 +1141,9 @@ extension AsTypePatternSyntax: CustomReflectable {
 public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `TuplePatternSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .tuplePattern else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .tuplePattern else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `TuplePatternSyntax` node from the given `SyntaxData`. This assumes
@@ -1412,11 +1396,9 @@ extension TuplePatternSyntax: CustomReflectable {
 public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `WildcardPatternSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .wildcardPattern else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .wildcardPattern else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `WildcardPatternSyntax` node from the given `SyntaxData`. This assumes
@@ -1598,11 +1580,9 @@ extension WildcardPatternSyntax: CustomReflectable {
 public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ExpressionPatternSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .expressionPattern else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .expressionPattern else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ExpressionPatternSyntax` node from the given `SyntaxData`. This assumes
@@ -1730,11 +1710,9 @@ extension ExpressionPatternSyntax: CustomReflectable {
 public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ValueBindingPatternSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .valueBindingPattern else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .valueBindingPattern else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ValueBindingPatternSyntax` node from the given `SyntaxData`. This assumes

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -18,11 +18,9 @@
 public struct UnknownStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `UnknownStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .unknownStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .unknownStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `UnknownStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -70,11 +68,9 @@ extension UnknownStmtSyntax: CustomReflectable {
 public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MissingStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .missingStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .missingStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MissingStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -122,11 +118,9 @@ extension MissingStmtSyntax: CustomReflectable {
 public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `LabeledStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .labeledStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .labeledStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `LabeledStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -360,11 +354,9 @@ extension LabeledStmtSyntax: CustomReflectable {
 public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ContinueStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .continueStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .continueStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ContinueStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -546,11 +538,9 @@ extension ContinueStmtSyntax: CustomReflectable {
 public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `WhileStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .whileStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .whileStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `WhileStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -803,11 +793,9 @@ extension WhileStmtSyntax: CustomReflectable {
 public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DeferStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .deferStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .deferStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DeferStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -988,11 +976,9 @@ extension DeferStmtSyntax: CustomReflectable {
 public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ExpressionStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .expressionStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .expressionStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ExpressionStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -1120,11 +1106,9 @@ extension ExpressionStmtSyntax: CustomReflectable {
 public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `RepeatWhileStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .repeatWhileStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .repeatWhileStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `RepeatWhileStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -1411,11 +1395,9 @@ extension RepeatWhileStmtSyntax: CustomReflectable {
 public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `GuardStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .guardStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .guardStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `GuardStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -1721,11 +1703,9 @@ extension GuardStmtSyntax: CustomReflectable {
 public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ForInStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .forInStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .forInStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ForInStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -2335,11 +2315,9 @@ extension ForInStmtSyntax: CustomReflectable {
 public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `SwitchStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .switchStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .switchStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `SwitchStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -2698,11 +2676,9 @@ extension SwitchStmtSyntax: CustomReflectable {
 public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DoStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .doStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .doStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DoStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -2956,11 +2932,9 @@ extension DoStmtSyntax: CustomReflectable {
 public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ReturnStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .returnStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .returnStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ReturnStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -3156,12 +3130,12 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     public init<Node: ExprSyntaxProtocol>(_ node: Node) {
       self = .simpleYield(ExprSyntax(node))
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(YieldListSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(YieldListSyntax.self) {
         self = .yieldList(node)
         return
       }
-      if let node = syntaxNode.as(ExprSyntax.self) {
+      if let node = node.as(ExprSyntax.self) {
         self = .simpleYield(node)
         return
       }
@@ -3178,11 +3152,9 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `YieldStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .yieldStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .yieldStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `YieldStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -3363,11 +3335,9 @@ extension YieldStmtSyntax: CustomReflectable {
 public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `FallthroughStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .fallthroughStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .fallthroughStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `FallthroughStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -3495,11 +3465,9 @@ extension FallthroughStmtSyntax: CustomReflectable {
 public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `BreakStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .breakStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .breakStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `BreakStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -3681,11 +3649,9 @@ extension BreakStmtSyntax: CustomReflectable {
 public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DeclarationStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .declarationStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .declarationStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DeclarationStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -3813,11 +3779,9 @@ extension DeclarationStmtSyntax: CustomReflectable {
 public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ThrowStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .throwStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .throwStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ThrowStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -4012,12 +3976,12 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     public init(_ node: CodeBlockSyntax) {
       self = .codeBlock(node)
     }
-    public init?<Node: SyntaxProtocol>(_ syntaxNode: Node) {
-      if let node = syntaxNode.as(IfStmtSyntax.self) {
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(IfStmtSyntax.self) {
         self = .ifStmt(node)
         return
       }
-      if let node = syntaxNode.as(CodeBlockSyntax.self) {
+      if let node = node.as(CodeBlockSyntax.self) {
         self = .codeBlock(node)
         return
       }
@@ -4034,11 +3998,9 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `IfStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .ifStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .ifStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `IfStmtSyntax` node from the given `SyntaxData`. This assumes
@@ -4399,11 +4361,9 @@ extension IfStmtSyntax: CustomReflectable {
 public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PoundAssertStmtSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .poundAssertStmt else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .poundAssertStmt else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PoundAssertStmtSyntax` node from the given `SyntaxData`. This assumes

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -18,11 +18,9 @@
 public struct UnknownTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `UnknownTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .unknownType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .unknownType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `UnknownTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -70,11 +68,9 @@ extension UnknownTypeSyntax: CustomReflectable {
 public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MissingTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .missingType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .missingType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MissingTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -122,11 +118,9 @@ extension MissingTypeSyntax: CustomReflectable {
 public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `SimpleTypeIdentifierSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .simpleTypeIdentifier else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .simpleTypeIdentifier else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `SimpleTypeIdentifierSyntax` node from the given `SyntaxData`. This assumes
@@ -308,11 +302,9 @@ extension SimpleTypeIdentifierSyntax: CustomReflectable {
 public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MemberTypeIdentifierSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .memberTypeIdentifier else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .memberTypeIdentifier else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MemberTypeIdentifierSyntax` node from the given `SyntaxData`. This assumes
@@ -600,11 +592,9 @@ extension MemberTypeIdentifierSyntax: CustomReflectable {
 public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ClassRestrictionTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .classRestrictionType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .classRestrictionType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ClassRestrictionTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -732,11 +722,9 @@ extension ClassRestrictionTypeSyntax: CustomReflectable {
 public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ArrayTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .arrayType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .arrayType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ArrayTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -970,11 +958,9 @@ extension ArrayTypeSyntax: CustomReflectable {
 public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `DictionaryTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .dictionaryType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .dictionaryType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `DictionaryTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -1314,11 +1300,9 @@ extension DictionaryTypeSyntax: CustomReflectable {
 public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `MetatypeTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .metatypeType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .metatypeType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `MetatypeTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -1552,11 +1536,9 @@ extension MetatypeTypeSyntax: CustomReflectable {
 public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `OptionalTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .optionalType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .optionalType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `OptionalTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -1737,11 +1719,9 @@ extension OptionalTypeSyntax: CustomReflectable {
 public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ConstrainedSugarTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .constrainedSugarType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .constrainedSugarType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ConstrainedSugarTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -1922,11 +1902,9 @@ extension ConstrainedSugarTypeSyntax: CustomReflectable {
 public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `ImplicitlyUnwrappedOptionalTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .implicitlyUnwrappedOptionalType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .implicitlyUnwrappedOptionalType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `ImplicitlyUnwrappedOptionalTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -2107,11 +2085,9 @@ extension ImplicitlyUnwrappedOptionalTypeSyntax: CustomReflectable {
 public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `CompositionTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .compositionType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .compositionType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `CompositionTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -2258,11 +2234,9 @@ extension CompositionTypeSyntax: CustomReflectable {
 public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `PackExpansionTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .packExpansionType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .packExpansionType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `PackExpansionTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -2443,11 +2417,9 @@ extension PackExpansionTypeSyntax: CustomReflectable {
 public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `TupleTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .tupleType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .tupleType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `TupleTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -2700,11 +2672,9 @@ extension TupleTypeSyntax: CustomReflectable {
 public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `FunctionTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .functionType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .functionType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `FunctionTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -3171,11 +3141,9 @@ extension FunctionTypeSyntax: CustomReflectable {
 public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `AttributedTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .attributedType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .attributedType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `AttributedTypeSyntax` node from the given `SyntaxData`. This assumes
@@ -3430,11 +3398,9 @@ extension AttributedTypeSyntax: CustomReflectable {
 public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
-  /// Converts the given `Syntax` node to a `NamedOpaqueReturnTypeSyntax` if possible. Returns
-  /// `nil` if the conversion is not possible.
-  public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .namedOpaqueReturnType else { return nil }
-    self._syntaxNode = syntax
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .namedOpaqueReturnType else { return nil }
+    self._syntaxNode = node._syntaxNode
   }
 
   /// Creates a `NamedOpaqueReturnTypeSyntax` node from the given `SyntaxData`. This assumes

--- a/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
@@ -264,6 +264,11 @@ public struct AttributeListBuilder {
   public static func buildExpression(_ expression: CustomAttribute) -> Self.Component {
     return buildExpression(.init (expression))
   }
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: IfConfigDecl) -> Self.Component {
+    return buildExpression(.init (expression))
+  }
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 


### PR DESCRIPTION
Rather than all syntax nodes taking a `Syntax`, instead make the initializer generic over a `SyntaxProtocol`. This is particularly useful now that each child has an enum for its kind.