### PR TITLE
Macro declaration

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
@@ -1502,6 +1502,79 @@ public let DECL_NODES: [Node] = [
                ])
        ]),
 
+  Node(name: "MacroDecl",
+       nameForDiagnostics: "macro",
+       kind: "Decl",
+       traits: [
+         "IdentifiedDecl"
+       ],
+       children: [
+         Child(name: "Attributes",
+               kind: "AttributeList",
+               isOptional: true,
+               collectionElementName: "Attribute"),
+         Child(name: "Modifiers",
+               kind: "ModifierList",
+               isOptional: true,
+               collectionElementName: "Modifier"),
+         Child(name: "MacroKeyword",
+               kind: "ContextualKeywordToken",
+               tokenChoices: [
+                 "ContextualKeyword"
+               ],
+               textChoices: [
+                 "macro"
+               ]),
+         Child(name: "Identifier",
+               kind: "IdentifierToken",
+               tokenChoices: [
+                 "Identifier"
+               ]),
+         Child(name: "GenericParameterClause",
+               kind: "GenericParameterClause",
+               isOptional: true),
+         Child(name: "Signature",
+               kind: "Syntax",
+               nodeChoices: [
+                 Child(name: "FunctionLike",
+                       kind: "FunctionSignature"),
+                 Child(name: "ValueLike",
+                       kind: "TypeAnnotation")
+               ]),
+         Child(name: "Equal",
+               kind: "EqualToken",
+               tokenChoices: [
+                 "Equal"
+               ]),
+         Child(name: "ExternalName",
+               kind: "ExternalMacroName",
+               isOptional: true),
+         Child(name: "GenericWhereClause",
+               kind: "GenericWhereClause",
+               isOptional: true)
+       ]),
+
+  Node(name: "ExternalMacroName",
+       nameForDiagnostics: "external macro name",
+       kind: "Syntax",
+       children: [
+         Child(name: "ModuleName",
+               kind: "IdentifierToken",
+               tokenChoices: [
+                 "Identifier"
+               ]),
+         Child(name: "Period",
+               kind: "PeriodToken",
+               tokenChoices: [
+                 "Period"
+               ]),
+         Child(name: "MacroTypeName",
+               kind: "IdentifierToken",
+               tokenChoices: [
+                 "Identifier"
+               ])
+       ]),
+
   Node(name: "MacroExpansionDecl",
        nameForDiagnostics: "pound literal declaration",
        kind: "Decl",

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/NodeSerializationCodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/NodeSerializationCodes.swift
@@ -298,4 +298,6 @@ public let SYNTAX_NODE_SERIALIZATION_CODES: [String: Int] = [
   "OldKeyPathExpr": 287,
   "MacroExpansionExpr": 288,
   "MacroExpansionDecl": 289,
+  "MacroDecl": 290,
+  "ExternalMacroName": 291,
 ]

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -322,6 +322,7 @@ enum DeclarationStart: RawTokenKindSubset {
   case importKeyword
   case initKeyword
   case letKeyword
+  case macroContextualKeyword
   case operatorKeyword
   case precedencegroupKeyword
   case protocolKeyword
@@ -333,6 +334,7 @@ enum DeclarationStart: RawTokenKindSubset {
   init?(lexeme: Lexer.Lexeme) {
     switch lexeme.tokenKind {
     case .identifier where lexeme.tokenText == "actor": self = .actorContextualKeyword
+    case .identifier where lexeme.tokenText == "macro": self = .macroContextualKeyword
     case .associatedtypeKeyword: self = .associatedtypeKeyword
     case .caseKeyword: self = .caseKeyword
     case .classKeyword: self = .classKeyword
@@ -367,6 +369,7 @@ enum DeclarationStart: RawTokenKindSubset {
     case .importKeyword: return .importKeyword
     case .initKeyword: return .initKeyword
     case .letKeyword: return .letKeyword
+    case .macroContextualKeyword: return .identifier
     case .operatorKeyword: return .operatorKeyword
     case .precedencegroupKeyword: return .precedencegroupKeyword
     case .protocolKeyword: return .protocolKeyword
@@ -380,6 +383,7 @@ enum DeclarationStart: RawTokenKindSubset {
   var contextualKeyword: SyntaxText? {
     switch self {
     case .actorContextualKeyword: return "actor"
+    case .macroContextualKeyword: return "macro"
     default: return nil
     }
   }
@@ -388,6 +392,7 @@ enum DeclarationStart: RawTokenKindSubset {
     switch self {
     case .actorContextualKeyword: return .declKeyword
     case .caseKeyword: return .declKeyword
+    case .macroContextualKeyword: return .declKeyword
     default: return nil
     }
   }

--- a/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
@@ -74,6 +74,7 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/EnumDeclSyntax>
 - <doc:SwiftSyntax/OperatorDeclSyntax>
 - <doc:SwiftSyntax/PrecedenceGroupDeclSyntax>
+- <doc:SwiftSyntax/MacroDeclSyntax>
 - <doc:SwiftSyntax/MacroExpansionDeclSyntax>
 
 ### Statements
@@ -354,6 +355,7 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/PrecedenceGroupNameElementSyntax>
 - <doc:SwiftSyntax/PrecedenceGroupAssignmentSyntax>
 - <doc:SwiftSyntax/PrecedenceGroupAssociativitySyntax>
+- <doc:SwiftSyntax/ExternalMacroNameSyntax>
 - <doc:SwiftSyntax/TokenListSyntax>
 - <doc:SwiftSyntax/NonEmptyTokenListSyntax>
 - <doc:SwiftSyntax/CustomAttributeSyntax>

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -35,7 +35,7 @@ public struct RawDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
 
   public static func isKindOf(_ raw: RawSyntax) -> Bool {
     switch raw.kind {
-    case .unknownDecl, .missingDecl, .typealiasDecl, .associatedtypeDecl, .ifConfigDecl, .poundErrorDecl, .poundWarningDecl, .poundSourceLocation, .classDecl, .actorDecl, .structDecl, .protocolDecl, .extensionDecl, .functionDecl, .initializerDecl, .deinitializerDecl, .subscriptDecl, .importDecl, .accessorDecl, .variableDecl, .enumCaseDecl, .enumDecl, .operatorDecl, .precedenceGroupDecl, .macroExpansionDecl: return true
+    case .unknownDecl, .missingDecl, .typealiasDecl, .associatedtypeDecl, .ifConfigDecl, .poundErrorDecl, .poundWarningDecl, .poundSourceLocation, .classDecl, .actorDecl, .structDecl, .protocolDecl, .extensionDecl, .functionDecl, .initializerDecl, .deinitializerDecl, .subscriptDecl, .importDecl, .accessorDecl, .variableDecl, .enumCaseDecl, .enumDecl, .operatorDecl, .precedenceGroupDecl, .macroDecl, .macroExpansionDecl: return true
     default: return false
     }
   }
@@ -11120,6 +11120,236 @@ public struct RawPrecedenceGroupAssociativitySyntax: RawSyntaxNodeProtocol, RawS
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
   }
   public var unexpectedAfterValue: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+}
+
+@_spi(RawSyntax)
+public struct RawMacroDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
+  public enum Signature: RawSyntaxNodeProtocol {
+    case `functionLike`(RawFunctionSignatureSyntax)
+    case `valueLike`(RawTypeAnnotationSyntax)
+
+    public static func isKindOf(_ raw: RawSyntax) -> Bool {
+      return RawFunctionSignatureSyntax.isKindOf(raw) || RawTypeAnnotationSyntax.isKindOf(raw)
+    }
+
+    public var raw: RawSyntax {
+      switch self {
+      case .functionLike(let node): return node.raw
+      case .valueLike(let node): return node.raw
+      }
+    }
+
+    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+      if let node = RawFunctionSignatureSyntax(other) {
+        self = .functionLike(node)
+        return
+      }
+      if let node = RawTypeAnnotationSyntax(other) {
+        self = .valueLike(node)
+        return
+      }
+      return nil
+    }
+  }
+
+  public typealias SyntaxType = MacroDeclSyntax
+
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .macroDecl
+  }
+
+  public var raw: RawSyntax
+  init(raw: RawSyntax) {
+    assert(Self.isKindOf(raw))
+    self.raw = raw
+  }
+
+  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+    guard Self.isKindOf(other.raw) else { return nil }
+    self.init(raw: other.raw)
+  }
+
+  public init(
+    _ unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? = nil,
+    attributes: RawAttributeListSyntax?,
+    _ unexpectedBetweenAttributesAndModifiers: RawUnexpectedNodesSyntax? = nil,
+    modifiers: RawModifierListSyntax?,
+    _ unexpectedBetweenModifiersAndMacroKeyword: RawUnexpectedNodesSyntax? = nil,
+    macroKeyword: RawTokenSyntax,
+    _ unexpectedBetweenMacroKeywordAndIdentifier: RawUnexpectedNodesSyntax? = nil,
+    identifier: RawTokenSyntax,
+    _ unexpectedBetweenIdentifierAndGenericParameterClause: RawUnexpectedNodesSyntax? = nil,
+    genericParameterClause: RawGenericParameterClauseSyntax?,
+    _ unexpectedBetweenGenericParameterClauseAndSignature: RawUnexpectedNodesSyntax? = nil,
+    signature: Signature,
+    _ unexpectedBetweenSignatureAndEqual: RawUnexpectedNodesSyntax? = nil,
+    equal: RawTokenSyntax,
+    _ unexpectedBetweenEqualAndExternalName: RawUnexpectedNodesSyntax? = nil,
+    externalName: RawExternalMacroNameSyntax?,
+    _ unexpectedBetweenExternalNameAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil,
+    genericWhereClause: RawGenericWhereClauseSyntax?,
+    _ unexpectedAfterGenericWhereClause: RawUnexpectedNodesSyntax? = nil,
+    arena: __shared SyntaxArena
+  ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .macroDecl, uninitializedCount: 19, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeAttributes?.raw
+      layout[1] = attributes?.raw
+      layout[2] = unexpectedBetweenAttributesAndModifiers?.raw
+      layout[3] = modifiers?.raw
+      layout[4] = unexpectedBetweenModifiersAndMacroKeyword?.raw
+      layout[5] = macroKeyword.raw
+      layout[6] = unexpectedBetweenMacroKeywordAndIdentifier?.raw
+      layout[7] = identifier.raw
+      layout[8] = unexpectedBetweenIdentifierAndGenericParameterClause?.raw
+      layout[9] = genericParameterClause?.raw
+      layout[10] = unexpectedBetweenGenericParameterClauseAndSignature?.raw
+      layout[11] = signature.raw
+      layout[12] = unexpectedBetweenSignatureAndEqual?.raw
+      layout[13] = equal.raw
+      layout[14] = unexpectedBetweenEqualAndExternalName?.raw
+      layout[15] = externalName?.raw
+      layout[16] = unexpectedBetweenExternalNameAndGenericWhereClause?.raw
+      layout[17] = genericWhereClause?.raw
+      layout[18] = unexpectedAfterGenericWhereClause?.raw
+    }
+    self.init(raw: raw)
+  }
+
+  public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var attributes: RawAttributeListSyntax? {
+    layoutView.children[1].map(RawAttributeListSyntax.init(raw:))
+  }
+  public var unexpectedBetweenAttributesAndModifiers: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var modifiers: RawModifierListSyntax? {
+    layoutView.children[3].map(RawModifierListSyntax.init(raw:))
+  }
+  public var unexpectedBetweenModifiersAndMacroKeyword: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var macroKeyword: RawTokenSyntax {
+    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedBetweenMacroKeywordAndIdentifier: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var identifier: RawTokenSyntax {
+    layoutView.children[7].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedBetweenIdentifierAndGenericParameterClause: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var genericParameterClause: RawGenericParameterClauseSyntax? {
+    layoutView.children[9].map(RawGenericParameterClauseSyntax.init(raw:))
+  }
+  public var unexpectedBetweenGenericParameterClauseAndSignature: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var signature: RawSyntax {
+    layoutView.children[11]!
+  }
+  public var unexpectedBetweenSignatureAndEqual: RawUnexpectedNodesSyntax? {
+    layoutView.children[12].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var equal: RawTokenSyntax {
+    layoutView.children[13].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedBetweenEqualAndExternalName: RawUnexpectedNodesSyntax? {
+    layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var externalName: RawExternalMacroNameSyntax? {
+    layoutView.children[15].map(RawExternalMacroNameSyntax.init(raw:))
+  }
+  public var unexpectedBetweenExternalNameAndGenericWhereClause: RawUnexpectedNodesSyntax? {
+    layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var genericWhereClause: RawGenericWhereClauseSyntax? {
+    layoutView.children[17].map(RawGenericWhereClauseSyntax.init(raw:))
+  }
+  public var unexpectedAfterGenericWhereClause: RawUnexpectedNodesSyntax? {
+    layoutView.children[18].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+}
+
+@_spi(RawSyntax)
+public struct RawExternalMacroNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  public typealias SyntaxType = ExternalMacroNameSyntax
+
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .externalMacroName
+  }
+
+  public var raw: RawSyntax
+  init(raw: RawSyntax) {
+    assert(Self.isKindOf(raw))
+    self.raw = raw
+  }
+
+  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+    guard Self.isKindOf(other.raw) else { return nil }
+    self.init(raw: other.raw)
+  }
+
+  public init(
+    _ unexpectedBeforeModuleName: RawUnexpectedNodesSyntax? = nil,
+    moduleName: RawTokenSyntax,
+    _ unexpectedBetweenModuleNameAndPeriod: RawUnexpectedNodesSyntax? = nil,
+    period: RawTokenSyntax,
+    _ unexpectedBetweenPeriodAndMacroTypeName: RawUnexpectedNodesSyntax? = nil,
+    macroTypeName: RawTokenSyntax,
+    _ unexpectedAfterMacroTypeName: RawUnexpectedNodesSyntax? = nil,
+    arena: __shared SyntaxArena
+  ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .externalMacroName, uninitializedCount: 7, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeModuleName?.raw
+      layout[1] = moduleName.raw
+      layout[2] = unexpectedBetweenModuleNameAndPeriod?.raw
+      layout[3] = period.raw
+      layout[4] = unexpectedBetweenPeriodAndMacroTypeName?.raw
+      layout[5] = macroTypeName.raw
+      layout[6] = unexpectedAfterMacroTypeName?.raw
+    }
+    self.init(raw: raw)
+  }
+
+  public var unexpectedBeforeModuleName: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var moduleName: RawTokenSyntax {
+    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedBetweenModuleNameAndPeriod: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var period: RawTokenSyntax {
+    layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedBetweenPeriodAndMacroTypeName: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var macroTypeName: RawTokenSyntax {
+    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterMacroTypeName: RawUnexpectedNodesSyntax? {
     layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
@@ -1607,6 +1607,41 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     break
+  case .macroDecl:
+    assert(layout.count == 19)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawAttributeListSyntax?.self))
+    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 3, verify(layout[3], as: RawModifierListSyntax?.self))
+    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self))
+    assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 7, verify(layout[7], as: RawTokenSyntax.self))
+    assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 9, verify(layout[9], as: RawGenericParameterClauseSyntax?.self))
+    assertNoError(kind, 10, verify(layout[10], as: RawUnexpectedNodesSyntax?.self))
+    assertAnyHasNoError(kind, 11, [
+      verify(layout[11], as: RawSyntax.self),
+      verify(layout[11], as: RawSyntax.self),
+    ])
+    assertNoError(kind, 12, verify(layout[12], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 13, verify(layout[13], as: RawTokenSyntax.self))
+    assertNoError(kind, 14, verify(layout[14], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 15, verify(layout[15], as: RawExternalMacroNameSyntax?.self))
+    assertNoError(kind, 16, verify(layout[16], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 17, verify(layout[17], as: RawGenericWhereClauseSyntax?.self))
+    assertNoError(kind, 18, verify(layout[18], as: RawUnexpectedNodesSyntax?.self))
+    break
+  case .externalMacroName:
+    assert(layout.count == 7)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self))
+    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self))
+    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self))
+    assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
+    break
   case .macroExpansionDecl:
     assert(layout.count == 17)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -178,6 +178,8 @@ extension Syntax {
       .node(PrecedenceGroupNameElementSyntax.self),
       .node(PrecedenceGroupAssignmentSyntax.self),
       .node(PrecedenceGroupAssociativitySyntax.self),
+      .node(MacroDeclSyntax.self),
+      .node(ExternalMacroNameSyntax.self),
       .node(MacroExpansionDeclSyntax.self),
       .node(TokenListSyntax.self),
       .node(NonEmptyTokenListSyntax.self),
@@ -465,6 +467,8 @@ extension SyntaxKind {
     case .precedenceGroupNameElement: return PrecedenceGroupNameElementSyntax.self
     case .precedenceGroupAssignment: return PrecedenceGroupAssignmentSyntax.self
     case .precedenceGroupAssociativity: return PrecedenceGroupAssociativitySyntax.self
+    case .macroDecl: return MacroDeclSyntax.self
+    case .externalMacroName: return ExternalMacroNameSyntax.self
     case .macroExpansionDecl: return MacroExpansionDeclSyntax.self
     case .tokenList: return TokenListSyntax.self
     case .nonEmptyTokenList: return NonEmptyTokenListSyntax.self
@@ -913,6 +917,10 @@ extension SyntaxKind {
       return "'assignment' property of precedencegroup"
     case .precedenceGroupAssociativity:
       return "'associativity' property of precedencegroup"
+    case .macroDecl:
+      return "macro"
+    case .externalMacroName:
+      return "external macro name"
     case .macroExpansionDecl:
       return "pound literal declaration"
     case .tokenList:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
@@ -1188,6 +1188,20 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   override open func visitPost(_ node: PrecedenceGroupAssociativitySyntax) {
     visitAnyPost(node._syntaxNode)
   }
+  override open func visit(_ node: MacroDeclSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: MacroDeclSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: ExternalMacroNameSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: ExternalMacroNameSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
   override open func visit(_ node: MacroExpansionDeclSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
@@ -67,7 +67,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public init?<S: SyntaxProtocol>(_ node: S) {
     switch node.raw.kind {
-    case .unknownDecl, .missingDecl, .typealiasDecl, .associatedtypeDecl, .ifConfigDecl, .poundErrorDecl, .poundWarningDecl, .poundSourceLocation, .classDecl, .actorDecl, .structDecl, .protocolDecl, .extensionDecl, .functionDecl, .initializerDecl, .deinitializerDecl, .subscriptDecl, .importDecl, .accessorDecl, .variableDecl, .enumCaseDecl, .enumDecl, .operatorDecl, .precedenceGroupDecl, .macroExpansionDecl:
+    case .unknownDecl, .missingDecl, .typealiasDecl, .associatedtypeDecl, .ifConfigDecl, .poundErrorDecl, .poundWarningDecl, .poundSourceLocation, .classDecl, .actorDecl, .structDecl, .protocolDecl, .extensionDecl, .functionDecl, .initializerDecl, .deinitializerDecl, .subscriptDecl, .importDecl, .accessorDecl, .variableDecl, .enumCaseDecl, .enumDecl, .operatorDecl, .precedenceGroupDecl, .macroDecl, .macroExpansionDecl:
       self._syntaxNode = node._syntaxNode
     default:
       return nil
@@ -81,7 +81,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     // Assert that the kind of the given data matches in debug builds.
 #if DEBUG
     switch data.raw.kind {
-    case .unknownDecl, .missingDecl, .typealiasDecl, .associatedtypeDecl, .ifConfigDecl, .poundErrorDecl, .poundWarningDecl, .poundSourceLocation, .classDecl, .actorDecl, .structDecl, .protocolDecl, .extensionDecl, .functionDecl, .initializerDecl, .deinitializerDecl, .subscriptDecl, .importDecl, .accessorDecl, .variableDecl, .enumCaseDecl, .enumDecl, .operatorDecl, .precedenceGroupDecl, .macroExpansionDecl:
+    case .unknownDecl, .missingDecl, .typealiasDecl, .associatedtypeDecl, .ifConfigDecl, .poundErrorDecl, .poundWarningDecl, .poundSourceLocation, .classDecl, .actorDecl, .structDecl, .protocolDecl, .extensionDecl, .functionDecl, .initializerDecl, .deinitializerDecl, .subscriptDecl, .importDecl, .accessorDecl, .variableDecl, .enumCaseDecl, .enumDecl, .operatorDecl, .precedenceGroupDecl, .macroDecl, .macroExpansionDecl:
       break
     default:
       fatalError("Unable to create DeclSyntax from \(data.raw.kind)")
@@ -143,6 +143,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       .node(EnumDeclSyntax.self),
       .node(OperatorDeclSyntax.self),
       .node(PrecedenceGroupDeclSyntax.self),
+      .node(MacroDeclSyntax.self),
       .node(MacroExpansionDeclSyntax.self),
     ])
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -177,6 +177,8 @@ public enum SyntaxEnum {
   case precedenceGroupNameElement(PrecedenceGroupNameElementSyntax)
   case precedenceGroupAssignment(PrecedenceGroupAssignmentSyntax)
   case precedenceGroupAssociativity(PrecedenceGroupAssociativitySyntax)
+  case macroDecl(MacroDeclSyntax)
+  case externalMacroName(ExternalMacroNameSyntax)
   case macroExpansionDecl(MacroExpansionDeclSyntax)
   case tokenList(TokenListSyntax)
   case nonEmptyTokenList(NonEmptyTokenListSyntax)
@@ -626,6 +628,10 @@ public extension Syntax {
       return .precedenceGroupAssignment(PrecedenceGroupAssignmentSyntax(self)!)
     case .precedenceGroupAssociativity:
       return .precedenceGroupAssociativity(PrecedenceGroupAssociativitySyntax(self)!)
+    case .macroDecl:
+      return .macroDecl(MacroDeclSyntax(self)!)
+    case .externalMacroName:
+      return .externalMacroName(ExternalMacroNameSyntax(self)!)
     case .macroExpansionDecl:
       return .macroExpansionDecl(MacroExpansionDeclSyntax(self)!)
     case .tokenList:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -5189,6 +5189,100 @@ public enum SyntaxFactory {
       return PrecedenceGroupAssociativitySyntax(data)
     }
   }
+  @available(*, deprecated, message: "Use initializer on MacroDeclSyntax")
+  public static func makeMacroDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndMacroKeyword: UnexpectedNodesSyntax? = nil, macroKeyword: TokenSyntax, _ unexpectedBetweenMacroKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? = nil, signature: Syntax, _ unexpectedBetweenSignatureAndEqual: UnexpectedNodesSyntax? = nil, equal: TokenSyntax, _ unexpectedBetweenEqualAndExternalName: UnexpectedNodesSyntax? = nil, externalName: ExternalMacroNameSyntax?, _ unexpectedBetweenExternalNameAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil) -> MacroDeclSyntax {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeAttributes?.raw,
+      attributes?.raw,
+      unexpectedBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      unexpectedBetweenModifiersAndMacroKeyword?.raw,
+      macroKeyword.raw,
+      unexpectedBetweenMacroKeywordAndIdentifier?.raw,
+      identifier.raw,
+      unexpectedBetweenIdentifierAndGenericParameterClause?.raw,
+      genericParameterClause?.raw,
+      unexpectedBetweenGenericParameterClauseAndSignature?.raw,
+      signature.raw,
+      unexpectedBetweenSignatureAndEqual?.raw,
+      equal.raw,
+      unexpectedBetweenEqualAndExternalName?.raw,
+      externalName?.raw,
+      unexpectedBetweenExternalNameAndGenericWhereClause?.raw,
+      genericWhereClause?.raw,
+      unexpectedAfterGenericWhereClause?.raw,
+    ]
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.macroDecl,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MacroDeclSyntax(data)
+    }
+  }
+
+  @available(*, deprecated, message: "Use initializer on MacroDeclSyntax")
+  public static func makeBlankMacroDecl(presence: SourcePresence = .present) -> MacroDeclSyntax {
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .macroDecl,
+        from: [
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        nil,
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: arena),
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+      ], arena: arena))
+      return MacroDeclSyntax(data)
+    }
+  }
+  @available(*, deprecated, message: "Use initializer on ExternalMacroNameSyntax")
+  public static func makeExternalMacroName(_ unexpectedBeforeModuleName: UnexpectedNodesSyntax? = nil, moduleName: TokenSyntax, _ unexpectedBetweenModuleNameAndPeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax, _ unexpectedBetweenPeriodAndMacroTypeName: UnexpectedNodesSyntax? = nil, macroTypeName: TokenSyntax, _ unexpectedAfterMacroTypeName: UnexpectedNodesSyntax? = nil) -> ExternalMacroNameSyntax {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeModuleName?.raw,
+      moduleName.raw,
+      unexpectedBetweenModuleNameAndPeriod?.raw,
+      period.raw,
+      unexpectedBetweenPeriodAndMacroTypeName?.raw,
+      macroTypeName.raw,
+      unexpectedAfterMacroTypeName?.raw,
+    ]
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.externalMacroName,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return ExternalMacroNameSyntax(data)
+    }
+  }
+
+  @available(*, deprecated, message: "Use initializer on ExternalMacroNameSyntax")
+  public static func makeBlankExternalMacroName(presence: SourcePresence = .present) -> ExternalMacroNameSyntax {
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .externalMacroName,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.period, arena: arena),
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        nil,
+      ], arena: arena))
+      return ExternalMacroNameSyntax(data)
+    }
+  }
   @available(*, deprecated, message: "Use initializer on MacroExpansionDeclSyntax")
   public static func makeMacroExpansionDecl(_ unexpectedBeforePoundToken: UnexpectedNodesSyntax? = nil, poundToken: TokenSyntax, _ unexpectedBetweenPoundTokenAndMacro: UnexpectedNodesSyntax? = nil, macro: TokenSyntax, _ unexpectedBetweenMacroAndGenericArguments: UnexpectedNodesSyntax? = nil, genericArguments: GenericArgumentClauseSyntax?, _ unexpectedBetweenGenericArgumentsAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax?, _ unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? = nil, argumentList: TupleExprElementListSyntax, _ unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax?, _ unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodesSyntax? = nil, trailingClosure: ClosureExprSyntax?, _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil, additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?, _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil) -> MacroExpansionDeclSyntax {
     let layout: [RawSyntax?] = [

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
@@ -177,6 +177,8 @@ public enum SyntaxKind {
   case precedenceGroupNameElement
   case precedenceGroupAssignment
   case precedenceGroupAssociativity
+  case macroDecl
+  case externalMacroName
   case macroExpansionDecl
   case tokenList
   case nonEmptyTokenList

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -1150,6 +1150,20 @@ open class SyntaxRewriter {
     return Syntax(visitChildren(node)).cast(PrecedenceGroupAssociativitySyntax.self)
   }
 
+  /// Visit a `MacroDeclSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: MacroDeclSyntax) -> DeclSyntax {
+    return DeclSyntax(visitChildren(node))
+  }
+
+  /// Visit a `ExternalMacroNameSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: ExternalMacroNameSyntax) -> ExternalMacroNameSyntax {
+    return Syntax(visitChildren(node)).cast(ExternalMacroNameSyntax.self)
+  }
+
   /// Visit a `MacroExpansionDeclSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -3711,6 +3725,26 @@ open class SyntaxRewriter {
   }
 
   /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplMacroDeclSyntax(_ data: SyntaxData) -> Syntax {
+      let node = MacroDeclSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return Syntax(visit(node))
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplExternalMacroNameSyntax(_ data: SyntaxData) -> Syntax {
+      let node = ExternalMacroNameSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return Syntax(visit(node))
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplMacroExpansionDeclSyntax(_ data: SyntaxData) -> Syntax {
       let node = MacroExpansionDeclSyntax(data)
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
@@ -5254,6 +5288,10 @@ open class SyntaxRewriter {
       return visitImplPrecedenceGroupAssignmentSyntax
     case .precedenceGroupAssociativity:
       return visitImplPrecedenceGroupAssociativitySyntax
+    case .macroDecl:
+      return visitImplMacroDeclSyntax
+    case .externalMacroName:
+      return visitImplExternalMacroNameSyntax
     case .macroExpansionDecl:
       return visitImplMacroExpansionDeclSyntax
     case .tokenList:
@@ -5825,6 +5863,10 @@ open class SyntaxRewriter {
       return visitImplPrecedenceGroupAssignmentSyntax(data)
     case .precedenceGroupAssociativity:
       return visitImplPrecedenceGroupAssociativitySyntax(data)
+    case .macroDecl:
+      return visitImplMacroDeclSyntax(data)
+    case .externalMacroName:
+      return visitImplExternalMacroNameSyntax(data)
     case .macroExpansionDecl:
       return visitImplMacroExpansionDeclSyntax(data)
     case .tokenList:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxTraits.swift
@@ -219,6 +219,7 @@ extension EnumCaseElementSyntax: WithTrailingCommaSyntax {}
 extension EnumDeclSyntax: IdentifiedDeclSyntax {}
 extension OperatorDeclSyntax: IdentifiedDeclSyntax {}
 extension PrecedenceGroupDeclSyntax: IdentifiedDeclSyntax {}
+extension MacroDeclSyntax: IdentifiedDeclSyntax {}
 extension LabeledSpecializeEntrySyntax: WithTrailingCommaSyntax {}
 extension TargetFunctionEntrySyntax: WithTrailingCommaSyntax {}
 extension DifferentiabilityParamSyntax: WithTrailingCommaSyntax {}

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
@@ -664,6 +664,14 @@ public protocol SyntaxTransformVisitor {
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: PrecedenceGroupAssociativitySyntax) -> ResultType
+  /// Visiting `MacroDeclSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: MacroDeclSyntax) -> ResultType
+  /// Visiting `ExternalMacroNameSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: ExternalMacroNameSyntax) -> ResultType
   /// Visiting `MacroExpansionDeclSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -2109,6 +2117,18 @@ extension SyntaxTransformVisitor {
   public func visit(_ node: PrecedenceGroupAssociativitySyntax) -> ResultType {
     visitAny(Syntax(node))
   }
+  /// Visiting `MacroDeclSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: MacroDeclSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
+  /// Visiting `ExternalMacroNameSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: ExternalMacroNameSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
   /// Visiting `MacroExpansionDeclSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
@@ -3139,6 +3159,10 @@ extension SyntaxTransformVisitor {
     case .precedenceGroupAssignment(let derived):
       return visit(derived)
     case .precedenceGroupAssociativity(let derived):
+      return visit(derived)
+    case .macroDecl(let derived):
+      return visit(derived)
+    case .externalMacroName(let derived):
       return visit(derived)
     case .macroExpansionDecl(let derived):
       return visit(derived)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -1651,6 +1651,26 @@ open class SyntaxVisitor {
   /// The function called after visiting `PrecedenceGroupAssociativitySyntax` and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: PrecedenceGroupAssociativitySyntax) {}
+  /// Visiting `MacroDeclSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: MacroDeclSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `MacroDeclSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: MacroDeclSyntax) {}
+  /// Visiting `ExternalMacroNameSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: ExternalMacroNameSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `ExternalMacroNameSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: ExternalMacroNameSyntax) {}
   /// Visiting `MacroExpansionDeclSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -4671,6 +4691,28 @@ open class SyntaxVisitor {
   }
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplMacroDeclSyntax(_ data: SyntaxData) {
+      let node = MacroDeclSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && !node.raw.layoutView!.children.isEmpty {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplExternalMacroNameSyntax(_ data: SyntaxData) {
+      let node = ExternalMacroNameSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && !node.raw.layoutView!.children.isEmpty {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplMacroExpansionDeclSyntax(_ data: SyntaxData) {
       let node = MacroExpansionDeclSyntax(data)
       let needsChildren = (visit(node) == .visitChildren)
@@ -6299,6 +6341,10 @@ open class SyntaxVisitor {
       visitImplPrecedenceGroupAssignmentSyntax(data)
     case .precedenceGroupAssociativity:
       visitImplPrecedenceGroupAssociativitySyntax(data)
+    case .macroDecl:
+      visitImplMacroDeclSyntax(data)
+    case .externalMacroName:
+      visitImplExternalMacroNameSyntax(data)
     case .macroExpansionDecl:
       visitImplMacroExpansionDeclSyntax(data)
     case .tokenList:

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -11935,6 +11935,242 @@ extension PrecedenceGroupAssociativitySyntax: CustomReflectable {
   }
 }
 
+// MARK: - ExternalMacroNameSyntax
+
+public struct ExternalMacroNameSyntax: SyntaxProtocol, SyntaxHashable {
+  public let _syntaxNode: Syntax
+
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .externalMacroName else { return nil }
+    self._syntaxNode = node._syntaxNode
+  }
+
+  /// Creates a `ExternalMacroNameSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .externalMacroName)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ unexpectedBeforeModuleName: UnexpectedNodesSyntax? = nil,
+    moduleName: TokenSyntax,
+    _ unexpectedBetweenModuleNameAndPeriod: UnexpectedNodesSyntax? = nil,
+    period: TokenSyntax,
+    _ unexpectedBetweenPeriodAndMacroTypeName: UnexpectedNodesSyntax? = nil,
+    macroTypeName: TokenSyntax,
+    _ unexpectedAfterMacroTypeName: UnexpectedNodesSyntax? = nil
+  ) {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeModuleName?.raw,
+      moduleName.raw,
+      unexpectedBetweenModuleNameAndPeriod?.raw,
+      period.raw,
+      unexpectedBetweenPeriodAndMacroTypeName?.raw,
+      macroTypeName.raw,
+      unexpectedAfterMacroTypeName?.raw,
+    ]
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.externalMacroName,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
+    self.init(data)
+  }
+
+  public var unexpectedBeforeModuleName: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 0, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBeforeModuleName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBeforeModuleName` replaced.
+  /// - param newChild: The new `unexpectedBeforeModuleName` to replace the node's
+  ///                   current `unexpectedBeforeModuleName`, if present.
+  public func withUnexpectedBeforeModuleName(_ newChild: UnexpectedNodesSyntax?) -> ExternalMacroNameSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw
+    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+    return ExternalMacroNameSyntax(newData)
+  }
+
+  public var moduleName: TokenSyntax {
+    get {
+      let childData = data.child(at: 1, parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withModuleName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `moduleName` replaced.
+  /// - param newChild: The new `moduleName` to replace the node's
+  ///                   current `moduleName`, if present.
+  public func withModuleName(_ newChild: TokenSyntax?) -> ExternalMacroNameSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+    return ExternalMacroNameSyntax(newData)
+  }
+
+  public var unexpectedBetweenModuleNameAndPeriod: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenModuleNameAndPeriod(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenModuleNameAndPeriod` replaced.
+  /// - param newChild: The new `unexpectedBetweenModuleNameAndPeriod` to replace the node's
+  ///                   current `unexpectedBetweenModuleNameAndPeriod`, if present.
+  public func withUnexpectedBetweenModuleNameAndPeriod(_ newChild: UnexpectedNodesSyntax?) -> ExternalMacroNameSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw
+    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+    return ExternalMacroNameSyntax(newData)
+  }
+
+  public var period: TokenSyntax {
+    get {
+      let childData = data.child(at: 3, parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withPeriod(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `period` replaced.
+  /// - param newChild: The new `period` to replace the node's
+  ///                   current `period`, if present.
+  public func withPeriod(_ newChild: TokenSyntax?) -> ExternalMacroNameSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: arena)
+    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+    return ExternalMacroNameSyntax(newData)
+  }
+
+  public var unexpectedBetweenPeriodAndMacroTypeName: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenPeriodAndMacroTypeName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenPeriodAndMacroTypeName` replaced.
+  /// - param newChild: The new `unexpectedBetweenPeriodAndMacroTypeName` to replace the node's
+  ///                   current `unexpectedBetweenPeriodAndMacroTypeName`, if present.
+  public func withUnexpectedBetweenPeriodAndMacroTypeName(_ newChild: UnexpectedNodesSyntax?) -> ExternalMacroNameSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw
+    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+    return ExternalMacroNameSyntax(newData)
+  }
+
+  public var macroTypeName: TokenSyntax {
+    get {
+      let childData = data.child(at: 5, parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withMacroTypeName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `macroTypeName` replaced.
+  /// - param newChild: The new `macroTypeName` to replace the node's
+  ///                   current `macroTypeName`, if present.
+  public func withMacroTypeName(_ newChild: TokenSyntax?) -> ExternalMacroNameSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+    return ExternalMacroNameSyntax(newData)
+  }
+
+  public var unexpectedAfterMacroTypeName: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterMacroTypeName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterMacroTypeName` replaced.
+  /// - param newChild: The new `unexpectedAfterMacroTypeName` to replace the node's
+  ///                   current `unexpectedAfterMacroTypeName`, if present.
+  public func withUnexpectedAfterMacroTypeName(_ newChild: UnexpectedNodesSyntax?) -> ExternalMacroNameSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw
+    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+    return ExternalMacroNameSyntax(newData)
+  }
+
+  public static var structure: SyntaxNodeStructure {
+    return .layout([
+      \Self.unexpectedBeforeModuleName,
+      \Self.moduleName,
+      \Self.unexpectedBetweenModuleNameAndPeriod,
+      \Self.period,
+      \Self.unexpectedBetweenPeriodAndMacroTypeName,
+      \Self.macroTypeName,
+      \Self.unexpectedAfterMacroTypeName,
+    ])
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "module name"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "macro type name"
+    case 6:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
+}
+
+extension ExternalMacroNameSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "unexpectedBeforeModuleName": unexpectedBeforeModuleName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "moduleName": Syntax(moduleName).asProtocol(SyntaxProtocol.self),
+      "unexpectedBetweenModuleNameAndPeriod": unexpectedBetweenModuleNameAndPeriod.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "period": Syntax(period).asProtocol(SyntaxProtocol.self),
+      "unexpectedBetweenPeriodAndMacroTypeName": unexpectedBetweenPeriodAndMacroTypeName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "macroTypeName": Syntax(macroTypeName).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterMacroTypeName": unexpectedAfterMacroTypeName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+    ])
+  }
+}
+
 // MARK: - CustomAttributeSyntax
 
 /// 

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -1807,6 +1807,30 @@ extension ExtensionDecl {
   }
 }
 
+extension ExternalMacroName {
+  /// Creates a `ExternalMacroName` using the provided parameters.
+  /// - Parameters:
+  ///   - unexpectedBeforeModuleName: 
+  ///   - moduleName: 
+  ///   - unexpectedBetweenModuleNameAndPeriod: 
+  ///   - period: 
+  ///   - unexpectedBetweenPeriodAndMacroTypeName: 
+  ///   - macroTypeName: 
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeModuleName: UnexpectedNodes? = nil, moduleName: Token, unexpectedBetweenModuleNameAndPeriod: UnexpectedNodes? = nil, period: Token = Token.`period`, unexpectedBetweenPeriodAndMacroTypeName: UnexpectedNodes? = nil, macroTypeName: Token) {
+    assert(period.text == ".")
+    self = ExternalMacroNameSyntax(unexpectedBeforeModuleName, moduleName: moduleName, unexpectedBetweenModuleNameAndPeriod, period: period, unexpectedBetweenPeriodAndMacroTypeName, macroTypeName: macroTypeName)
+    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }
+  /// A convenience initializer that allows:
+  ///  - Initializing syntax collections using result builders
+  ///  - Initializing tokens without default text using strings
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeModuleName: UnexpectedNodes? = nil, moduleName: String, unexpectedBetweenModuleNameAndPeriod: UnexpectedNodes? = nil, period: Token = Token.`period`, unexpectedBetweenPeriodAndMacroTypeName: UnexpectedNodes? = nil, macroTypeName: String) {
+    self.init (unexpectedBeforeModuleName, moduleName: Token.`identifier`(moduleName), unexpectedBetweenModuleNameAndPeriod, period: period, unexpectedBetweenPeriodAndMacroTypeName, macroTypeName: Token.`identifier`(macroTypeName))
+    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }
+}
+
 extension FallthroughStmt {
   /// Creates a `FallthroughStmt` using the provided parameters.
   /// - Parameters:
@@ -2795,6 +2819,43 @@ extension LayoutRequirement {
     }, unexpectedBetweenSizeAndComma, comma: comma, unexpectedBetweenCommaAndAlignment, alignment: alignment.map { 
       Token.`integerLiteral`($0) 
     }, unexpectedBetweenAlignmentAndRightParen, rightParen: rightParen)
+    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }
+}
+
+extension MacroDecl {
+  /// Creates a `MacroDecl` using the provided parameters.
+  /// - Parameters:
+  ///   - unexpectedBeforeAttributes: 
+  ///   - attributes: 
+  ///   - unexpectedBetweenAttributesAndModifiers: 
+  ///   - modifiers: 
+  ///   - unexpectedBetweenModifiersAndMacroKeyword: 
+  ///   - macroKeyword: 
+  ///   - unexpectedBetweenMacroKeywordAndIdentifier: 
+  ///   - identifier: 
+  ///   - unexpectedBetweenIdentifierAndGenericParameterClause: 
+  ///   - genericParameterClause: 
+  ///   - unexpectedBetweenGenericParameterClauseAndSignature: 
+  ///   - signature: 
+  ///   - unexpectedBetweenSignatureAndEqual: 
+  ///   - equal: 
+  ///   - unexpectedBetweenEqualAndExternalName: 
+  ///   - externalName: 
+  ///   - unexpectedBetweenExternalNameAndGenericWhereClause: 
+  ///   - genericWhereClause: 
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndMacroKeyword: UnexpectedNodes? = nil, macroKeyword: Token, unexpectedBetweenMacroKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodes? = nil, signature: Signature, unexpectedBetweenSignatureAndEqual: UnexpectedNodes? = nil, equal: Token = Token.`equal`, unexpectedBetweenEqualAndExternalName: UnexpectedNodes? = nil, externalName: ExternalMacroName? = nil, unexpectedBetweenExternalNameAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil) {
+    assert(macroKeyword.text == "macro")
+    assert(equal.text == "=")
+    self = MacroDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndMacroKeyword, macroKeyword: macroKeyword, unexpectedBetweenMacroKeywordAndIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature, signature: signature, unexpectedBetweenSignatureAndEqual, equal: equal, unexpectedBetweenEqualAndExternalName, externalName: externalName, unexpectedBetweenExternalNameAndGenericWhereClause, genericWhereClause: genericWhereClause)
+    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }
+  /// A convenience initializer that allows:
+  ///  - Initializing syntax collections using result builders
+  ///  - Initializing tokens without default text using strings
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndMacroKeyword: UnexpectedNodes? = nil, macroKeyword: String, unexpectedBetweenMacroKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodes? = nil, signature: Signature, unexpectedBetweenSignatureAndEqual: UnexpectedNodes? = nil, equal: Token = Token.`equal`, unexpectedBetweenEqualAndExternalName: UnexpectedNodes? = nil, externalName: ExternalMacroName? = nil, unexpectedBetweenExternalNameAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil) {
+    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndMacroKeyword, macroKeyword: Token.`contextualKeyword`(macroKeyword), unexpectedBetweenMacroKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature, signature: signature, unexpectedBetweenSignatureAndEqual, equal: equal, unexpectedBetweenEqualAndExternalName, externalName: externalName, unexpectedBetweenExternalNameAndGenericWhereClause, genericWhereClause: genericWhereClause)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
   }
 }

--- a/Sources/SwiftSyntaxBuilder/generated/Typealiases.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/Typealiases.swift
@@ -213,6 +213,8 @@ public typealias ExpressionStmt = ExpressionStmtSyntax
 
 public typealias ExtensionDecl = ExtensionDeclSyntax
 
+public typealias ExternalMacroName = ExternalMacroNameSyntax
+
 public typealias FallthroughStmt = FallthroughStmtSyntax
 
 public typealias FloatLiteralExpr = FloatLiteralExprSyntax
@@ -312,6 +314,8 @@ public typealias LabeledSpecializeEntry = LabeledSpecializeEntrySyntax
 public typealias LabeledStmt = LabeledStmtSyntax
 
 public typealias LayoutRequirement = LayoutRequirementSyntax
+
+public typealias MacroDecl = MacroDeclSyntax
 
 public typealias MacroExpansionDecl = MacroExpansionDeclSyntax
 

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/SyntaxExpressibleByStringInterpolationConformances.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/SyntaxExpressibleByStringInterpolationConformances.swift
@@ -282,6 +282,8 @@ extension OperatorDeclSyntax: SyntaxExpressibleByStringInterpolation {}
 
 extension PrecedenceGroupDeclSyntax: SyntaxExpressibleByStringInterpolation {}
 
+extension MacroDeclSyntax: SyntaxExpressibleByStringInterpolation {}
+
 extension MacroExpansionDeclSyntax: SyntaxExpressibleByStringInterpolation {}
 
 extension LabeledStmtSyntax: SyntaxExpressibleByStringInterpolation {}

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1322,6 +1322,25 @@ final class DeclarationTests: XCTestCase {
 
     AssertParse("func foo(body: (isolated String) -> Int) {}")
   }
+
+  func testMacroDecl() {
+    AssertParse("""
+      macro m1: Int = A.M1
+      macro m2(_: Int) = A.M2
+      macro m3(a b: Int) -> Int = A.M3
+      macro m4<T>: T = A.M4 where T.Assoc: P
+      macro m4<T: P>(_: T) = A.M4
+      """)
+
+    AssertParse("""
+      macro m1 1️⃣= A2️⃣
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected parameter clause in function signature"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected '.' and macro type name in external macro name"),
+      ]
+    )
+  }
 }
 
 extension Parser.DeclAttributes {

--- a/gyb_syntax_support/DeclNodes.py
+++ b/gyb_syntax_support/DeclNodes.py
@@ -916,6 +916,36 @@ DECL_NODES = [
                    '''),
          ]),
 
+    Node('MacroDecl', name_for_diagnostics='macro', kind='Decl',
+         traits=['IdentifiedDecl'],
+         children=[
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
+                   collection_element_name='Attribute', is_optional=True),
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
+                   collection_element_name='Modifier', is_optional=True),
+             Child('MacroKeyword', kind='ContextualKeywordToken',
+                   text_choices=['macro']),
+             Child('Identifier', kind='IdentifierToken'),
+             Child('GenericParameterClause', kind='GenericParameterClause', name_for_diagnostics='generic parameter clause',
+                   is_optional=True),
+             Child('Signature', kind='Syntax', name_for_diagnostics='macro signature',
+                   node_choices=[
+                       Child('FunctionLike', kind='FunctionSignature', name_for_diagnostics="macro signature"),
+                       Child('ValueLike', kind='TypeAnnotation', name_for_diagnostics="macro signature"),
+                   ]),
+             Child('Equal', kind='EqualToken'),
+             Child('ExternalName', kind='ExternalMacroName', name_for_diagnostics='external macro name', is_optional = True),
+             Child('GenericWhereClause', kind='GenericWhereClause', name_for_diagnostics='generic where clause',
+                   is_optional=True),
+         ]),
+
+    Node('ExternalMacroName', name_for_diagnostics='external macro name', kind='Syntax',
+         children=[
+             Child('ModuleName', kind='IdentifierToken', name_for_diagnostics='module name'),
+             Child('Period', kind='PeriodToken'),
+             Child('MacroTypeName', kind='IdentifierToken', name_for_diagnostics='macro type name'),
+         ]),
+
     # e.g., "#embed("filename.txt")"
     Node('MacroExpansionDecl',
          name_for_diagnostics="pound literal declaration", kind='Decl',

--- a/gyb_syntax_support/NodeSerializationCodes.py
+++ b/gyb_syntax_support/NodeSerializationCodes.py
@@ -289,8 +289,9 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'OldKeyPathExpr': 287,
     'MacroExpansionExpr': 288,
     'MacroExpansionDecl': 289,
+    'MacroDecl': 290,
+    'ExternalMacroName': 291,
 }
-
 
 def verify_syntax_node_serialization_codes(nodes, serialization_codes):
     # Verify that all nodes have serialization codes


### PR DESCRIPTION
Introduce syntax node and parsing logic for macro declarations, e.g.,

```swift
macro stringify<T>(_ value: T) -> (T, String)
```