### PR TITLE
Add Binary Operators to the Exception List for 'yield'

### DIFF
--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -1196,11 +1196,14 @@ extension Parser.Lookahead {
        case .prefixAmpersand:
          // "yield &" always denotes a yield statement.
          return true
-       case .leftParen:
+      case .leftParen:
          // "yield (", by contrast, must be disambiguated with additional
          // context. We always consider it an apply expression of a function
          // called `yield` for the purposes of the parse.
          return false
+      case .spacedBinaryOperator, .unspacedBinaryOperator:
+        // 'yield &= x' treats yield as an identifier.
+        return false
        default:
         // "yield" followed immediately by any other token is likely a
         // yield statement of some singular expression.

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -489,6 +489,32 @@ final class StatementTests: XCTestCase {
         rightParen: .rightParenToken(),
         trailingClosure: nil,
         additionalTrailingClosures: nil)))
+
+    AssertParse(
+      """
+      func f() -> Int {
+        1️⃣yield & 5
+      }
+      """,
+      substructure: Syntax(SequenceExprSyntax(elements: ExprListSyntax([
+        IdentifierExprSyntax(identifier: .identifier("yield"), declNameArguments: nil),
+        BinaryOperatorExprSyntax(operatorToken: .spacedBinaryOperator("&")),
+        IntegerLiteralExprSyntax(5)
+      ]))),
+      substructureAfterMarker: "1️⃣")
+
+    AssertParse(
+      """
+      func f() -> Int {
+        1️⃣yield&5
+      }
+      """,
+      substructure: Syntax(SequenceExprSyntax(elements: ExprListSyntax([
+        IdentifierExprSyntax(identifier: .identifier("yield"), declNameArguments: nil),
+        BinaryOperatorExprSyntax(operatorToken: .unspacedBinaryOperator("&")),
+        IntegerLiteralExprSyntax(5)
+      ]))),
+      substructureAfterMarker: "1️⃣")
   }
 
   func testDefaultIdentIdentifierInReturnStmt() {


### PR DESCRIPTION
This is a stopgap that prevents us from parsing yield followed by an operator as a yield statement. This is not a fantastic solution in the long run because

```
_modify {
  yield += x
}
```

is meant to actually be a parse-time error under the current rules. I suspect the proper solution is to have an UnresolvedYieldSyntax node and make either ASTGen or operator folding do the right thing here. For now, fix the regression in parsing.