### PR TITLE
Revert "Revert "Eliminate SWIFT_SYNTAX_ALWAYS_SINGLE_THREADED""

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,12 +42,6 @@ if (NOT SWIFT_SUPPORTS_DISABLE_IMPLICIT_STRING_PROCESSING_MODULE_IMPORT)
     $<$<COMPILE_LANGUAGE:Swift>:-disable-implicit-string-processing-module-import>)
 endif()
 
-# Force single-threaded-only syntax trees to eliminate the Darwin
-# dependency in the compiler.
-add_compile_definitions(
-  $<$<COMPILE_LANGUAGE:Swift>:SWIFT_SYNTAX_ALWAYS_SINGLE_THREADED>
-)
-
 add_subdirectory(Sources)
 
 export(EXPORT SwiftSyntaxTargets

--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -10,14 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !SWIFT_SYNTAX_ALWAYS_SINGLE_THREADED
-#if canImport(Darwin)
-@_implementationOnly import Darwin
-#elseif canImport(Glibc)
-@_implementationOnly import Glibc
-#endif
-#endif
-
 /// Represent a string.
 ///
 /// This type does not own the string data. The data reside in some other buffer
@@ -220,17 +212,17 @@ extension String {
   }
 }
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(FreeBSD) || os(OpenBSD)
+@_silgen_name("memcmp")
+public func memcmp(_: UnsafeRawPointer?, _: UnsafeRawPointer?, _: Int) -> Int32
+#endif
+
 private func compareMemory(
   _ s1: UnsafePointer<UInt8>, _ s2: UnsafePointer<UInt8>, _ count: Int
 ) -> Bool {
   assert(count >= 0)
-#if SWIFT_SYNTAX_ALWAYS_SINGLE_THREADED
-  return UnsafeBufferPointer(start: s1, count: count)
-    .elementsEqual(UnsafeBufferPointer(start: s2, count: count))
-#elseif canImport(Darwin)
-  return Darwin.memcmp(s1, s2, count) == 0
-#elseif canImport(Glibc)
-  return Glibc.memcmp(s1, s2, count) == 0
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Linux) || os(FreeBSD) || os(OpenBSD)
+  return memcmp(s1, s2, count) == 0
 #else
   return UnsafeBufferPointer(start: s1, count: count)
     .elementsEqual(UnsafeBufferPointer(start: s2, count: count))

--- a/Tests/SwiftParserTest/LinkageTests.swift
+++ b/Tests/SwiftParserTest/LinkageTests.swift
@@ -32,7 +32,6 @@ final class LinkageTest: XCTestCase {
       .library("-lswiftCompatibility56", condition: .mayBeAbsent("Starting in Xcode 14 this library is not always autolinked")),
       .library("-lswiftCompatibilityConcurrency"),
       .library("-lswiftCore"),
-      .library("-lswiftDarwin", condition: .mayBeAbsent("Not present when building inside the compiler")),
       .library("-lswiftSwiftOnoneSupport", condition: .when(configuration: .debug)),
       .library("-lswift_Concurrency"),
       .library("-lswift_StringProcessing", condition: .mayBeAbsent("Starting in Xcode 14 this library is not always autolinked")),


### PR DESCRIPTION
Re-apply.

Reverts apple/swift-syntax#1066