### PR TITLE
[Macros] Add notion of owning module and supplemental modules for macros

### DIFF
--- a/Sources/_SwiftSyntaxMacros/MacroSystem+Builtin.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem+Builtin.swift
@@ -27,6 +27,8 @@ struct ColumnMacro: ExpressionMacro {
 
   static var signature: TypeSyntax = "T"
 
+  static var owningModule: String = "Swift"
+
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
   ) -> MacroResult<ExprSyntax> {
@@ -50,6 +52,8 @@ struct LineMacro: ExpressionMacro {
      """
 
   static var signature: TypeSyntax = "T"
+
+  static var owningModule: String = "Swift"
 
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
@@ -86,6 +90,8 @@ struct FunctionMacro: ExpressionMacro {
      """
 
   static var signature: TypeSyntax = "T"
+
+  static var owningModule: String = "Swift"
 
   /// Form a function name.
   private static func formFunctionName(
@@ -221,6 +227,10 @@ struct ColorLiteralMacro: ExpressionMacro {
      ) -> T
      """
 
+  // FIXME: Not entirely correct, should use _ColorLiteralType from
+  // appropriate place.
+  static var owningModule: String = "Swift"
+
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
   ) -> MacroResult<ExprSyntax> {
@@ -249,6 +259,8 @@ struct FileLiteralMacro: ExpressionMacro {
 
   static var signature: TypeSyntax =
       "(resourceName path: String) -> T"
+
+  static var owningModule: String = "Swift"
 
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
@@ -279,6 +291,9 @@ struct ImageLiteralMacro: ExpressionMacro {
   static var signature: TypeSyntax =
       "(resourceName path: String) -> T"
 
+  // FIXME: Not really correct, use _ImageLiteralType
+  static var owningModule: String = "Swift"
+
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
   ) -> MacroResult<ExprSyntax> {
@@ -307,6 +322,8 @@ struct FilePathMacro: ExpressionMacro {
 
   static var signature: TypeSyntax = "T"
 
+  static var owningModule: String = "Swift"
+
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
   ) -> MacroResult<ExprSyntax> {
@@ -334,6 +351,8 @@ struct FileIDMacro: ExpressionMacro {
      """
 
   static var signature: TypeSyntax = "T"
+
+  static var owningModule: String = "Swift"
 
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
@@ -368,6 +387,8 @@ struct FileMacro: ExpressionMacro {
      """
 
   static var signature: TypeSyntax = "T"
+
+  static var owningModule: String = "Swift"
 
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext

--- a/Sources/_SwiftSyntaxMacros/MacroSystem+Examples.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem+Examples.swift
@@ -25,6 +25,8 @@ struct StringifyMacro: ExpressionMacro {
 
   static var signature: TypeSyntax = "(T) -> (T, String)"
 
+  static var owningModule: String = "Swift"
+
   static func apply(
     _ macro: MacroExpansionExprSyntax, in context: MacroEvaluationContext
   ) -> MacroResult<ExprSyntax> {


### PR DESCRIPTION
Macros are associated with a module, which is the module in which they would be defined if the macro could be defined within the language itself. We call this the owning module. It will need to be imported in any Swift source file that wants to use the macro. Introduce an "owningModule" requirement to the Macro protocol to describe this.

The signatures of macros can make use of types in the owning module, but might also require other modules (e.g., that the owning module depends on). Introduce a "supplementalSignatureModules" requirement to the Macro protocol, with a default implementation of `[]` since this is unlikely to be used often.

Both the owning and supplemental modules will be imported when processing the macro signature.