### PR TITLE
[Refactor] Add a refactor action to replace "some" parameters with generics

### DIFF
--- a/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
+++ b/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
@@ -1,0 +1,213 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+fileprivate typealias RewrittenSome = (
+  ConstrainedSugarTypeSyntax,
+  GenericParameterSyntax,
+  SimpleTypeIdentifierSyntax
+)
+
+/// Rewrite `some` parameters to explicit generic parameters.
+///
+/// ## Before
+///
+/// ```swift
+/// func someFunction(_ input: some Value) {}
+/// ```
+///
+/// ## After
+///
+/// ```swift
+/// func someFunction<T1: Value>(_ input: T1) {}
+/// ```
+fileprivate class SomeParameterRewriter: SyntaxRewriter {
+  var rewrittenSomeParameters: [RewrittenSome] = []
+
+  override func visit(_ node: ConstrainedSugarTypeSyntax) -> TypeSyntax {
+    if node.someOrAnySpecifier.text != "some" {
+      return TypeSyntax(node)
+    }
+
+    let paramName = "T\(rewrittenSomeParameters.count + 1)"
+    let paramNameSyntax = TokenSyntax.identifier(paramName)
+
+    let inheritedType: TypeSyntax?
+    let colon: TokenSyntax?
+    if node.baseType.description != "Any" {
+      colon = .colonToken()
+      inheritedType = node.baseType.withLeadingTrivia(.space)
+    } else {
+      colon = nil
+      inheritedType = nil
+    }
+
+    let genericParam = GenericParameterSyntax(
+      attributes: nil, name: paramNameSyntax, ellipsis: nil, colon: colon,
+      inheritedType: inheritedType, trailingComma: nil
+    )
+
+    let genericParamRef = SimpleTypeIdentifierSyntax(
+      name: .identifier(paramName), genericArgumentClause: nil
+    )
+
+    rewrittenSomeParameters.append((node, genericParam, genericParamRef))
+
+    return TypeSyntax(genericParamRef)
+  }
+
+  override func visit(_ node: TupleTypeSyntax) -> TypeSyntax {
+    let newNode = super.visit(node)
+
+    // If this tuple type is simple parentheses around a replaced "some"
+    // parameter, drop the parentheses.
+    guard let newTuple = newNode.as(TupleTypeSyntax.self),
+          newTuple.elements.count == 1,
+          let onlyElement = newTuple.elements.first,
+          onlyElement.name == nil,
+          onlyElement.ellipsis == nil,
+          let onlyIdentifierType =
+            onlyElement.type.as(SimpleTypeIdentifierSyntax.self),
+          rewrittenSomeParameters.first(
+            where: { $0.2.name.text == onlyIdentifierType.name.text }
+          ) != nil
+    else {
+      return newNode
+    }
+
+    return TypeSyntax(onlyIdentifierType)
+  }
+}
+
+/// Rewrite `some` parameters to explicit generic parameters.
+///
+/// ## Before
+///
+/// ```swift
+/// func someFunction(_ input: some Value) {}
+/// ```
+///
+/// ## After
+///
+/// ```swift
+/// func someFunction<T1: Value>(_ input: T1) {}
+/// ```
+public struct OpaqueParameterToGeneric: RefactoringProvider {
+  /// Replace all of the "some" parameters in the given parameter clause with
+  /// freshly-created generic parameters.
+  ///
+  /// - Returns: nil if there was nothing to rewrite, or a pair of the
+  /// rewritten parameters and augmented generic parameter list.
+  static func replaceSomeParameters(
+    in params: ParameterClauseSyntax,
+    augmenting genericParams: GenericParameterClauseSyntax?
+  ) -> (ParameterClauseSyntax, GenericParameterClauseSyntax)? {
+    let rewriter = SomeParameterRewriter()
+    let rewrittenParams = rewriter.visit(params.parameterList)
+
+    if rewriter.rewrittenSomeParameters.isEmpty {
+      return nil
+    }
+
+    var newGenericParams: [GenericParameterSyntax] = []
+    if let genericParams = genericParams {
+      newGenericParams.append(contentsOf: genericParams.genericParameterList)
+    }
+
+    for (_, newGenericParam, _) in rewriter.rewrittenSomeParameters {
+      // Add a trailing comma to the prior generic parameter, if there is one.
+      if let lastNewGenericParam = newGenericParams.last {
+        newGenericParams[newGenericParams.count-1] =
+            lastNewGenericParam.withTrailingComma(.commaToken())
+        newGenericParams.append(newGenericParam.withLeadingTrivia(.space))
+      } else {
+        newGenericParams.append(newGenericParam)
+      }
+    }
+
+    let newGenericParamSyntax = GenericParameterListSyntax(newGenericParams)
+    let newGenericParamClause: GenericParameterClauseSyntax
+    if let genericParams = genericParams {
+      newGenericParamClause = genericParams.withGenericParameterList(
+        newGenericParamSyntax
+      )
+    } else {
+      newGenericParamClause = GenericParameterClauseSyntax(
+        leftAngleBracket: .leftAngleToken(),
+        genericParameterList: newGenericParamSyntax,
+        genericWhereClause: nil,
+        rightAngleBracket: .rightAngleToken()
+      )
+    }
+
+    return (
+      params.withParameterList(rewrittenParams),
+      newGenericParamClause
+    )
+  }
+
+  public static func refactor(
+    syntax decl: DeclSyntax, in context: Void
+  ) -> DeclSyntax? {
+    // Function declaration.
+    if let funcSyntax = decl.as(FunctionDeclSyntax.self) {
+      guard let (newInput, newGenericParams) = replaceSomeParameters(
+        in: funcSyntax.signature.input,
+        augmenting: funcSyntax.genericParameterClause
+      ) else {
+        return nil
+      }
+
+      return DeclSyntax(
+        funcSyntax
+          .withSignature(funcSyntax.signature.withInput(newInput))
+          .withGenericParameterClause(newGenericParams)
+      )
+    }
+
+    // Initializer declaration.
+    if let initSyntax = decl.as(InitializerDeclSyntax.self) {
+      guard let (newInput, newGenericParams) = replaceSomeParameters(
+        in: initSyntax.signature.input,
+        augmenting: initSyntax.genericParameterClause
+      ) else {
+        return nil
+      }
+
+      return DeclSyntax(
+        initSyntax
+          .withSignature(initSyntax.signature.withInput(newInput))
+          .withGenericParameterClause(newGenericParams)
+      )
+    }
+
+    // Subscript declaration.
+    if let subscriptSyntax = decl.as(SubscriptDeclSyntax.self) {
+      guard let (newIndices, newGenericParams) = replaceSomeParameters(
+        in: subscriptSyntax.indices,
+        augmenting: subscriptSyntax.genericParameterClause
+      ) else {
+        return nil
+      }
+
+      return DeclSyntax(
+        subscriptSyntax
+          .withIndices(newIndices)
+          .withGenericParameterClause(newGenericParams)
+      )
+    }
+
+    return nil
+  }
+}
+

--- a/Tests/SwiftRefactorTest/OpaqueParameterToGeneric.swift
+++ b/Tests/SwiftRefactorTest/OpaqueParameterToGeneric.swift
@@ -48,7 +48,7 @@ final class OpaqueParameterToGenericTest: XCTestCase {
 
     let expected: DeclSyntax = """
       init<A, T1: P<A>, T2: Hashable & Codable, T3>(
-        x: (T1),
+        x: T1,
         y: [T2: T3]
       ) { }
       """

--- a/Tests/SwiftRefactorTest/OpaqueParameterToGeneric.swift
+++ b/Tests/SwiftRefactorTest/OpaqueParameterToGeneric.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftRefactor
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+import XCTest
+import _SwiftSyntaxTestSupport
+
+final class OpaqueParameterToGenericTest: XCTestCase {
+  func testRefactoringFunc() throws {
+    let baseline: DeclSyntax = """
+      func f(
+        x: some P,
+        y: [some Hashable & Codable: some Any]
+      ) -> some Equatable { }
+      """
+
+    let expected: DeclSyntax = """
+      func f<T1: P, T2: Hashable & Codable, T3>(
+        x: T1,
+        y: [T2: T3]
+      ) -> some Equatable { }
+      """
+
+    let refactored = try XCTUnwrap(OpaqueParameterToGeneric.refactor(syntax: baseline))
+
+    AssertStringsEqualWithDiff(expected.description, refactored.description)
+  }
+
+  func testRefactoringInit() throws {
+    let baseline: DeclSyntax = """
+      init<A>(
+        x: some P<A>,
+        y: [some Hashable & Codable: some Any]
+      ) { }
+      """
+
+    let expected: DeclSyntax = """
+      init<A, T1: P<A>, T2: Hashable & Codable, T3>(
+        x: T1,
+        y: [T2: T3]
+      ) { }
+      """
+
+    let refactored = try XCTUnwrap(OpaqueParameterToGeneric.refactor(syntax: baseline))
+
+    AssertStringsEqualWithDiff(expected.description, refactored.description)
+  }
+
+  func testRefactoringSubscript() throws {
+    let baseline: DeclSyntax = """
+      subscript(index: some Hashable) -> String
+      """
+
+    let expected: DeclSyntax = """
+      subscript<T1: Hashable>(index: T1) -> String
+      """
+
+    let refactored = try XCTUnwrap(OpaqueParameterToGeneric.refactor(syntax: baseline))
+
+    AssertStringsEqualWithDiff(expected.description, refactored.description)
+  }
+}

--- a/Tests/SwiftRefactorTest/OpaqueParameterToGeneric.swift
+++ b/Tests/SwiftRefactorTest/OpaqueParameterToGeneric.swift
@@ -41,14 +41,14 @@ final class OpaqueParameterToGenericTest: XCTestCase {
   func testRefactoringInit() throws {
     let baseline: DeclSyntax = """
       init<A>(
-        x: some P<A>,
+        x: (some P<A>),
         y: [some Hashable & Codable: some Any]
       ) { }
       """
 
     let expected: DeclSyntax = """
       init<A, T1: P<A>, T2: Hashable & Codable, T3>(
-        x: T1,
+        x: (T1),
         y: [T2: T3]
       ) { }
       """


### PR DESCRIPTION
[SE-0341](https://github.com/apple/swift-evolution/blob/main/proposals/0341-opaque-parameters.md) introduced opaque parameter declarations, which are syntactic sugar for introducing a generic parameter that is only used once in the signature of the type. Provide a refactoring action that replaces all each use of an opaque parameter declarations in a declaration, e.g.,

    func lazyConcatenate<T> {
      _ sequence1: some Sequence<T>, _ sequence2: some Sequence<T>
    ) -> some Sequence<T> { ... }

with a newly-created generic parameter, so the end result is equivalent but works with early compilers:

    func lazyConcatenate<T, T1: Sequence<T>, T2: Sequence<T>> {
      _ sequence1: T1, T2
    ) -> some Sequence<T> { ... }