### PR TITLE
Revert "Revert "Revert "Eliminate SWIFT_SYNTAX_ALWAYS_SINGLE_THREADED"""

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,12 @@ if (NOT SWIFT_SUPPORTS_DISABLE_IMPLICIT_STRING_PROCESSING_MODULE_IMPORT)
     $<$<COMPILE_LANGUAGE:Swift>:-disable-implicit-string-processing-module-import>)
 endif()
 
+# Force single-threaded-only syntax trees to eliminate the Darwin
+# dependency in the compiler.
+add_compile_definitions(
+  $<$<COMPILE_LANGUAGE:Swift>:SWIFT_SYNTAX_ALWAYS_SINGLE_THREADED>
+)
+
 add_subdirectory(Sources)
 
 export(EXPORT SwiftSyntaxTargets

--- a/Tests/SwiftParserTest/LinkageTests.swift
+++ b/Tests/SwiftParserTest/LinkageTests.swift
@@ -32,6 +32,7 @@ final class LinkageTest: XCTestCase {
       .library("-lswiftCompatibility56", condition: .mayBeAbsent("Starting in Xcode 14 this library is not always autolinked")),
       .library("-lswiftCompatibilityConcurrency"),
       .library("-lswiftCore"),
+      .library("-lswiftDarwin", condition: .mayBeAbsent("Not present when building inside the compiler")),
       .library("-lswiftSwiftOnoneSupport", condition: .when(configuration: .debug)),
       .library("-lswift_Concurrency"),
       .library("-lswift_StringProcessing", condition: .mayBeAbsent("Starting in Xcode 14 this library is not always autolinked")),


### PR DESCRIPTION
Seems to be failing again https://ci.swift.org/job/oss-swift-incremental-RA-macos-apple-silicon//2207/console
Reverts apple/swift-syntax#1068