### PR TITLE
Separate SyntaxArena for parsing

### DIFF
--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -118,7 +118,7 @@ extension Parser {
 /// operates on a copy of the lexical stream, no input tokens are lost..
 public struct Parser: TokenConsumer {
   @_spi(RawSyntax)
-  public var arena: SyntaxArena
+  public var arena: ParsingSyntaxArena
   /// A view of the sequence of lexemes in the input.
   var lexemes: Lexer.LexemeSequence
   /// The current token. If there was no input, this token will have a kind of `.eof`.
@@ -153,7 +153,7 @@ public struct Parser: TokenConsumer {
   ///            arena is created automatically, and `input` copied into the
   ///            arena. If non-`nil`, `input` must be the registered source
   ///            buffer of `arena` or a slice of the source buffer.
-  public init(_ input: UnsafeBufferPointer<UInt8>, maximumNestingLevel: Int? = nil, arena: SyntaxArena? = nil) {
+  public init(_ input: UnsafeBufferPointer<UInt8>, maximumNestingLevel: Int? = nil, arena: ParsingSyntaxArena? = nil) {
     self.maximumNestingLevel = maximumNestingLevel ?? Self.defaultMaximumNestingLevel
 
     var sourceBuffer: UnsafeBufferPointer<UInt8>
@@ -162,7 +162,7 @@ public struct Parser: TokenConsumer {
       sourceBuffer = input
       assert(arena.contains(text: SyntaxText(baseAddress: input.baseAddress, count: input.count)))
    } else {
-     self.arena = SyntaxArena(
+     self.arena = ParsingSyntaxArena(
       parseTriviaFunction: TriviaParser.parseTrivia(_:position:))
      sourceBuffer = self.arena.internSourceBuffer(input)
     }

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -459,6 +459,8 @@ extension RawSyntax {
   ) -> RawSyntax {
     assert(arena.contains(text: wholeText),
            "token text must be managed by the arena")
+    assert(arena is ParsingSyntaxArena || textRange == wholeText.indices,
+           "arena must be able to parse trivia")
     let payload = RawSyntaxData.ParsedToken(
       tokenKind: kind,
       wholeText: wholeText,

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -95,7 +95,8 @@ public struct RawSyntaxTokenView {
   public var leadingRawTriviaPieces: [RawTriviaPiece] {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
-      return raw.arena.parseTrivia(source: dat.leadingTriviaText, position: .leading)
+      let arena = raw.arena as! ParsingSyntaxArena
+      return arena.parseTrivia(source: dat.leadingTriviaText, position: .leading)
     case .materializedToken(let dat):
       return Array(dat.leadingTrivia)
     case .layout(_):
@@ -107,7 +108,8 @@ public struct RawSyntaxTokenView {
   public var trailingRawTriviaPieces: [RawTriviaPiece] {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
-      return raw.arena.parseTrivia(source: dat.trailingTriviaText, position: .trailing)
+      let arena = raw.arena as! ParsingSyntaxArena
+      return arena.parseTrivia(source: dat.trailingTriviaText, position: .trailing)
     case .materializedToken(let dat):
       return Array(dat.trailingTrivia)
     case .layout(_):

--- a/Tests/SwiftSyntaxTest/BumpPtrAllocatorTests.swift
+++ b/Tests/SwiftSyntaxTest/BumpPtrAllocatorTests.swift
@@ -16,7 +16,7 @@ import XCTest
 final class BumpPtrAllocatorTests: XCTestCase {
 
     func testBasic() {
-      let allocator = BumpPtrAllocator()
+      let allocator = BumpPtrAllocator(slabSize: 4096)
 
       let byteBuffer = allocator.allocate(byteCount: 42, alignment: 4)
       XCTAssertNotNil(byteBuffer.baseAddress)

--- a/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
@@ -104,7 +104,7 @@ final class RawSyntaxTests: XCTestCase {
       return [.unexpectedText(source)]
     }
 
-    withExtendedLifetime(SyntaxArena(parseTriviaFunction: dummyParseToken)) { arena in
+    withExtendedLifetime(ParsingSyntaxArena(parseTriviaFunction: dummyParseToken)) { arena in
       let ident = RawTokenSyntax(
         kind: .identifier, wholeText: arena.intern("\nfoo "), textRange: 1..<4,
         presence: .present,


### PR DESCRIPTION
Minimize the default memory footprint of `SyntaxArena` (for non-parsing). Introduce `ParsingSyntaxArena` as a subclass of `SyntaxArena` optimized for parsing.
