### PR TITLE
Add `*Syntax.parse` methods for the nodes that we support parsing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -112,10 +112,11 @@ let package = Package(
       dependencies: ["SwiftDiagnostics", "SwiftSyntax"],
       exclude: [
         "CMakeLists.txt",
-        "README.md",
-        "TypeAttribute.swift.gyb",
         "DeclarationModifier.swift.gyb",
         "DeclarationAttribute.swift.gyb",
+        "Parser+Entry.swift.gyb",
+        "README.md",
+        "TypeAttribute.swift.gyb",
       ]
     ),
     .target(

--- a/Sources/SwiftCompilerSupport/ConsistencyCheck.swift
+++ b/Sources/SwiftCompilerSupport/ConsistencyCheck.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftOperators
-@_spi(Testing) @_spi(RawSyntax) import SwiftParser
+import SwiftParser
 import SwiftParserDiagnostics
-@_spi(RawSyntax) import SwiftSyntax
+import SwiftSyntax
 
 extension Syntax {
   /// Whether this syntax node is or is enclosed within a #if.
@@ -51,11 +51,11 @@ public func _parserConsistencyCheck(
   var parser = Parser(buffer)
   return withExtendedLifetime(parser) { () -> CInt in
     // Parse the source file
-    let rawSourceFile = parser.parseSourceFile()
+    let sourceFile = SourceFileSyntax.parse(from: &parser)
 
     // Round-trip test.
     if flags & 0x01 != 0 {
-      if rawSourceFile.raw.syntaxTextBytes != [UInt8](buffer) {
+      if sourceFile.syntaxTextBytes != [UInt8](buffer) {
         print(
           "\(String(cString: filename)): error: file failed to round-trip")
         return 1
@@ -66,7 +66,6 @@ public func _parserConsistencyCheck(
     if flags & 0x02 != 0 {
       var anyDiags = false
 
-      let sourceFile = Syntax(raw: rawSourceFile.raw).as(SourceFileSyntax.self)!
       let diags = ParseDiagnosticsGenerator.diagnostics(
         for: sourceFile)
       for diag in diags {

--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(SwiftParser STATIC
 
   gyb_generated/DeclarationAttribute.swift
   gyb_generated/DeclarationModifier.swift
+  gyb_generated/Parser+Entry.swift
   gyb_generated/TypeAttribute.swift)
 
 target_link_libraries(SwiftParser PUBLIC

--- a/Sources/SwiftParser/Parser+Entry.swift.gyb
+++ b/Sources/SwiftParser/Parser+Entry.swift.gyb
@@ -1,0 +1,76 @@
+%{
+  from gyb_syntax_support import *
+  # -*- mode: Swift -*-
+  # Ignore the following admonition it applies to the resulting .swift file only
+}%
+//// Automatically Generated From Entry.swift.gyb.
+//// Do Not Edit Directly!
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RawSyntax) import SwiftSyntax
+
+extension Parser {
+  /// Parse the source code in the given string as Swift source file. See
+  /// `Parser.init` for more details.
+  public static func parse(
+    source: String,
+    parseTransition: IncrementalParseTransition? = nil
+  ) -> SourceFileSyntax {
+    var parser = Parser(source)
+    return SourceFileSyntax.parse(from: &parser)
+  }
+
+  /// Parse the source code in the given string as Swift source file. See
+  /// `Parser.init` for more details.
+  public static func parse(
+    source: UnsafeBufferPointer<UInt8>,
+    maximumNestingLevel: Int? = nil,
+    parseTransition: IncrementalParseTransition? = nil
+  ) -> SourceFileSyntax {
+    var parser = Parser(source, maximumNestingLevel: maximumNestingLevel)
+    return SourceFileSyntax.parse(from: &parser)
+  }
+}
+
+public protocol SyntaxParseable: SyntaxProtocol {
+  static func parse(from parser: inout Parser) -> Self
+}
+
+% for node in SYNTAX_NODES:
+%   if node.parser_function:
+extension ${node.name}: SyntaxParseable {
+  public static func parse(from parser: inout Parser) -> Self {
+    let node = parser.${node.parser_function}()
+    return parser.parseRemainder(into: node).syntax
+  }
+}
+
+%   end
+% end
+fileprivate extension Parser {
+  mutating func parseRemainder<R: RawSyntaxNodeProtocol>(into: R) -> R {
+    guard !into.raw.kind.isSyntaxCollection, let layout = into.raw.layoutView else {
+      assertionFailure("Only support parsing of non-collection layout nodes")
+      return into
+    }
+
+    let remainingTokens = self.consumeRemainingTokens()
+    if remainingTokens.isEmpty {
+      return into
+    }
+
+    let unexpected = RawUnexpectedNodesSyntax(elements: remainingTokens, arena: self.arena)
+    let withUnexpected = layout.replacingChild(at: layout.children.count - 1, with: unexpected.raw, arena: self.arena)
+    return R.init(withUnexpected)!
+  }
+}

--- a/Sources/SwiftParser/gyb_generated/Parser+Entry.swift
+++ b/Sources/SwiftParser/gyb_generated/Parser+Entry.swift
@@ -1,0 +1,130 @@
+//// Automatically Generated From Entry.swift.gyb.
+//// Do Not Edit Directly!
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RawSyntax) import SwiftSyntax
+
+extension Parser {
+  /// Parse the source code in the given string as Swift source file. See
+  /// `Parser.init` for more details.
+  public static func parse(
+    source: String,
+    parseTransition: IncrementalParseTransition? = nil
+  ) -> SourceFileSyntax {
+    var parser = Parser(source)
+    return SourceFileSyntax.parse(from: &parser)
+  }
+
+  /// Parse the source code in the given string as Swift source file. See
+  /// `Parser.init` for more details.
+  public static func parse(
+    source: UnsafeBufferPointer<UInt8>,
+    maximumNestingLevel: Int? = nil,
+    parseTransition: IncrementalParseTransition? = nil
+  ) -> SourceFileSyntax {
+    var parser = Parser(source, maximumNestingLevel: maximumNestingLevel)
+    return SourceFileSyntax.parse(from: &parser)
+  }
+}
+
+public protocol SyntaxParseable: SyntaxProtocol {
+  static func parse(from parser: inout Parser) -> Self
+}
+
+extension DeclSyntax: SyntaxParseable {
+  public static func parse(from parser: inout Parser) -> Self {
+    let node = parser.parseDeclaration()
+    return parser.parseRemainder(into: node).syntax
+  }
+}
+
+extension ExprSyntax: SyntaxParseable {
+  public static func parse(from parser: inout Parser) -> Self {
+    let node = parser.parseExpression()
+    return parser.parseRemainder(into: node).syntax
+  }
+}
+
+extension StmtSyntax: SyntaxParseable {
+  public static func parse(from parser: inout Parser) -> Self {
+    let node = parser.parseStatement()
+    return parser.parseRemainder(into: node).syntax
+  }
+}
+
+extension TypeSyntax: SyntaxParseable {
+  public static func parse(from parser: inout Parser) -> Self {
+    let node = parser.parseType()
+    return parser.parseRemainder(into: node).syntax
+  }
+}
+
+extension PatternSyntax: SyntaxParseable {
+  public static func parse(from parser: inout Parser) -> Self {
+    let node = parser.parsePattern()
+    return parser.parseRemainder(into: node).syntax
+  }
+}
+
+extension MemberDeclBlockSyntax: SyntaxParseable {
+  public static func parse(from parser: inout Parser) -> Self {
+    let node = parser.parseMemberDeclList()
+    return parser.parseRemainder(into: node).syntax
+  }
+}
+
+extension SourceFileSyntax: SyntaxParseable {
+  public static func parse(from parser: inout Parser) -> Self {
+    let node = parser.parseSourceFile()
+    return parser.parseRemainder(into: node).syntax
+  }
+}
+
+extension SwitchCaseSyntax: SyntaxParseable {
+  public static func parse(from parser: inout Parser) -> Self {
+    let node = parser.parseSwitchCase()
+    return parser.parseRemainder(into: node).syntax
+  }
+}
+
+extension CatchClauseSyntax: SyntaxParseable {
+  public static func parse(from parser: inout Parser) -> Self {
+    let node = parser.parseCatchClause()
+    return parser.parseRemainder(into: node).syntax
+  }
+}
+
+extension GenericParameterClauseSyntax: SyntaxParseable {
+  public static func parse(from parser: inout Parser) -> Self {
+    let node = parser.parseGenericParameters()
+    return parser.parseRemainder(into: node).syntax
+  }
+}
+
+fileprivate extension Parser {
+  mutating func parseRemainder<R: RawSyntaxNodeProtocol>(into: R) -> R {
+    guard !into.raw.kind.isSyntaxCollection, let layout = into.raw.layoutView else {
+      assertionFailure("Only support parsing of non-collection layout nodes")
+      return into
+    }
+
+    let remainingTokens = self.consumeRemainingTokens()
+    if remainingTokens.isEmpty {
+      return into
+    }
+
+    let unexpected = RawUnexpectedNodesSyntax(elements: remainingTokens, arena: self.arena)
+    let withUnexpected = layout.replacingChild(at: layout.children.count - 1, with: unexpected.raw, arena: self.arena)
+    return R.init(withUnexpected)!
+  }
+}

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -236,10 +236,13 @@ public protocol RawSyntaxToSyntax: RawSyntaxNodeProtocol {
   associatedtype SyntaxType: SyntaxProtocol
 }
 
+// TODO: Is it worth having this?
+// The only place that should be using it is the parser, which only converts
+// to `Syntax` in a few places anyway - we could just do the case there.
 @_spi(RawSyntax)
 public extension RawSyntaxToSyntax {
   /// Realizes a `Syntax` node for this `RawSyntax` node.
   var syntax: SyntaxType {
-    return Syntax(raw: raw).as(SyntaxType.self)!
+    return Syntax(raw: raw).cast(SyntaxType.self)
   }
 }

--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
@@ -109,7 +109,7 @@ extension FunctionCallExpr {
   /// instead of having to wrap them in a `TupleExprElementList`.
   /// The presence of the parenthesis will be inferred based on the presence of arguments and the trailing closure.
   public init(
-    callee: String,
+    callee: ExprSyntax,
     trailingClosure: ClosureExprSyntax? = nil,
     additionalTrailingClosures: MultipleTrailingClosureElementList? = nil,
     @TupleExprElementListBuilder argumentList: () -> TupleExprElementList = { [] }
@@ -117,7 +117,7 @@ extension FunctionCallExpr {
     let argumentList = argumentList()
     let shouldOmitParens = argumentList.isEmpty && trailingClosure != nil
     self.init(
-      calledExpression: Expr(callee),
+      calledExpression: callee,
       leftParen: shouldOmitParens ? nil : .leftParen,
       argumentList: argumentList,
       rightParen: shouldOmitParens ? nil : .rightParen,
@@ -129,6 +129,12 @@ extension FunctionCallExpr {
 
 // MARK: - FunctionParameter
 
+// TODO: We should split FunctionParameter into separate nodes
+//
+// This would allow them to be both `SyntaxParseable` and
+// `SyntaxExpressibleByStringInterpolation`, allowing this initializer to be
+// removed. In general we shouldn't allow the builder to take arbitrary
+// strings, only literals.
 extension FunctionParameter {
   public init(
     _ source: String,
@@ -292,8 +298,8 @@ extension StringLiteralExpr {
 // MARK: - SwitchCase
 
 extension SwitchCase {
-  public init(_ label: String, @CodeBlockItemListBuilder statementsBuilder: () -> CodeBlockItemListSyntax) {
-    self.init("\(label)")
+  public init(_ label: SwitchCase, @CodeBlockItemListBuilder statementsBuilder: () -> CodeBlockItemListSyntax) {
+    self = label
     self.statements = statementsBuilder()
   }
 }

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -10,33 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
-@_spi(RawSyntax) import SwiftParser
-import SwiftParserDiagnostics
-import SwiftDiagnostics
 import SwiftBasicFormat
-
-func performParse<SyntaxType: SyntaxProtocol>(source: [UInt8], parse: (inout Parser) throws -> SyntaxType) throws -> SyntaxType {
-  return try source.withUnsafeBufferPointer { buffer in
-    var parser = Parser(buffer)
-    // FIXME: When the parser supports incremental parsing, put the
-    // interpolatedSyntaxNodes in so we don't have to parse them again.
-    let result = try parse(&parser)
-    if !parser.at(.eof) {
-      var remainingTokens: [TokenSyntax] = []
-      while !parser.at(.eof) {
-        remainingTokens.append(parser.consumeAnyToken().syntax)
-      }
-      throw SyntaxStringInterpolationError.didNotConsumeAllTokens(remainingTokens: remainingTokens)
-    }
-    if result.hasError {
-      let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: result)
-      assert(!diagnostics.isEmpty)
-      throw SyntaxStringInterpolationError.diagnostics(diagnostics, tree: Syntax(result))
-    }
-    return result
-  }
-}
+import SwiftDiagnostics
+import SwiftSyntax
 
 /// An individual interpolated syntax node.
 struct InterpolatedSyntaxNode {
@@ -113,6 +89,14 @@ extension SyntaxStringInterpolation: StringInterpolationProtocol {
     self.lastIndentation = nil
   }
 
+  // Append a value of any metatype as source text
+  public mutating func appendInterpolation<T>(
+    _ type: T.Type
+  ) {
+    sourceText.append(contentsOf: String(describing: type).utf8)
+    self.lastIndentation = nil
+  }
+
   public mutating func appendInterpolation<Buildable: SyntaxProtocol>(
     _ buildable: Buildable,
     format: BasicFormat = BasicFormat()
@@ -126,24 +110,19 @@ extension SyntaxStringInterpolation: StringInterpolationProtocol {
 public protocol SyntaxExpressibleByStringInterpolation:
     ExpressibleByStringInterpolation, SyntaxProtocol
     where Self.StringInterpolation == SyntaxStringInterpolation {
-  /// Create an instance of this syntax node by parsing it from the given
-  /// parser.
-  static func parse(from parser: inout Parser) throws -> Self
+  init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws
 }
 
 enum SyntaxStringInterpolationError: Error, CustomStringConvertible {
-  case didNotConsumeAllTokens(remainingTokens: [TokenSyntax])
   case producedInvalidNodeType(expectedType: SyntaxProtocol.Type, actualType: SyntaxProtocol.Type)
   case diagnostics([Diagnostic], tree: Syntax)
 
   var description: String {
     switch self {
-    case .didNotConsumeAllTokens(remainingTokens: let tokens):
-      return "Extraneous text in snippet: '\(tokens.map(\.description).joined())'"
     case .producedInvalidNodeType(expectedType: let expectedType, actualType: let actualType):
       return "Parsing the code snippet was expected to produce a \(expectedType) but produced a \(actualType)"
     case .diagnostics(let diagnostics, let tree):
-      // Start the diagnostc on a new line so it isn't prefixed with the file, which messes up the
+      // Start the diagnostic on a new line so it isn't prefixed with the file, which messes up the
       // column-aligned message from `DiagnosticsFormatter`.
       return "\n" + DiagnosticsFormatter.annotatedSource(tree: tree, diags: diagnostics)
     }
@@ -165,10 +144,6 @@ extension SyntaxExpressibleByStringInterpolation {
     }
   }
 
-  public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
-    self = try performParse(source: stringInterpolation.sourceText, parse: Self.parse)
-  }
-
   @_transparent
   public init(stringLiteral value: String) {
     do {
@@ -183,10 +158,5 @@ extension SyntaxExpressibleByStringInterpolation {
     var interpolation = SyntaxStringInterpolation()
     interpolation.appendLiteral(value)
     try self.init(stringInterpolationOrThrow: interpolation)
-  }
-
-  /// Construct this node by parsing `source`. If parsing fails, raise a `fatalError`.
-  public init(_ source: String) {
-    self.init(stringLiteral: source)
   }
 }

--- a/Sources/SwiftSyntaxBuilder/SyntaxExpressibleByStringInterpolationConformances.swift.gyb
+++ b/Sources/SwiftSyntaxBuilder/SyntaxExpressibleByStringInterpolationConformances.swift.gyb
@@ -1,6 +1,5 @@
 %{
   from gyb_syntax_support import *
-  NODE_MAP = create_node_map()
   # -*- mode: Swift -*-
   # Ignore the following admonition it applies to the resulting .swift file only
 }%
@@ -18,49 +17,58 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
-@_spi(RawSyntax) import SwiftParser
+import SwiftSyntax
+import SwiftParser
+import SwiftParserDiagnostics
 
-% STRING_INTERPOLATION_BASE_KINDS = [base_kind for base_kind in SYNTAX_BASE_KINDS if base_kind != 'Syntax' and base_kind != 'SyntaxCollection']
-% for base_kind in STRING_INTERPOLATION_BASE_KINDS:
-%   node = NODE_MAP[base_kind]
-extension ${base_kind}SyntaxProtocol {
-  public static func parse(from parser: inout Parser) throws -> Self {
-    let node = parser.${node.parser_function}().syntax
-    guard let result = node.as(Self.self) else {
-      throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: type(of: node.asProtocol(${base_kind}SyntaxProtocol.self)))
+extension SyntaxParseable {
+  public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
+      return Self.parse(from: &parser)
+    })
+  }
+}
+
+% for node in SYNTAX_NODES:
+%   if node.parser_function and node.is_base():
+extension ${node.name}Protocol {
+  public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
+      let node = ${node.name}.parse(from: &parser)
+      guard let result = node.as(Self.self) else {
+        throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: node.kind.syntaxNodeType)
+      }
+      return result
+    })
+  }
+}
+extension ${node.name}: SyntaxExpressibleByStringInterpolation {
+  public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
+      return Self.parse(from: &parser)
+    })
+  }
+}
+
+%   elif node.parser_function or (node.base_type != 'Syntax' and node.base_type != 'SyntaxCollection'):
+extension ${node.name}: SyntaxExpressibleByStringInterpolation { }
+
+%   end
+% end
+
+// TODO: This should be fileprivate, but is currently used in
+// `ConvenienceInitializers.swift`. See the corresponding TODO there.
+func performParse<SyntaxType: SyntaxProtocol>(source: [UInt8], parse: (inout Parser) throws -> SyntaxType) throws -> SyntaxType {
+  return try source.withUnsafeBufferPointer { buffer in
+    var parser = Parser(buffer)
+    // FIXME: When the parser supports incremental parsing, put the
+    // interpolatedSyntaxNodes in so we don't have to parse them again.
+    let result = try parse(&parser)
+    if result.hasError {
+      let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: result)
+      assert(!diagnostics.isEmpty)
+      throw SyntaxStringInterpolationError.diagnostics(diagnostics, tree: Syntax(result))
     }
     return result
   }
 }
-
-% end
-
-%{
-def parser_invocation(node):
-  if node.kind == 'Expr':
-    return "return ExprSyntax(parser.parseExpression().syntax).castOrFatalError(Self.self)"
-  elif node.kind == 'Stmt':
-    return "return StmtSyntax(parser.parseStatement().syntax).castOrFatalError(Self.self)"
-  elif node.kind == 'Type':
-    return "return TypeSyntax(parser.parseType().syntax).castOrFatalError(Self.self)"
-  elif node.kind == 'Pattern':
-    return "return PatternSyntax(parser.parsePattern().syntax).castOrFatalError(Self.self)"
-  elif node.parser_function is not None:
-    return f"return parser.{node.parser_function}().syntax"
-  else:
-    return None
-}%
-% for node in SYNTAX_NODES:
-%   if node.kind in STRING_INTERPOLATION_BASE_KINDS:
-extension ${node.name}: SyntaxExpressibleByStringInterpolation {}
-
-%   elif node.parser_function:
-extension ${node.name}: SyntaxExpressibleByStringInterpolation {
-  public static func parse(from parser: inout Parser) -> Self {
-    return parser.${node.parser_function}().syntax
-  }
-}
-
-%   end
-% end

--- a/Sources/SwiftSyntaxBuilder/SyntaxNodeWithBody.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxNodeWithBody.swift
@@ -14,13 +14,31 @@ import SwiftSyntax
 
 // MARK: - HasCodeBlock
 
+// TODO: Consider removing `HasTrailingCodeBlock` and friends
+// It'd be much nicer if we didn't have any builder APIs taking strings. We
+// should just make convenvience inits where needed such that we could write:
+//   `IfStmt("if foo")` -> `IfStmt(conditions: [.expression("foo")])`
+//   `ProtocolDecl("public protocol SomeProto") -> `ProtocolDecl(modifiers: [.public], identifier: "SomeProto")`
+//
+// This is sort of what we used to have, but there weren't enough convenience
+// initializers.
+//   `SwitchCase(label: SwitchCaseLabel(caseItems: [CaseItem(pattern: ExpressionPattern(expression: MemberAccessExpr(name: "contextualKeyword")))]))`
+// is currently
+//   `SwitchCase("case .contextualKeyword:")`
+// but ideally we'd have enough convenience initializers such that we could have:
+//   `SwitchCase(pattern: ".contextualKeyword") { }`
+//
+// Another example is that we now have
+//   `ExtensionDecl("\(docComment)extension \(node.type.shorthandName): ExpressibleByArrayLiteral")`
+// which could be
+//   `ExtensionDecl(leadingTrivia: docComment, extendedType: "\(node.type.shorthandName)", inheritances: ["ExpressibleByArrayLiteral"])`
 public protocol HasTrailingCodeBlock {
   var body: CodeBlock { get set }
 }
 
 public extension HasTrailingCodeBlock where Self: SyntaxExpressibleByStringInterpolation {
   init(_ signature: String, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax) {
-    self.init("\(signature) {}")
+    self = "\(signature) {}"
     self.body = CodeBlock(statements: bodyBuilder())
   }
 }
@@ -40,7 +58,7 @@ public protocol HasTrailingOptionalCodeBlock {
 
 public extension HasTrailingOptionalCodeBlock where Self: SyntaxExpressibleByStringInterpolation {
   init(_ signature: String, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax) {
-    self.init("\(signature) {}")
+    self = "\(signature) {}"
     self.body = CodeBlock(statements: bodyBuilder())
   }
 }
@@ -59,7 +77,7 @@ public protocol HasTrailingMemberDeclBlock {
 
 public extension HasTrailingMemberDeclBlock where Self: SyntaxExpressibleByStringInterpolation {
   init(_ signature: String, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax) {
-    self.init("\(signature) {}")
+    self = "\(signature) {}"
     self.members = MemberDeclBlock(members: membersBuilder())
   }
 }

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/SyntaxExpressibleByStringInterpolationConformances.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/SyntaxExpressibleByStringInterpolationConformances.swift
@@ -12,379 +12,399 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(RawSyntax) import SwiftSyntax
-@_spi(RawSyntax) import SwiftParser
+import SwiftSyntax
+import SwiftParser
+import SwiftParserDiagnostics
+
+extension SyntaxParseable {
+  public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
+      return Self.parse(from: &parser)
+    })
+  }
+}
 
 extension DeclSyntaxProtocol {
-  public static func parse(from parser: inout Parser) throws -> Self {
-    let node = parser.parseDeclaration().syntax
-    guard let result = node.as(Self.self) else {
-      throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: type(of: node.asProtocol(DeclSyntaxProtocol.self)))
-    }
-    return result
+  public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
+      let node = DeclSyntax.parse(from: &parser)
+      guard let result = node.as(Self.self) else {
+        throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: node.kind.syntaxNodeType)
+      }
+      return result
+    })
+  }
+}
+extension DeclSyntax: SyntaxExpressibleByStringInterpolation {
+  public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
+      return Self.parse(from: &parser)
+    })
   }
 }
 
 extension ExprSyntaxProtocol {
-  public static func parse(from parser: inout Parser) throws -> Self {
-    let node = parser.parseExpression().syntax
-    guard let result = node.as(Self.self) else {
-      throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: type(of: node.asProtocol(ExprSyntaxProtocol.self)))
-    }
-    return result
+  public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
+      let node = ExprSyntax.parse(from: &parser)
+      guard let result = node.as(Self.self) else {
+        throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: node.kind.syntaxNodeType)
+      }
+      return result
+    })
   }
 }
-
-extension PatternSyntaxProtocol {
-  public static func parse(from parser: inout Parser) throws -> Self {
-    let node = parser.parsePattern().syntax
-    guard let result = node.as(Self.self) else {
-      throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: type(of: node.asProtocol(PatternSyntaxProtocol.self)))
-    }
-    return result
+extension ExprSyntax: SyntaxExpressibleByStringInterpolation {
+  public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
+      return Self.parse(from: &parser)
+    })
   }
 }
 
 extension StmtSyntaxProtocol {
-  public static func parse(from parser: inout Parser) throws -> Self {
-    let node = parser.parseStatement().syntax
-    guard let result = node.as(Self.self) else {
-      throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: type(of: node.asProtocol(StmtSyntaxProtocol.self)))
-    }
-    return result
+  public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
+      let node = StmtSyntax.parse(from: &parser)
+      guard let result = node.as(Self.self) else {
+        throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: node.kind.syntaxNodeType)
+      }
+      return result
+    })
+  }
+}
+extension StmtSyntax: SyntaxExpressibleByStringInterpolation {
+  public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
+      return Self.parse(from: &parser)
+    })
   }
 }
 
 extension TypeSyntaxProtocol {
-  public static func parse(from parser: inout Parser) throws -> Self {
-    let node = parser.parseType().syntax
-    guard let result = node.as(Self.self) else {
-      throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: type(of: node.asProtocol(TypeSyntaxProtocol.self)))
+  public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
+      let node = TypeSyntax.parse(from: &parser)
+      guard let result = node.as(Self.self) else {
+        throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: node.kind.syntaxNodeType)
+      }
+      return result
+    })
+  }
+}
+extension TypeSyntax: SyntaxExpressibleByStringInterpolation {
+  public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
+      return Self.parse(from: &parser)
+    })
+  }
+}
+
+extension PatternSyntaxProtocol {
+  public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
+      let node = PatternSyntax.parse(from: &parser)
+      guard let result = node.as(Self.self) else {
+        throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: node.kind.syntaxNodeType)
+      }
+      return result
+    })
+  }
+}
+extension PatternSyntax: SyntaxExpressibleByStringInterpolation {
+  public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
+      return Self.parse(from: &parser)
+    })
+  }
+}
+
+extension UnknownDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension UnknownExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension UnknownStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension UnknownTypeSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension UnknownPatternSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension MissingDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension MissingExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension MissingStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension MissingTypeSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension MissingPatternSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension InOutExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PoundColumnExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension TryExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension AwaitExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension MoveExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension IdentifierExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension SuperRefExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension NilLiteralExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension DiscardAssignmentExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension AssignmentExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension SequenceExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PoundLineExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PoundFileExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PoundFileIDExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PoundFilePathExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PoundFunctionExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PoundDsohandleExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension SymbolicReferenceExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PrefixOperatorExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension BinaryOperatorExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ArrowExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension InfixOperatorExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension FloatLiteralExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension TupleExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ArrayExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension DictionaryExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension IntegerLiteralExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension BooleanLiteralExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension UnresolvedTernaryExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension TernaryExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension MemberAccessExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension UnresolvedIsExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension IsExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension UnresolvedAsExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension AsExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension TypeExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ClosureExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension UnresolvedPatternExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension FunctionCallExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension SubscriptExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension OptionalChainingExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ForcedValueExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PostfixUnaryExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension SpecializeExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension StringLiteralExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension RegexLiteralExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension KeyPathExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension OldKeyPathExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension KeyPathBaseExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ObjcKeyPathExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ObjcSelectorExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension MacroExpansionExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PostfixIfConfigExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension EditorPlaceholderExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ObjectLiteralExprSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension TypealiasDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension AssociatedtypeDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension IfConfigDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PoundErrorDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PoundWarningDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PoundSourceLocationSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ClassDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ActorDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension StructDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ProtocolDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ExtensionDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension MemberDeclBlockSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension SourceFileSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension FunctionDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension InitializerDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension DeinitializerDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension SubscriptDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ImportDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension AccessorDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension VariableDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension EnumCaseDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension EnumDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension OperatorDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PrecedenceGroupDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension MacroDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension MacroExpansionDeclSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension LabeledStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ContinueStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension WhileStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension DeferStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ExpressionStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension RepeatWhileStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension GuardStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ForInStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension SwitchStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension DoStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ReturnStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension YieldStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension FallthroughStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension BreakStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension DeclarationStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ThrowStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension IfStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension SwitchCaseSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension CatchClauseSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PoundAssertStmtSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension GenericParameterClauseSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension SimpleTypeIdentifierSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension MemberTypeIdentifierSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ClassRestrictionTypeSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ArrayTypeSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension DictionaryTypeSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension MetatypeTypeSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension OptionalTypeSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ConstrainedSugarTypeSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ImplicitlyUnwrappedOptionalTypeSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension CompositionTypeSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension PackExpansionTypeSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension TupleTypeSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension FunctionTypeSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension AttributedTypeSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension NamedOpaqueReturnTypeSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension EnumCasePatternSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension IsTypePatternSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension OptionalPatternSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension IdentifierPatternSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension AsTypePatternSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension TuplePatternSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension WildcardPatternSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ExpressionPatternSyntax: SyntaxExpressibleByStringInterpolation { }
+
+extension ValueBindingPatternSyntax: SyntaxExpressibleByStringInterpolation { }
+
+
+// TODO: This should be fileprivate, but is currently used in
+// `ConvenienceInitializers.swift`. See the corresponding TODO there.
+func performParse<SyntaxType: SyntaxProtocol>(source: [UInt8], parse: (inout Parser) throws -> SyntaxType) throws -> SyntaxType {
+  return try source.withUnsafeBufferPointer { buffer in
+    var parser = Parser(buffer)
+    // FIXME: When the parser supports incremental parsing, put the
+    // interpolatedSyntaxNodes in so we don't have to parse them again.
+    let result = try parse(&parser)
+    if result.hasError {
+      let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: result)
+      assert(!diagnostics.isEmpty)
+      throw SyntaxStringInterpolationError.diagnostics(diagnostics, tree: Syntax(result))
     }
     return result
   }
 }
-
-
-extension DeclSyntax: SyntaxExpressibleByStringInterpolation {
-  public static func parse(from parser: inout Parser) -> Self {
-    return parser.parseDeclaration().syntax
-  }
-}
-
-extension ExprSyntax: SyntaxExpressibleByStringInterpolation {
-  public static func parse(from parser: inout Parser) -> Self {
-    return parser.parseExpression().syntax
-  }
-}
-
-extension StmtSyntax: SyntaxExpressibleByStringInterpolation {
-  public static func parse(from parser: inout Parser) -> Self {
-    return parser.parseStatement().syntax
-  }
-}
-
-extension TypeSyntax: SyntaxExpressibleByStringInterpolation {
-  public static func parse(from parser: inout Parser) -> Self {
-    return parser.parseType().syntax
-  }
-}
-
-extension PatternSyntax: SyntaxExpressibleByStringInterpolation {
-  public static func parse(from parser: inout Parser) -> Self {
-    return parser.parsePattern().syntax
-  }
-}
-
-extension UnknownDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension UnknownExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension UnknownStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension UnknownTypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension UnknownPatternSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension MissingDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension MissingExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension MissingStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension MissingTypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension MissingPatternSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension InOutExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension PoundColumnExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension TryExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension AwaitExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension MoveExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension IdentifierExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension SuperRefExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension NilLiteralExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension DiscardAssignmentExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension AssignmentExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension SequenceExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension PoundLineExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension PoundFileExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension PoundFileIDExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension PoundFilePathExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension PoundFunctionExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension PoundDsohandleExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension SymbolicReferenceExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension PrefixOperatorExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension BinaryOperatorExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ArrowExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension InfixOperatorExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension FloatLiteralExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension TupleExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ArrayExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension DictionaryExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension IntegerLiteralExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension BooleanLiteralExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension UnresolvedTernaryExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension TernaryExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension MemberAccessExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension UnresolvedIsExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension IsExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension UnresolvedAsExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension AsExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension TypeExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ClosureExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension UnresolvedPatternExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension FunctionCallExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension SubscriptExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension OptionalChainingExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ForcedValueExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension PostfixUnaryExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension SpecializeExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension StringLiteralExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension RegexLiteralExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension KeyPathExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension OldKeyPathExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension KeyPathBaseExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ObjcKeyPathExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ObjcSelectorExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension MacroExpansionExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension PostfixIfConfigExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension EditorPlaceholderExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ObjectLiteralExprSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension TypealiasDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension AssociatedtypeDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension IfConfigDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension PoundErrorDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension PoundWarningDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension PoundSourceLocationSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ClassDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ActorDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension StructDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ProtocolDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ExtensionDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension MemberDeclBlockSyntax: SyntaxExpressibleByStringInterpolation {
-  public static func parse(from parser: inout Parser) -> Self {
-    return parser.parseMemberDeclList().syntax
-  }
-}
-
-extension SourceFileSyntax: SyntaxExpressibleByStringInterpolation {
-  public static func parse(from parser: inout Parser) -> Self {
-    return parser.parseSourceFile().syntax
-  }
-}
-
-extension FunctionDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension InitializerDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension DeinitializerDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension SubscriptDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ImportDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension AccessorDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension VariableDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension EnumCaseDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension EnumDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension OperatorDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension PrecedenceGroupDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension MacroDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension MacroExpansionDeclSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension LabeledStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ContinueStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension WhileStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension DeferStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ExpressionStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension RepeatWhileStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension GuardStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ForInStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension SwitchStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension DoStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ReturnStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension YieldStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension FallthroughStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension BreakStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension DeclarationStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ThrowStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension IfStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension SwitchCaseSyntax: SyntaxExpressibleByStringInterpolation {
-  public static func parse(from parser: inout Parser) -> Self {
-    return parser.parseSwitchCase().syntax
-  }
-}
-
-extension CatchClauseSyntax: SyntaxExpressibleByStringInterpolation {
-  public static func parse(from parser: inout Parser) -> Self {
-    return parser.parseCatchClause().syntax
-  }
-}
-
-extension PoundAssertStmtSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension GenericParameterClauseSyntax: SyntaxExpressibleByStringInterpolation {
-  public static func parse(from parser: inout Parser) -> Self {
-    return parser.parseGenericParameters().syntax
-  }
-}
-
-extension SimpleTypeIdentifierSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension MemberTypeIdentifierSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ClassRestrictionTypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ArrayTypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension DictionaryTypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension MetatypeTypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension OptionalTypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ConstrainedSugarTypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ImplicitlyUnwrappedOptionalTypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension CompositionTypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension PackExpansionTypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension TupleTypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension FunctionTypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension AttributedTypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension NamedOpaqueReturnTypeSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension EnumCasePatternSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension IsTypePatternSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension OptionalPatternSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension IdentifierPatternSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension AsTypePatternSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension TuplePatternSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension WildcardPatternSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ExpressionPatternSyntax: SyntaxExpressibleByStringInterpolation {}
-
-extension ValueBindingPatternSyntax: SyntaxExpressibleByStringInterpolation {}
-

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -98,7 +98,6 @@ final class AttributeTests: XCTestCase {
       @1️⃣rethrows
       protocol P { }
       """,
-      { $0.parseDeclaration() },
       substructure: Syntax(TokenSyntax.identifier("rethrows")),
       substructureAfterMarker: "1️⃣"
     )

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -118,7 +118,7 @@ final class DeclarationTests: XCTestCase {
 
     AssertParse(
       "<@NSApplicationMain T: AnyObject>",
-      { $0.parseGenericParameters() }
+      { GenericParameterClauseSyntax.parse(from: &$0) }
     )
 
     AssertParse("class T where t1️⃣",
@@ -599,8 +599,7 @@ final class DeclarationTests: XCTestCase {
 
   func testMissingColonInFunctionSignature() {
     AssertParse(
-      "(first second 1️⃣Int)",
-      { $0.parseFunctionSignature() },
+      "func test(first second 1️⃣Int)",
       diagnostics: [
         DiagnosticSpec(message: "expected ':' in parameter")
       ]
@@ -609,8 +608,7 @@ final class DeclarationTests: XCTestCase {
 
   func testExtraArgumentLabelsInFunctionSignature() {
     AssertParse(
-      "(first second 1️⃣third fourth: Int)",
-      { $0.parseFunctionSignature() },
+      "func test(first second 1️⃣third fourth: Int)",
       diagnostics: [
         DiagnosticSpec(message: "unexpected code 'third fourth' in parameter")
       ]
@@ -619,8 +617,7 @@ final class DeclarationTests: XCTestCase {
 
   func testMissingClosingParenInFunctionSignature() {
     AssertParse(
-      "(first second: Int1️⃣",
-      { $0.parseFunctionSignature() },
+      "func test(first second: Int1️⃣",
       diagnostics: [
         DiagnosticSpec(message: "expected ')' to end parameter clause")
       ]
@@ -629,8 +626,7 @@ final class DeclarationTests: XCTestCase {
 
   func testMissingOpeningParenInFunctionSignature() {
     AssertParse(
-      "1️⃣first second: Int)",
-      { $0.parseFunctionSignature() },
+      "func test 1️⃣first second: Int)",
       diagnostics: [
         DiagnosticSpec(message: "expected '(' to start parameter clause")
       ]
@@ -673,12 +669,11 @@ final class DeclarationTests: XCTestCase {
 
   func testThrowsInWrongLocation() {
     AssertParse(
-      "() -> 1️⃣throws Int",
-      { $0.parseFunctionSignature() },
+      "func test() -> 1️⃣throws Int",
       diagnostics: [
         DiagnosticSpec(message: "'throws' may only occur before '->'", fixIts: ["move 'throws' in front of '->'"])
       ],
-      fixedSource: "() throws -> Int"
+      fixedSource: "func test() throws -> Int"
     )
   }
 
@@ -788,8 +783,7 @@ final class DeclarationTests: XCTestCase {
 
   func testRecoverOneExtraLabel() {
     AssertParse(
-      "(first second 1️⃣third: Int)",
-      { $0.parseFunctionSignature() },
+      "func test(first second 1️⃣third: Int)",
       substructure: Syntax(FunctionParameterSyntax(
         attributes: nil,
         modifiers: nil,
@@ -810,8 +804,7 @@ final class DeclarationTests: XCTestCase {
 
   func testRecoverTwoExtraLabels() {
     AssertParse(
-      "(first second 1️⃣third fourth: Int)",
-      { $0.parseFunctionSignature() },
+      "func test(first second 1️⃣third fourth: Int)",
       substructure: Syntax(FunctionParameterSyntax(
         attributes: nil,
         modifiers: nil,
@@ -855,8 +848,7 @@ final class DeclarationTests: XCTestCase {
 
   func testRecoverFromParens() {
     AssertParse(
-      "(first second 1️⃣[third fourth]: Int)",
-      { $0.parseFunctionSignature() },
+      "func test(first second 1️⃣[third fourth]: Int)",
       substructure: Syntax(FunctionParameterSyntax(
         attributes: nil,
         modifiers: nil,
@@ -965,8 +957,8 @@ final class DeclarationTests: XCTestCase {
   }
 
   func testDeinitializers() {
-    AssertParse("deinit {}", { $0.parseDeinitializerDeclaration(.empty, .constant(.deinitKeyword)) })
-    AssertParse("deinit", { $0.parseDeinitializerDeclaration(.empty, .constant(.deinitKeyword)) })
+    AssertParse("deinit {}")
+    AssertParse("deinit")
   }
 
   func testAttributedMember() {

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -701,7 +701,7 @@ final class ExpressionTests: XCTestCase {
   func testParseArrowExpr() {
     AssertParse(
       "Foo 1️⃣async ->2️⃣",
-      { $0.parseSequenceExpression(.basic, forDirective: false) },
+      { ExprSyntax.parse(from: &$0) },
       substructure: Syntax(TokenSyntax.contextualKeyword("async")),
       substructureAfterMarker: "1️⃣",
       diagnostics: [

--- a/Tests/SwiftParserTest/Parser+EntryTests.swift
+++ b/Tests/SwiftParserTest/Parser+EntryTests.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftParser
+import XCTest
+
+public class EntryTests: XCTestCase {
+  func testTopLevelStringParse() throws {
+    AssertParse("func test() {}", { Parser.parse(source: $0) })
+  }
+
+  func testTopLevelBufferParse() throws {
+    AssertParse("func test() {}", { source in
+      var source = source
+      source.makeContiguousUTF8()
+      return source.withUTF8 { Parser.parse(source: $0) }
+    })
+  }
+
+  func testSyntaxParse() throws {
+    AssertParse("func test() {}",
+                { DeclSyntax.parse(from: &$0) })
+  }
+
+  func testRemainderUnexpected() throws {
+    AssertParse("func test() {} 1️⃣other tokens",
+                { DeclSyntax.parse(from: &$0) },
+                diagnostics: [DiagnosticSpec(message: "unexpected code 'other tokens' in function")])
+  }
+}

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -114,11 +114,11 @@ final class StatementTests: XCTestCase {
   }
 
   func testReturn() {
-    AssertParse("return actor", { $0.parseReturnStatement(returnHandle: .constant(.returnKeyword)) })
+    AssertParse("return actor", { StmtSyntax.parse(from: &$0) })
 
     AssertParse(
       "{ 1️⃣return 0 }",
-      { $0.parseClosureExpression() },
+      { ExprSyntax.parse(from: &$0) },
       substructure: Syntax(ReturnStmtSyntax(returnKeyword: .returnKeyword(),
                                             expression: ExprSyntax(IntegerLiteralExprSyntax(digits: .integerLiteral("0"))))),
       substructureAfterMarker: "1️⃣"

--- a/Tests/SwiftParserTest/TypeTests.swift
+++ b/Tests/SwiftParserTest/TypeTests.swift
@@ -28,12 +28,12 @@ final class TypeTests: XCTestCase {
   func testClosureParsing() {
     AssertParse(
       "(a, b) -> c",
-      { $0.parseType() }
+      { TypeSyntax.parse(from: &$0) }
     )
 
     AssertParse(
       "@MainActor (a, b) async throws -> c",
-      { $0.parseType() }
+      { TypeSyntax.parse(from: &$0) }
     )
 
     AssertParse("() -> (\u{feff})")
@@ -47,7 +47,7 @@ final class TypeTests: XCTestCase {
                   V, Baz<Quux>
               >>
       """,
-      { $0.parseType() }
+      { TypeSyntax.parse(from: &$0) }
     )
   }
 
@@ -72,15 +72,15 @@ final class TypeTests: XCTestCase {
                 { ()
                 throws -> Void in }
                 """,
-                { $0.parseClosureExpression() })
+                { ExprSyntax.parse(from: &$0) })
 
     AssertParse("""
                 { [weak a, unowned(safe) self, b = 3] (a: Int, b: Int, _: Int) -> Int in }
                 """,
-                { $0.parseClosureExpression() })
+                { ExprSyntax.parse(from: &$0) })
 
     AssertParse("{[1️⃣class]in2️⃣",
-                { $0.parseClosureExpression() },
+                { ExprSyntax.parse(from: &$0) },
                 diagnostics: [
                   DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in closure capture item"),
                   DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected 'class' keyword in closure capture signature"),
@@ -88,13 +88,13 @@ final class TypeTests: XCTestCase {
                 ])
 
     AssertParse("{[n1️⃣`]in}",
-                { $0.parseClosureExpression() },
+                { ExprSyntax.parse(from: &$0) },
                 diagnostics: [
                   DiagnosticSpec(message: "unexpected code '`' in closure capture signature")
                 ])
 
     AssertParse("{[weak1️⃣^]in}",
-                { $0.parseClosureExpression() },
+                { ExprSyntax.parse(from: &$0) },
                 diagnostics: [
                   DiagnosticSpec(message: "expected identifier in closure capture item"),
                   DiagnosticSpec(message: "unexpected code '^' in closure capture signature"),

--- a/Tests/SwiftSyntaxBuilderTest/DoStmtTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/DoStmtTests.swift
@@ -22,8 +22,8 @@ final class DoStmtTests: XCTestCase {
       }),
       catchClauses: [
         CatchClause(CatchItemList {
-          CatchItem(pattern: Pattern("Error1"))
-          CatchItem(pattern: Pattern("Error2"))
+          CatchItem(pattern: PatternSyntax("Error1"))
+          CatchItem(pattern: PatternSyntax("Error2"))
         }) {
           FunctionCallExpr(callee: "print") {
             TupleExprElement(expression: StringLiteralExpr(content: "Known error"))
@@ -31,7 +31,7 @@ final class DoStmtTests: XCTestCase {
         },
         CatchClause(CatchItemList {
           CatchItem(
-            pattern: Pattern("Error3"), whereClause: WhereClause(guardResult: MemberAccessExpr(base: "error", name: "isError4")))
+            pattern: PatternSyntax("Error3"), whereClause: WhereClause(guardResult: MemberAccessExpr(base: "error", name: "isError4")))
         }) {
           ThrowStmt(expression: MemberAccessExpr(base: "Error4", name: "error3"))
         },

--- a/Tests/SwiftSyntaxBuilderTest/ExtensionDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ExtensionDeclTests.swift
@@ -26,7 +26,7 @@ final class ExtensionDeclTests: XCTestCase {
         modifiers: [DeclModifier(name: .public)],
         letOrVarKeyword: .var
       ) {
-        PatternBinding(pattern: Pattern("`\(keyword)`"),
+        PatternBinding(pattern: PatternSyntax("`\(keyword)`"),
                        typeAnnotation: TypeAnnotation(type: Type("TokenSyntax")),
                        initializer: nil,
                        accessor: .getter(body))

--- a/Tests/SwiftSyntaxBuilderTest/IfStmtTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/IfStmtTests.swift
@@ -52,7 +52,7 @@ final class IfStmtTests: XCTestCase {
       conditions: ConditionElementList {
         OptionalBindingCondition(
           letOrVarKeyword: .let,
-          pattern: Pattern("x"),
+          pattern: PatternSyntax("x"),
           initializer: InitializerClause(value: Expr("y"))
         )
       }

--- a/Tests/SwiftSyntaxBuilderTest/TriviaTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/TriviaTests.swift
@@ -22,7 +22,12 @@ final class TriviaTests: XCTestCase {
       letOrVarKeyword: .var
     ) {
       PatternBinding(
-        pattern: Pattern("test"),
+        // TODO: This is meant to be `Pattern`, but it's ambiguous with XCTest
+        // Really we should just remove that method in favor of the regular
+        // syntax `init`, though that will mean callers have to wrap in
+        // `PatternSyntax`. Changing those inits to be generic would be
+        // possible, but then still fails here for the same reason.
+        pattern: PatternSyntax("test"),
         typeAnnotation: TypeAnnotation(type: Type("String"))
       )
     }

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -19,7 +19,7 @@ final class VariableTests: XCTestCase {
     let leadingTrivia = Trivia.unexpectedText("␣")
 
     let buildable = VariableDecl(leadingTrivia: leadingTrivia, letOrVarKeyword: .let) {
-      PatternBinding(pattern: Pattern("a"), typeAnnotation: TypeAnnotation(type: ArrayType(elementType: Type("Int"))))
+      PatternBinding(pattern: PatternSyntax("a"), typeAnnotation: TypeAnnotation(type: ArrayType(elementType: Type("Int"))))
     }
 
     AssertBuildResult(buildable, "␣let a: [Int]")
@@ -30,7 +30,7 @@ final class VariableTests: XCTestCase {
 
     let buildable = VariableDecl(leadingTrivia: leadingTrivia, letOrVarKeyword: .var) {
       PatternBinding(
-        pattern: Pattern("d"),
+        pattern: PatternSyntax("d"),
         typeAnnotation: TypeAnnotation(type: DictionaryType(keyType: Type("String"), valueType: Type("Int"))),
         initializer: InitializerClause(value: DictionaryExpr()))
     }
@@ -40,7 +40,7 @@ final class VariableTests: XCTestCase {
 
   func testVariableDeclWithExplicitTrailingCommas() {
     let buildable = VariableDecl(letOrVarKeyword: .let, bindings: [
-      PatternBinding(pattern: Pattern("a"), initializer: InitializerClause(value: ArrayExpr(
+      PatternBinding(pattern: PatternSyntax("a"), initializer: InitializerClause(value: ArrayExpr(
         leftSquare: .`leftSquareBracket`.withTrailingTrivia(.newline)) {
           for i in 1...3 {
             ArrayElement(
@@ -62,18 +62,18 @@ final class VariableTests: XCTestCase {
 
   func testMultiPatternVariableDecl() {
     let buildable = VariableDecl(letOrVarKeyword: .let) {
-      PatternBinding(pattern: Pattern("a"), initializer: InitializerClause(value: ArrayExpr {
+      PatternBinding(pattern: PatternSyntax("a"), initializer: InitializerClause(value: ArrayExpr {
         for i in 1...3 {
           ArrayElement(expression: IntegerLiteralExpr(i))
         }
       }))
-      PatternBinding(pattern: Pattern("d"), initializer: InitializerClause(value: DictionaryExpr {
+      PatternBinding(pattern: PatternSyntax("d"), initializer: InitializerClause(value: DictionaryExpr {
         for i in 1...3 {
           DictionaryElement(keyExpression: StringLiteralExpr(content: "key\(i)"), valueExpression: IntegerLiteralExpr(i))
         }
       }))
-      PatternBinding(pattern: Pattern("i"), typeAnnotation: TypeAnnotation(type: Type("Int")))
-      PatternBinding(pattern: Pattern("s"), typeAnnotation: TypeAnnotation(type: Type("String")))
+      PatternBinding(pattern: PatternSyntax("i"), typeAnnotation: TypeAnnotation(type: Type("Int")))
+      PatternBinding(pattern: PatternSyntax("s"), typeAnnotation: TypeAnnotation(type: Type("String")))
     }
     AssertBuildResult(buildable, #"let a = [1, 2, 3], d = ["key1": 1, "key2": 2, "key3": 3], i: Int, s: String"#)
   }
@@ -81,7 +81,7 @@ final class VariableTests: XCTestCase {
   func testClosureTypeVariableDecl() {
     let type = FunctionType(arguments: [TupleTypeElement(type: Type("Int"))], returnType: Type("Bool"))
     let buildable = VariableDecl(letOrVarKeyword: .let) {
-      PatternBinding(pattern: Pattern("c"), typeAnnotation: TypeAnnotation(type: type))
+      PatternBinding(pattern: PatternSyntax("c"), typeAnnotation: TypeAnnotation(type: type))
     }
     AssertBuildResult(buildable, "let c: (Int) -> Bool")
   }


### PR DESCRIPTION
Adds a new `SyntaxParseable` protocol with a single `parse(from:)` method. Any nodes with `parser_function` defined implement this protocol.

Other updates:
  - `SyntaxExpressibleByStringInterpolation` nodes to use these new methods
  - Parser tests to check against `*Syntax` rather than `Raw*Syntax` nodes
  - Builder methods to to take nodes (which are expressible by string literals) rather than `String`