### PR TITLE
Add test case for tracking memory layout of syntax node data

### DIFF
--- a/Sources/SwiftSyntax/MemoryLayout.swift
+++ b/Sources/SwiftSyntax/MemoryLayout.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if DEBUG
+// See `MemoryLayoutTest.swift`.
+@_spi(Testing) public enum SyntaxMemoryLayout {
+  public struct Value: Equatable {
+    var size: Int
+    var stride: Int
+    var alignment: Int
+
+    public init(size: Int, stride: Int, alignment: Int) {
+      self.size = size
+      self.stride = stride
+      self.alignment = alignment
+    }
+  }
+
+  public static var values: [String : Value] {
+    let uniq: (Value, Value) -> Value =  { _, _ in preconditionFailure() }
+
+    var result: [String : Value] = [:]
+    result.merge(RawSyntaxDataMemoryLayouts, uniquingKeysWith: uniq)
+    result.merge(SyntaxDataMemoryLayouts, uniquingKeysWith: uniq)
+    return result
+  }
+}
+#endif

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -786,3 +786,28 @@ extension RawSyntax {
   }
 }
 
+#if DEBUG
+/// See `SyntaxMemoryLayout`.
+var RawSyntaxDataMemoryLayouts: [String : SyntaxMemoryLayout.Value] = [
+  "RawSyntaxData": .init(
+    size: MemoryLayout<RawSyntaxData>.size,
+    stride: MemoryLayout<RawSyntaxData>.stride,
+    alignment: MemoryLayout<RawSyntaxData>.alignment),
+  "RawSyntaxData.Layout": .init(
+    size: MemoryLayout<RawSyntaxData.Layout>.size,
+    stride: MemoryLayout<RawSyntaxData.Layout>.stride,
+    alignment: MemoryLayout<RawSyntaxData.Layout>.alignment),
+  "RawSyntaxData.ParsedToken": .init(
+    size: MemoryLayout<RawSyntaxData.ParsedToken>.size,
+    stride: MemoryLayout<RawSyntaxData.ParsedToken>.stride,
+    alignment: MemoryLayout<RawSyntaxData.ParsedToken>.alignment),
+  "RawSyntaxData.MaterializedToken": .init(
+    size: MemoryLayout<RawSyntaxData.MaterializedToken>.size,
+    stride: MemoryLayout<RawSyntaxData.MaterializedToken>.stride,
+    alignment: MemoryLayout<RawSyntaxData.MaterializedToken>.alignment),
+  "RawSyntax?": .init(
+    size: MemoryLayout<RawSyntax?>.size,
+    stride: MemoryLayout<RawSyntax?>.stride,
+    alignment: MemoryLayout<RawSyntax?>.alignment),
+]
+#endif

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -195,7 +195,7 @@ struct AbsoluteRawSyntax {
 /// SyntaxData is an implementation detail, and should not be exposed to clients
 /// of SwiftSyntax.
 struct SyntaxData {
-  private enum Info {
+  fileprivate enum Info {
     case root(Root)
     indirect case nonRoot(NonRoot)
 
@@ -372,3 +372,25 @@ struct SyntaxData {
     }
   }
 }
+
+#if DEBUG
+/// See `SyntaxMemoryLayout`.
+var SyntaxDataMemoryLayouts: [String : SyntaxMemoryLayout.Value] = [
+  "SyntaxData": .init(
+    size: MemoryLayout<SyntaxData>.size,
+    stride: MemoryLayout<SyntaxData>.stride,
+    alignment: MemoryLayout<SyntaxData>.alignment),
+  "SyntaxData.Info": .init(
+    size: MemoryLayout<SyntaxData.Info>.size,
+    stride: MemoryLayout<SyntaxData.Info>.stride,
+    alignment: MemoryLayout<SyntaxData.Info>.alignment),
+  "SyntaxData.Info.Root": .init(
+    size: MemoryLayout<SyntaxData.Info.Root>.size,
+    stride: MemoryLayout<SyntaxData.Info.Root>.stride,
+    alignment: MemoryLayout<SyntaxData.Info.Root>.alignment),
+  "SyntaxData.Info.NonRoot": .init(
+    size: MemoryLayout<SyntaxData.Info.NonRoot>.size,
+    stride: MemoryLayout<SyntaxData.Info.NonRoot>.stride,
+    alignment: MemoryLayout<SyntaxData.Info.NonRoot>.alignment),
+]
+#endif

--- a/Tests/SwiftSyntaxTest/MemoryLayoutTest.swift
+++ b/Tests/SwiftSyntaxTest/MemoryLayoutTest.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@_spi(Testing) import SwiftSyntax
+
+#if DEBUG
+final class MemoryLayoutTest: XCTestCase {
+
+  func testMemoryLayouts() throws {
+    /// This test result is just for tracking the memory footprint of syntax nodes,
+    /// and they are totally informative purpose. Although we want to keep the
+    /// numbers as low as possible, nothing should rely on them, and are not hard
+    /// limits in any way.
+    /// If this fails, just update the numbers.
+#if arch(x86_64) || arch(arm64)
+    let expected: [String: SyntaxMemoryLayout.Value] = [
+      "RawSyntaxData.Layout": .init(size: 41, stride: 48, alignment: 8),
+      "RawSyntaxData.ParsedToken": .init(size: 42, stride: 48, alignment: 8),
+      "RawSyntaxData.MaterializedToken": .init(size: 49, stride: 56, alignment: 8),
+      "RawSyntaxData": .init(size: 64, stride: 64, alignment: 8),
+      "RawSyntax?": .init(size: 8, stride: 8, alignment: 8),
+
+      "SyntaxData": .init(size: 16, stride: 16, alignment: 8),
+      "SyntaxData.Info": .init(size: 8, stride: 8, alignment: 8),
+      "SyntaxData.Info.Root": .init(size: 8, stride: 8, alignment: 8),
+      "SyntaxData.Info.NonRoot": .init(size: 36, stride: 40, alignment: 8),
+    ]
+#else
+    XCTSkip()
+#endif
+
+    let values = SyntaxMemoryLayout.values
+    XCTAssertEqual(values.count, expected.count)
+    for exp in expected {
+      let actualValue = try XCTUnwrap(values[exp.key], "Missing '\(exp.key)'")
+      XCTAssertEqual(actualValue, exp.value, "Matching '\(exp.key)' values")
+    }
+  }
+
+}
+#endif


### PR DESCRIPTION
This is useful to estimate how much memory is required.