### PR TITLE
Remove superfluous `RawSyntaxLayoutView.numberOfChildern`

### DIFF
--- a/Sources/SwiftSyntax/Raw/RawSyntaxLayoutView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxLayoutView.swift
@@ -166,11 +166,5 @@ public struct RawSyntaxLayoutView {
   public var children: RawSyntaxBuffer {
     layoutData.layout
   }
-
-  /// The number of children, `present` or `missing`, in this node.
-  @_spi(RawSyntax)
-  public var numberOfChildren: Int {
-    return children.count
-  }
 }
 


### PR DESCRIPTION
We already expose `children`, so we can just use `children.count`.