### PR TITLE
Add remapping  to identifier when parsing argument label

### DIFF
--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -31,6 +31,9 @@ extension Parser {
         self.missingToken(.identifier, text: nil)
       )
     } else {
+      if let wildcardToken = self.consume(if: .wildcardKeyword) {
+        return (nil, wildcardToken)
+      }
       return (nil, self.consumeAnyToken(remapping: .identifier))
     }
   }

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -31,7 +31,7 @@ extension Parser {
         self.missingToken(.identifier, text: nil)
       )
     } else {
-      return (nil, self.consumeAnyToken())
+      return (nil, self.consumeAnyToken(remapping: .identifier))
     }
   }
 }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -73,6 +73,22 @@ final class DeclarationTests: XCTestCase {
     )
 
     AssertParse("func /^ (lhs: Int, rhs: Int) -> Int { 1 / 2 }")
+    
+    AssertParse(
+      """
+      func name(_ default: Int) {}
+      """,
+      substructure: Syntax(FunctionParameterSyntax(
+        attributes: nil,
+        modifiers: nil,
+        firstName: .wildcardKeyword(),
+        secondName: .identifier("default"),
+        colon: TokenSyntax.colonToken(),
+        type: TypeSyntax(SimpleTypeIdentifierSyntax(name: TokenSyntax.identifier("Int"), genericArgumentClause: nil)),
+        ellipsis: nil,
+        defaultArgument: nil,
+        trailingComma: nil))
+    )
   }
 
   func testFuncAfterUnbalancedClosingBrace() {

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -494,4 +494,30 @@ final class StatementTests: XCTestCase {
   func testDefaultIdentIdentifierInReturnStmt() {
     AssertParse("return FileManager.default")
   }
+  
+  func testDefaultAsIdentifierInSubscript() {
+    AssertParse(
+         """
+         data[position, default: 0]
+         """,
+         substructure: Syntax(ExprSyntax(SubscriptExprSyntax(
+          calledExpression: ExprSyntax(IdentifierExprSyntax(identifier: .identifier("data"), declNameArguments: nil)),
+          leftBracket: .leftSquareBracketToken(),
+          argumentList: TupleExprElementListSyntax([
+            TupleExprElementSyntax(
+              label: nil,
+              colon: nil,
+              expression: ExprSyntax(IdentifierExprSyntax(identifier: .identifier("position"), declNameArguments: nil)),
+              trailingComma: .commaToken()),
+            TupleExprElementSyntax(
+              label: .identifier("default"),
+              colon: .colonToken(),
+              expression: ExprSyntax(IntegerLiteralExprSyntax(0)),
+              trailingComma: nil),
+          ]),
+          rightBracket: .rightSquareBracketToken(),
+          trailingClosure: nil,
+          additionalTrailingClosures: nil)))
+    )
+  }
 }


### PR DESCRIPTION
Fixes the issue #829 by remapping the `default keyword` to identifier.