### PR TITLE
Refactor `Syntax` initializer

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntaxbuilder/BuildableNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntaxbuilder/BuildableNodesFile.swift
@@ -25,35 +25,36 @@ let buildableNodesFile = SourceFile {
     let type = node.type
     let hasTrailingComma = node.traits.contains("WithTrailingComma")
 
-    let docComment: SwiftSyntax.Trivia = node.documentation.isEmpty ? [] : .docLineComment("/// \(node.documentation)") + .newline
-    ExtensionDecl(
-      leadingTrivia: docComment,
-      extendedType: SimpleTypeIdentifier(name: .identifier(type.shorthandName)),
-      inheritanceClause: hasTrailingComma ? TypeInheritanceClause { InheritedType(typeName: Type("HasTrailingComma")) } : nil
-    ) {
-      // Generate initializers
-      createDefaultInitializer(node: node)
-      if let convenienceInit = createConvenienceInitializer(node: node) {
-        convenienceInit
-      }
+    let convenienceInit = createConvenienceInitializer(node: node)
+    if convenienceInit != nil || hasTrailingComma {
+      let docComment: SwiftSyntax.Trivia = node.documentation.isEmpty ? [] : .docLineComment("/// \(node.documentation)") + .newline
+      ExtensionDecl(
+        leadingTrivia: docComment,
+        extendedType: SimpleTypeIdentifier(name: .identifier(type.shorthandName)),
+        inheritanceClause: hasTrailingComma ? TypeInheritanceClause { InheritedType(typeName: Type("HasTrailingComma")) } : nil
+      ) {
+        if let convenienceInit = convenienceInit {
+          convenienceInit
+        }
 
-      if hasTrailingComma {
-        VariableDecl(
+        if hasTrailingComma {
+          VariableDecl(
           """
           var hasTrailingComma: Bool {
             return trailingComma != nil
           }
           """
-        )
+          )
 
-        FunctionDecl(
+          FunctionDecl(
           """
           /// Conformance to `HasTrailingComma`.
           public func withTrailingComma(_ withComma: Bool) -> Self {
             return withTrailingComma(withComma ? .commaToken() : nil)
           }
           """
-        )
+          )
+        }
       }
     }
   }
@@ -64,57 +65,6 @@ private func convertFromSyntaxProtocolToSyntaxType(child: Child) -> Expr {
     return Expr(FunctionCallExpr("\(raw: child.type.syntaxBaseName)(fromProtocol: \(raw: child.swiftName))"))
   } else {
     return Expr(IdentifierExpr(identifier: .identifier(child.swiftName)))
-  }
-}
-
-/// Create the default initializer for the given node.
-private func createDefaultInitializer(node: Node) -> InitializerDecl {
-  let type = node.type
-  return InitializerDecl(
-    leadingTrivia: ([
-      "/// Creates a `\(type.shorthandName)` using the provided parameters.",
-      "/// - Parameters:",
-    ] + node.children.map { child in
-      "///   - \(child.swiftName): \(child.documentation)"
-    }).map { .docLineComment($0) + .newline }.reduce([], +),
-    // FIXME: If all parameters are specified, the SwiftSyntaxBuilder initializer is ambigious
-    // with the memberwise initializer in SwiftSyntax.
-    // Hot-fix this by preferring the overload in SwiftSyntax. In the long term, consider sinking
-    // this initializer to SwiftSyntax.
-    attributes: AttributeList { CustomAttribute("_disfavoredOverload").withTrailingTrivia(.space) },
-    modifiers: [DeclModifier(name: .public)],
-    signature: FunctionSignature(
-      input: ParameterClause {
-        for trivia in ["leadingTrivia", "trailingTrivia"] {
-          FunctionParameter("\(trivia): Trivia = []", for: .functionParameters)
-        }
-        for child in node.children {
-          FunctionParameter(
-            firstName: .identifier(child.swiftName),
-            colon: .colon,
-            type: child.parameterType,
-            defaultArgument: child.type.defaultInitialization.map { InitializerClause(value: $0) }
-          )
-        }
-      }
-    )
-  ) {
-    for child in node.children {
-      if let assertStmt = child.generateAssertStmtTextChoices(varName: child.swiftName) {
-        assertStmt
-      }
-    }
-    let nodeConstructorCall = FunctionCallExpr(callee: Expr(IdentifierExpr(identifier: .identifier(type.syntaxBaseName)))) {
-      for child in node.children {
-        TupleExprElement(
-          label: child.isUnexpectedNodes ? nil : child.swiftName,
-          expression: convertFromSyntaxProtocolToSyntaxType(child: child)
-        )
-      }
-    }
-    SequenceExpr("self = \(nodeConstructorCall)")
-    SequenceExpr("self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])")
-    SequenceExpr("self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])")
   }
 }
 
@@ -192,28 +142,24 @@ private func createConvenienceInitializer(node: Node) -> InitializerDecl? {
       "///  - Initializing syntax collections using result builders",
       "///  - Initializing tokens without default text using strings",
     ].map { .docLineComment($0) + .newline }.reduce([], +),
-    // FIXME: If all parameters are specified, the SwiftSyntaxBuilder initializer is ambigious
-    // with the memberwise initializer in SwiftSyntax.
-    // Hot-fix this by preferring the overload in SwiftSyntax. In the long term, consider sinking
-    // this initializer to SwiftSyntax.
-    attributes: AttributeList { CustomAttribute("_disfavoredOverload").withTrailingTrivia(.space) },
     modifiers: [DeclModifier(name: .public)],
     signature: FunctionSignature(
       input: ParameterClause {
-        FunctionParameter("leadingTrivia: Trivia = []", for: .functionParameters)
+        FunctionParameter("leadingTrivia: Trivia? = nil", for: .functionParameters)
         for param in normalParameters + builderParameters {
           param
         }
+        FunctionParameter("trailingTrivia: Trivia? = nil", for: .functionParameters)
       }
     )
   ) {
     FunctionCallExpr(callee: "self.init") {
+      TupleExprElement(label: "leadingTrivia", expression: "leadingTrivia")
       for arg in delegatedInitArgs {
         arg
       }
+      TupleExprElement(label: "trailingTrivia", expression: "trailingTrivia")
     }
-
-    SequenceExpr("self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])")
   }
 }
 

--- a/CodeGeneration/Sources/generate-swiftsyntaxbuilder/SyntaxExpressibleByStringInterpolationConformancesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntaxbuilder/SyntaxExpressibleByStringInterpolationConformancesFile.swift
@@ -36,23 +36,24 @@ let syntaxExpressibleByStringInterpolationConformancesFile = SourceFile {
   }
   
   for node in SYNTAX_NODES {
-    if node.parserFunction != nil && node.isBase {
+    if node.isBase {
       ExtensionDecl("extension \(node.name)Protocol") {
         InitializerDecl(
           """
           public init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
-              self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
-                let node = \(raw: node.name).parse(from: &parser)
-                guard let result = node.as(Self.self) else {
-                  throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: node.kind.syntaxNodeType)
-                }
-                return result
-              })
-            }
+            self = try performParse(source: stringInterpolation.sourceText, parse: { parser in
+              let node = \(raw: node.name).parse(from: &parser)
+              guard let result = node.as(Self.self) else {
+                throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: node.kind.syntaxNodeType)
+              }
+              return result
+            })
+          }
           """)
-        
       }
-      
+    }
+
+    if node.parserFunction != nil {
       ExtensionDecl("extension \(node.name): SyntaxExpressibleByStringInterpolation") {
         InitializerDecl(
           """
@@ -63,7 +64,7 @@ let syntaxExpressibleByStringInterpolationConformancesFile = SourceFile {
           }
           """)
       }
-    } else if node.parserFunction != nil || (node.baseType.baseName != "Syntax" && node.baseType.baseName != "SyntaxCollection") {
+    } else if !node.isMissing && node.baseType.baseName != "Syntax" && node.baseType.baseName != "SyntaxCollection" {
       ExtensionDecl("extension \(raw: node.name): SyntaxExpressibleByStringInterpolation { }")
     }
   }

--- a/Sources/SwiftOperators/OperatorTable+Defaults.swift
+++ b/Sources/SwiftOperators/OperatorTable+Defaults.swift
@@ -411,8 +411,7 @@ extension OperatorTable {
 
       Operator(
         kind: .infix,
-        name: "~>",
-        precedenceGroup: nil
+        name: "~>"
       )
     ]
 

--- a/Sources/SwiftOperators/SyntaxSynthesis.swift
+++ b/Sources/SwiftOperators/SyntaxSynthesis.swift
@@ -17,7 +17,7 @@ extension Operator {
   /// semantic definition.
   public func synthesizedSyntax() -> OperatorDeclSyntax {
     let modifiers = ModifierListSyntax(
-      [DeclModifierSyntax(name: .identifier("\(kind)"), detail: nil)]
+      [DeclModifierSyntax(name: .identifier("\(kind)"))]
     )
     let operatorKeyword = TokenSyntax.operatorKeyword(leadingTrivia: .space)
     let identifierSyntax =
@@ -31,7 +31,7 @@ extension Operator {
     }
 
     return OperatorDeclSyntax(
-      attributes: nil, modifiers: modifiers, operatorKeyword: operatorKeyword,
+      modifiers: modifiers, operatorKeyword: operatorKeyword,
       identifier: identifierSyntax,
       operatorPrecedenceAndTypes: precedenceGroupSyntax
     )
@@ -55,8 +55,7 @@ extension PrecedenceRelation {
       otherNames: PrecedenceGroupNameListSyntax(
         [
           PrecedenceGroupNameElementSyntax(
-            name: .identifier(groupName, leadingTrivia:  .space),
-            trailingComma: nil)
+            name: .identifier(groupName, leadingTrivia:  .space))
         ]
       )
     )
@@ -126,7 +125,6 @@ extension PrecedenceGroup {
     )
 
     return PrecedenceGroupDeclSyntax(
-      attributes: nil, modifiers: nil,
       precedencegroupKeyword: precedencegroupKeyword,
       identifier: identifierSyntax, leftBrace: leftBrace,
       groupAttributes: PrecedenceGroupAttributeListSyntax(groupAttributes),

--- a/Sources/SwiftParserDiagnostics/PresenceUtils.swift
+++ b/Sources/SwiftParserDiagnostics/PresenceUtils.swift
@@ -77,9 +77,6 @@ class PresentMaker: SyntaxRewriter {
       modifiers: node.modifiers,
       structKeyword: .structKeyword(presence: .missing),
       identifier: .identifier("<#declaration#>", leadingTrivia: leadingTriviaBeforePlaceholder),
-      genericParameterClause: nil,
-      inheritanceClause: nil,
-      genericWhereClause: nil,
       members: MemberDeclBlockSyntax(
         leftBrace: .leftBraceToken(presence: .missing),
         members: MemberDeclListSyntax([]),
@@ -89,39 +86,24 @@ class PresentMaker: SyntaxRewriter {
   }
 
   override func visit(_ node: MissingExprSyntax) -> ExprSyntax {
-    return ExprSyntax(IdentifierExprSyntax(
-      identifier: .identifier("<#expression#>"),
-      declNameArguments: nil
-    ))
+    return ExprSyntax(IdentifierExprSyntax(identifier: .identifier("<#expression#>")))
   }
 
   override func visit(_ node: MissingPatternSyntax) -> PatternSyntax {
-    return PatternSyntax(IdentifierPatternSyntax(
-      identifier: .identifier("<#pattern#>")
-    ))
+    return PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("<#pattern#>")))
   }
 
   override func visit(_ node: MissingStmtSyntax) -> StmtSyntax {
     return StmtSyntax(ExpressionStmtSyntax(
-      expression: ExprSyntax(IdentifierExprSyntax(
-        identifier: .identifier("<#statement#>"),
-        declNameArguments: nil
-      ))
-    ))
+      expression: IdentifierExprSyntax(identifier: .identifier("<#statement#>"))))
   }
 
   override func visit(_ node: MissingTypeSyntax) -> TypeSyntax {
-    return TypeSyntax(SimpleTypeIdentifierSyntax(
-      name: .identifier("<#type#>"),
-      genericArgumentClause: nil
-    ))
+    return TypeSyntax(SimpleTypeIdentifierSyntax(name: .identifier("<#type#>")))
   }
 
   override func visit(_ node: MissingSyntax) -> Syntax {
-    return Syntax(IdentifierExprSyntax(
-      identifier: .identifier("<#syntax#>"),
-      declNameArguments: nil
-    ))
+    return Syntax(IdentifierExprSyntax(identifier: .identifier("<#syntax#>")))
   }
 }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -692,9 +692,24 @@ extension RawSyntax {
   static func makeLayout<C: Collection>(
     kind: SyntaxKind,
     from collection: C,
-    arena: SyntaxArena
+    arena: SyntaxArena,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil
   ) -> RawSyntax where C.Element == RawSyntax? {
-    .makeLayout(kind: kind, uninitializedCount: collection.count, arena: arena) {
+    if leadingTrivia != nil || trailingTrivia != nil {
+      var layout = Array(collection)
+      if let leadingTrivia = leadingTrivia,
+         let idx = layout.firstIndex(where: {$0 != nil}) {
+        layout[idx] = layout[idx]!.withLeadingTrivia(leadingTrivia, arena: arena)
+      }
+      if let trailingTrivia = trailingTrivia,
+         let idx = layout.lastIndex(where: {$0 != nil}) {
+        layout[idx] = layout[idx]!.withTrailingTrivia(trailingTrivia, arena: arena)
+      }
+      return .makeLayout(kind: kind, from: layout, arena: arena)
+    }
+
+    return .makeLayout(kind: kind, uninitializedCount: collection.count, arena: arena) {
       _ = $0.initialize(from: collection)
     }
   }

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
@@ -113,35 +113,60 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
-%     for (index, child) in enumerate(node.children):
-%       comma = ',' if index != len(node.children) - 1 else ''
-%       param_type = child.name if child.node_choices else child.type_name
-%       if child.is_optional:
-%         param_type = param_type + "?"
-%       if child.is_unexpected_nodes():
-    _ ${child.swift_name}: ${param_type} = nil${comma}
-%       else:
-    ${child.swift_name}: ${param_type}${comma}
-%       end
-%     end
-  ) {
+  ${node.generate_initializer_decl(optional_base_as_missing=False, current_indentation="  ")} {
+%     if node.children:
     let layout: [RawSyntax?] = [
-%     for child in node.children:
-%       if child.is_optional:
+%       for child in node.children:
+%         if child.is_optional:
       ${child.swift_name}?.raw,
-%       else:
+%         else:
       ${child.swift_name}.raw,
+%         end
 %       end
-%     end
     ]
+%     end
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.${node.swift_syntax_kind},
-        from: layout, arena: arena)
+%     if node.children:
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.${node.swift_syntax_kind}, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
+%     else:
+      let raw = RawSyntax.makeEmptyLayout(kind: SyntaxKind.${node.swift_syntax_kind}, arena: arena)
+%     end
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
   }
+%     if node.has_optional_base_type_child():
+
+% # TODO: Remove when we no longer support compiling in Swift 5.6. Change the
+% # above constructor to use `Optional<BaseType.none` instead.
+  /// This initializer exists solely because Swift 5.6 does not support
+  /// `Optional<ConcreteType>.none` as a default value of a generic parameter.
+  /// The above initializer thus defaults to `nil` instead, but that means it
+  /// is not actually callable when either not passing the defaulted parameter,
+  /// or passing `nil`.
+  ///
+  /// Hack around that limitation using this initializer, which takes a
+  /// `Missing*` syntax node instead. `Missing*` is used over the base type as
+  /// the base type would allow implicit conversion from a string literal,
+  /// which the above initializer doesn't support.
+  ${node.generate_initializer_decl(optional_base_as_missing=True, current_indentation="  ")} {
+    self.init(
+      leadingTrivia: leadingTrivia,
+%     for child in node.children:
+%       if child.has_optional_base_type():
+      ${child.swift_name}: Optional<${child.type_name}>.none,
+%       elif child.is_unexpected_nodes():
+      ${child.swift_name},
+%       else:
+      ${child.swift_name}: ${child.swift_name},
+%       end
+%     end
+      trailingTrivia: trailingTrivia
+    )
+  }
+%     end
 %     for (idx, child) in enumerate(node.children):
 %       child_node = NODE_MAP.get(child.syntax_kind)
 %

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -32,11 +32,13 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
-    _ unexpectedAfterModifiers: UnexpectedNodesSyntax? = nil
+    modifiers: ModifierListSyntax? = nil,
+    _ unexpectedAfterModifiers: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -46,8 +48,9 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterModifiers?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.missingDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -255,21 +258,23 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndTypealiasKeyword: UnexpectedNodesSyntax? = nil,
-    typealiasKeyword: TokenSyntax,
+    typealiasKeyword: TokenSyntax = .typealiasKeyword(),
     _ unexpectedBetweenTypealiasKeywordAndIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil,
-    genericParameterClause: GenericParameterClauseSyntax?,
+    genericParameterClause: GenericParameterClauseSyntax? = nil,
     _ unexpectedBetweenGenericParameterClauseAndInitializer: UnexpectedNodesSyntax? = nil,
     initializer: TypeInitializerClauseSyntax,
     _ unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
-    genericWhereClause: GenericWhereClauseSyntax?,
-    _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil
+    genericWhereClause: GenericWhereClauseSyntax? = nil,
+    _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -289,8 +294,9 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterGenericWhereClause?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.typealiasDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.typealiasDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -745,21 +751,23 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndAssociatedtypeKeyword: UnexpectedNodesSyntax? = nil,
-    associatedtypeKeyword: TokenSyntax,
+    associatedtypeKeyword: TokenSyntax = .associatedtypeKeyword(),
     _ unexpectedBetweenAssociatedtypeKeywordAndIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndInheritanceClause: UnexpectedNodesSyntax? = nil,
-    inheritanceClause: TypeInheritanceClauseSyntax?,
+    inheritanceClause: TypeInheritanceClauseSyntax? = nil,
     _ unexpectedBetweenInheritanceClauseAndInitializer: UnexpectedNodesSyntax? = nil,
-    initializer: TypeInitializerClauseSyntax?,
+    initializer: TypeInitializerClauseSyntax? = nil,
     _ unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
-    genericWhereClause: GenericWhereClauseSyntax?,
-    _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil
+    genericWhereClause: GenericWhereClauseSyntax? = nil,
+    _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -779,8 +787,9 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterGenericWhereClause?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.associatedtypeDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.associatedtypeDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1236,11 +1245,13 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeClauses: UnexpectedNodesSyntax? = nil,
     clauses: IfConfigClauseListSyntax,
     _ unexpectedBetweenClausesAndPoundEndif: UnexpectedNodesSyntax? = nil,
-    poundEndif: TokenSyntax,
-    _ unexpectedAfterPoundEndif: UnexpectedNodesSyntax? = nil
+    poundEndif: TokenSyntax = .poundEndifKeyword(),
+    _ unexpectedAfterPoundEndif: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeClauses?.raw,
@@ -1250,8 +1261,9 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterPoundEndif?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.ifConfigDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1438,15 +1450,17 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforePoundError: UnexpectedNodesSyntax? = nil,
-    poundError: TokenSyntax,
+    poundError: TokenSyntax = .poundErrorKeyword(),
     _ unexpectedBetweenPoundErrorAndLeftParen: UnexpectedNodesSyntax? = nil,
-    leftParen: TokenSyntax,
+    leftParen: TokenSyntax = .leftParenToken(),
     _ unexpectedBetweenLeftParenAndMessage: UnexpectedNodesSyntax? = nil,
     message: StringLiteralExprSyntax,
     _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax,
-    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
+    rightParen: TokenSyntax = .rightParenToken(),
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundError?.raw,
@@ -1460,8 +1474,9 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterRightParen?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundErrorDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.poundErrorDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1727,15 +1742,17 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforePoundWarning: UnexpectedNodesSyntax? = nil,
-    poundWarning: TokenSyntax,
+    poundWarning: TokenSyntax = .poundWarningKeyword(),
     _ unexpectedBetweenPoundWarningAndLeftParen: UnexpectedNodesSyntax? = nil,
-    leftParen: TokenSyntax,
+    leftParen: TokenSyntax = .leftParenToken(),
     _ unexpectedBetweenLeftParenAndMessage: UnexpectedNodesSyntax? = nil,
     message: StringLiteralExprSyntax,
     _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax,
-    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
+    rightParen: TokenSyntax = .rightParenToken(),
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundWarning?.raw,
@@ -1749,8 +1766,9 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterRightParen?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundWarningDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.poundWarningDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2016,15 +2034,17 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforePoundSourceLocation: UnexpectedNodesSyntax? = nil,
-    poundSourceLocation: TokenSyntax,
+    poundSourceLocation: TokenSyntax = .poundSourceLocationKeyword(),
     _ unexpectedBetweenPoundSourceLocationAndLeftParen: UnexpectedNodesSyntax? = nil,
-    leftParen: TokenSyntax,
+    leftParen: TokenSyntax = .leftParenToken(),
     _ unexpectedBetweenLeftParenAndArgs: UnexpectedNodesSyntax? = nil,
-    args: PoundSourceLocationArgsSyntax?,
+    args: PoundSourceLocationArgsSyntax? = nil,
     _ unexpectedBetweenArgsAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax,
-    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
+    rightParen: TokenSyntax = .rightParenToken(),
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundSourceLocation?.raw,
@@ -2038,8 +2058,9 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterRightParen?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundSourceLocation,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.poundSourceLocation, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2306,23 +2327,25 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndClassKeyword: UnexpectedNodesSyntax? = nil,
-    classKeyword: TokenSyntax,
+    classKeyword: TokenSyntax = .classKeyword(),
     _ unexpectedBetweenClassKeywordAndIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil,
-    genericParameterClause: GenericParameterClauseSyntax?,
+    genericParameterClause: GenericParameterClauseSyntax? = nil,
     _ unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil,
-    inheritanceClause: TypeInheritanceClauseSyntax?,
+    inheritanceClause: TypeInheritanceClauseSyntax? = nil,
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
-    genericWhereClause: GenericWhereClauseSyntax?,
+    genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil,
     members: MemberDeclBlockSyntax,
-    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -2344,8 +2367,9 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterMembers?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.classDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.classDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2850,23 +2874,25 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndActorKeyword: UnexpectedNodesSyntax? = nil,
-    actorKeyword: TokenSyntax,
+    actorKeyword: TokenSyntax = .contextualKeyword("actor"),
     _ unexpectedBetweenActorKeywordAndIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil,
-    genericParameterClause: GenericParameterClauseSyntax?,
+    genericParameterClause: GenericParameterClauseSyntax? = nil,
     _ unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil,
-    inheritanceClause: TypeInheritanceClauseSyntax?,
+    inheritanceClause: TypeInheritanceClauseSyntax? = nil,
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
-    genericWhereClause: GenericWhereClauseSyntax?,
+    genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil,
     members: MemberDeclBlockSyntax,
-    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -2888,8 +2914,9 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterMembers?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.actorDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.actorDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3394,23 +3421,25 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndStructKeyword: UnexpectedNodesSyntax? = nil,
-    structKeyword: TokenSyntax,
+    structKeyword: TokenSyntax = .structKeyword(),
     _ unexpectedBetweenStructKeywordAndIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil,
-    genericParameterClause: GenericParameterClauseSyntax?,
+    genericParameterClause: GenericParameterClauseSyntax? = nil,
     _ unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil,
-    inheritanceClause: TypeInheritanceClauseSyntax?,
+    inheritanceClause: TypeInheritanceClauseSyntax? = nil,
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
-    genericWhereClause: GenericWhereClauseSyntax?,
+    genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil,
     members: MemberDeclBlockSyntax,
-    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -3432,8 +3461,9 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterMembers?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.structDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.structDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3938,23 +3968,25 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndProtocolKeyword: UnexpectedNodesSyntax? = nil,
-    protocolKeyword: TokenSyntax,
+    protocolKeyword: TokenSyntax = .protocolKeyword(),
     _ unexpectedBetweenProtocolKeywordAndIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause: UnexpectedNodesSyntax? = nil,
-    primaryAssociatedTypeClause: PrimaryAssociatedTypeClauseSyntax?,
+    primaryAssociatedTypeClause: PrimaryAssociatedTypeClauseSyntax? = nil,
     _ unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil,
-    inheritanceClause: TypeInheritanceClauseSyntax?,
+    inheritanceClause: TypeInheritanceClauseSyntax? = nil,
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
-    genericWhereClause: GenericWhereClauseSyntax?,
+    genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil,
     members: MemberDeclBlockSyntax,
-    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -3976,8 +4008,9 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterMembers?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.protocolDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.protocolDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4481,22 +4514,24 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndExtensionKeyword: UnexpectedNodesSyntax? = nil,
-    extensionKeyword: TokenSyntax,
+    extensionKeyword: TokenSyntax = .extensionKeyword(),
     _ unexpectedBetweenExtensionKeywordAndExtendedType: UnexpectedNodesSyntax? = nil,
-    extendedType: TypeSyntax,
+    extendedType: E,
     _ unexpectedBetweenExtendedTypeAndInheritanceClause: UnexpectedNodesSyntax? = nil,
-    inheritanceClause: TypeInheritanceClauseSyntax?,
+    inheritanceClause: TypeInheritanceClauseSyntax? = nil,
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
-    genericWhereClause: GenericWhereClauseSyntax?,
+    genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil,
     members: MemberDeclBlockSyntax,
-    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -4516,8 +4551,9 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterMembers?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.extensionDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.extensionDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4972,23 +5008,25 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndFuncKeyword: UnexpectedNodesSyntax? = nil,
-    funcKeyword: TokenSyntax,
+    funcKeyword: TokenSyntax = .funcKeyword(),
     _ unexpectedBetweenFuncKeywordAndIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil,
-    genericParameterClause: GenericParameterClauseSyntax?,
+    genericParameterClause: GenericParameterClauseSyntax? = nil,
     _ unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? = nil,
     signature: FunctionSignatureSyntax,
     _ unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
-    genericWhereClause: GenericWhereClauseSyntax?,
+    genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodesSyntax? = nil,
-    body: CodeBlockSyntax?,
-    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
+    body: CodeBlockSyntax? = nil,
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -5010,8 +5048,9 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterBody?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.functionDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5516,23 +5555,25 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndInitKeyword: UnexpectedNodesSyntax? = nil,
-    initKeyword: TokenSyntax,
+    initKeyword: TokenSyntax = .initKeyword(),
     _ unexpectedBetweenInitKeywordAndOptionalMark: UnexpectedNodesSyntax? = nil,
-    optionalMark: TokenSyntax?,
+    optionalMark: TokenSyntax? = nil,
     _ unexpectedBetweenOptionalMarkAndGenericParameterClause: UnexpectedNodesSyntax? = nil,
-    genericParameterClause: GenericParameterClauseSyntax?,
+    genericParameterClause: GenericParameterClauseSyntax? = nil,
     _ unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? = nil,
     signature: FunctionSignatureSyntax,
     _ unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
-    genericWhereClause: GenericWhereClauseSyntax?,
+    genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodesSyntax? = nil,
-    body: CodeBlockSyntax?,
-    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
+    body: CodeBlockSyntax? = nil,
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -5554,8 +5595,9 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterBody?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.initializerDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.initializerDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6061,15 +6103,17 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndDeinitKeyword: UnexpectedNodesSyntax? = nil,
-    deinitKeyword: TokenSyntax,
+    deinitKeyword: TokenSyntax = .deinitKeyword(),
     _ unexpectedBetweenDeinitKeywordAndBody: UnexpectedNodesSyntax? = nil,
-    body: CodeBlockSyntax?,
-    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
+    body: CodeBlockSyntax? = nil,
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -6083,8 +6127,9 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterBody?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.deinitializerDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.deinitializerDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6427,23 +6472,25 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndSubscriptKeyword: UnexpectedNodesSyntax? = nil,
-    subscriptKeyword: TokenSyntax,
+    subscriptKeyword: TokenSyntax = .subscriptKeyword(),
     _ unexpectedBetweenSubscriptKeywordAndGenericParameterClause: UnexpectedNodesSyntax? = nil,
-    genericParameterClause: GenericParameterClauseSyntax?,
+    genericParameterClause: GenericParameterClauseSyntax? = nil,
     _ unexpectedBetweenGenericParameterClauseAndIndices: UnexpectedNodesSyntax? = nil,
     indices: ParameterClauseSyntax,
     _ unexpectedBetweenIndicesAndResult: UnexpectedNodesSyntax? = nil,
     result: ReturnClauseSyntax,
     _ unexpectedBetweenResultAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
-    genericWhereClause: GenericWhereClauseSyntax?,
+    genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndAccessor: UnexpectedNodesSyntax? = nil,
-    accessor: Accessor?,
-    _ unexpectedAfterAccessor: UnexpectedNodesSyntax? = nil
+    accessor: Accessor? = nil,
+    _ unexpectedAfterAccessor: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -6465,8 +6512,9 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterAccessor?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.subscriptDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.subscriptDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6971,17 +7019,19 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndImportTok: UnexpectedNodesSyntax? = nil,
-    importTok: TokenSyntax,
+    importTok: TokenSyntax = .importKeyword(),
     _ unexpectedBetweenImportTokAndImportKind: UnexpectedNodesSyntax? = nil,
-    importKind: TokenSyntax?,
+    importKind: TokenSyntax? = nil,
     _ unexpectedBetweenImportKindAndPath: UnexpectedNodesSyntax? = nil,
     path: AccessPathSyntax,
-    _ unexpectedAfterPath: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterPath: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -6997,8 +7047,9 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterPath?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.importDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.importDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7373,21 +7424,23 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifier: UnexpectedNodesSyntax? = nil,
-    modifier: DeclModifierSyntax?,
+    modifier: DeclModifierSyntax? = nil,
     _ unexpectedBetweenModifierAndAccessorKind: UnexpectedNodesSyntax? = nil,
     accessorKind: TokenSyntax,
     _ unexpectedBetweenAccessorKindAndParameter: UnexpectedNodesSyntax? = nil,
-    parameter: AccessorParameterSyntax?,
+    parameter: AccessorParameterSyntax? = nil,
     _ unexpectedBetweenParameterAndAsyncKeyword: UnexpectedNodesSyntax? = nil,
-    asyncKeyword: TokenSyntax?,
+    asyncKeyword: TokenSyntax? = nil,
     _ unexpectedBetweenAsyncKeywordAndThrowsKeyword: UnexpectedNodesSyntax? = nil,
-    throwsKeyword: TokenSyntax?,
+    throwsKeyword: TokenSyntax? = nil,
     _ unexpectedBetweenThrowsKeywordAndBody: UnexpectedNodesSyntax? = nil,
-    body: CodeBlockSyntax?,
-    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
+    body: CodeBlockSyntax? = nil,
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -7407,8 +7460,9 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterBody?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.accessorDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7846,15 +7900,17 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndLetOrVarKeyword: UnexpectedNodesSyntax? = nil,
     letOrVarKeyword: TokenSyntax,
     _ unexpectedBetweenLetOrVarKeywordAndBindings: UnexpectedNodesSyntax? = nil,
     bindings: PatternBindingListSyntax,
-    _ unexpectedAfterBindings: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterBindings: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -7868,8 +7924,9 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterBindings?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.variableDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.variableDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -8199,15 +8256,17 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndCaseKeyword: UnexpectedNodesSyntax? = nil,
-    caseKeyword: TokenSyntax,
+    caseKeyword: TokenSyntax = .caseKeyword(),
     _ unexpectedBetweenCaseKeywordAndElements: UnexpectedNodesSyntax? = nil,
     elements: EnumCaseElementListSyntax,
-    _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -8221,8 +8280,9 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterElements?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.enumCaseDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -8556,23 +8616,25 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndEnumKeyword: UnexpectedNodesSyntax? = nil,
-    enumKeyword: TokenSyntax,
+    enumKeyword: TokenSyntax = .enumKeyword(),
     _ unexpectedBetweenEnumKeywordAndIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndGenericParameters: UnexpectedNodesSyntax? = nil,
-    genericParameters: GenericParameterClauseSyntax?,
+    genericParameters: GenericParameterClauseSyntax? = nil,
     _ unexpectedBetweenGenericParametersAndInheritanceClause: UnexpectedNodesSyntax? = nil,
-    inheritanceClause: TypeInheritanceClauseSyntax?,
+    inheritanceClause: TypeInheritanceClauseSyntax? = nil,
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
-    genericWhereClause: GenericWhereClauseSyntax?,
+    genericWhereClause: GenericWhereClauseSyntax? = nil,
     _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil,
     members: MemberDeclBlockSyntax,
-    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -8594,8 +8656,9 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterMembers?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.enumDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -9127,17 +9190,19 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndOperatorKeyword: UnexpectedNodesSyntax? = nil,
-    operatorKeyword: TokenSyntax,
+    operatorKeyword: TokenSyntax = .operatorKeyword(),
     _ unexpectedBetweenOperatorKeywordAndIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes: UnexpectedNodesSyntax? = nil,
-    operatorPrecedenceAndTypes: OperatorPrecedenceAndTypesSyntax?,
-    _ unexpectedAfterOperatorPrecedenceAndTypes: UnexpectedNodesSyntax? = nil
+    operatorPrecedenceAndTypes: OperatorPrecedenceAndTypesSyntax? = nil,
+    _ unexpectedAfterOperatorPrecedenceAndTypes: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -9153,8 +9218,9 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterOperatorPrecedenceAndTypes?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.operatorDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -9521,21 +9587,23 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndPrecedencegroupKeyword: UnexpectedNodesSyntax? = nil,
-    precedencegroupKeyword: TokenSyntax,
+    precedencegroupKeyword: TokenSyntax = .precedencegroupKeyword(),
     _ unexpectedBetweenPrecedencegroupKeywordAndIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndLeftBrace: UnexpectedNodesSyntax? = nil,
-    leftBrace: TokenSyntax,
+    leftBrace: TokenSyntax = .leftBraceToken(),
     _ unexpectedBetweenLeftBraceAndGroupAttributes: UnexpectedNodesSyntax? = nil,
     groupAttributes: PrecedenceGroupAttributeListSyntax,
     _ unexpectedBetweenGroupAttributesAndRightBrace: UnexpectedNodesSyntax? = nil,
-    rightBrace: TokenSyntax,
-    _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil
+    rightBrace: TokenSyntax = .rightBraceToken(),
+    _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -9555,8 +9623,9 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterRightBrace?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.precedenceGroupDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -10077,23 +10146,25 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?,
+    modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndMacroKeyword: UnexpectedNodesSyntax? = nil,
-    macroKeyword: TokenSyntax,
+    macroKeyword: TokenSyntax = .contextualKeyword("macro"),
     _ unexpectedBetweenMacroKeywordAndIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil,
-    genericParameterClause: GenericParameterClauseSyntax?,
+    genericParameterClause: GenericParameterClauseSyntax? = nil,
     _ unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? = nil,
     signature: Signature,
     _ unexpectedBetweenSignatureAndDefinition: UnexpectedNodesSyntax? = nil,
-    definition: InitializerClauseSyntax?,
+    definition: InitializerClauseSyntax? = nil,
     _ unexpectedBetweenDefinitionAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
-    genericWhereClause: GenericWhereClauseSyntax?,
-    _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil
+    genericWhereClause: GenericWhereClauseSyntax? = nil,
+    _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -10115,8 +10186,9 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterGenericWhereClause?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.macroDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.macroDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -10621,23 +10693,25 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforePoundToken: UnexpectedNodesSyntax? = nil,
-    poundToken: TokenSyntax,
+    poundToken: TokenSyntax = .poundToken(),
     _ unexpectedBetweenPoundTokenAndMacro: UnexpectedNodesSyntax? = nil,
     macro: TokenSyntax,
     _ unexpectedBetweenMacroAndGenericArguments: UnexpectedNodesSyntax? = nil,
-    genericArguments: GenericArgumentClauseSyntax?,
+    genericArguments: GenericArgumentClauseSyntax? = nil,
     _ unexpectedBetweenGenericArgumentsAndLeftParen: UnexpectedNodesSyntax? = nil,
-    leftParen: TokenSyntax?,
+    leftParen: TokenSyntax? = nil,
     _ unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? = nil,
     argumentList: TupleExprElementListSyntax,
     _ unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax?,
+    rightParen: TokenSyntax? = nil,
     _ unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodesSyntax? = nil,
-    trailingClosure: ClosureExprSyntax?,
+    trailingClosure: ClosureExprSyntax? = nil,
     _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil,
-    additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?,
-    _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil
+    additionalTrailingClosures: MultipleTrailingClosureElementListSyntax? = nil,
+    _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundToken?.raw,
@@ -10659,8 +10733,9 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.macroExpansionDecl,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.macroExpansionDecl, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -31,13 +31,9 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
-  ) {
-    let layout: [RawSyntax?] = [
-    ]
+  public init() {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -81,12 +77,14 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAmpersand: UnexpectedNodesSyntax? = nil,
-    ampersand: TokenSyntax,
+    ampersand: TokenSyntax = .prefixAmpersandToken(),
     _ unexpectedBetweenAmpersandAndExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax,
-    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
+    expression: E,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAmpersand?.raw,
@@ -96,8 +94,9 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterExpression?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.inOutExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.inOutExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -265,9 +264,11 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforePoundColumn: UnexpectedNodesSyntax? = nil,
-    poundColumn: TokenSyntax,
-    _ unexpectedAfterPoundColumn: UnexpectedNodesSyntax? = nil
+    poundColumn: TokenSyntax = .poundColumnKeyword(),
+    _ unexpectedAfterPoundColumn: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundColumn?.raw,
@@ -275,8 +276,9 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterPoundColumn?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundColumnExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.poundColumnExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -394,14 +396,16 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeTryKeyword: UnexpectedNodesSyntax? = nil,
-    tryKeyword: TokenSyntax,
+    tryKeyword: TokenSyntax = .tryKeyword(),
     _ unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil,
-    questionOrExclamationMark: TokenSyntax?,
+    questionOrExclamationMark: TokenSyntax? = nil,
     _ unexpectedBetweenQuestionOrExclamationMarkAndExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax,
-    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
+    expression: E,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeTryKeyword?.raw,
@@ -413,8 +417,9 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterExpression?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tryExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.tryExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -631,12 +636,14 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAwaitKeyword: UnexpectedNodesSyntax? = nil,
-    awaitKeyword: TokenSyntax,
+    awaitKeyword: TokenSyntax = .contextualKeyword("await"),
     _ unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax,
-    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
+    expression: E,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAwaitKeyword?.raw,
@@ -646,8 +653,9 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterExpression?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.awaitExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.awaitExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -814,12 +822,14 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeMoveKeyword: UnexpectedNodesSyntax? = nil,
-    moveKeyword: TokenSyntax,
+    moveKeyword: TokenSyntax = .contextualKeyword("_move"),
     _ unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax,
-    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
+    expression: E,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeMoveKeyword?.raw,
@@ -829,8 +839,9 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterExpression?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.moveExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.moveExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -998,11 +1009,13 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
-    declNameArguments: DeclNameArgumentsSyntax?,
-    _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil
+    declNameArguments: DeclNameArgumentsSyntax? = nil,
+    _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
@@ -1012,8 +1025,9 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterDeclNameArguments?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.identifierExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.identifierExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1182,9 +1196,11 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeSuperKeyword: UnexpectedNodesSyntax? = nil,
-    superKeyword: TokenSyntax,
-    _ unexpectedAfterSuperKeyword: UnexpectedNodesSyntax? = nil
+    superKeyword: TokenSyntax = .superKeyword(),
+    _ unexpectedAfterSuperKeyword: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSuperKeyword?.raw,
@@ -1192,8 +1208,9 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterSuperKeyword?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.superRefExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.superRefExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1312,9 +1329,11 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeNilKeyword: UnexpectedNodesSyntax? = nil,
-    nilKeyword: TokenSyntax,
-    _ unexpectedAfterNilKeyword: UnexpectedNodesSyntax? = nil
+    nilKeyword: TokenSyntax = .nilKeyword(),
+    _ unexpectedAfterNilKeyword: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeNilKeyword?.raw,
@@ -1322,8 +1341,9 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterNilKeyword?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.nilLiteralExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.nilLiteralExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1442,9 +1462,11 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeWildcard: UnexpectedNodesSyntax? = nil,
-    wildcard: TokenSyntax,
-    _ unexpectedAfterWildcard: UnexpectedNodesSyntax? = nil
+    wildcard: TokenSyntax = .wildcardKeyword(),
+    _ unexpectedAfterWildcard: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWildcard?.raw,
@@ -1452,8 +1474,9 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterWildcard?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.discardAssignmentExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.discardAssignmentExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1572,9 +1595,11 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAssignToken: UnexpectedNodesSyntax? = nil,
-    assignToken: TokenSyntax,
-    _ unexpectedAfterAssignToken: UnexpectedNodesSyntax? = nil
+    assignToken: TokenSyntax = .equalToken(),
+    _ unexpectedAfterAssignToken: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAssignToken?.raw,
@@ -1582,8 +1607,9 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterAssignToken?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.assignmentExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.assignmentExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1702,9 +1728,11 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeElements: UnexpectedNodesSyntax? = nil,
     elements: ExprListSyntax,
-    _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeElements?.raw,
@@ -1712,8 +1740,9 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterElements?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.sequenceExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.sequenceExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1851,11 +1880,13 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
-    genericArgumentClause: GenericArgumentClauseSyntax?,
-    _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil
+    genericArgumentClause: GenericArgumentClauseSyntax? = nil,
+    _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
@@ -1865,8 +1896,9 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterGenericArgumentClause?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.symbolicReferenceExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.symbolicReferenceExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2034,12 +2066,14 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<P: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeOperatorToken: UnexpectedNodesSyntax? = nil,
-    operatorToken: TokenSyntax?,
+    operatorToken: TokenSyntax? = nil,
     _ unexpectedBetweenOperatorTokenAndPostfixExpression: UnexpectedNodesSyntax? = nil,
-    postfixExpression: ExprSyntax,
-    _ unexpectedAfterPostfixExpression: UnexpectedNodesSyntax? = nil
+    postfixExpression: P,
+    _ unexpectedAfterPostfixExpression: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeOperatorToken?.raw,
@@ -2049,8 +2083,9 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterPostfixExpression?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.prefixOperatorExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.prefixOperatorExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2219,9 +2254,11 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeOperatorToken: UnexpectedNodesSyntax? = nil,
     operatorToken: TokenSyntax,
-    _ unexpectedAfterOperatorToken: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterOperatorToken: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeOperatorToken?.raw,
@@ -2229,8 +2266,9 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterOperatorToken?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.binaryOperatorExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.binaryOperatorExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2349,13 +2387,15 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAsyncKeyword: UnexpectedNodesSyntax? = nil,
-    asyncKeyword: TokenSyntax?,
+    asyncKeyword: TokenSyntax? = nil,
     _ unexpectedBetweenAsyncKeywordAndThrowsToken: UnexpectedNodesSyntax? = nil,
-    throwsToken: TokenSyntax?,
+    throwsToken: TokenSyntax? = nil,
     _ unexpectedBetweenThrowsTokenAndArrowToken: UnexpectedNodesSyntax? = nil,
-    arrowToken: TokenSyntax,
-    _ unexpectedAfterArrowToken: UnexpectedNodesSyntax? = nil
+    arrowToken: TokenSyntax = .arrowToken(),
+    _ unexpectedAfterArrowToken: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAsyncKeyword?.raw,
@@ -2367,8 +2407,9 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterArrowToken?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrowExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.arrowExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2586,14 +2627,16 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<L: ExprSyntaxProtocol, O: ExprSyntaxProtocol, R: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeLeftOperand: UnexpectedNodesSyntax? = nil,
-    leftOperand: ExprSyntax,
+    leftOperand: L,
     _ unexpectedBetweenLeftOperandAndOperatorOperand: UnexpectedNodesSyntax? = nil,
-    operatorOperand: ExprSyntax,
+    operatorOperand: O,
     _ unexpectedBetweenOperatorOperandAndRightOperand: UnexpectedNodesSyntax? = nil,
-    rightOperand: ExprSyntax,
-    _ unexpectedAfterRightOperand: UnexpectedNodesSyntax? = nil
+    rightOperand: R,
+    _ unexpectedAfterRightOperand: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftOperand?.raw,
@@ -2605,8 +2648,9 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterRightOperand?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.infixOperatorExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.infixOperatorExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2823,9 +2867,11 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeFloatingDigits: UnexpectedNodesSyntax? = nil,
     floatingDigits: TokenSyntax,
-    _ unexpectedAfterFloatingDigits: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterFloatingDigits: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeFloatingDigits?.raw,
@@ -2833,8 +2879,9 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterFloatingDigits?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.floatLiteralExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.floatLiteralExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2953,13 +3000,15 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil,
-    leftParen: TokenSyntax,
+    leftParen: TokenSyntax = .leftParenToken(),
     _ unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil,
     elementList: TupleExprElementListSyntax,
     _ unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax,
-    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
+    rightParen: TokenSyntax = .rightParenToken(),
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
@@ -2971,8 +3020,9 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterRightParen?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.tupleExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3208,13 +3258,15 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeLeftSquare: UnexpectedNodesSyntax? = nil,
-    leftSquare: TokenSyntax,
+    leftSquare: TokenSyntax = .leftSquareBracketToken(),
     _ unexpectedBetweenLeftSquareAndElements: UnexpectedNodesSyntax? = nil,
     elements: ArrayElementListSyntax,
     _ unexpectedBetweenElementsAndRightSquare: UnexpectedNodesSyntax? = nil,
-    rightSquare: TokenSyntax,
-    _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil
+    rightSquare: TokenSyntax = .rightSquareBracketToken(),
+    _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftSquare?.raw,
@@ -3226,8 +3278,9 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterRightSquare?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.arrayExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3499,13 +3552,15 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeLeftSquare: UnexpectedNodesSyntax? = nil,
-    leftSquare: TokenSyntax,
+    leftSquare: TokenSyntax = .leftSquareBracketToken(),
     _ unexpectedBetweenLeftSquareAndContent: UnexpectedNodesSyntax? = nil,
     content: Content,
     _ unexpectedBetweenContentAndRightSquare: UnexpectedNodesSyntax? = nil,
-    rightSquare: TokenSyntax,
-    _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil
+    rightSquare: TokenSyntax = .rightSquareBracketToken(),
+    _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftSquare?.raw,
@@ -3517,8 +3572,9 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterRightSquare?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.dictionaryExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3735,9 +3791,11 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeDigits: UnexpectedNodesSyntax? = nil,
     digits: TokenSyntax,
-    _ unexpectedAfterDigits: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterDigits: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDigits?.raw,
@@ -3745,8 +3803,9 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterDigits?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.integerLiteralExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.integerLiteralExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3865,9 +3924,11 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeBooleanLiteral: UnexpectedNodesSyntax? = nil,
     booleanLiteral: TokenSyntax,
-    _ unexpectedAfterBooleanLiteral: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterBooleanLiteral: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBooleanLiteral?.raw,
@@ -3875,8 +3936,9 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterBooleanLiteral?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.booleanLiteralExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.booleanLiteralExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3994,14 +4056,16 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<F: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeQuestionMark: UnexpectedNodesSyntax? = nil,
-    questionMark: TokenSyntax,
+    questionMark: TokenSyntax = .infixQuestionMarkToken(),
     _ unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? = nil,
-    firstChoice: ExprSyntax,
+    firstChoice: F,
     _ unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? = nil,
-    colonMark: TokenSyntax,
-    _ unexpectedAfterColonMark: UnexpectedNodesSyntax? = nil
+    colonMark: TokenSyntax = .colonToken(),
+    _ unexpectedAfterColonMark: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeQuestionMark?.raw,
@@ -4013,8 +4077,9 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterColonMark?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedTernaryExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.unresolvedTernaryExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4230,18 +4295,20 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<C: ExprSyntaxProtocol, F: ExprSyntaxProtocol, S: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeConditionExpression: UnexpectedNodesSyntax? = nil,
-    conditionExpression: ExprSyntax,
+    conditionExpression: C,
     _ unexpectedBetweenConditionExpressionAndQuestionMark: UnexpectedNodesSyntax? = nil,
-    questionMark: TokenSyntax,
+    questionMark: TokenSyntax = .infixQuestionMarkToken(),
     _ unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? = nil,
-    firstChoice: ExprSyntax,
+    firstChoice: F,
     _ unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? = nil,
-    colonMark: TokenSyntax,
+    colonMark: TokenSyntax = .colonToken(),
     _ unexpectedBetweenColonMarkAndSecondChoice: UnexpectedNodesSyntax? = nil,
-    secondChoice: ExprSyntax,
-    _ unexpectedAfterSecondChoice: UnexpectedNodesSyntax? = nil
+    secondChoice: S,
+    _ unexpectedAfterSecondChoice: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeConditionExpression?.raw,
@@ -4257,8 +4324,9 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterSecondChoice?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.ternaryExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.ternaryExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4572,16 +4640,18 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<B: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil,
-    base: ExprSyntax?,
+    base: B? = nil,
     _ unexpectedBetweenBaseAndDot: UnexpectedNodesSyntax? = nil,
     dot: TokenSyntax,
     _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
-    declNameArguments: DeclNameArgumentsSyntax?,
-    _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil
+    declNameArguments: DeclNameArgumentsSyntax? = nil,
+    _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBase?.raw,
@@ -4595,11 +4665,50 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterDeclNameArguments?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberAccessExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.memberAccessExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
+  }
+
+  /// This initializer exists solely because Swift 5.6 does not support
+  /// `Optional<ConcreteType>.none` as a default value of a generic parameter.
+  /// The above initializer thus defaults to `nil` instead, but that means it
+  /// is not actually callable when either not passing the defaulted parameter,
+  /// or passing `nil`.
+  ///
+  /// Hack around that limitation using this initializer, which takes a
+  /// `Missing*` syntax node instead. `Missing*` is used over the base type as
+  /// the base type would allow implicit conversion from a string literal,
+  /// which the above initializer doesn't support.
+  public init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil,
+    base: MissingExprSyntax? = nil,
+    _ unexpectedBetweenBaseAndDot: UnexpectedNodesSyntax? = nil,
+    dot: TokenSyntax,
+    _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ unexpectedBetweenNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
+    declNameArguments: DeclNameArgumentsSyntax? = nil,
+    _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeBase,
+      base: Optional<ExprSyntax>.none,
+      unexpectedBetweenBaseAndDot,
+      dot: dot,
+      unexpectedBetweenDotAndName,
+      name: name,
+      unexpectedBetweenNameAndDeclNameArguments,
+      declNameArguments: declNameArguments,
+      unexpectedAfterDeclNameArguments,
+      trailingTrivia: trailingTrivia
+    )
   }
 
   public var unexpectedBeforeBase: UnexpectedNodesSyntax? {
@@ -4864,9 +4973,11 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeIsTok: UnexpectedNodesSyntax? = nil,
-    isTok: TokenSyntax,
-    _ unexpectedAfterIsTok: UnexpectedNodesSyntax? = nil
+    isTok: TokenSyntax = .isKeyword(),
+    _ unexpectedAfterIsTok: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIsTok?.raw,
@@ -4874,8 +4985,9 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterIsTok?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedIsExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.unresolvedIsExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4993,14 +5105,16 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: ExprSyntaxProtocol, T: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax,
+    expression: E,
     _ unexpectedBetweenExpressionAndIsTok: UnexpectedNodesSyntax? = nil,
-    isTok: TokenSyntax,
+    isTok: TokenSyntax = .isKeyword(),
     _ unexpectedBetweenIsTokAndTypeName: UnexpectedNodesSyntax? = nil,
-    typeName: TypeSyntax,
-    _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil
+    typeName: T,
+    _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
@@ -5012,8 +5126,9 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterTypeName?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.isExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.isExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5230,11 +5345,13 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAsTok: UnexpectedNodesSyntax? = nil,
-    asTok: TokenSyntax,
+    asTok: TokenSyntax = .asKeyword(),
     _ unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil,
-    questionOrExclamationMark: TokenSyntax?,
-    _ unexpectedAfterQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil
+    questionOrExclamationMark: TokenSyntax? = nil,
+    _ unexpectedAfterQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAsTok?.raw,
@@ -5244,8 +5361,9 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterQuestionOrExclamationMark?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedAsExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.unresolvedAsExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5413,16 +5531,18 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: ExprSyntaxProtocol, T: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax,
+    expression: E,
     _ unexpectedBetweenExpressionAndAsTok: UnexpectedNodesSyntax? = nil,
-    asTok: TokenSyntax,
+    asTok: TokenSyntax = .asKeyword(),
     _ unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil,
-    questionOrExclamationMark: TokenSyntax?,
+    questionOrExclamationMark: TokenSyntax? = nil,
     _ unexpectedBetweenQuestionOrExclamationMarkAndTypeName: UnexpectedNodesSyntax? = nil,
-    typeName: TypeSyntax,
-    _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil
+    typeName: T,
+    _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
@@ -5436,8 +5556,9 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterTypeName?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.asExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.asExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5703,10 +5824,12 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<T: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeType: UnexpectedNodesSyntax? = nil,
-    type: TypeSyntax,
-    _ unexpectedAfterType: UnexpectedNodesSyntax? = nil
+    type: T,
+    _ unexpectedAfterType: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeType?.raw,
@@ -5714,8 +5837,9 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterType?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.typeExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5834,15 +5958,17 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? = nil,
-    leftBrace: TokenSyntax,
+    leftBrace: TokenSyntax = .leftBraceToken(),
     _ unexpectedBetweenLeftBraceAndSignature: UnexpectedNodesSyntax? = nil,
-    signature: ClosureSignatureSyntax?,
+    signature: ClosureSignatureSyntax? = nil,
     _ unexpectedBetweenSignatureAndStatements: UnexpectedNodesSyntax? = nil,
     statements: CodeBlockItemListSyntax,
     _ unexpectedBetweenStatementsAndRightBrace: UnexpectedNodesSyntax? = nil,
-    rightBrace: TokenSyntax,
-    _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil
+    rightBrace: TokenSyntax = .rightBraceToken(),
+    _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftBrace?.raw,
@@ -5856,8 +5982,9 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterRightBrace?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.closureExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6142,10 +6269,12 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<P: PatternSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil,
-    pattern: PatternSyntax,
-    _ unexpectedAfterPattern: UnexpectedNodesSyntax? = nil
+    pattern: P,
+    _ unexpectedAfterPattern: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePattern?.raw,
@@ -6153,8 +6282,9 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterPattern?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedPatternExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.unresolvedPatternExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6272,20 +6402,22 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<C: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeCalledExpression: UnexpectedNodesSyntax? = nil,
-    calledExpression: ExprSyntax,
+    calledExpression: C,
     _ unexpectedBetweenCalledExpressionAndLeftParen: UnexpectedNodesSyntax? = nil,
-    leftParen: TokenSyntax?,
+    leftParen: TokenSyntax? = nil,
     _ unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? = nil,
     argumentList: TupleExprElementListSyntax,
     _ unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax?,
+    rightParen: TokenSyntax? = nil,
     _ unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodesSyntax? = nil,
-    trailingClosure: ClosureExprSyntax?,
+    trailingClosure: ClosureExprSyntax? = nil,
     _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil,
-    additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?,
-    _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil
+    additionalTrailingClosures: MultipleTrailingClosureElementListSyntax? = nil,
+    _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeCalledExpression?.raw,
@@ -6303,8 +6435,9 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionCallExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.functionCallExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6709,20 +6842,22 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<C: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeCalledExpression: UnexpectedNodesSyntax? = nil,
-    calledExpression: ExprSyntax,
+    calledExpression: C,
     _ unexpectedBetweenCalledExpressionAndLeftBracket: UnexpectedNodesSyntax? = nil,
-    leftBracket: TokenSyntax,
+    leftBracket: TokenSyntax = .leftSquareBracketToken(),
     _ unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodesSyntax? = nil,
     argumentList: TupleExprElementListSyntax,
     _ unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodesSyntax? = nil,
-    rightBracket: TokenSyntax,
+    rightBracket: TokenSyntax = .rightSquareBracketToken(),
     _ unexpectedBetweenRightBracketAndTrailingClosure: UnexpectedNodesSyntax? = nil,
-    trailingClosure: ClosureExprSyntax?,
+    trailingClosure: ClosureExprSyntax? = nil,
     _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil,
-    additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?,
-    _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil
+    additionalTrailingClosures: MultipleTrailingClosureElementListSyntax? = nil,
+    _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeCalledExpression?.raw,
@@ -6740,8 +6875,9 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.subscriptExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.subscriptExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7144,12 +7280,14 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax,
+    expression: E,
     _ unexpectedBetweenExpressionAndQuestionMark: UnexpectedNodesSyntax? = nil,
-    questionMark: TokenSyntax,
-    _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil
+    questionMark: TokenSyntax = .postfixQuestionMarkToken(),
+    _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
@@ -7159,8 +7297,9 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterQuestionMark?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalChainingExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.optionalChainingExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7327,12 +7466,14 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax,
+    expression: E,
     _ unexpectedBetweenExpressionAndExclamationMark: UnexpectedNodesSyntax? = nil,
-    exclamationMark: TokenSyntax,
-    _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil
+    exclamationMark: TokenSyntax = .exclamationMarkToken(),
+    _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
@@ -7342,8 +7483,9 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterExclamationMark?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.forcedValueExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.forcedValueExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7510,12 +7652,14 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax,
+    expression: E,
     _ unexpectedBetweenExpressionAndOperatorToken: UnexpectedNodesSyntax? = nil,
     operatorToken: TokenSyntax,
-    _ unexpectedAfterOperatorToken: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterOperatorToken: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
@@ -7525,8 +7669,9 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterOperatorToken?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.postfixUnaryExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.postfixUnaryExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7693,12 +7838,14 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax,
+    expression: E,
     _ unexpectedBetweenExpressionAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
     genericArgumentClause: GenericArgumentClauseSyntax,
-    _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
@@ -7708,8 +7855,9 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterGenericArgumentClause?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.specializeExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.specializeExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7877,8 +8025,9 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeOpenDelimiter: UnexpectedNodesSyntax? = nil,
-    openDelimiter: TokenSyntax?,
+    openDelimiter: TokenSyntax? = nil,
     _ unexpectedBetweenOpenDelimiterAndOpenQuote: UnexpectedNodesSyntax? = nil,
     openQuote: TokenSyntax,
     _ unexpectedBetweenOpenQuoteAndSegments: UnexpectedNodesSyntax? = nil,
@@ -7886,8 +8035,9 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenSegmentsAndCloseQuote: UnexpectedNodesSyntax? = nil,
     closeQuote: TokenSyntax,
     _ unexpectedBetweenCloseQuoteAndCloseDelimiter: UnexpectedNodesSyntax? = nil,
-    closeDelimiter: TokenSyntax?,
-    _ unexpectedAfterCloseDelimiter: UnexpectedNodesSyntax? = nil
+    closeDelimiter: TokenSyntax? = nil,
+    _ unexpectedAfterCloseDelimiter: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeOpenDelimiter?.raw,
@@ -7903,8 +8053,9 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterCloseDelimiter?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.stringLiteralExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -8240,9 +8391,11 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeRegex: UnexpectedNodesSyntax? = nil,
     regex: TokenSyntax,
-    _ unexpectedAfterRegex: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterRegex: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeRegex?.raw,
@@ -8250,8 +8403,9 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterRegex?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.regexLiteralExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.regexLiteralExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -8369,14 +8523,16 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<R: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil,
-    backslash: TokenSyntax,
+    backslash: TokenSyntax = .backslashToken(),
     _ unexpectedBetweenBackslashAndRoot: UnexpectedNodesSyntax? = nil,
-    root: TypeSyntax?,
+    root: R? = nil,
     _ unexpectedBetweenRootAndComponents: UnexpectedNodesSyntax? = nil,
     components: KeyPathComponentListSyntax,
-    _ unexpectedAfterComponents: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterComponents: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBackslash?.raw,
@@ -8388,11 +8544,46 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterComponents?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.keyPathExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
+  }
+
+  /// This initializer exists solely because Swift 5.6 does not support
+  /// `Optional<ConcreteType>.none` as a default value of a generic parameter.
+  /// The above initializer thus defaults to `nil` instead, but that means it
+  /// is not actually callable when either not passing the defaulted parameter,
+  /// or passing `nil`.
+  ///
+  /// Hack around that limitation using this initializer, which takes a
+  /// `Missing*` syntax node instead. `Missing*` is used over the base type as
+  /// the base type would allow implicit conversion from a string literal,
+  /// which the above initializer doesn't support.
+  public init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil,
+    backslash: TokenSyntax = .backslashToken(),
+    _ unexpectedBetweenBackslashAndRoot: UnexpectedNodesSyntax? = nil,
+    root: MissingTypeSyntax? = nil,
+    _ unexpectedBetweenRootAndComponents: UnexpectedNodesSyntax? = nil,
+    components: KeyPathComponentListSyntax,
+    _ unexpectedAfterComponents: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeBackslash,
+      backslash: backslash,
+      unexpectedBetweenBackslashAndRoot,
+      root: Optional<TypeSyntax>.none,
+      unexpectedBetweenRootAndComponents,
+      components: components,
+      unexpectedAfterComponents,
+      trailingTrivia: trailingTrivia
+    )
   }
 
   public var unexpectedBeforeBackslash: UnexpectedNodesSyntax? {
@@ -8626,23 +8817,25 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforePoundToken: UnexpectedNodesSyntax? = nil,
-    poundToken: TokenSyntax,
+    poundToken: TokenSyntax = .poundToken(),
     _ unexpectedBetweenPoundTokenAndMacro: UnexpectedNodesSyntax? = nil,
     macro: TokenSyntax,
     _ unexpectedBetweenMacroAndGenericArguments: UnexpectedNodesSyntax? = nil,
-    genericArguments: GenericArgumentClauseSyntax?,
+    genericArguments: GenericArgumentClauseSyntax? = nil,
     _ unexpectedBetweenGenericArgumentsAndLeftParen: UnexpectedNodesSyntax? = nil,
-    leftParen: TokenSyntax?,
+    leftParen: TokenSyntax? = nil,
     _ unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? = nil,
     argumentList: TupleExprElementListSyntax,
     _ unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax?,
+    rightParen: TokenSyntax? = nil,
     _ unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodesSyntax? = nil,
-    trailingClosure: ClosureExprSyntax?,
+    trailingClosure: ClosureExprSyntax? = nil,
     _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil,
-    additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?,
-    _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil
+    additionalTrailingClosures: MultipleTrailingClosureElementListSyntax? = nil,
+    _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundToken?.raw,
@@ -8664,8 +8857,9 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.macroExpansionExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.macroExpansionExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -9170,12 +9364,14 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<B: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil,
-    base: ExprSyntax?,
+    base: B? = nil,
     _ unexpectedBetweenBaseAndConfig: UnexpectedNodesSyntax? = nil,
     config: IfConfigDeclSyntax,
-    _ unexpectedAfterConfig: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterConfig: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBase?.raw,
@@ -9185,11 +9381,42 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterConfig?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.postfixIfConfigExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.postfixIfConfigExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
+  }
+
+  /// This initializer exists solely because Swift 5.6 does not support
+  /// `Optional<ConcreteType>.none` as a default value of a generic parameter.
+  /// The above initializer thus defaults to `nil` instead, but that means it
+  /// is not actually callable when either not passing the defaulted parameter,
+  /// or passing `nil`.
+  ///
+  /// Hack around that limitation using this initializer, which takes a
+  /// `Missing*` syntax node instead. `Missing*` is used over the base type as
+  /// the base type would allow implicit conversion from a string literal,
+  /// which the above initializer doesn't support.
+  public init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil,
+    base: MissingExprSyntax? = nil,
+    _ unexpectedBetweenBaseAndConfig: UnexpectedNodesSyntax? = nil,
+    config: IfConfigDeclSyntax,
+    _ unexpectedAfterConfig: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeBase,
+      base: Optional<ExprSyntax>.none,
+      unexpectedBetweenBaseAndConfig,
+      config: config,
+      unexpectedAfterConfig,
+      trailingTrivia: trailingTrivia
+    )
   }
 
   public var unexpectedBeforeBase: UnexpectedNodesSyntax? {
@@ -9355,9 +9582,11 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
-    _ unexpectedAfterIdentifier: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterIdentifier: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
@@ -9365,8 +9594,9 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       unexpectedAfterIdentifier?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.editorPlaceholderExpr,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.editorPlaceholderExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -31,13 +31,9 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
-  ) {
-    let layout: [RawSyntax?] = [
-    ]
+  public init() {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingStmt, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -81,14 +77,16 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<S: StmtSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeLabelName: UnexpectedNodesSyntax? = nil,
     labelName: TokenSyntax,
     _ unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? = nil,
-    labelColon: TokenSyntax,
+    labelColon: TokenSyntax = .colonToken(),
     _ unexpectedBetweenLabelColonAndStatement: UnexpectedNodesSyntax? = nil,
-    statement: StmtSyntax,
-    _ unexpectedAfterStatement: UnexpectedNodesSyntax? = nil
+    statement: S,
+    _ unexpectedAfterStatement: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabelName?.raw,
@@ -100,8 +98,9 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterStatement?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.labeledStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.labeledStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -318,11 +317,13 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeContinueKeyword: UnexpectedNodesSyntax? = nil,
-    continueKeyword: TokenSyntax,
+    continueKeyword: TokenSyntax = .continueKeyword(),
     _ unexpectedBetweenContinueKeywordAndLabel: UnexpectedNodesSyntax? = nil,
-    label: TokenSyntax?,
-    _ unexpectedAfterLabel: UnexpectedNodesSyntax? = nil
+    label: TokenSyntax? = nil,
+    _ unexpectedAfterLabel: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeContinueKeyword?.raw,
@@ -332,8 +333,9 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterLabel?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.continueStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.continueStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -502,13 +504,15 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeWhileKeyword: UnexpectedNodesSyntax? = nil,
-    whileKeyword: TokenSyntax,
+    whileKeyword: TokenSyntax = .whileKeyword(),
     _ unexpectedBetweenWhileKeywordAndConditions: UnexpectedNodesSyntax? = nil,
     conditions: ConditionElementListSyntax,
     _ unexpectedBetweenConditionsAndBody: UnexpectedNodesSyntax? = nil,
     body: CodeBlockSyntax,
-    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWhileKeyword?.raw,
@@ -520,8 +524,9 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterBody?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.whileStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.whileStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -757,11 +762,13 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeDeferKeyword: UnexpectedNodesSyntax? = nil,
-    deferKeyword: TokenSyntax,
+    deferKeyword: TokenSyntax = .deferKeyword(),
     _ unexpectedBetweenDeferKeywordAndBody: UnexpectedNodesSyntax? = nil,
     body: CodeBlockSyntax,
-    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDeferKeyword?.raw,
@@ -771,8 +778,9 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterBody?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.deferStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.deferStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -939,10 +947,12 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax,
-    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
+    expression: E,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
@@ -950,8 +960,9 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterExpression?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.expressionStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1069,16 +1080,18 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<C: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeRepeatKeyword: UnexpectedNodesSyntax? = nil,
-    repeatKeyword: TokenSyntax,
+    repeatKeyword: TokenSyntax = .repeatKeyword(),
     _ unexpectedBetweenRepeatKeywordAndBody: UnexpectedNodesSyntax? = nil,
     body: CodeBlockSyntax,
     _ unexpectedBetweenBodyAndWhileKeyword: UnexpectedNodesSyntax? = nil,
-    whileKeyword: TokenSyntax,
+    whileKeyword: TokenSyntax = .whileKeyword(),
     _ unexpectedBetweenWhileKeywordAndCondition: UnexpectedNodesSyntax? = nil,
-    condition: ExprSyntax,
-    _ unexpectedAfterCondition: UnexpectedNodesSyntax? = nil
+    condition: C,
+    _ unexpectedAfterCondition: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeRepeatKeyword?.raw,
@@ -1092,8 +1105,9 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterCondition?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.repeatWhileStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.repeatWhileStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1359,15 +1373,17 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeGuardKeyword: UnexpectedNodesSyntax? = nil,
-    guardKeyword: TokenSyntax,
+    guardKeyword: TokenSyntax = .guardKeyword(),
     _ unexpectedBetweenGuardKeywordAndConditions: UnexpectedNodesSyntax? = nil,
     conditions: ConditionElementListSyntax,
     _ unexpectedBetweenConditionsAndElseKeyword: UnexpectedNodesSyntax? = nil,
-    elseKeyword: TokenSyntax,
+    elseKeyword: TokenSyntax = .elseKeyword(),
     _ unexpectedBetweenElseKeywordAndBody: UnexpectedNodesSyntax? = nil,
     body: CodeBlockSyntax,
-    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeGuardKeyword?.raw,
@@ -1381,8 +1397,9 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterBody?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.guardStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.guardStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1666,28 +1683,30 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<P: PatternSyntaxProtocol, S: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeForKeyword: UnexpectedNodesSyntax? = nil,
-    forKeyword: TokenSyntax,
+    forKeyword: TokenSyntax = .forKeyword(),
     _ unexpectedBetweenForKeywordAndTryKeyword: UnexpectedNodesSyntax? = nil,
-    tryKeyword: TokenSyntax?,
+    tryKeyword: TokenSyntax? = nil,
     _ unexpectedBetweenTryKeywordAndAwaitKeyword: UnexpectedNodesSyntax? = nil,
-    awaitKeyword: TokenSyntax?,
+    awaitKeyword: TokenSyntax? = nil,
     _ unexpectedBetweenAwaitKeywordAndCaseKeyword: UnexpectedNodesSyntax? = nil,
-    caseKeyword: TokenSyntax?,
+    caseKeyword: TokenSyntax? = nil,
     _ unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodesSyntax? = nil,
-    pattern: PatternSyntax,
+    pattern: P,
     _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil,
-    typeAnnotation: TypeAnnotationSyntax?,
+    typeAnnotation: TypeAnnotationSyntax? = nil,
     _ unexpectedBetweenTypeAnnotationAndInKeyword: UnexpectedNodesSyntax? = nil,
-    inKeyword: TokenSyntax,
+    inKeyword: TokenSyntax = .inKeyword(),
     _ unexpectedBetweenInKeywordAndSequenceExpr: UnexpectedNodesSyntax? = nil,
-    sequenceExpr: ExprSyntax,
+    sequenceExpr: S,
     _ unexpectedBetweenSequenceExprAndWhereClause: UnexpectedNodesSyntax? = nil,
-    whereClause: WhereClauseSyntax?,
+    whereClause: WhereClauseSyntax? = nil,
     _ unexpectedBetweenWhereClauseAndBody: UnexpectedNodesSyntax? = nil,
     body: CodeBlockSyntax,
-    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeForKeyword?.raw,
@@ -1713,8 +1732,9 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterBody?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.forInStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.forInStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2278,18 +2298,20 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeSwitchKeyword: UnexpectedNodesSyntax? = nil,
-    switchKeyword: TokenSyntax,
+    switchKeyword: TokenSyntax = .switchKeyword(),
     _ unexpectedBetweenSwitchKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax,
+    expression: E,
     _ unexpectedBetweenExpressionAndLeftBrace: UnexpectedNodesSyntax? = nil,
-    leftBrace: TokenSyntax,
+    leftBrace: TokenSyntax = .leftBraceToken(),
     _ unexpectedBetweenLeftBraceAndCases: UnexpectedNodesSyntax? = nil,
     cases: SwitchCaseListSyntax,
     _ unexpectedBetweenCasesAndRightBrace: UnexpectedNodesSyntax? = nil,
-    rightBrace: TokenSyntax,
-    _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil
+    rightBrace: TokenSyntax = .rightBraceToken(),
+    _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSwitchKeyword?.raw,
@@ -2305,8 +2327,9 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterRightBrace?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.switchStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2640,13 +2663,15 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeDoKeyword: UnexpectedNodesSyntax? = nil,
-    doKeyword: TokenSyntax,
+    doKeyword: TokenSyntax = .doKeyword(),
     _ unexpectedBetweenDoKeywordAndBody: UnexpectedNodesSyntax? = nil,
     body: CodeBlockSyntax,
     _ unexpectedBetweenBodyAndCatchClauses: UnexpectedNodesSyntax? = nil,
-    catchClauses: CatchClauseListSyntax?,
-    _ unexpectedAfterCatchClauses: UnexpectedNodesSyntax? = nil
+    catchClauses: CatchClauseListSyntax? = nil,
+    _ unexpectedAfterCatchClauses: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDoKeyword?.raw,
@@ -2658,8 +2683,9 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterCatchClauses?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.doStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.doStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2895,12 +2921,14 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeReturnKeyword: UnexpectedNodesSyntax? = nil,
-    returnKeyword: TokenSyntax,
+    returnKeyword: TokenSyntax = .returnKeyword(),
     _ unexpectedBetweenReturnKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax?,
-    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
+    expression: E? = nil,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeReturnKeyword?.raw,
@@ -2910,11 +2938,42 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterExpression?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.returnStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.returnStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
+  }
+
+  /// This initializer exists solely because Swift 5.6 does not support
+  /// `Optional<ConcreteType>.none` as a default value of a generic parameter.
+  /// The above initializer thus defaults to `nil` instead, but that means it
+  /// is not actually callable when either not passing the defaulted parameter,
+  /// or passing `nil`.
+  ///
+  /// Hack around that limitation using this initializer, which takes a
+  /// `Missing*` syntax node instead. `Missing*` is used over the base type as
+  /// the base type would allow implicit conversion from a string literal,
+  /// which the above initializer doesn't support.
+  public init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeReturnKeyword: UnexpectedNodesSyntax? = nil,
+    returnKeyword: TokenSyntax = .returnKeyword(),
+    _ unexpectedBetweenReturnKeywordAndExpression: UnexpectedNodesSyntax? = nil,
+    expression: MissingExprSyntax? = nil,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      unexpectedBeforeReturnKeyword,
+      returnKeyword: returnKeyword,
+      unexpectedBetweenReturnKeywordAndExpression,
+      expression: Optional<ExprSyntax>.none,
+      unexpectedAfterExpression,
+      trailingTrivia: trailingTrivia
+    )
   }
 
   public var unexpectedBeforeReturnKeyword: UnexpectedNodesSyntax? {
@@ -3116,11 +3175,13 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeYieldKeyword: UnexpectedNodesSyntax? = nil,
-    yieldKeyword: TokenSyntax,
+    yieldKeyword: TokenSyntax = .yieldToken(),
     _ unexpectedBetweenYieldKeywordAndYields: UnexpectedNodesSyntax? = nil,
     yields: Yields,
-    _ unexpectedAfterYields: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterYields: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeYieldKeyword?.raw,
@@ -3130,8 +3191,9 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterYields?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.yieldStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3299,9 +3361,11 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeFallthroughKeyword: UnexpectedNodesSyntax? = nil,
-    fallthroughKeyword: TokenSyntax,
-    _ unexpectedAfterFallthroughKeyword: UnexpectedNodesSyntax? = nil
+    fallthroughKeyword: TokenSyntax = .fallthroughKeyword(),
+    _ unexpectedAfterFallthroughKeyword: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeFallthroughKeyword?.raw,
@@ -3309,8 +3373,9 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterFallthroughKeyword?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.fallthroughStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.fallthroughStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3429,11 +3494,13 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeBreakKeyword: UnexpectedNodesSyntax? = nil,
-    breakKeyword: TokenSyntax,
+    breakKeyword: TokenSyntax = .breakKeyword(),
     _ unexpectedBetweenBreakKeywordAndLabel: UnexpectedNodesSyntax? = nil,
-    label: TokenSyntax?,
-    _ unexpectedAfterLabel: UnexpectedNodesSyntax? = nil
+    label: TokenSyntax? = nil,
+    _ unexpectedAfterLabel: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBreakKeyword?.raw,
@@ -3443,8 +3510,9 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterLabel?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.breakStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.breakStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3612,10 +3680,12 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<D: DeclSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeDeclaration: UnexpectedNodesSyntax? = nil,
-    declaration: DeclSyntax,
-    _ unexpectedAfterDeclaration: UnexpectedNodesSyntax? = nil
+    declaration: D,
+    _ unexpectedAfterDeclaration: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDeclaration?.raw,
@@ -3623,8 +3693,9 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterDeclaration?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.declarationStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.declarationStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3742,12 +3813,14 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeThrowKeyword: UnexpectedNodesSyntax? = nil,
-    throwKeyword: TokenSyntax,
+    throwKeyword: TokenSyntax = .throwKeyword(),
     _ unexpectedBetweenThrowKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax,
-    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
+    expression: E,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeThrowKeyword?.raw,
@@ -3757,8 +3830,9 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterExpression?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.throwStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.throwStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3962,17 +4036,19 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeIfKeyword: UnexpectedNodesSyntax? = nil,
-    ifKeyword: TokenSyntax,
+    ifKeyword: TokenSyntax = .ifKeyword(),
     _ unexpectedBetweenIfKeywordAndConditions: UnexpectedNodesSyntax? = nil,
     conditions: ConditionElementListSyntax,
     _ unexpectedBetweenConditionsAndBody: UnexpectedNodesSyntax? = nil,
     body: CodeBlockSyntax,
     _ unexpectedBetweenBodyAndElseKeyword: UnexpectedNodesSyntax? = nil,
-    elseKeyword: TokenSyntax?,
+    elseKeyword: TokenSyntax? = nil,
     _ unexpectedBetweenElseKeywordAndElseBody: UnexpectedNodesSyntax? = nil,
-    elseBody: ElseBody?,
-    _ unexpectedAfterElseBody: UnexpectedNodesSyntax? = nil
+    elseBody: ElseBody? = nil,
+    _ unexpectedAfterElseBody: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIfKeyword?.raw,
@@ -3988,8 +4064,9 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterElseBody?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.ifStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4324,20 +4401,22 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<C: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforePoundAssert: UnexpectedNodesSyntax? = nil,
-    poundAssert: TokenSyntax,
+    poundAssert: TokenSyntax = .poundAssertKeyword(),
     _ unexpectedBetweenPoundAssertAndLeftParen: UnexpectedNodesSyntax? = nil,
-    leftParen: TokenSyntax,
+    leftParen: TokenSyntax = .leftParenToken(),
     _ unexpectedBetweenLeftParenAndCondition: UnexpectedNodesSyntax? = nil,
-    condition: ExprSyntax,
+    condition: C,
     _ unexpectedBetweenConditionAndComma: UnexpectedNodesSyntax? = nil,
-    comma: TokenSyntax?,
+    comma: TokenSyntax? = nil,
     _ unexpectedBetweenCommaAndMessage: UnexpectedNodesSyntax? = nil,
-    message: TokenSyntax?,
+    message: TokenSyntax? = nil,
     _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax,
-    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
+    rightParen: TokenSyntax = .rightParenToken(),
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundAssert?.raw,
@@ -4355,8 +4434,9 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       unexpectedAfterRightParen?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundAssertStmt,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.poundAssertStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -31,13 +31,9 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
-  ) {
-    let layout: [RawSyntax?] = [
-    ]
+  public init() {
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingType,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -82,11 +78,13 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
-    genericArgumentClause: GenericArgumentClauseSyntax?,
-    _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil
+    genericArgumentClause: GenericArgumentClauseSyntax? = nil,
+    _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
@@ -96,8 +94,9 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       unexpectedAfterGenericArgumentClause?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.simpleTypeIdentifier,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.simpleTypeIdentifier, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -265,16 +264,18 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<B: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil,
-    baseType: TypeSyntax,
+    baseType: B,
     _ unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? = nil,
     period: TokenSyntax,
     _ unexpectedBetweenPeriodAndName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
-    genericArgumentClause: GenericArgumentClauseSyntax?,
-    _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil
+    genericArgumentClause: GenericArgumentClauseSyntax? = nil,
+    _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBaseType?.raw,
@@ -288,8 +289,9 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       unexpectedAfterGenericArgumentClause?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberTypeIdentifier,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.memberTypeIdentifier, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -556,9 +558,11 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeClassKeyword: UnexpectedNodesSyntax? = nil,
-    classKeyword: TokenSyntax,
-    _ unexpectedAfterClassKeyword: UnexpectedNodesSyntax? = nil
+    classKeyword: TokenSyntax = .classKeyword(),
+    _ unexpectedAfterClassKeyword: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeClassKeyword?.raw,
@@ -566,8 +570,9 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       unexpectedAfterClassKeyword?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.classRestrictionType,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.classRestrictionType, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -685,14 +690,16 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<E: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeLeftSquareBracket: UnexpectedNodesSyntax? = nil,
-    leftSquareBracket: TokenSyntax,
+    leftSquareBracket: TokenSyntax = .leftSquareBracketToken(),
     _ unexpectedBetweenLeftSquareBracketAndElementType: UnexpectedNodesSyntax? = nil,
-    elementType: TypeSyntax,
+    elementType: E,
     _ unexpectedBetweenElementTypeAndRightSquareBracket: UnexpectedNodesSyntax? = nil,
-    rightSquareBracket: TokenSyntax,
-    _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil
+    rightSquareBracket: TokenSyntax = .rightSquareBracketToken(),
+    _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftSquareBracket?.raw,
@@ -704,8 +711,9 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       unexpectedAfterRightSquareBracket?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayType,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.arrayType, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -921,18 +929,20 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<K: TypeSyntaxProtocol, V: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeLeftSquareBracket: UnexpectedNodesSyntax? = nil,
-    leftSquareBracket: TokenSyntax,
+    leftSquareBracket: TokenSyntax = .leftSquareBracketToken(),
     _ unexpectedBetweenLeftSquareBracketAndKeyType: UnexpectedNodesSyntax? = nil,
-    keyType: TypeSyntax,
+    keyType: K,
     _ unexpectedBetweenKeyTypeAndColon: UnexpectedNodesSyntax? = nil,
-    colon: TokenSyntax,
+    colon: TokenSyntax = .colonToken(),
     _ unexpectedBetweenColonAndValueType: UnexpectedNodesSyntax? = nil,
-    valueType: TypeSyntax,
+    valueType: V,
     _ unexpectedBetweenValueTypeAndRightSquareBracket: UnexpectedNodesSyntax? = nil,
-    rightSquareBracket: TokenSyntax,
-    _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil
+    rightSquareBracket: TokenSyntax = .rightSquareBracketToken(),
+    _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftSquareBracket?.raw,
@@ -948,8 +958,9 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       unexpectedAfterRightSquareBracket?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryType,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.dictionaryType, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1263,14 +1274,16 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<B: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil,
-    baseType: TypeSyntax,
+    baseType: B,
     _ unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? = nil,
-    period: TokenSyntax,
+    period: TokenSyntax = .periodToken(),
     _ unexpectedBetweenPeriodAndTypeOrProtocol: UnexpectedNodesSyntax? = nil,
     typeOrProtocol: TokenSyntax,
-    _ unexpectedAfterTypeOrProtocol: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterTypeOrProtocol: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBaseType?.raw,
@@ -1282,8 +1295,9 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       unexpectedAfterTypeOrProtocol?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.metatypeType,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.metatypeType, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1499,12 +1513,14 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<W: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeWrappedType: UnexpectedNodesSyntax? = nil,
-    wrappedType: TypeSyntax,
+    wrappedType: W,
     _ unexpectedBetweenWrappedTypeAndQuestionMark: UnexpectedNodesSyntax? = nil,
-    questionMark: TokenSyntax,
-    _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil
+    questionMark: TokenSyntax = .postfixQuestionMarkToken(),
+    _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWrappedType?.raw,
@@ -1514,8 +1530,9 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       unexpectedAfterQuestionMark?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalType,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.optionalType, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1682,12 +1699,14 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<B: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeSomeOrAnySpecifier: UnexpectedNodesSyntax? = nil,
     someOrAnySpecifier: TokenSyntax,
     _ unexpectedBetweenSomeOrAnySpecifierAndBaseType: UnexpectedNodesSyntax? = nil,
-    baseType: TypeSyntax,
-    _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil
+    baseType: B,
+    _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSomeOrAnySpecifier?.raw,
@@ -1697,8 +1716,9 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       unexpectedAfterBaseType?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.constrainedSugarType,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.constrainedSugarType, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1865,12 +1885,14 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<W: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeWrappedType: UnexpectedNodesSyntax? = nil,
-    wrappedType: TypeSyntax,
+    wrappedType: W,
     _ unexpectedBetweenWrappedTypeAndExclamationMark: UnexpectedNodesSyntax? = nil,
-    exclamationMark: TokenSyntax,
-    _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil
+    exclamationMark: TokenSyntax = .exclamationMarkToken(),
+    _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWrappedType?.raw,
@@ -1880,8 +1902,9 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
       unexpectedAfterExclamationMark?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.implicitlyUnwrappedOptionalType,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.implicitlyUnwrappedOptionalType, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2049,9 +2072,11 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeElements: UnexpectedNodesSyntax? = nil,
     elements: CompositionTypeElementListSyntax,
-    _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil
+    _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeElements?.raw,
@@ -2059,8 +2084,9 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       unexpectedAfterElements?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionType,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.compositionType, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2197,12 +2223,14 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<P: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforePatternType: UnexpectedNodesSyntax? = nil,
-    patternType: TypeSyntax,
+    patternType: P,
     _ unexpectedBetweenPatternTypeAndEllipsis: UnexpectedNodesSyntax? = nil,
-    ellipsis: TokenSyntax,
-    _ unexpectedAfterEllipsis: UnexpectedNodesSyntax? = nil
+    ellipsis: TokenSyntax = .ellipsisToken(),
+    _ unexpectedAfterEllipsis: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePatternType?.raw,
@@ -2212,8 +2240,9 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       unexpectedAfterEllipsis?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.packExpansionType,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.packExpansionType, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2380,12 +2409,14 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<P: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeEachKeyword: UnexpectedNodesSyntax? = nil,
     eachKeyword: TokenSyntax,
     _ unexpectedBetweenEachKeywordAndPackType: UnexpectedNodesSyntax? = nil,
-    packType: TypeSyntax,
-    _ unexpectedAfterPackType: UnexpectedNodesSyntax? = nil
+    packType: P,
+    _ unexpectedAfterPackType: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeEachKeyword?.raw,
@@ -2395,8 +2426,9 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       unexpectedAfterPackType?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.packReferenceType,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.packReferenceType, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2564,13 +2596,15 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil,
-    leftParen: TokenSyntax,
+    leftParen: TokenSyntax = .leftParenToken(),
     _ unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? = nil,
     elements: TupleTypeElementListSyntax,
     _ unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax,
-    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
+    rightParen: TokenSyntax = .rightParenToken(),
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
@@ -2582,8 +2616,9 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       unexpectedAfterRightParen?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleType,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.tupleType, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2818,22 +2853,24 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<R: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil,
-    leftParen: TokenSyntax,
+    leftParen: TokenSyntax = .leftParenToken(),
     _ unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil,
     arguments: TupleTypeElementListSyntax,
     _ unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax,
+    rightParen: TokenSyntax = .rightParenToken(),
     _ unexpectedBetweenRightParenAndAsyncKeyword: UnexpectedNodesSyntax? = nil,
-    asyncKeyword: TokenSyntax?,
+    asyncKeyword: TokenSyntax? = nil,
     _ unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodesSyntax? = nil,
-    throwsOrRethrowsKeyword: TokenSyntax?,
+    throwsOrRethrowsKeyword: TokenSyntax? = nil,
     _ unexpectedBetweenThrowsOrRethrowsKeywordAndArrow: UnexpectedNodesSyntax? = nil,
-    arrow: TokenSyntax,
+    arrow: TokenSyntax = .arrowToken(),
     _ unexpectedBetweenArrowAndReturnType: UnexpectedNodesSyntax? = nil,
-    returnType: TypeSyntax,
-    _ unexpectedAfterReturnType: UnexpectedNodesSyntax? = nil
+    returnType: R,
+    _ unexpectedAfterReturnType: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
@@ -2853,8 +2890,9 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       unexpectedAfterReturnType?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionType,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.functionType, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3287,14 +3325,16 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<B: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeSpecifier: UnexpectedNodesSyntax? = nil,
-    specifier: TokenSyntax?,
+    specifier: TokenSyntax? = nil,
     _ unexpectedBetweenSpecifierAndAttributes: UnexpectedNodesSyntax? = nil,
-    attributes: AttributeListSyntax?,
+    attributes: AttributeListSyntax? = nil,
     _ unexpectedBetweenAttributesAndBaseType: UnexpectedNodesSyntax? = nil,
-    baseType: TypeSyntax,
-    _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil
+    baseType: B,
+    _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSpecifier?.raw,
@@ -3306,8 +3346,9 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       unexpectedAfterBaseType?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.attributedType,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.attributedType, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3544,12 +3585,14 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init(
+  public init<B: TypeSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeGenericParameters: UnexpectedNodesSyntax? = nil,
     genericParameters: GenericParameterClauseSyntax,
     _ unexpectedBetweenGenericParametersAndBaseType: UnexpectedNodesSyntax? = nil,
-    baseType: TypeSyntax,
-    _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil
+    baseType: B,
+    _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeGenericParameters?.raw,
@@ -3559,8 +3602,9 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       unexpectedAfterBaseType?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.namedOpaqueReturnType,
-        from: layout, arena: arena)
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.namedOpaqueReturnType, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)

--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
@@ -44,7 +44,7 @@ extension CatchClause {
   ) {
     self.init(
       leadingTrivia: leadingTrivia,
-      catchKeyword: .catch.withTrailingTrivia(catchItems.isEmpty ? [] : .space),
+      catchKeyword: .catchKeyword(trailingTrivia: catchItems.isEmpty ? [] : .space),
       catchItems: catchItems,
       body: CodeBlockSyntax(statements: bodyBuilder())
     )
@@ -84,7 +84,7 @@ extension DictionaryExpr {
     let elementList = contentBuilder()
     self.init(
       leftSquare: leftSquare,
-      content: elementList.isEmpty ? .colon(Token.colon.withTrailingTrivia([])) : .elements(elementList),
+      content: elementList.isEmpty ? .colon(.colonToken()) : .elements(elementList),
       rightSquare: rightSquare
     )
   }
@@ -122,7 +122,7 @@ extension Expr {
   /// literal anywhere in its syntax tree. Use a convenience initializer on a
   /// specific type if you need that exact type in the syntax tree.
   public init<Literal: ExpressibleByLiteralSyntax>(literal: Literal) {
-    self.init(fromProtocol: literal.makeLiteralSyntax())
+    self.init(literal.makeLiteralSyntax())
   }
 }
 
@@ -141,12 +141,11 @@ extension FloatLiteralExprSyntax: ExpressibleByFloatLiteral {
 // MARK: - FunctionCallExpr
 
 extension FunctionCallExpr {
-  // Need an overload that's explicitly `ExprSyntax` for code literals to work.
   /// A convenience initializer that allows passing in arguments using a result builder
   /// instead of having to wrap them in a `TupleExprElementList`.
   /// The presence of the parenthesis will be inferred based on the presence of arguments and the trailing closure.
-  public init(
-    callee: ExprSyntax,
+  public init<C: ExprSyntaxProtocol>(
+    callee: C,
     trailingClosure: ClosureExprSyntax? = nil,
     additionalTrailingClosures: MultipleTrailingClosureElementList? = nil,
     @TupleExprElementListBuilder argumentList: () -> TupleExprElementList = { [] }
@@ -160,23 +159,6 @@ extension FunctionCallExpr {
       rightParen: shouldOmitParens ? nil : .rightParen,
       trailingClosure: trailingClosure,
       additionalTrailingClosures: additionalTrailingClosures
-    )
-  }
-
-  /// A convenience initializer that allows passing in arguments using a result builder
-  /// instead of having to wrap them in a `TupleExprElementList`.
-  /// The presence of the parenthesis will be inferred based on the presence of arguments and the trailing closure.
-  public init(
-    callee: ExprSyntaxProtocol,
-    trailingClosure: ClosureExprSyntax? = nil,
-    additionalTrailingClosures: MultipleTrailingClosureElementList? = nil,
-    @TupleExprElementListBuilder argumentList: () -> TupleExprElementList = { [] }
-  ) {
-    self.init(
-      callee: ExprSyntax(fromProtocol: callee),
-      trailingClosure: trailingClosure,
-      additionalTrailingClosures: additionalTrailingClosures,
-      argumentList: argumentList
     )
   }
 }
@@ -218,7 +200,7 @@ extension IfStmt {
       leadingTrivia: leadingTrivia,
       conditions: conditions,
       body: CodeBlockSyntax(statements: body()),
-      elseKeyword: generatedElseBody == nil ? nil : Token.else.withLeadingTrivia(.space).withTrailingTrivia([]),
+      elseKeyword: generatedElseBody == nil ? nil : .elseKeyword(leadingTrivia: .space),
       elseBody: generatedElseBody.map { .codeBlock(CodeBlock(statements: $0)) }
     )
   }
@@ -247,7 +229,7 @@ extension MemberAccessExpr {
     name: String,
     declNameArguments: DeclNameArgumentsSyntax? = nil
   ) {
-    self.init(base: base, dot: dot, name: TokenSyntax.identifier(name), declNameArguments: declNameArguments)
+    self.init(base: base, dot: dot, name: .identifier(name), declNameArguments: declNameArguments)
   }
 }
 
@@ -372,16 +354,16 @@ extension SwitchCase {
 // MARK: - TernaryExpr
 
 extension TernaryExpr {
-  public init(
-    if condition: ExprSyntaxProtocol,
-    then firstChoice: ExprSyntaxProtocol,
-    else secondChoice: ExprSyntaxProtocol
+  public init<C: ExprSyntaxProtocol, F: ExprSyntaxProtocol, S: ExprSyntaxProtocol>(
+    if condition: C,
+    then firstChoice: F,
+    else secondChoice: S
   ) {
     self.init(
       conditionExpression: condition,
-      questionMark: .infixQuestionMark.withLeadingTrivia(.space).withTrailingTrivia(.space),
+      questionMark: .infixQuestionMarkToken(leadingTrivia: .space, trailingTrivia: .space),
       firstChoice: firstChoice,
-      colonMark: .colon.withLeadingTrivia(.space),
+      colonMark: .colonToken(leadingTrivia: .space),
       secondChoice: secondChoice
     )
   }
@@ -394,7 +376,9 @@ extension TupleExprElement {
   /// The presence of the colon will be inferred based on the presence of the label.
   public init(label: String? = nil, expression: ExprSyntax) {
     self.init(
-      label: label.map { Token.identifier($0) }, colon: label == nil ? nil : Token.colon, expression: expression, trailingComma: nil)
+      label: label.map { .identifier($0) },
+      colon: label == nil ? nil : .colonToken(),
+      expression: expression)
   }
 }
 

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -194,6 +194,8 @@ enum SyntaxStringInterpolationError: Error, CustomStringConvertible {
 /// produce correct syntax trees for infinities and NaNs, nested optionals
 /// produce `.some(nil)` where appropriate, etc.
 public protocol ExpressibleByLiteralSyntax {
+  associatedtype LiteralType where LiteralType: ExprSyntaxProtocol
+
   /// Returns a syntax tree that represents the value of this instance.
   ///
   /// This method is usually not called directly. Instead, conforming types can
@@ -208,7 +210,7 @@ public protocol ExpressibleByLiteralSyntax {
   ///     let greeting = "Hello, world!"
   ///     let expr1 = ExprSyntax("print(\(literal: greeting))")
   ///     // `expr1` is a syntax tree for `print("Hello, world!")`
-  func makeLiteralSyntax() -> ExprSyntaxProtocol
+  func makeLiteralSyntax() -> LiteralType
 }
 
 extension SyntaxExpressibleByStringInterpolation {
@@ -246,20 +248,20 @@ extension SyntaxExpressibleByStringInterpolation {
 // MARK: ExpressibleByLiteralSyntax conformances
 
 extension Substring: ExpressibleByLiteralSyntax {
-  public func makeLiteralSyntax() -> ExprSyntaxProtocol {
+  public func makeLiteralSyntax() -> StringLiteralExpr {
     String(self).makeLiteralSyntax()
   }
 }
 
 extension String: ExpressibleByLiteralSyntax {
-  public func makeLiteralSyntax() -> ExprSyntaxProtocol {
+  public func makeLiteralSyntax() -> StringLiteralExpr {
     // TODO: Use a multi-line literal if there are more than N inner newlines.
     StringLiteralExpr(content: self)
   }
 }
 
 extension ExpressibleByLiteralSyntax where Self: BinaryInteger {
-  public func makeLiteralSyntax() -> ExprSyntaxProtocol {
+  public func makeLiteralSyntax() -> IntegerLiteralExpr {
     // TODO: Radix selection? Thousands separators?
     let digits = String(self, radix: 10)
     return IntegerLiteralExpr(digits: digits)
@@ -277,27 +279,27 @@ extension UInt32: ExpressibleByLiteralSyntax {}
 extension UInt64: ExpressibleByLiteralSyntax {}
 
 extension ExpressibleByLiteralSyntax where Self: FloatingPoint, Self: LosslessStringConvertible {
-  public func makeLiteralSyntax() -> ExprSyntaxProtocol {
+  public func makeLiteralSyntax() -> ExprSyntax {
     switch floatingPointClass {
     case .positiveInfinity:
-      return MemberAccessExpr(name: "infinity")
+      return ExprSyntax(MemberAccessExpr(name: "infinity"))
 
     case .quietNaN:
-      return MemberAccessExpr(name: "nan")
+      return ExprSyntax(MemberAccessExpr(name: "nan"))
 
     case .signalingNaN:
-      return MemberAccessExpr(name: "signalingNaN")
+      return ExprSyntax(MemberAccessExpr(name: "signalingNaN"))
 
     case .negativeInfinity, .negativeZero:
-      return PrefixOperatorExpr(
+      return ExprSyntax(PrefixOperatorExpr(
         operatorToken: "-",
         postfixExpression: (-self).makeLiteralSyntax()
-      )
+      ))
 
     case .negativeNormal, .negativeSubnormal, .positiveZero, .positiveSubnormal, .positiveNormal:
       // TODO: Thousands separators?
       let digits = String(self)
-      return FloatLiteralExpr(floatingDigits: digits)
+      return ExprSyntax(FloatLiteralExpr(floatingDigits: digits))
     }
 
   }
@@ -311,18 +313,18 @@ extension Float16: ExpressibleByLiteralSyntax {}
 #endif
 
 extension Bool: ExpressibleByLiteralSyntax {
-  public func makeLiteralSyntax() -> ExprSyntaxProtocol {
+  public func makeLiteralSyntax() -> BooleanLiteralExpr {
     BooleanLiteralExpr(self)
   }
 }
 
 extension ArraySlice: ExpressibleByLiteralSyntax where Element: ExpressibleByLiteralSyntax {
-  public func makeLiteralSyntax() -> ExprSyntaxProtocol {
-    ArrayExpr(
+  public func makeLiteralSyntax() -> ArrayExprSyntax {
+    ArrayExprSyntax(
       leftSquare: .leftSquareBracket,
       elements: ArrayElementList {
         for elem in self {
-          ArrayElement(expression: elem.makeLiteralSyntax())
+          ArrayElementSyntax(expression: elem.makeLiteralSyntax())
         }
       },
       rightSquare: .rightSquareBracket
@@ -331,13 +333,13 @@ extension ArraySlice: ExpressibleByLiteralSyntax where Element: ExpressibleByLit
 }
 
 extension Array: ExpressibleByLiteralSyntax where Element: ExpressibleByLiteralSyntax {
-  public func makeLiteralSyntax() -> ExprSyntaxProtocol {
+  public func makeLiteralSyntax() -> ArrayExprSyntax {
     self[...].makeLiteralSyntax()
   }
 }
 
 extension Set: ExpressibleByLiteralSyntax where Element: ExpressibleByLiteralSyntax {
-  public func makeLiteralSyntax() -> ExprSyntaxProtocol {
+  public func makeLiteralSyntax() -> ArrayExprSyntax {
     // Sets are unordered. Sort the elements by their source-code representation to emit them in a stable order.
     let elemSyntaxes = map {
       $0.makeLiteralSyntax()
@@ -345,11 +347,11 @@ extension Set: ExpressibleByLiteralSyntax where Element: ExpressibleByLiteralSyn
       $0.syntaxTextBytes.lexicographicallyPrecedes($1.syntaxTextBytes)
     }
 
-    return ArrayExpr(
+    return ArrayExprSyntax(
       leftSquare: .leftSquareBracket,
       elements: ArrayElementList {
         for elemSyntax in elemSyntaxes {
-          ArrayElement(expression: elemSyntax)
+          ArrayElementSyntax(expression: elemSyntax)
         }
       },
       rightSquare: .rightSquareBracket
@@ -358,10 +360,10 @@ extension Set: ExpressibleByLiteralSyntax where Element: ExpressibleByLiteralSyn
 }
 
 extension KeyValuePairs: ExpressibleByLiteralSyntax where Key: ExpressibleByLiteralSyntax, Value: ExpressibleByLiteralSyntax {
-  public func makeLiteralSyntax() -> ExprSyntaxProtocol {
-    DictionaryExpr(leftSquare: .leftSquareBracket, rightSquare: .rightSquareBracket) {
+  public func makeLiteralSyntax() -> DictionaryExprSyntax {
+    DictionaryExprSyntax(leftSquare: .leftSquareBracket, rightSquare: .rightSquareBracket) {
       for elem in self {
-        DictionaryElement(
+        DictionaryElementSyntax(
           keyExpression: elem.key.makeLiteralSyntax(),
           colon: .colon,
           valueExpression: elem.value.makeLiteralSyntax()
@@ -372,7 +374,7 @@ extension KeyValuePairs: ExpressibleByLiteralSyntax where Key: ExpressibleByLite
 }
 
 extension Dictionary: ExpressibleByLiteralSyntax where Key: ExpressibleByLiteralSyntax, Value: ExpressibleByLiteralSyntax {
-  public func makeLiteralSyntax() -> ExprSyntaxProtocol {
+  public func makeLiteralSyntax() -> DictionaryExprSyntax {
     // Dictionaries are unordered. Sort the elements by their keys' source-code representation to emit them in a stable order.
     let elemSyntaxes = map {
       (key: $0.key.makeLiteralSyntax(), value: $0.value.makeLiteralSyntax())
@@ -380,9 +382,9 @@ extension Dictionary: ExpressibleByLiteralSyntax where Key: ExpressibleByLiteral
       $0.key.syntaxTextBytes.lexicographicallyPrecedes($1.key.syntaxTextBytes)
     }
 
-    return DictionaryExpr(leftSquare: .leftSquareBracket, rightSquare: .rightSquareBracket) {
+    return DictionaryExprSyntax(leftSquare: .leftSquareBracket, rightSquare: .rightSquareBracket) {
       for elemSyntax in elemSyntaxes {
-        DictionaryElement(
+        DictionaryElementSyntax(
           keyExpression: elemSyntax.key,
           colon: .colon,
           valueExpression: elemSyntax.value
@@ -393,7 +395,7 @@ extension Dictionary: ExpressibleByLiteralSyntax where Key: ExpressibleByLiteral
 }
 
 extension Optional: ExpressibleByLiteralSyntax where Wrapped: ExpressibleByLiteralSyntax {
-  public func makeLiteralSyntax() -> ExprSyntaxProtocol {
+  public func makeLiteralSyntax() -> ExprSyntax {
     func containsNil(_ expr: ExprSyntaxProtocol) -> Bool {
       if expr.is(NilLiteralExpr.self) {
         return true
@@ -411,7 +413,7 @@ extension Optional: ExpressibleByLiteralSyntax where Wrapped: ExpressibleByLiter
 
     switch self {
     case nil:
-      return NilLiteralExpr()
+      return ExprSyntax(NilLiteralExpr())
 
     case let wrapped?:
       let wrappedExpr = wrapped.makeLiteralSyntax()
@@ -420,12 +422,12 @@ extension Optional: ExpressibleByLiteralSyntax where Wrapped: ExpressibleByLiter
       // e.g. `.some(nil)`, add a layer of `.some(_:)` around it to preserve the
       // depth of the data structure.
       if containsNil(wrappedExpr) {
-        return FunctionCallExpr(callee: MemberAccessExpr(name: "some")) {
+        return ExprSyntax(FunctionCallExpr(callee: MemberAccessExpr(name: "some")) {
           TupleExprElement(expression: wrappedExpr)
-        }
+        })
       }
 
-      return wrappedExpr
+      return ExprSyntax(wrappedExpr)
     }
   }
 }

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -16,186 +16,59 @@
 import SwiftSyntax
 
 extension AccessLevelModifier {
-  /// Creates a `AccessLevelModifier` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeName: 
-  ///   - name: 
-  ///   - unexpectedBetweenNameAndModifier: 
-  ///   - modifier: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndModifier: UnexpectedNodes? = nil, modifier: DeclModifierDetail? = nil) {
-    self = AccessLevelModifierSyntax(unexpectedBeforeName, name: name, unexpectedBetweenNameAndModifier, modifier: modifier)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndModifier: UnexpectedNodes? = nil, modifier: DeclModifierDetail? = nil) {
-    self.init (unexpectedBeforeName, name: Token.`identifier`(name), unexpectedBetweenNameAndModifier, modifier: modifier)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeName: UnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndModifier: UnexpectedNodes? = nil, modifier: DeclModifierDetail? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeName, name: Token.`identifier`(name), unexpectedBetweenNameAndModifier, modifier: modifier, trailingTrivia: trailingTrivia)
   }
 }
 
 extension AccessPathComponent {
-  /// Creates a `AccessPathComponent` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeName: 
-  ///   - name: 
-  ///   - unexpectedBetweenNameAndTrailingDot: 
-  ///   - trailingDot: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndTrailingDot: UnexpectedNodes? = nil, trailingDot: Token? = nil) {
-    assert(trailingDot == nil || trailingDot!.text == ".")
-    self = AccessPathComponentSyntax(unexpectedBeforeName, name: name, unexpectedBetweenNameAndTrailingDot, trailingDot: trailingDot)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndTrailingDot: UnexpectedNodes? = nil, trailingDot: Token? = nil) {
-    self.init (unexpectedBeforeName, name: Token.`identifier`(name), unexpectedBetweenNameAndTrailingDot, trailingDot: trailingDot)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension AccessorBlock {
-  /// Creates a `AccessorBlock` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftBrace: 
-  ///   - leftBrace: 
-  ///   - unexpectedBetweenLeftBraceAndAccessors: 
-  ///   - accessors: 
-  ///   - unexpectedBetweenAccessorsAndRightBrace: 
-  ///   - rightBrace: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndAccessors: UnexpectedNodes? = nil, accessors: AccessorList, unexpectedBetweenAccessorsAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
-    assert(leftBrace.text == "{")
-    assert(rightBrace.text == "}")
-    self = AccessorBlockSyntax(unexpectedBeforeLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndAccessors, accessors: accessors, unexpectedBetweenAccessorsAndRightBrace, rightBrace: rightBrace)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeName: UnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndTrailingDot: UnexpectedNodes? = nil, trailingDot: Token? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeName, name: Token.`identifier`(name), unexpectedBetweenNameAndTrailingDot, trailingDot: trailingDot, trailingTrivia: trailingTrivia)
   }
 }
 
 extension AccessorDecl {
-  /// Creates a `AccessorDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifier: 
-  ///   - modifier: 
-  ///   - unexpectedBetweenModifierAndAccessorKind: 
-  ///   - accessorKind: 
-  ///   - unexpectedBetweenAccessorKindAndParameter: 
-  ///   - parameter: 
-  ///   - unexpectedBetweenParameterAndAsyncKeyword: 
-  ///   - asyncKeyword: 
-  ///   - unexpectedBetweenAsyncKeywordAndThrowsKeyword: 
-  ///   - throwsKeyword: 
-  ///   - unexpectedBetweenThrowsKeywordAndBody: 
-  ///   - body: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifier: UnexpectedNodes? = nil, modifier: DeclModifier? = nil, unexpectedBetweenModifierAndAccessorKind: UnexpectedNodes? = nil, accessorKind: Token, unexpectedBetweenAccessorKindAndParameter: UnexpectedNodes? = nil, parameter: AccessorParameter? = nil, unexpectedBetweenParameterAndAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: Token? = nil, unexpectedBetweenAsyncKeywordAndThrowsKeyword: UnexpectedNodes? = nil, throwsKeyword: Token? = nil, unexpectedBetweenThrowsKeywordAndBody: UnexpectedNodes? = nil, body: CodeBlock? = nil) {
-    assert(accessorKind.text == "get" || accessorKind.text == "set" || accessorKind.text == "didSet" || accessorKind.text == "willSet" || accessorKind.text == "unsafeAddress" || accessorKind.text == "addressWithOwner" || accessorKind.text == "addressWithNativeOwner" || accessorKind.text == "unsafeMutableAddress" || accessorKind.text == "mutableAddressWithOwner" || accessorKind.text == "mutableAddressWithNativeOwner" || accessorKind.text == "_read" || accessorKind.text == "_modify")
-    assert(asyncKeyword == nil || asyncKeyword!.text == "async")
-    assert(throwsKeyword == nil || throwsKeyword!.text == "throws" || throwsKeyword!.text == "rethrows")
-    self = AccessorDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifier, modifier: modifier, unexpectedBetweenModifierAndAccessorKind, accessorKind: accessorKind, unexpectedBetweenAccessorKindAndParameter, parameter: parameter, unexpectedBetweenParameterAndAsyncKeyword, asyncKeyword: asyncKeyword, unexpectedBetweenAsyncKeywordAndThrowsKeyword, throwsKeyword: throwsKeyword, unexpectedBetweenThrowsKeywordAndBody, body: body)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifier: UnexpectedNodes? = nil, modifier: DeclModifier? = nil, unexpectedBetweenModifierAndAccessorKind: UnexpectedNodes? = nil, accessorKind: Token, unexpectedBetweenAccessorKindAndParameter: UnexpectedNodes? = nil, parameter: AccessorParameter? = nil, unexpectedBetweenParameterAndAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: String?, unexpectedBetweenAsyncKeywordAndThrowsKeyword: UnexpectedNodes? = nil, throwsKeyword: Token? = nil, unexpectedBetweenThrowsKeywordAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax? = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifier: UnexpectedNodes? = nil, modifier: DeclModifier? = nil, unexpectedBetweenModifierAndAccessorKind: UnexpectedNodes? = nil, accessorKind: Token, unexpectedBetweenAccessorKindAndParameter: UnexpectedNodes? = nil, parameter: AccessorParameter? = nil, unexpectedBetweenParameterAndAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: String?, unexpectedBetweenAsyncKeywordAndThrowsKeyword: UnexpectedNodes? = nil, throwsKeyword: Token? = nil, unexpectedBetweenThrowsKeywordAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax? = {
     nil
-  }) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifier, modifier: modifier, unexpectedBetweenModifierAndAccessorKind, accessorKind: accessorKind, unexpectedBetweenAccessorKindAndParameter, parameter: parameter, unexpectedBetweenParameterAndAsyncKeyword, asyncKeyword: asyncKeyword.map { 
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifier, modifier: modifier, unexpectedBetweenModifierAndAccessorKind, accessorKind: accessorKind, unexpectedBetweenAccessorKindAndParameter, parameter: parameter, unexpectedBetweenParameterAndAsyncKeyword, asyncKeyword: asyncKeyword.map { 
       Token.`contextualKeyword`($0) 
     }, unexpectedBetweenAsyncKeywordAndThrowsKeyword, throwsKeyword: throwsKeyword, unexpectedBetweenThrowsKeywordAndBody, body: bodyBuilder().map { 
       CodeBlockSyntax(statements: $0) 
-    })
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    }, trailingTrivia: trailingTrivia)
   }
 }
 
 extension AccessorParameter {
-  /// Creates a `AccessorParameter` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndName: 
-  ///   - name: 
-  ///   - unexpectedBetweenNameAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndName: UnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = AccessorParameterSyntax(unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndName, name: name, unexpectedBetweenNameAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndName: UnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    self.init (unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndName, name: Token.`identifier`(name), unexpectedBetweenNameAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndName: UnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndName, name: Token.`identifier`(name), unexpectedBetweenNameAndRightParen, rightParen: rightParen, trailingTrivia: trailingTrivia)
   }
 }
 
 extension ActorDecl {
-  /// Creates a `ActorDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: 
-  ///   - unexpectedBetweenModifiersAndActorKeyword: 
-  ///   - actorKeyword: 
-  ///   - unexpectedBetweenActorKeywordAndIdentifier: 
-  ///   - identifier: 
-  ///   - unexpectedBetweenIdentifierAndGenericParameterClause: 
-  ///   - genericParameterClause: 
-  ///   - unexpectedBetweenGenericParameterClauseAndInheritanceClause: 
-  ///   - inheritanceClause: 
-  ///   - unexpectedBetweenInheritanceClauseAndGenericWhereClause: 
-  ///   - genericWhereClause: 
-  ///   - unexpectedBetweenGenericWhereClauseAndMembers: 
-  ///   - members: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndActorKeyword: UnexpectedNodes? = nil, actorKeyword: Token, unexpectedBetweenActorKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, members: MemberDeclBlock) {
-    assert(actorKeyword.text == "actor")
-    self = ActorDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndActorKeyword, actorKeyword: actorKeyword, unexpectedBetweenActorKeywordAndIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: members)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndActorKeyword: UnexpectedNodes? = nil, actorKeyword: String, unexpectedBetweenActorKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndActorKeyword: UnexpectedNodes? = nil, actorKeyword: String, unexpectedBetweenActorKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
     MemberDeclListSyntax([])
-  }) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndActorKeyword, actorKeyword: Token.`contextualKeyword`(actorKeyword), unexpectedBetweenActorKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: MemberDeclBlockSyntax(members: membersBuilder()))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndActorKeyword, actorKeyword: Token.`contextualKeyword`(actorKeyword), unexpectedBetweenActorKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: MemberDeclBlockSyntax(members: membersBuilder()), trailingTrivia: trailingTrivia)
   }
 }
 
 extension ArrayElement: HasTrailingComma {
-  /// Creates a `ArrayElement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeExpression: 
-  ///   - expression: 
-  ///   - unexpectedBetweenExpressionAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = ArrayElementSyntax(unexpectedBeforeExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
@@ -207,453 +80,97 @@ extension ArrayElement: HasTrailingComma {
 }
 
 extension ArrayExpr {
-  /// Creates a `ArrayExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftSquare: 
-  ///   - leftSquare: 
-  ///   - unexpectedBetweenLeftSquareAndElements: 
-  ///   - elements: 
-  ///   - unexpectedBetweenElementsAndRightSquare: 
-  ///   - rightSquare: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftSquare: UnexpectedNodes? = nil, leftSquare: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareAndElements: UnexpectedNodes? = nil, elements: ArrayElementList, unexpectedBetweenElementsAndRightSquare: UnexpectedNodes? = nil, rightSquare: Token = Token.`rightSquareBracket`) {
-    assert(leftSquare.text == "[")
-    assert(rightSquare.text == "]")
-    self = ArrayExprSyntax(unexpectedBeforeLeftSquare, leftSquare: leftSquare, unexpectedBetweenLeftSquareAndElements, elements: elements, unexpectedBetweenElementsAndRightSquare, rightSquare: rightSquare)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftSquare: UnexpectedNodes? = nil, leftSquare: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareAndElements: UnexpectedNodes? = nil, unexpectedBetweenElementsAndRightSquare: UnexpectedNodes? = nil, rightSquare: Token = Token.`rightSquareBracket`, @ArrayElementListBuilder elementsBuilder: () -> ArrayElementListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLeftSquare: UnexpectedNodes? = nil, leftSquare: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareAndElements: UnexpectedNodes? = nil, unexpectedBetweenElementsAndRightSquare: UnexpectedNodes? = nil, rightSquare: Token = Token.`rightSquareBracket`, @ArrayElementListBuilder elementsBuilder: () -> ArrayElementListSyntax = {
     ArrayElementListSyntax([])
-  }) {
-    self.init (unexpectedBeforeLeftSquare, leftSquare: leftSquare, unexpectedBetweenLeftSquareAndElements, elements: elementsBuilder(), unexpectedBetweenElementsAndRightSquare, rightSquare: rightSquare)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension ArrayType {
-  /// Creates a `ArrayType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftSquareBracket: 
-  ///   - leftSquareBracket: 
-  ///   - unexpectedBetweenLeftSquareBracketAndElementType: 
-  ///   - elementType: 
-  ///   - unexpectedBetweenElementTypeAndRightSquareBracket: 
-  ///   - rightSquareBracket: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftSquareBracket: UnexpectedNodes? = nil, leftSquareBracket: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareBracketAndElementType: UnexpectedNodes? = nil, elementType: TypeSyntaxProtocol, unexpectedBetweenElementTypeAndRightSquareBracket: UnexpectedNodes? = nil, rightSquareBracket: Token = Token.`rightSquareBracket`) {
-    assert(leftSquareBracket.text == "[")
-    assert(rightSquareBracket.text == "]")
-    self = ArrayTypeSyntax(unexpectedBeforeLeftSquareBracket, leftSquareBracket: leftSquareBracket, unexpectedBetweenLeftSquareBracketAndElementType, elementType: TypeSyntax(fromProtocol: elementType), unexpectedBetweenElementTypeAndRightSquareBracket, rightSquareBracket: rightSquareBracket)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLeftSquare, leftSquare: leftSquare, unexpectedBetweenLeftSquareAndElements, elements: elementsBuilder(), unexpectedBetweenElementsAndRightSquare, rightSquare: rightSquare, trailingTrivia: trailingTrivia)
   }
 }
 
 extension ArrowExpr {
-  /// Creates a `ArrowExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAsyncKeyword: 
-  ///   - asyncKeyword: 
-  ///   - unexpectedBetweenAsyncKeywordAndThrowsToken: 
-  ///   - throwsToken: 
-  ///   - unexpectedBetweenThrowsTokenAndArrowToken: 
-  ///   - arrowToken: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: Token? = nil, unexpectedBetweenAsyncKeywordAndThrowsToken: UnexpectedNodes? = nil, throwsToken: Token? = nil, unexpectedBetweenThrowsTokenAndArrowToken: UnexpectedNodes? = nil, arrowToken: Token = Token.`arrow`) {
-    assert(asyncKeyword == nil || asyncKeyword!.text == "async")
-    assert(throwsToken == nil || throwsToken!.text == "throws")
-    assert(arrowToken.text == "->")
-    self = ArrowExprSyntax(unexpectedBeforeAsyncKeyword, asyncKeyword: asyncKeyword, unexpectedBetweenAsyncKeywordAndThrowsToken, throwsToken: throwsToken, unexpectedBetweenThrowsTokenAndArrowToken, arrowToken: arrowToken)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: String?, unexpectedBetweenAsyncKeywordAndThrowsToken: UnexpectedNodes? = nil, throwsToken: Token? = nil, unexpectedBetweenThrowsTokenAndArrowToken: UnexpectedNodes? = nil, arrowToken: Token = Token.`arrow`) {
-    self.init (unexpectedBeforeAsyncKeyword, asyncKeyword: asyncKeyword.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: String?, unexpectedBetweenAsyncKeywordAndThrowsToken: UnexpectedNodes? = nil, throwsToken: Token? = nil, unexpectedBetweenThrowsTokenAndArrowToken: UnexpectedNodes? = nil, arrowToken: Token = Token.`arrow`, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAsyncKeyword, asyncKeyword: asyncKeyword.map { 
       Token.`contextualKeyword`($0) 
-    }, unexpectedBetweenAsyncKeywordAndThrowsToken, throwsToken: throwsToken, unexpectedBetweenThrowsTokenAndArrowToken, arrowToken: arrowToken)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension AsExpr {
-  /// Creates a `AsExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeExpression: 
-  ///   - expression: 
-  ///   - unexpectedBetweenExpressionAndAsTok: 
-  ///   - asTok: 
-  ///   - unexpectedBetweenAsTokAndQuestionOrExclamationMark: 
-  ///   - questionOrExclamationMark: 
-  ///   - unexpectedBetweenQuestionOrExclamationMarkAndTypeName: 
-  ///   - typeName: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndAsTok: UnexpectedNodes? = nil, asTok: Token = Token.`as`, unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodes? = nil, questionOrExclamationMark: Token? = nil, unexpectedBetweenQuestionOrExclamationMarkAndTypeName: UnexpectedNodes? = nil, typeName: TypeSyntaxProtocol) {
-    assert(asTok.text == "as")
-    assert(questionOrExclamationMark == nil || questionOrExclamationMark!.text == "?" || questionOrExclamationMark!.text == "!")
-    self = AsExprSyntax(unexpectedBeforeExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndAsTok, asTok: asTok, unexpectedBetweenAsTokAndQuestionOrExclamationMark, questionOrExclamationMark: questionOrExclamationMark, unexpectedBetweenQuestionOrExclamationMarkAndTypeName, typeName: TypeSyntax(fromProtocol: typeName))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension AsTypePattern {
-  /// Creates a `AsTypePattern` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePattern: 
-  ///   - pattern: 
-  ///   - unexpectedBetweenPatternAndAsKeyword: 
-  ///   - asKeyword: 
-  ///   - unexpectedBetweenAsKeywordAndType: 
-  ///   - type: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePattern: UnexpectedNodes? = nil, pattern: PatternSyntaxProtocol, unexpectedBetweenPatternAndAsKeyword: UnexpectedNodes? = nil, asKeyword: Token = Token.`as`, unexpectedBetweenAsKeywordAndType: UnexpectedNodes? = nil, type: TypeSyntaxProtocol) {
-    assert(asKeyword.text == "as")
-    self = AsTypePatternSyntax(unexpectedBeforePattern, pattern: PatternSyntax(fromProtocol: pattern), unexpectedBetweenPatternAndAsKeyword, asKeyword: asKeyword, unexpectedBetweenAsKeywordAndType, type: TypeSyntax(fromProtocol: type))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension AssignmentExpr {
-  /// Creates a `AssignmentExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAssignToken: 
-  ///   - assignToken: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAssignToken: UnexpectedNodes? = nil, assignToken: Token = Token.`equal`) {
-    assert(assignToken.text == "=")
-    self = AssignmentExprSyntax(unexpectedBeforeAssignToken, assignToken: assignToken)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+    }, unexpectedBetweenAsyncKeywordAndThrowsToken, throwsToken: throwsToken, unexpectedBetweenThrowsTokenAndArrowToken, arrowToken: arrowToken, trailingTrivia: trailingTrivia)
   }
 }
 
 extension AssociatedtypeDecl {
-  /// Creates a `AssociatedtypeDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: 
-  ///   - unexpectedBetweenModifiersAndAssociatedtypeKeyword: 
-  ///   - associatedtypeKeyword: 
-  ///   - unexpectedBetweenAssociatedtypeKeywordAndIdentifier: 
-  ///   - identifier: 
-  ///   - unexpectedBetweenIdentifierAndInheritanceClause: 
-  ///   - inheritanceClause: 
-  ///   - unexpectedBetweenInheritanceClauseAndInitializer: 
-  ///   - initializer: 
-  ///   - unexpectedBetweenInitializerAndGenericWhereClause: 
-  ///   - genericWhereClause: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndAssociatedtypeKeyword: UnexpectedNodes? = nil, associatedtypeKeyword: Token = Token.`associatedtype`, unexpectedBetweenAssociatedtypeKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndInitializer: UnexpectedNodes? = nil, initializer: TypeInitializerClause? = nil, unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil) {
-    assert(associatedtypeKeyword.text == "associatedtype")
-    self = AssociatedtypeDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndAssociatedtypeKeyword, associatedtypeKeyword: associatedtypeKeyword, unexpectedBetweenAssociatedtypeKeywordAndIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndInitializer, initializer: initializer, unexpectedBetweenInitializerAndGenericWhereClause, genericWhereClause: genericWhereClause)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndAssociatedtypeKeyword: UnexpectedNodes? = nil, associatedtypeKeyword: Token = Token.`associatedtype`, unexpectedBetweenAssociatedtypeKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndInitializer: UnexpectedNodes? = nil, initializer: TypeInitializerClause? = nil, unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndAssociatedtypeKeyword, associatedtypeKeyword: associatedtypeKeyword, unexpectedBetweenAssociatedtypeKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndInitializer, initializer: initializer, unexpectedBetweenInitializerAndGenericWhereClause, genericWhereClause: genericWhereClause)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-/// An `@` attribute.
-extension Attribute {
-  /// Creates a `Attribute` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAtSignToken: 
-  ///   - atSignToken: The `@` sign.
-  ///   - unexpectedBetweenAtSignTokenAndAttributeName: 
-  ///   - attributeName: The name of the attribute.
-  ///   - unexpectedBetweenAttributeNameAndLeftParen: 
-  ///   - leftParen: If the attribute takes arguments, the opening parenthesis.
-  ///   - unexpectedBetweenLeftParenAndArgument: 
-  ///   - argument: The arguments of the attribute. In case the attributetakes multiple arguments, they are gather in theappropriate takes first.
-  ///   - unexpectedBetweenArgumentAndRightParen: 
-  ///   - rightParen: If the attribute takes arguments, the closing parenthesis.
-  ///   - unexpectedBetweenRightParenAndTokenList: 
-  ///   - tokenList: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAtSignToken: UnexpectedNodes? = nil, atSignToken: Token = Token.`atSign`, unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodes? = nil, attributeName: Token, unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgument: UnexpectedNodes? = nil, argument: Argument? = nil, unexpectedBetweenArgumentAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTokenList: UnexpectedNodes? = nil, tokenList: TokenList? = nil) {
-    assert(atSignToken.text == "@")
-    assert(leftParen == nil || leftParen!.text == "(")
-    assert(rightParen == nil || rightParen!.text == ")")
-    self = AttributeSyntax(unexpectedBeforeAtSignToken, atSignToken: atSignToken, unexpectedBetweenAtSignTokenAndAttributeName, attributeName: attributeName, unexpectedBetweenAttributeNameAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgument, argument: argument, unexpectedBetweenArgumentAndRightParen, rightParen: rightParen, unexpectedBetweenRightParenAndTokenList, tokenList: tokenList)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension AttributedType {
-  /// Creates a `AttributedType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeSpecifier: 
-  ///   - specifier: 
-  ///   - unexpectedBetweenSpecifierAndAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndBaseType: 
-  ///   - baseType: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeSpecifier: UnexpectedNodes? = nil, specifier: Token? = nil, unexpectedBetweenSpecifierAndAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndBaseType: UnexpectedNodes? = nil, baseType: TypeSyntaxProtocol) {
-    assert(specifier == nil || specifier!.text == "inout" || specifier!.text == "__shared" || specifier!.text == "__owned")
-    self = AttributedTypeSyntax(unexpectedBeforeSpecifier, specifier: specifier, unexpectedBetweenSpecifierAndAttributes, attributes: attributes, unexpectedBetweenAttributesAndBaseType, baseType: TypeSyntax(fromProtocol: baseType))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-/// A single argument to an `@available` argument like `*`, `iOS 10.1`,or `message: "This has been deprecated"`.
-extension AvailabilityArgument {
-  /// Creates a `AvailabilityArgument` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeEntry: 
-  ///   - entry: The actual argument
-  ///   - unexpectedBetweenEntryAndTrailingComma: 
-  ///   - trailingComma: A trailing comma if the argument is followed by anotherargument
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeEntry: UnexpectedNodes? = nil, entry: Entry, unexpectedBetweenEntryAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = AvailabilityArgumentSyntax(unexpectedBeforeEntry, entry: entry, unexpectedBetweenEntryAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension AvailabilityCondition {
-  /// Creates a `AvailabilityCondition` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePoundAvailableKeyword: 
-  ///   - poundAvailableKeyword: 
-  ///   - unexpectedBetweenPoundAvailableKeywordAndLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndAvailabilitySpec: 
-  ///   - availabilitySpec: 
-  ///   - unexpectedBetweenAvailabilitySpecAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundAvailableKeyword: UnexpectedNodes? = nil, poundAvailableKeyword: Token = Token.`poundAvailable`, unexpectedBetweenPoundAvailableKeywordAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodes? = nil, availabilitySpec: AvailabilitySpecList, unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(poundAvailableKeyword.text == "#available")
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = AvailabilityConditionSyntax(unexpectedBeforePoundAvailableKeyword, poundAvailableKeyword: poundAvailableKeyword, unexpectedBetweenPoundAvailableKeywordAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndAvailabilitySpec, availabilitySpec: availabilitySpec, unexpectedBetweenAvailabilitySpecAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndAssociatedtypeKeyword: UnexpectedNodes? = nil, associatedtypeKeyword: Token = Token.`associatedtype`, unexpectedBetweenAssociatedtypeKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndInitializer: UnexpectedNodes? = nil, initializer: TypeInitializerClause? = nil, unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndAssociatedtypeKeyword, associatedtypeKeyword: associatedtypeKeyword, unexpectedBetweenAssociatedtypeKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndInitializer, initializer: initializer, unexpectedBetweenInitializerAndGenericWhereClause, genericWhereClause: genericWhereClause, trailingTrivia: trailingTrivia)
   }
 }
 
 /// The availability argument for the _specialize attribute
 extension AvailabilityEntry {
-  /// Creates a `AvailabilityEntry` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLabel: 
-  ///   - label: The label of the argument
-  ///   - unexpectedBetweenLabelAndColon: 
-  ///   - colon: The colon separating the label and the value
-  ///   - unexpectedBetweenColonAndAvailabilityList: 
-  ///   - availabilityList: 
-  ///   - unexpectedBetweenAvailabilityListAndSemicolon: 
-  ///   - semicolon: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabel: UnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndAvailabilityList: UnexpectedNodes? = nil, availabilityList: AvailabilitySpecList, unexpectedBetweenAvailabilityListAndSemicolon: UnexpectedNodes? = nil, semicolon: Token = Token.`semicolon`) {
-    assert(colon.text == ":")
-    assert(semicolon.text == ";")
-    self = AvailabilityEntrySyntax(unexpectedBeforeLabel, label: label, unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndAvailabilityList, availabilityList: availabilityList, unexpectedBetweenAvailabilityListAndSemicolon, semicolon: semicolon)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: UnexpectedNodes? = nil, label: String, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndAvailabilityList: UnexpectedNodes? = nil, availabilityList: AvailabilitySpecList, unexpectedBetweenAvailabilityListAndSemicolon: UnexpectedNodes? = nil, semicolon: Token = Token.`semicolon`) {
-    self.init (unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndAvailabilityList, availabilityList: availabilityList, unexpectedBetweenAvailabilityListAndSemicolon, semicolon: semicolon)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLabel: UnexpectedNodes? = nil, label: String, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndAvailabilityList: UnexpectedNodes? = nil, availabilityList: AvailabilitySpecList, unexpectedBetweenAvailabilityListAndSemicolon: UnexpectedNodes? = nil, semicolon: Token = Token.`semicolon`, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndAvailabilityList, availabilityList: availabilityList, unexpectedBetweenAvailabilityListAndSemicolon, semicolon: semicolon, trailingTrivia: trailingTrivia)
   }
 }
 
 /// A argument to an `@available` attribute that consists of a label anda value, e.g. `message: "This has been deprecated"`.
 extension AvailabilityLabeledArgument {
-  /// Creates a `AvailabilityLabeledArgument` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLabel: 
-  ///   - label: The label of the argument
-  ///   - unexpectedBetweenLabelAndColon: 
-  ///   - colon: The colon separating label and value
-  ///   - unexpectedBetweenColonAndValue: 
-  ///   - value: The value of this labeled argument
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabel: UnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: UnexpectedNodes? = nil, value: Value) {
-    assert(colon.text == ":")
-    self = AvailabilityLabeledArgumentSyntax(unexpectedBeforeLabel, label: label, unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndValue, value: value)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: UnexpectedNodes? = nil, label: String, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: UnexpectedNodes? = nil, value: Value) {
-    self.init (unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndValue, value: value)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLabel: UnexpectedNodes? = nil, label: String, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: UnexpectedNodes? = nil, value: Value, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndValue, value: value, trailingTrivia: trailingTrivia)
   }
 }
 
 /// An argument to `@available` that restricts the availability on acertain platform to a version, e.g. `iOS 10` or `swift 3.4`.
 extension AvailabilityVersionRestriction {
-  /// Creates a `AvailabilityVersionRestriction` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePlatform: 
-  ///   - platform: The name of the OS on which the availability should berestricted or 'swift' if the availability should berestricted based on a Swift version.
-  ///   - unexpectedBetweenPlatformAndVersion: 
-  ///   - version: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePlatform: UnexpectedNodes? = nil, platform: Token, unexpectedBetweenPlatformAndVersion: UnexpectedNodes? = nil, version: VersionTuple? = nil) {
-    self = AvailabilityVersionRestrictionSyntax(unexpectedBeforePlatform, platform: platform, unexpectedBetweenPlatformAndVersion, version: version)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforePlatform: UnexpectedNodes? = nil, platform: String, unexpectedBetweenPlatformAndVersion: UnexpectedNodes? = nil, version: VersionTuple? = nil) {
-    self.init (unexpectedBeforePlatform, platform: Token.`identifier`(platform), unexpectedBetweenPlatformAndVersion, version: version)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforePlatform: UnexpectedNodes? = nil, platform: String, unexpectedBetweenPlatformAndVersion: UnexpectedNodes? = nil, version: VersionTuple? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforePlatform, platform: Token.`identifier`(platform), unexpectedBetweenPlatformAndVersion, version: version, trailingTrivia: trailingTrivia)
   }
 }
 
 extension AwaitExpr {
-  /// Creates a `AwaitExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAwaitKeyword: 
-  ///   - awaitKeyword: 
-  ///   - unexpectedBetweenAwaitKeywordAndExpression: 
-  ///   - expression: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAwaitKeyword: UnexpectedNodes? = nil, awaitKeyword: Token, unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol) {
-    assert(awaitKeyword.text == "await")
-    self = AwaitExprSyntax(unexpectedBeforeAwaitKeyword, awaitKeyword: awaitKeyword, unexpectedBetweenAwaitKeywordAndExpression, expression: ExprSyntax(fromProtocol: expression))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAwaitKeyword: UnexpectedNodes? = nil, awaitKeyword: String, unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol) {
-    self.init (unexpectedBeforeAwaitKeyword, awaitKeyword: Token.`contextualKeyword`(awaitKeyword), unexpectedBetweenAwaitKeywordAndExpression, expression: ExprSyntax(fromProtocol: expression))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAwaitKeyword: UnexpectedNodes? = nil, awaitKeyword: String, unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAwaitKeyword, awaitKeyword: Token.`contextualKeyword`(awaitKeyword), unexpectedBetweenAwaitKeywordAndExpression, expression: ExprSyntax(fromProtocol: expression), trailingTrivia: trailingTrivia)
   }
 }
 
 /// A collection of arguments for the `@_backDeploy` attribute
 extension BackDeployAttributeSpecList {
-  /// Creates a `BackDeployAttributeSpecList` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeBeforeLabel: 
-  ///   - beforeLabel: The "before" label.
-  ///   - unexpectedBetweenBeforeLabelAndColon: 
-  ///   - colon: The colon separating "before" and the parameter list.
-  ///   - unexpectedBetweenColonAndVersionList: 
-  ///   - versionList: The list of OS versions in which the declaration became ABIstable.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBeforeLabel: UnexpectedNodes? = nil, beforeLabel: Token, unexpectedBetweenBeforeLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndVersionList: UnexpectedNodes? = nil, versionList: BackDeployVersionList) {
-    assert(beforeLabel.text == "before")
-    assert(colon.text == ":")
-    self = BackDeployAttributeSpecListSyntax(unexpectedBeforeBeforeLabel, beforeLabel: beforeLabel, unexpectedBetweenBeforeLabelAndColon, colon: colon, unexpectedBetweenColonAndVersionList, versionList: versionList)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeBeforeLabel: UnexpectedNodes? = nil, beforeLabel: String, unexpectedBetweenBeforeLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndVersionList: UnexpectedNodes? = nil, versionList: BackDeployVersionList) {
-    self.init (unexpectedBeforeBeforeLabel, beforeLabel: Token.`identifier`(beforeLabel), unexpectedBetweenBeforeLabelAndColon, colon: colon, unexpectedBetweenColonAndVersionList, versionList: versionList)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-/// A single platform/version pair in a `@_backDeploy` attribute,e.g. `iOS 10.1`.
-extension BackDeployVersionArgument {
-  /// Creates a `BackDeployVersionArgument` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAvailabilityVersionRestriction: 
-  ///   - availabilityVersionRestriction: 
-  ///   - unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma: 
-  ///   - trailingComma: A trailing comma if the argument is followed by anotherargument
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAvailabilityVersionRestriction: UnexpectedNodes? = nil, availabilityVersionRestriction: AvailabilityVersionRestriction, unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = BackDeployVersionArgumentSyntax(unexpectedBeforeAvailabilityVersionRestriction, availabilityVersionRestriction: availabilityVersionRestriction, unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension BinaryOperatorExpr {
-  /// Creates a `BinaryOperatorExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeOperatorToken: 
-  ///   - operatorToken: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeOperatorToken: UnexpectedNodes? = nil, operatorToken: Token) {
-    self = BinaryOperatorExprSyntax(unexpectedBeforeOperatorToken, operatorToken: operatorToken)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension BooleanLiteralExpr {
-  /// Creates a `BooleanLiteralExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeBooleanLiteral: 
-  ///   - booleanLiteral: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBooleanLiteral: UnexpectedNodes? = nil, booleanLiteral: Token) {
-    assert(booleanLiteral.text == "true" || booleanLiteral.text == "false")
-    self = BooleanLiteralExprSyntax(unexpectedBeforeBooleanLiteral, booleanLiteral: booleanLiteral)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeBeforeLabel: UnexpectedNodes? = nil, beforeLabel: String, unexpectedBetweenBeforeLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndVersionList: UnexpectedNodes? = nil, versionList: BackDeployVersionList, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeBeforeLabel, beforeLabel: Token.`identifier`(beforeLabel), unexpectedBetweenBeforeLabelAndColon, colon: colon, unexpectedBetweenColonAndVersionList, versionList: versionList, trailingTrivia: trailingTrivia)
   }
 }
 
 extension BreakStmt {
-  /// Creates a `BreakStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeBreakKeyword: 
-  ///   - breakKeyword: 
-  ///   - unexpectedBetweenBreakKeywordAndLabel: 
-  ///   - label: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBreakKeyword: UnexpectedNodes? = nil, breakKeyword: Token = Token.`break`, unexpectedBetweenBreakKeywordAndLabel: UnexpectedNodes? = nil, label: Token? = nil) {
-    assert(breakKeyword.text == "break")
-    self = BreakStmtSyntax(unexpectedBeforeBreakKeyword, breakKeyword: breakKeyword, unexpectedBetweenBreakKeywordAndLabel, label: label)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeBreakKeyword: UnexpectedNodes? = nil, breakKeyword: Token = Token.`break`, unexpectedBetweenBreakKeywordAndLabel: UnexpectedNodes? = nil, label: String?) {
-    self.init (unexpectedBeforeBreakKeyword, breakKeyword: breakKeyword, unexpectedBetweenBreakKeywordAndLabel, label: label.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeBreakKeyword: UnexpectedNodes? = nil, breakKeyword: Token = Token.`break`, unexpectedBetweenBreakKeywordAndLabel: UnexpectedNodes? = nil, label: String?, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeBreakKeyword, breakKeyword: breakKeyword, unexpectedBetweenBreakKeywordAndLabel, label: label.map { 
       Token.`identifier`($0) 
-    })
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    }, trailingTrivia: trailingTrivia)
   }
 }
 
 extension CaseItem: HasTrailingComma {
-  /// Creates a `CaseItem` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePattern: 
-  ///   - pattern: 
-  ///   - unexpectedBetweenPatternAndWhereClause: 
-  ///   - whereClause: 
-  ///   - unexpectedBetweenWhereClauseAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePattern: UnexpectedNodes? = nil, pattern: PatternSyntaxProtocol, unexpectedBetweenPatternAndWhereClause: UnexpectedNodes? = nil, whereClause: WhereClause? = nil, unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = CaseItemSyntax(unexpectedBeforePattern, pattern: PatternSyntax(fromProtocol: pattern), unexpectedBetweenPatternAndWhereClause, whereClause: whereClause, unexpectedBetweenWhereClauseAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
@@ -665,48 +182,17 @@ extension CaseItem: HasTrailingComma {
 }
 
 extension CatchClause {
-  /// Creates a `CatchClause` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeCatchKeyword: 
-  ///   - catchKeyword: 
-  ///   - unexpectedBetweenCatchKeywordAndCatchItems: 
-  ///   - catchItems: 
-  ///   - unexpectedBetweenCatchItemsAndBody: 
-  ///   - body: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeCatchKeyword: UnexpectedNodes? = nil, catchKeyword: Token = Token.`catch`, unexpectedBetweenCatchKeywordAndCatchItems: UnexpectedNodes? = nil, catchItems: CatchItemList? = nil, unexpectedBetweenCatchItemsAndBody: UnexpectedNodes? = nil, body: CodeBlock) {
-    assert(catchKeyword.text == "catch")
-    self = CatchClauseSyntax(unexpectedBeforeCatchKeyword, catchKeyword: catchKeyword, unexpectedBetweenCatchKeywordAndCatchItems, catchItems: catchItems, unexpectedBetweenCatchItemsAndBody, body: body)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeCatchKeyword: UnexpectedNodes? = nil, catchKeyword: Token = Token.`catch`, unexpectedBetweenCatchKeywordAndCatchItems: UnexpectedNodes? = nil, catchItems: CatchItemList? = nil, unexpectedBetweenCatchItemsAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeCatchKeyword: UnexpectedNodes? = nil, catchKeyword: Token = Token.`catch`, unexpectedBetweenCatchKeywordAndCatchItems: UnexpectedNodes? = nil, catchItems: CatchItemList? = nil, unexpectedBetweenCatchItemsAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
     CodeBlockItemListSyntax([])
-  }) {
-    self.init (unexpectedBeforeCatchKeyword, catchKeyword: catchKeyword, unexpectedBetweenCatchKeywordAndCatchItems, catchItems: catchItems, unexpectedBetweenCatchItemsAndBody, body: CodeBlockSyntax(statements: bodyBuilder()))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeCatchKeyword, catchKeyword: catchKeyword, unexpectedBetweenCatchKeywordAndCatchItems, catchItems: catchItems, unexpectedBetweenCatchItemsAndBody, body: CodeBlockSyntax(statements: bodyBuilder()), trailingTrivia: trailingTrivia)
   }
 }
 
 extension CatchItem: HasTrailingComma {
-  /// Creates a `CatchItem` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePattern: 
-  ///   - pattern: 
-  ///   - unexpectedBetweenPatternAndWhereClause: 
-  ///   - whereClause: 
-  ///   - unexpectedBetweenWhereClauseAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePattern: UnexpectedNodes? = nil, pattern: PatternSyntaxProtocol? = nil, unexpectedBetweenPatternAndWhereClause: UnexpectedNodes? = nil, whereClause: WhereClause? = nil, unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = CatchItemSyntax(unexpectedBeforePattern, pattern: PatternSyntax(fromProtocol: pattern), unexpectedBetweenPatternAndWhereClause, whereClause: whereClause, unexpectedBetweenWhereClauseAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
@@ -718,84 +204,24 @@ extension CatchItem: HasTrailingComma {
 }
 
 extension ClassDecl {
-  /// Creates a `ClassDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: 
-  ///   - unexpectedBetweenModifiersAndClassKeyword: 
-  ///   - classKeyword: 
-  ///   - unexpectedBetweenClassKeywordAndIdentifier: 
-  ///   - identifier: 
-  ///   - unexpectedBetweenIdentifierAndGenericParameterClause: 
-  ///   - genericParameterClause: 
-  ///   - unexpectedBetweenGenericParameterClauseAndInheritanceClause: 
-  ///   - inheritanceClause: 
-  ///   - unexpectedBetweenInheritanceClauseAndGenericWhereClause: 
-  ///   - genericWhereClause: 
-  ///   - unexpectedBetweenGenericWhereClauseAndMembers: 
-  ///   - members: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndClassKeyword: UnexpectedNodes? = nil, classKeyword: Token = Token.`class`, unexpectedBetweenClassKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, members: MemberDeclBlock) {
-    assert(classKeyword.text == "class")
-    self = ClassDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndClassKeyword, classKeyword: classKeyword, unexpectedBetweenClassKeywordAndIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: members)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndClassKeyword: UnexpectedNodes? = nil, classKeyword: Token = Token.`class`, unexpectedBetweenClassKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndClassKeyword: UnexpectedNodes? = nil, classKeyword: Token = Token.`class`, unexpectedBetweenClassKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
     MemberDeclListSyntax([])
-  }) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndClassKeyword, classKeyword: classKeyword, unexpectedBetweenClassKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: MemberDeclBlockSyntax(members: membersBuilder()))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension ClassRestrictionType {
-  /// Creates a `ClassRestrictionType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeClassKeyword: 
-  ///   - classKeyword: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeClassKeyword: UnexpectedNodes? = nil, classKeyword: Token = Token.`class`) {
-    assert(classKeyword.text == "class")
-    self = ClassRestrictionTypeSyntax(unexpectedBeforeClassKeyword, classKeyword: classKeyword)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndClassKeyword, classKeyword: classKeyword, unexpectedBetweenClassKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: MemberDeclBlockSyntax(members: membersBuilder()), trailingTrivia: trailingTrivia)
   }
 }
 
 extension ClosureCaptureItem: HasTrailingComma {
-  /// Creates a `ClosureCaptureItem` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeSpecifier: 
-  ///   - specifier: 
-  ///   - unexpectedBetweenSpecifierAndName: 
-  ///   - name: 
-  ///   - unexpectedBetweenNameAndAssignToken: 
-  ///   - assignToken: 
-  ///   - unexpectedBetweenAssignTokenAndExpression: 
-  ///   - expression: 
-  ///   - unexpectedBetweenExpressionAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeSpecifier: UnexpectedNodes? = nil, specifier: TokenList? = nil, unexpectedBetweenSpecifierAndName: UnexpectedNodes? = nil, name: Token? = nil, unexpectedBetweenNameAndAssignToken: UnexpectedNodes? = nil, assignToken: Token? = nil, unexpectedBetweenAssignTokenAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(assignToken == nil || assignToken!.text == "=")
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = ClosureCaptureItemSyntax(unexpectedBeforeSpecifier, specifier: specifier, unexpectedBetweenSpecifierAndName, name: name, unexpectedBetweenNameAndAssignToken, assignToken: assignToken, unexpectedBetweenAssignTokenAndExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeSpecifier: UnexpectedNodes? = nil, specifier: TokenList? = nil, unexpectedBetweenSpecifierAndName: UnexpectedNodes? = nil, name: String?, unexpectedBetweenNameAndAssignToken: UnexpectedNodes? = nil, assignToken: Token? = nil, unexpectedBetweenAssignTokenAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    self.init (unexpectedBeforeSpecifier, specifier: specifier, unexpectedBetweenSpecifierAndName, name: name.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeSpecifier: UnexpectedNodes? = nil, specifier: TokenList? = nil, unexpectedBetweenSpecifierAndName: UnexpectedNodes? = nil, name: String?, unexpectedBetweenNameAndAssignToken: UnexpectedNodes? = nil, assignToken: Token? = nil, unexpectedBetweenAssignTokenAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeSpecifier, specifier: specifier, unexpectedBetweenSpecifierAndName, name: name.map { 
       Token.`identifier`($0) 
-    }, unexpectedBetweenNameAndAssignToken, assignToken: assignToken, unexpectedBetweenAssignTokenAndExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    }, unexpectedBetweenNameAndAssignToken, assignToken: assignToken, unexpectedBetweenAssignTokenAndExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndTrailingComma, trailingComma: trailingComma, trailingTrivia: trailingTrivia)
   }
   
   var hasTrailingComma: Bool {
@@ -809,77 +235,28 @@ extension ClosureCaptureItem: HasTrailingComma {
 }
 
 extension ClosureCaptureSignature {
-  /// Creates a `ClosureCaptureSignature` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftSquare: 
-  ///   - leftSquare: 
-  ///   - unexpectedBetweenLeftSquareAndItems: 
-  ///   - items: 
-  ///   - unexpectedBetweenItemsAndRightSquare: 
-  ///   - rightSquare: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftSquare: UnexpectedNodes? = nil, leftSquare: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareAndItems: UnexpectedNodes? = nil, items: ClosureCaptureItemList? = nil, unexpectedBetweenItemsAndRightSquare: UnexpectedNodes? = nil, rightSquare: Token = Token.`rightSquareBracket`) {
-    assert(leftSquare.text == "[")
-    assert(rightSquare.text == "]")
-    self = ClosureCaptureSignatureSyntax(unexpectedBeforeLeftSquare, leftSquare: leftSquare, unexpectedBetweenLeftSquareAndItems, items: items, unexpectedBetweenItemsAndRightSquare, rightSquare: rightSquare)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftSquare: UnexpectedNodes? = nil, leftSquare: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareAndItems: UnexpectedNodes? = nil, unexpectedBetweenItemsAndRightSquare: UnexpectedNodes? = nil, rightSquare: Token = Token.`rightSquareBracket`, @ClosureCaptureItemListBuilder itemsBuilder: () -> ClosureCaptureItemListSyntax? = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLeftSquare: UnexpectedNodes? = nil, leftSquare: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareAndItems: UnexpectedNodes? = nil, unexpectedBetweenItemsAndRightSquare: UnexpectedNodes? = nil, rightSquare: Token = Token.`rightSquareBracket`, @ClosureCaptureItemListBuilder itemsBuilder: () -> ClosureCaptureItemListSyntax? = {
     nil
-  }) {
-    self.init (unexpectedBeforeLeftSquare, leftSquare: leftSquare, unexpectedBetweenLeftSquareAndItems, items: itemsBuilder(), unexpectedBetweenItemsAndRightSquare, rightSquare: rightSquare)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLeftSquare, leftSquare: leftSquare, unexpectedBetweenLeftSquareAndItems, items: itemsBuilder(), unexpectedBetweenItemsAndRightSquare, rightSquare: rightSquare, trailingTrivia: trailingTrivia)
   }
 }
 
 extension ClosureExpr {
-  /// Creates a `ClosureExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftBrace: 
-  ///   - leftBrace: 
-  ///   - unexpectedBetweenLeftBraceAndSignature: 
-  ///   - signature: 
-  ///   - unexpectedBetweenSignatureAndStatements: 
-  ///   - statements: 
-  ///   - unexpectedBetweenStatementsAndRightBrace: 
-  ///   - rightBrace: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndSignature: UnexpectedNodes? = nil, signature: ClosureSignature? = nil, unexpectedBetweenSignatureAndStatements: UnexpectedNodes? = nil, statements: CodeBlockItemList, unexpectedBetweenStatementsAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
-    assert(leftBrace.text == "{")
-    assert(rightBrace.text == "}")
-    self = ClosureExprSyntax(unexpectedBeforeLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndSignature, signature: signature, unexpectedBetweenSignatureAndStatements, statements: statements, unexpectedBetweenStatementsAndRightBrace, rightBrace: rightBrace)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndSignature: UnexpectedNodes? = nil, signature: ClosureSignature? = nil, unexpectedBetweenSignatureAndStatements: UnexpectedNodes? = nil, unexpectedBetweenStatementsAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`, @CodeBlockItemListBuilder statementsBuilder: () -> CodeBlockItemListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndSignature: UnexpectedNodes? = nil, signature: ClosureSignature? = nil, unexpectedBetweenSignatureAndStatements: UnexpectedNodes? = nil, unexpectedBetweenStatementsAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`, @CodeBlockItemListBuilder statementsBuilder: () -> CodeBlockItemListSyntax = {
     CodeBlockItemListSyntax([])
-  }) {
-    self.init (unexpectedBeforeLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndSignature, signature: signature, unexpectedBetweenSignatureAndStatements, statements: statementsBuilder(), unexpectedBetweenStatementsAndRightBrace, rightBrace: rightBrace)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndSignature, signature: signature, unexpectedBetweenSignatureAndStatements, statements: statementsBuilder(), unexpectedBetweenStatementsAndRightBrace, rightBrace: rightBrace, trailingTrivia: trailingTrivia)
   }
 }
 
 extension ClosureParam: HasTrailingComma {
-  /// Creates a `ClosureParam` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeName: 
-  ///   - name: 
-  ///   - unexpectedBetweenNameAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = ClosureParamSyntax(unexpectedBeforeName, name: name, unexpectedBetweenNameAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
@@ -891,129 +268,28 @@ extension ClosureParam: HasTrailingComma {
 }
 
 extension ClosureSignature {
-  /// Creates a `ClosureSignature` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndCapture: 
-  ///   - capture: 
-  ///   - unexpectedBetweenCaptureAndInput: 
-  ///   - input: 
-  ///   - unexpectedBetweenInputAndAsyncKeyword: 
-  ///   - asyncKeyword: 
-  ///   - unexpectedBetweenAsyncKeywordAndThrowsTok: 
-  ///   - throwsTok: 
-  ///   - unexpectedBetweenThrowsTokAndOutput: 
-  ///   - output: 
-  ///   - unexpectedBetweenOutputAndInTok: 
-  ///   - inTok: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndCapture: UnexpectedNodes? = nil, capture: ClosureCaptureSignature? = nil, unexpectedBetweenCaptureAndInput: UnexpectedNodes? = nil, input: Input? = nil, unexpectedBetweenInputAndAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: Token? = nil, unexpectedBetweenAsyncKeywordAndThrowsTok: UnexpectedNodes? = nil, throwsTok: Token? = nil, unexpectedBetweenThrowsTokAndOutput: UnexpectedNodes? = nil, output: ReturnClause? = nil, unexpectedBetweenOutputAndInTok: UnexpectedNodes? = nil, inTok: Token = Token.`in`) {
-    assert(asyncKeyword == nil || asyncKeyword!.text == "async")
-    assert(throwsTok == nil || throwsTok!.text == "throws")
-    assert(inTok.text == "in")
-    self = ClosureSignatureSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndCapture, capture: capture, unexpectedBetweenCaptureAndInput, input: input, unexpectedBetweenInputAndAsyncKeyword, asyncKeyword: asyncKeyword, unexpectedBetweenAsyncKeywordAndThrowsTok, throwsTok: throwsTok, unexpectedBetweenThrowsTokAndOutput, output: output, unexpectedBetweenOutputAndInTok, inTok: inTok)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndCapture: UnexpectedNodes? = nil, capture: ClosureCaptureSignature? = nil, unexpectedBetweenCaptureAndInput: UnexpectedNodes? = nil, input: Input? = nil, unexpectedBetweenInputAndAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: String?, unexpectedBetweenAsyncKeywordAndThrowsTok: UnexpectedNodes? = nil, throwsTok: Token? = nil, unexpectedBetweenThrowsTokAndOutput: UnexpectedNodes? = nil, output: ReturnClause? = nil, unexpectedBetweenOutputAndInTok: UnexpectedNodes? = nil, inTok: Token = Token.`in`) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndCapture, capture: capture, unexpectedBetweenCaptureAndInput, input: input, unexpectedBetweenInputAndAsyncKeyword, asyncKeyword: asyncKeyword.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndCapture: UnexpectedNodes? = nil, capture: ClosureCaptureSignature? = nil, unexpectedBetweenCaptureAndInput: UnexpectedNodes? = nil, input: Input? = nil, unexpectedBetweenInputAndAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: String?, unexpectedBetweenAsyncKeywordAndThrowsTok: UnexpectedNodes? = nil, throwsTok: Token? = nil, unexpectedBetweenThrowsTokAndOutput: UnexpectedNodes? = nil, output: ReturnClause? = nil, unexpectedBetweenOutputAndInTok: UnexpectedNodes? = nil, inTok: Token = Token.`in`, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndCapture, capture: capture, unexpectedBetweenCaptureAndInput, input: input, unexpectedBetweenInputAndAsyncKeyword, asyncKeyword: asyncKeyword.map { 
       Token.`contextualKeyword`($0) 
-    }, unexpectedBetweenAsyncKeywordAndThrowsTok, throwsTok: throwsTok, unexpectedBetweenThrowsTokAndOutput, output: output, unexpectedBetweenOutputAndInTok, inTok: inTok)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-/// A CodeBlockItem is any Syntax node that appears on its own line insidea CodeBlock.
-extension CodeBlockItem {
-  /// Creates a `CodeBlockItem` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeItem: 
-  ///   - item: The underlying node inside the code block.
-  ///   - unexpectedBetweenItemAndSemicolon: 
-  ///   - semicolon: If present, the trailing semicolon at the end of the item.
-  ///   - unexpectedBetweenSemicolonAndErrorTokens: 
-  ///   - errorTokens: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeItem: UnexpectedNodes? = nil, item: Item, unexpectedBetweenItemAndSemicolon: UnexpectedNodes? = nil, semicolon: Token? = nil, unexpectedBetweenSemicolonAndErrorTokens: UnexpectedNodes? = nil, errorTokens: SyntaxProtocol? = nil) {
-    assert(semicolon == nil || semicolon!.text == ";")
-    self = CodeBlockItemSyntax(unexpectedBeforeItem, item: item, unexpectedBetweenItemAndSemicolon, semicolon: semicolon, unexpectedBetweenSemicolonAndErrorTokens, errorTokens: Syntax(fromProtocol: errorTokens))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+    }, unexpectedBetweenAsyncKeywordAndThrowsTok, throwsTok: throwsTok, unexpectedBetweenThrowsTokAndOutput, output: output, unexpectedBetweenOutputAndInTok, inTok: inTok, trailingTrivia: trailingTrivia)
   }
 }
 
 extension CodeBlock {
-  /// Creates a `CodeBlock` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftBrace: 
-  ///   - leftBrace: 
-  ///   - unexpectedBetweenLeftBraceAndStatements: 
-  ///   - statements: 
-  ///   - unexpectedBetweenStatementsAndRightBrace: 
-  ///   - rightBrace: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndStatements: UnexpectedNodes? = nil, statements: CodeBlockItemList, unexpectedBetweenStatementsAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
-    assert(leftBrace.text == "{")
-    assert(rightBrace.text == "}")
-    self = CodeBlockSyntax(unexpectedBeforeLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndStatements, statements: statements, unexpectedBetweenStatementsAndRightBrace, rightBrace: rightBrace)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndStatements: UnexpectedNodes? = nil, unexpectedBetweenStatementsAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`, @CodeBlockItemListBuilder statementsBuilder: () -> CodeBlockItemListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndStatements: UnexpectedNodes? = nil, unexpectedBetweenStatementsAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`, @CodeBlockItemListBuilder statementsBuilder: () -> CodeBlockItemListSyntax = {
     CodeBlockItemListSyntax([])
-  }) {
-    self.init (unexpectedBeforeLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndStatements, statements: statementsBuilder(), unexpectedBetweenStatementsAndRightBrace, rightBrace: rightBrace)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension CompositionTypeElement {
-  /// Creates a `CompositionTypeElement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeType: 
-  ///   - type: 
-  ///   - unexpectedBetweenTypeAndAmpersand: 
-  ///   - ampersand: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeType: UnexpectedNodes? = nil, type: TypeSyntaxProtocol, unexpectedBetweenTypeAndAmpersand: UnexpectedNodes? = nil, ampersand: Token? = nil) {
-    assert(ampersand == nil || ampersand!.text == "&")
-    self = CompositionTypeElementSyntax(unexpectedBeforeType, type: TypeSyntax(fromProtocol: type), unexpectedBetweenTypeAndAmpersand, ampersand: ampersand)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension CompositionType {
-  /// Creates a `CompositionType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeElements: 
-  ///   - elements: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeElements: UnexpectedNodes? = nil, elements: CompositionTypeElementList) {
-    self = CompositionTypeSyntax(unexpectedBeforeElements, elements: elements)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndStatements, statements: statementsBuilder(), unexpectedBetweenStatementsAndRightBrace, rightBrace: rightBrace, trailingTrivia: trailingTrivia)
   }
 }
 
 extension ConditionElement: HasTrailingComma {
-  /// Creates a `ConditionElement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeCondition: 
-  ///   - condition: 
-  ///   - unexpectedBetweenConditionAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeCondition: UnexpectedNodes? = nil, condition: Condition, unexpectedBetweenConditionAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = ConditionElementSyntax(unexpectedBeforeCondition, condition: condition, unexpectedBetweenConditionAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
@@ -1024,406 +300,117 @@ extension ConditionElement: HasTrailingComma {
   }
 }
 
-extension ConformanceRequirement {
-  /// Creates a `ConformanceRequirement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftTypeIdentifier: 
-  ///   - leftTypeIdentifier: 
-  ///   - unexpectedBetweenLeftTypeIdentifierAndColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndRightTypeIdentifier: 
-  ///   - rightTypeIdentifier: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftTypeIdentifier: UnexpectedNodes? = nil, leftTypeIdentifier: TypeSyntaxProtocol, unexpectedBetweenLeftTypeIdentifierAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndRightTypeIdentifier: UnexpectedNodes? = nil, rightTypeIdentifier: TypeSyntaxProtocol) {
-    assert(colon.text == ":")
-    self = ConformanceRequirementSyntax(unexpectedBeforeLeftTypeIdentifier, leftTypeIdentifier: TypeSyntax(fromProtocol: leftTypeIdentifier), unexpectedBetweenLeftTypeIdentifierAndColon, colon: colon, unexpectedBetweenColonAndRightTypeIdentifier, rightTypeIdentifier: TypeSyntax(fromProtocol: rightTypeIdentifier))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
 extension ConstrainedSugarType {
-  /// Creates a `ConstrainedSugarType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeSomeOrAnySpecifier: 
-  ///   - someOrAnySpecifier: 
-  ///   - unexpectedBetweenSomeOrAnySpecifierAndBaseType: 
-  ///   - baseType: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeSomeOrAnySpecifier: UnexpectedNodes? = nil, someOrAnySpecifier: Token, unexpectedBetweenSomeOrAnySpecifierAndBaseType: UnexpectedNodes? = nil, baseType: TypeSyntaxProtocol) {
-    assert(someOrAnySpecifier.text == "some" || someOrAnySpecifier.text == "any")
-    self = ConstrainedSugarTypeSyntax(unexpectedBeforeSomeOrAnySpecifier, someOrAnySpecifier: someOrAnySpecifier, unexpectedBetweenSomeOrAnySpecifierAndBaseType, baseType: TypeSyntax(fromProtocol: baseType))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeSomeOrAnySpecifier: UnexpectedNodes? = nil, someOrAnySpecifier: String, unexpectedBetweenSomeOrAnySpecifierAndBaseType: UnexpectedNodes? = nil, baseType: TypeSyntaxProtocol) {
-    self.init (unexpectedBeforeSomeOrAnySpecifier, someOrAnySpecifier: Token.`identifier`(someOrAnySpecifier), unexpectedBetweenSomeOrAnySpecifierAndBaseType, baseType: TypeSyntax(fromProtocol: baseType))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeSomeOrAnySpecifier: UnexpectedNodes? = nil, someOrAnySpecifier: String, unexpectedBetweenSomeOrAnySpecifierAndBaseType: UnexpectedNodes? = nil, baseType: TypeSyntaxProtocol, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeSomeOrAnySpecifier, someOrAnySpecifier: Token.`identifier`(someOrAnySpecifier), unexpectedBetweenSomeOrAnySpecifierAndBaseType, baseType: TypeSyntax(fromProtocol: baseType), trailingTrivia: trailingTrivia)
   }
 }
 
 extension ContinueStmt {
-  /// Creates a `ContinueStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeContinueKeyword: 
-  ///   - continueKeyword: 
-  ///   - unexpectedBetweenContinueKeywordAndLabel: 
-  ///   - label: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeContinueKeyword: UnexpectedNodes? = nil, continueKeyword: Token = Token.`continue`, unexpectedBetweenContinueKeywordAndLabel: UnexpectedNodes? = nil, label: Token? = nil) {
-    assert(continueKeyword.text == "continue")
-    self = ContinueStmtSyntax(unexpectedBeforeContinueKeyword, continueKeyword: continueKeyword, unexpectedBetweenContinueKeywordAndLabel, label: label)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeContinueKeyword: UnexpectedNodes? = nil, continueKeyword: Token = Token.`continue`, unexpectedBetweenContinueKeywordAndLabel: UnexpectedNodes? = nil, label: String?) {
-    self.init (unexpectedBeforeContinueKeyword, continueKeyword: continueKeyword, unexpectedBetweenContinueKeywordAndLabel, label: label.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeContinueKeyword: UnexpectedNodes? = nil, continueKeyword: Token = Token.`continue`, unexpectedBetweenContinueKeywordAndLabel: UnexpectedNodes? = nil, label: String?, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeContinueKeyword, continueKeyword: continueKeyword, unexpectedBetweenContinueKeywordAndLabel, label: label.map { 
       Token.`identifier`($0) 
-    })
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    }, trailingTrivia: trailingTrivia)
   }
 }
 
 /// The arguments for the '@convention(...)'.
 extension ConventionAttributeArguments {
-  /// Creates a `ConventionAttributeArguments` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeConventionLabel: 
-  ///   - conventionLabel: The convention label.
-  ///   - unexpectedBetweenConventionLabelAndComma: 
-  ///   - comma: 
-  ///   - unexpectedBetweenCommaAndCTypeLabel: 
-  ///   - cTypeLabel: 
-  ///   - unexpectedBetweenCTypeLabelAndColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndCTypeString: 
-  ///   - cTypeString: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeConventionLabel: UnexpectedNodes? = nil, conventionLabel: Token, unexpectedBetweenConventionLabelAndComma: UnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndCTypeLabel: UnexpectedNodes? = nil, cTypeLabel: Token? = nil, unexpectedBetweenCTypeLabelAndColon: UnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndCTypeString: UnexpectedNodes? = nil, cTypeString: Token? = nil) {
-    assert(conventionLabel.text == "block" || conventionLabel.text == "c" || conventionLabel.text == "objc_method" || conventionLabel.text == "thin" || conventionLabel.text == "thick")
-    assert(comma == nil || comma!.text == ",")
-    assert(cTypeLabel == nil || cTypeLabel!.text == "cType")
-    assert(colon == nil || colon!.text == ":")
-    self = ConventionAttributeArgumentsSyntax(unexpectedBeforeConventionLabel, conventionLabel: conventionLabel, unexpectedBetweenConventionLabelAndComma, comma: comma, unexpectedBetweenCommaAndCTypeLabel, cTypeLabel: cTypeLabel, unexpectedBetweenCTypeLabelAndColon, colon: colon, unexpectedBetweenColonAndCTypeString, cTypeString: cTypeString)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeConventionLabel: UnexpectedNodes? = nil, conventionLabel: String, unexpectedBetweenConventionLabelAndComma: UnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndCTypeLabel: UnexpectedNodes? = nil, cTypeLabel: String?, unexpectedBetweenCTypeLabelAndColon: UnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndCTypeString: UnexpectedNodes? = nil, cTypeString: String?) {
-    self.init (unexpectedBeforeConventionLabel, conventionLabel: Token.`identifier`(conventionLabel), unexpectedBetweenConventionLabelAndComma, comma: comma, unexpectedBetweenCommaAndCTypeLabel, cTypeLabel: cTypeLabel.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeConventionLabel: UnexpectedNodes? = nil, conventionLabel: String, unexpectedBetweenConventionLabelAndComma: UnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndCTypeLabel: UnexpectedNodes? = nil, cTypeLabel: String?, unexpectedBetweenCTypeLabelAndColon: UnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndCTypeString: UnexpectedNodes? = nil, cTypeString: String?, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeConventionLabel, conventionLabel: Token.`identifier`(conventionLabel), unexpectedBetweenConventionLabelAndComma, comma: comma, unexpectedBetweenCommaAndCTypeLabel, cTypeLabel: cTypeLabel.map { 
       Token.`identifier`($0) 
     }, unexpectedBetweenCTypeLabelAndColon, colon: colon, unexpectedBetweenColonAndCTypeString, cTypeString: cTypeString.map { 
       Token.`stringLiteral`($0) 
-    })
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    }, trailingTrivia: trailingTrivia)
   }
 }
 
 /// The arguments for the '@convention(witness_method: ...)'.
 extension ConventionWitnessMethodAttributeArguments {
-  /// Creates a `ConventionWitnessMethodAttributeArguments` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeWitnessMethodLabel: 
-  ///   - witnessMethodLabel: 
-  ///   - unexpectedBetweenWitnessMethodLabelAndColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndProtocolName: 
-  ///   - protocolName: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWitnessMethodLabel: UnexpectedNodes? = nil, witnessMethodLabel: Token, unexpectedBetweenWitnessMethodLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndProtocolName: UnexpectedNodes? = nil, protocolName: Token) {
-    assert(colon.text == ":")
-    self = ConventionWitnessMethodAttributeArgumentsSyntax(unexpectedBeforeWitnessMethodLabel, witnessMethodLabel: witnessMethodLabel, unexpectedBetweenWitnessMethodLabelAndColon, colon: colon, unexpectedBetweenColonAndProtocolName, protocolName: protocolName)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeWitnessMethodLabel: UnexpectedNodes? = nil, witnessMethodLabel: String, unexpectedBetweenWitnessMethodLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndProtocolName: UnexpectedNodes? = nil, protocolName: String) {
-    self.init (unexpectedBeforeWitnessMethodLabel, witnessMethodLabel: Token.`identifier`(witnessMethodLabel), unexpectedBetweenWitnessMethodLabelAndColon, colon: colon, unexpectedBetweenColonAndProtocolName, protocolName: Token.`identifier`(protocolName))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeWitnessMethodLabel: UnexpectedNodes? = nil, witnessMethodLabel: String, unexpectedBetweenWitnessMethodLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndProtocolName: UnexpectedNodes? = nil, protocolName: String, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeWitnessMethodLabel, witnessMethodLabel: Token.`identifier`(witnessMethodLabel), unexpectedBetweenWitnessMethodLabelAndColon, colon: colon, unexpectedBetweenColonAndProtocolName, protocolName: Token.`identifier`(protocolName), trailingTrivia: trailingTrivia)
   }
 }
 
 /// A custom `@` attribute.
 extension CustomAttribute {
-  /// Creates a `CustomAttribute` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAtSignToken: 
-  ///   - atSignToken: The `@` sign.
-  ///   - unexpectedBetweenAtSignTokenAndAttributeName: 
-  ///   - attributeName: The name of the attribute.
-  ///   - unexpectedBetweenAttributeNameAndLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndArgumentList: 
-  ///   - argumentList: 
-  ///   - unexpectedBetweenArgumentListAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAtSignToken: UnexpectedNodes? = nil, atSignToken: Token = Token.`atSign`, unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodes? = nil, attributeName: TypeSyntaxProtocol, unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodes? = nil, argumentList: TupleExprElementList? = nil, unexpectedBetweenArgumentListAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil) {
-    assert(atSignToken.text == "@")
-    assert(leftParen == nil || leftParen!.text == "(")
-    assert(rightParen == nil || rightParen!.text == ")")
-    self = CustomAttributeSyntax(unexpectedBeforeAtSignToken, atSignToken: atSignToken, unexpectedBetweenAtSignTokenAndAttributeName, attributeName: TypeSyntax(fromProtocol: attributeName), unexpectedBetweenAttributeNameAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList: argumentList, unexpectedBetweenArgumentListAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAtSignToken: UnexpectedNodes? = nil, atSignToken: Token = Token.`atSign`, unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodes? = nil, attributeName: TypeSyntaxProtocol, unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodes? = nil, unexpectedBetweenArgumentListAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil, @TupleExprElementListBuilder argumentListBuilder: () -> TupleExprElementListSyntax? = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAtSignToken: UnexpectedNodes? = nil, atSignToken: Token = Token.`atSign`, unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodes? = nil, attributeName: TypeSyntaxProtocol, unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodes? = nil, unexpectedBetweenArgumentListAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil, @TupleExprElementListBuilder argumentListBuilder: () -> TupleExprElementListSyntax? = {
     nil
-  }) {
-    self.init (unexpectedBeforeAtSignToken, atSignToken: atSignToken, unexpectedBetweenAtSignTokenAndAttributeName, attributeName: TypeSyntax(fromProtocol: attributeName), unexpectedBetweenAttributeNameAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList: argumentListBuilder(), unexpectedBetweenArgumentListAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAtSignToken, atSignToken: atSignToken, unexpectedBetweenAtSignTokenAndAttributeName, attributeName: TypeSyntax(fromProtocol: attributeName), unexpectedBetweenAttributeNameAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList: argumentListBuilder(), unexpectedBetweenArgumentListAndRightParen, rightParen: rightParen, trailingTrivia: trailingTrivia)
   }
 }
 
 extension DeclModifierDetail {
-  /// Creates a `DeclModifierDetail` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndDetail: 
-  ///   - detail: 
-  ///   - unexpectedBetweenDetailAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndDetail: UnexpectedNodes? = nil, detail: Token, unexpectedBetweenDetailAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = DeclModifierDetailSyntax(unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndDetail, detail: detail, unexpectedBetweenDetailAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndDetail: UnexpectedNodes? = nil, detail: String, unexpectedBetweenDetailAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    self.init (unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndDetail, detail: Token.`identifier`(detail), unexpectedBetweenDetailAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension DeclModifier {
-  /// Creates a `DeclModifier` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeName: 
-  ///   - name: 
-  ///   - unexpectedBetweenNameAndDetail: 
-  ///   - detail: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndDetail: UnexpectedNodes? = nil, detail: DeclModifierDetail? = nil) {
-    assert(name.text == "class" || name.text == "convenience" || name.text == "dynamic" || name.text == "final" || name.text == "infix" || name.text == "lazy" || name.text == "optional" || name.text == "override" || name.text == "postfix" || name.text == "prefix" || name.text == "required" || name.text == "static" || name.text == "unowned" || name.text == "weak" || name.text == "private" || name.text == "fileprivate" || name.text == "internal" || name.text == "public" || name.text == "open" || name.text == "mutating" || name.text == "nonmutating" || name.text == "indirect" || name.text == "__consuming" || name.text == "actor" || name.text == "async" || name.text == "distributed" || name.text == "isolated" || name.text == "nonisolated" || name.text == "_const" || name.text == "_local")
-    self = DeclModifierSyntax(unexpectedBeforeName, name: name, unexpectedBetweenNameAndDetail, detail: detail)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension DeclNameArgument {
-  /// Creates a `DeclNameArgument` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeName: 
-  ///   - name: 
-  ///   - unexpectedBetweenNameAndColon: 
-  ///   - colon: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`) {
-    assert(colon.text == ":")
-    self = DeclNameArgumentSyntax(unexpectedBeforeName, name: name, unexpectedBetweenNameAndColon, colon: colon)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension DeclNameArguments {
-  /// Creates a `DeclNameArguments` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndArguments: 
-  ///   - arguments: 
-  ///   - unexpectedBetweenArgumentsAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndArguments: UnexpectedNodes? = nil, arguments: DeclNameArgumentList, unexpectedBetweenArgumentsAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = DeclNameArgumentsSyntax(unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArguments, arguments: arguments, unexpectedBetweenArgumentsAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension DeclName {
-  /// Creates a `DeclName` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeDeclBaseName: 
-  ///   - declBaseName: The base name of the protocol's requirement.
-  ///   - unexpectedBetweenDeclBaseNameAndDeclNameArguments: 
-  ///   - declNameArguments: The argument labels of the protocol's requirement if itis a function requirement.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDeclBaseName: UnexpectedNodes? = nil, declBaseName: Token, unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodes? = nil, declNameArguments: DeclNameArguments? = nil) {
-    self = DeclNameSyntax(unexpectedBeforeDeclBaseName, declBaseName: declBaseName, unexpectedBetweenDeclBaseNameAndDeclNameArguments, declNameArguments: declNameArguments)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension DeclarationStmt {
-  /// Creates a `DeclarationStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeDeclaration: 
-  ///   - declaration: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDeclaration: UnexpectedNodes? = nil, declaration: DeclSyntaxProtocol) {
-    self = DeclarationStmtSyntax(unexpectedBeforeDeclaration, declaration: DeclSyntax(fromProtocol: declaration))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndDetail: UnexpectedNodes? = nil, detail: String, unexpectedBetweenDetailAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndDetail, detail: Token.`identifier`(detail), unexpectedBetweenDetailAndRightParen, rightParen: rightParen, trailingTrivia: trailingTrivia)
   }
 }
 
 extension DeferStmt {
-  /// Creates a `DeferStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeDeferKeyword: 
-  ///   - deferKeyword: 
-  ///   - unexpectedBetweenDeferKeywordAndBody: 
-  ///   - body: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDeferKeyword: UnexpectedNodes? = nil, deferKeyword: Token = Token.`defer`, unexpectedBetweenDeferKeywordAndBody: UnexpectedNodes? = nil, body: CodeBlock) {
-    assert(deferKeyword.text == "defer")
-    self = DeferStmtSyntax(unexpectedBeforeDeferKeyword, deferKeyword: deferKeyword, unexpectedBetweenDeferKeywordAndBody, body: body)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeDeferKeyword: UnexpectedNodes? = nil, deferKeyword: Token = Token.`defer`, unexpectedBetweenDeferKeywordAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeDeferKeyword: UnexpectedNodes? = nil, deferKeyword: Token = Token.`defer`, unexpectedBetweenDeferKeywordAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
     CodeBlockItemListSyntax([])
-  }) {
-    self.init (unexpectedBeforeDeferKeyword, deferKeyword: deferKeyword, unexpectedBetweenDeferKeywordAndBody, body: CodeBlockSyntax(statements: bodyBuilder()))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeDeferKeyword, deferKeyword: deferKeyword, unexpectedBetweenDeferKeywordAndBody, body: CodeBlockSyntax(statements: bodyBuilder()), trailingTrivia: trailingTrivia)
   }
 }
 
 extension DeinitializerDecl {
-  /// Creates a `DeinitializerDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: 
-  ///   - unexpectedBetweenModifiersAndDeinitKeyword: 
-  ///   - deinitKeyword: 
-  ///   - unexpectedBetweenDeinitKeywordAndBody: 
-  ///   - body: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndDeinitKeyword: UnexpectedNodes? = nil, deinitKeyword: Token = Token.`deinit`, unexpectedBetweenDeinitKeywordAndBody: UnexpectedNodes? = nil, body: CodeBlock? = nil) {
-    assert(deinitKeyword.text == "deinit")
-    self = DeinitializerDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndDeinitKeyword, deinitKeyword: deinitKeyword, unexpectedBetweenDeinitKeywordAndBody, body: body)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndDeinitKeyword: UnexpectedNodes? = nil, deinitKeyword: Token = Token.`deinit`, unexpectedBetweenDeinitKeywordAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax? = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndDeinitKeyword: UnexpectedNodes? = nil, deinitKeyword: Token = Token.`deinit`, unexpectedBetweenDeinitKeywordAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax? = {
     nil
-  }) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndDeinitKeyword, deinitKeyword: deinitKeyword, unexpectedBetweenDeinitKeywordAndBody, body: bodyBuilder().map { 
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndDeinitKeyword, deinitKeyword: deinitKeyword, unexpectedBetweenDeinitKeywordAndBody, body: bodyBuilder().map { 
       CodeBlockSyntax(statements: $0) 
-    })
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    }, trailingTrivia: trailingTrivia)
   }
 }
 
 /// The arguments for the '@derivative(of:)' and '@transpose(of:)'attributes: the 'of:' label, the original declaration name, and anoptional differentiability parameter list.
 extension DerivativeRegistrationAttributeArguments {
-  /// Creates a `DerivativeRegistrationAttributeArguments` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeOfLabel: 
-  ///   - ofLabel: The "of" label.
-  ///   - unexpectedBetweenOfLabelAndColon: 
-  ///   - colon: The colon separating the "of" label and the originaldeclaration name.
-  ///   - unexpectedBetweenColonAndOriginalDeclName: 
-  ///   - originalDeclName: The referenced original declaration name.
-  ///   - unexpectedBetweenOriginalDeclNameAndPeriod: 
-  ///   - period: The period separating the original declaration name and theaccessor name.
-  ///   - unexpectedBetweenPeriodAndAccessorKind: 
-  ///   - accessorKind: The accessor name.
-  ///   - unexpectedBetweenAccessorKindAndComma: 
-  ///   - comma: 
-  ///   - unexpectedBetweenCommaAndDiffParams: 
-  ///   - diffParams: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeOfLabel: UnexpectedNodes? = nil, ofLabel: Token, unexpectedBetweenOfLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndOriginalDeclName: UnexpectedNodes? = nil, originalDeclName: QualifiedDeclName, unexpectedBetweenOriginalDeclNameAndPeriod: UnexpectedNodes? = nil, period: Token? = nil, unexpectedBetweenPeriodAndAccessorKind: UnexpectedNodes? = nil, accessorKind: Token? = nil, unexpectedBetweenAccessorKindAndComma: UnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndDiffParams: UnexpectedNodes? = nil, diffParams: DifferentiabilityParamsClause? = nil) {
-    assert(ofLabel.text == "of")
-    assert(colon.text == ":")
-    assert(period == nil || period!.text == ".")
-    assert(accessorKind == nil || accessorKind!.text == "get" || accessorKind!.text == "set")
-    assert(comma == nil || comma!.text == ",")
-    self = DerivativeRegistrationAttributeArgumentsSyntax(unexpectedBeforeOfLabel, ofLabel: ofLabel, unexpectedBetweenOfLabelAndColon, colon: colon, unexpectedBetweenColonAndOriginalDeclName, originalDeclName: originalDeclName, unexpectedBetweenOriginalDeclNameAndPeriod, period: period, unexpectedBetweenPeriodAndAccessorKind, accessorKind: accessorKind, unexpectedBetweenAccessorKindAndComma, comma: comma, unexpectedBetweenCommaAndDiffParams, diffParams: diffParams)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeOfLabel: UnexpectedNodes? = nil, ofLabel: String, unexpectedBetweenOfLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndOriginalDeclName: UnexpectedNodes? = nil, originalDeclName: QualifiedDeclName, unexpectedBetweenOriginalDeclNameAndPeriod: UnexpectedNodes? = nil, period: Token? = nil, unexpectedBetweenPeriodAndAccessorKind: UnexpectedNodes? = nil, accessorKind: String?, unexpectedBetweenAccessorKindAndComma: UnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndDiffParams: UnexpectedNodes? = nil, diffParams: DifferentiabilityParamsClause? = nil) {
-    self.init (unexpectedBeforeOfLabel, ofLabel: Token.`identifier`(ofLabel), unexpectedBetweenOfLabelAndColon, colon: colon, unexpectedBetweenColonAndOriginalDeclName, originalDeclName: originalDeclName, unexpectedBetweenOriginalDeclNameAndPeriod, period: period, unexpectedBetweenPeriodAndAccessorKind, accessorKind: accessorKind.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeOfLabel: UnexpectedNodes? = nil, ofLabel: String, unexpectedBetweenOfLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndOriginalDeclName: UnexpectedNodes? = nil, originalDeclName: QualifiedDeclName, unexpectedBetweenOriginalDeclNameAndPeriod: UnexpectedNodes? = nil, period: Token? = nil, unexpectedBetweenPeriodAndAccessorKind: UnexpectedNodes? = nil, accessorKind: String?, unexpectedBetweenAccessorKindAndComma: UnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndDiffParams: UnexpectedNodes? = nil, diffParams: DifferentiabilityParamsClause? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeOfLabel, ofLabel: Token.`identifier`(ofLabel), unexpectedBetweenOfLabelAndColon, colon: colon, unexpectedBetweenColonAndOriginalDeclName, originalDeclName: originalDeclName, unexpectedBetweenOriginalDeclNameAndPeriod, period: period, unexpectedBetweenPeriodAndAccessorKind, accessorKind: accessorKind.map { 
       Token.`identifier`($0) 
-    }, unexpectedBetweenAccessorKindAndComma, comma: comma, unexpectedBetweenCommaAndDiffParams, diffParams: diffParams)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    }, unexpectedBetweenAccessorKindAndComma, comma: comma, unexpectedBetweenCommaAndDiffParams, diffParams: diffParams, trailingTrivia: trailingTrivia)
   }
 }
 
 extension DesignatedTypeElement {
-  /// Creates a `DesignatedTypeElement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeadingComma: 
-  ///   - leadingComma: 
-  ///   - unexpectedBetweenLeadingCommaAndName: 
-  ///   - name: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeadingComma: UnexpectedNodes? = nil, leadingComma: Token = Token.`comma`, unexpectedBetweenLeadingCommaAndName: UnexpectedNodes? = nil, name: Token) {
-    assert(leadingComma.text == ",")
-    self = DesignatedTypeElementSyntax(unexpectedBeforeLeadingComma, leadingComma: leadingComma, unexpectedBetweenLeadingCommaAndName, name: name)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLeadingComma: UnexpectedNodes? = nil, leadingComma: Token = Token.`comma`, unexpectedBetweenLeadingCommaAndName: UnexpectedNodes? = nil, name: String) {
-    self.init (unexpectedBeforeLeadingComma, leadingComma: leadingComma, unexpectedBetweenLeadingCommaAndName, name: Token.`identifier`(name))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLeadingComma: UnexpectedNodes? = nil, leadingComma: Token = Token.`comma`, unexpectedBetweenLeadingCommaAndName: UnexpectedNodes? = nil, name: String, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLeadingComma, leadingComma: leadingComma, unexpectedBetweenLeadingCommaAndName, name: Token.`identifier`(name), trailingTrivia: trailingTrivia)
   }
 }
 
 extension DictionaryElement: HasTrailingComma {
-  /// Creates a `DictionaryElement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeKeyExpression: 
-  ///   - keyExpression: 
-  ///   - unexpectedBetweenKeyExpressionAndColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndValueExpression: 
-  ///   - valueExpression: 
-  ///   - unexpectedBetweenValueExpressionAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeKeyExpression: UnexpectedNodes? = nil, keyExpression: ExprSyntaxProtocol, unexpectedBetweenKeyExpressionAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValueExpression: UnexpectedNodes? = nil, valueExpression: ExprSyntaxProtocol, unexpectedBetweenValueExpressionAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(colon.text == ":")
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = DictionaryElementSyntax(unexpectedBeforeKeyExpression, keyExpression: ExprSyntax(fromProtocol: keyExpression), unexpectedBetweenKeyExpressionAndColon, colon: colon, unexpectedBetweenColonAndValueExpression, valueExpression: ExprSyntax(fromProtocol: valueExpression), unexpectedBetweenValueExpressionAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
@@ -1434,62 +421,8 @@ extension DictionaryElement: HasTrailingComma {
   }
 }
 
-extension DictionaryExpr {
-  /// Creates a `DictionaryExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftSquare: 
-  ///   - leftSquare: 
-  ///   - unexpectedBetweenLeftSquareAndContent: 
-  ///   - content: 
-  ///   - unexpectedBetweenContentAndRightSquare: 
-  ///   - rightSquare: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftSquare: UnexpectedNodes? = nil, leftSquare: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareAndContent: UnexpectedNodes? = nil, content: Content, unexpectedBetweenContentAndRightSquare: UnexpectedNodes? = nil, rightSquare: Token = Token.`rightSquareBracket`) {
-    assert(leftSquare.text == "[")
-    assert(rightSquare.text == "]")
-    self = DictionaryExprSyntax(unexpectedBeforeLeftSquare, leftSquare: leftSquare, unexpectedBetweenLeftSquareAndContent, content: content, unexpectedBetweenContentAndRightSquare, rightSquare: rightSquare)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension DictionaryType {
-  /// Creates a `DictionaryType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftSquareBracket: 
-  ///   - leftSquareBracket: 
-  ///   - unexpectedBetweenLeftSquareBracketAndKeyType: 
-  ///   - keyType: 
-  ///   - unexpectedBetweenKeyTypeAndColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndValueType: 
-  ///   - valueType: 
-  ///   - unexpectedBetweenValueTypeAndRightSquareBracket: 
-  ///   - rightSquareBracket: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftSquareBracket: UnexpectedNodes? = nil, leftSquareBracket: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareBracketAndKeyType: UnexpectedNodes? = nil, keyType: TypeSyntaxProtocol, unexpectedBetweenKeyTypeAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValueType: UnexpectedNodes? = nil, valueType: TypeSyntaxProtocol, unexpectedBetweenValueTypeAndRightSquareBracket: UnexpectedNodes? = nil, rightSquareBracket: Token = Token.`rightSquareBracket`) {
-    assert(leftSquareBracket.text == "[")
-    assert(colon.text == ":")
-    assert(rightSquareBracket.text == "]")
-    self = DictionaryTypeSyntax(unexpectedBeforeLeftSquareBracket, leftSquareBracket: leftSquareBracket, unexpectedBetweenLeftSquareBracketAndKeyType, keyType: TypeSyntax(fromProtocol: keyType), unexpectedBetweenKeyTypeAndColon, colon: colon, unexpectedBetweenColonAndValueType, valueType: TypeSyntax(fromProtocol: valueType), unexpectedBetweenValueTypeAndRightSquareBracket, rightSquareBracket: rightSquareBracket)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
 /// A differentiability parameter: either the "self" identifier, a functionparameter name, or a function parameter index.
 extension DifferentiabilityParam: HasTrailingComma {
-  /// Creates a `DifferentiabilityParam` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeParameter: 
-  ///   - parameter: 
-  ///   - unexpectedBetweenParameterAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeParameter: UnexpectedNodes? = nil, parameter: Token, unexpectedBetweenParameterAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = DifferentiabilityParamSyntax(unexpectedBeforeParameter, parameter: parameter, unexpectedBetweenParameterAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
@@ -1502,199 +435,65 @@ extension DifferentiabilityParam: HasTrailingComma {
 
 /// A clause containing differentiability parameters.
 extension DifferentiabilityParamsClause {
-  /// Creates a `DifferentiabilityParamsClause` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeWrtLabel: 
-  ///   - wrtLabel: The "wrt" label.
-  ///   - unexpectedBetweenWrtLabelAndColon: 
-  ///   - colon: The colon separating "wrt" and the parameter list.
-  ///   - unexpectedBetweenColonAndParameters: 
-  ///   - parameters: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWrtLabel: UnexpectedNodes? = nil, wrtLabel: Token, unexpectedBetweenWrtLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndParameters: UnexpectedNodes? = nil, parameters: Parameters) {
-    assert(wrtLabel.text == "wrt")
-    assert(colon.text == ":")
-    self = DifferentiabilityParamsClauseSyntax(unexpectedBeforeWrtLabel, wrtLabel: wrtLabel, unexpectedBetweenWrtLabelAndColon, colon: colon, unexpectedBetweenColonAndParameters, parameters: parameters)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeWrtLabel: UnexpectedNodes? = nil, wrtLabel: String, unexpectedBetweenWrtLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndParameters: UnexpectedNodes? = nil, parameters: Parameters) {
-    self.init (unexpectedBeforeWrtLabel, wrtLabel: Token.`identifier`(wrtLabel), unexpectedBetweenWrtLabelAndColon, colon: colon, unexpectedBetweenColonAndParameters, parameters: parameters)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-/// The differentiability parameters.
-extension DifferentiabilityParams {
-  /// Creates a `DifferentiabilityParams` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndDiffParams: 
-  ///   - diffParams: The parameters for differentiation.
-  ///   - unexpectedBetweenDiffParamsAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndDiffParams: UnexpectedNodes? = nil, diffParams: DifferentiabilityParamList, unexpectedBetweenDiffParamsAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = DifferentiabilityParamsSyntax(unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndDiffParams, diffParams: diffParams, unexpectedBetweenDiffParamsAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeWrtLabel: UnexpectedNodes? = nil, wrtLabel: String, unexpectedBetweenWrtLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndParameters: UnexpectedNodes? = nil, parameters: Parameters, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeWrtLabel, wrtLabel: Token.`identifier`(wrtLabel), unexpectedBetweenWrtLabelAndColon, colon: colon, unexpectedBetweenColonAndParameters, parameters: parameters, trailingTrivia: trailingTrivia)
   }
 }
 
 /// The arguments for the `@differentiable` attribute: an optionaldifferentiability kind, an optional differentiability parameter clause,and an optional 'where' clause.
 extension DifferentiableAttributeArguments {
-  /// Creates a `DifferentiableAttributeArguments` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeDiffKind: 
-  ///   - diffKind: 
-  ///   - unexpectedBetweenDiffKindAndDiffKindComma: 
-  ///   - diffKindComma: The comma following the differentiability kind, if it exists.
-  ///   - unexpectedBetweenDiffKindCommaAndDiffParams: 
-  ///   - diffParams: 
-  ///   - unexpectedBetweenDiffParamsAndDiffParamsComma: 
-  ///   - diffParamsComma: The comma following the differentiability parameters clause,if it exists.
-  ///   - unexpectedBetweenDiffParamsCommaAndWhereClause: 
-  ///   - whereClause: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDiffKind: UnexpectedNodes? = nil, diffKind: Token? = nil, unexpectedBetweenDiffKindAndDiffKindComma: UnexpectedNodes? = nil, diffKindComma: Token? = nil, unexpectedBetweenDiffKindCommaAndDiffParams: UnexpectedNodes? = nil, diffParams: DifferentiabilityParamsClause? = nil, unexpectedBetweenDiffParamsAndDiffParamsComma: UnexpectedNodes? = nil, diffParamsComma: Token? = nil, unexpectedBetweenDiffParamsCommaAndWhereClause: UnexpectedNodes? = nil, whereClause: GenericWhereClause? = nil) {
-    assert(diffKind == nil || diffKind!.text == "forward" || diffKind!.text == "reverse" || diffKind!.text == "linear")
-    assert(diffKindComma == nil || diffKindComma!.text == ",")
-    assert(diffParamsComma == nil || diffParamsComma!.text == ",")
-    self = DifferentiableAttributeArgumentsSyntax(unexpectedBeforeDiffKind, diffKind: diffKind, unexpectedBetweenDiffKindAndDiffKindComma, diffKindComma: diffKindComma, unexpectedBetweenDiffKindCommaAndDiffParams, diffParams: diffParams, unexpectedBetweenDiffParamsAndDiffParamsComma, diffParamsComma: diffParamsComma, unexpectedBetweenDiffParamsCommaAndWhereClause, whereClause: whereClause)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeDiffKind: UnexpectedNodes? = nil, diffKind: String?, unexpectedBetweenDiffKindAndDiffKindComma: UnexpectedNodes? = nil, diffKindComma: Token? = nil, unexpectedBetweenDiffKindCommaAndDiffParams: UnexpectedNodes? = nil, diffParams: DifferentiabilityParamsClause? = nil, unexpectedBetweenDiffParamsAndDiffParamsComma: UnexpectedNodes? = nil, diffParamsComma: Token? = nil, unexpectedBetweenDiffParamsCommaAndWhereClause: UnexpectedNodes? = nil, whereClause: GenericWhereClause? = nil) {
-    self.init (unexpectedBeforeDiffKind, diffKind: diffKind.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeDiffKind: UnexpectedNodes? = nil, diffKind: String?, unexpectedBetweenDiffKindAndDiffKindComma: UnexpectedNodes? = nil, diffKindComma: Token? = nil, unexpectedBetweenDiffKindCommaAndDiffParams: UnexpectedNodes? = nil, diffParams: DifferentiabilityParamsClause? = nil, unexpectedBetweenDiffParamsAndDiffParamsComma: UnexpectedNodes? = nil, diffParamsComma: Token? = nil, unexpectedBetweenDiffParamsCommaAndWhereClause: UnexpectedNodes? = nil, whereClause: GenericWhereClause? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeDiffKind, diffKind: diffKind.map { 
       Token.`identifier`($0) 
-    }, unexpectedBetweenDiffKindAndDiffKindComma, diffKindComma: diffKindComma, unexpectedBetweenDiffKindCommaAndDiffParams, diffParams: diffParams, unexpectedBetweenDiffParamsAndDiffParamsComma, diffParamsComma: diffParamsComma, unexpectedBetweenDiffParamsCommaAndWhereClause, whereClause: whereClause)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension DiscardAssignmentExpr {
-  /// Creates a `DiscardAssignmentExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeWildcard: 
-  ///   - wildcard: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWildcard: UnexpectedNodes? = nil, wildcard: Token = Token.`wildcard`) {
-    assert(wildcard.text == "_")
-    self = DiscardAssignmentExprSyntax(unexpectedBeforeWildcard, wildcard: wildcard)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+    }, unexpectedBetweenDiffKindAndDiffKindComma, diffKindComma: diffKindComma, unexpectedBetweenDiffKindCommaAndDiffParams, diffParams: diffParams, unexpectedBetweenDiffParamsAndDiffParamsComma, diffParamsComma: diffParamsComma, unexpectedBetweenDiffParamsCommaAndWhereClause, whereClause: whereClause, trailingTrivia: trailingTrivia)
   }
 }
 
 extension DoStmt {
-  /// Creates a `DoStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeDoKeyword: 
-  ///   - doKeyword: 
-  ///   - unexpectedBetweenDoKeywordAndBody: 
-  ///   - body: 
-  ///   - unexpectedBetweenBodyAndCatchClauses: 
-  ///   - catchClauses: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDoKeyword: UnexpectedNodes? = nil, doKeyword: Token = Token.`do`, unexpectedBetweenDoKeywordAndBody: UnexpectedNodes? = nil, body: CodeBlock, unexpectedBetweenBodyAndCatchClauses: UnexpectedNodes? = nil, catchClauses: CatchClauseList? = nil) {
-    assert(doKeyword.text == "do")
-    self = DoStmtSyntax(unexpectedBeforeDoKeyword, doKeyword: doKeyword, unexpectedBetweenDoKeywordAndBody, body: body, unexpectedBetweenBodyAndCatchClauses, catchClauses: catchClauses)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeDoKeyword: UnexpectedNodes? = nil, doKeyword: Token = Token.`do`, unexpectedBetweenDoKeywordAndBody: UnexpectedNodes? = nil, unexpectedBetweenBodyAndCatchClauses: UnexpectedNodes? = nil, catchClauses: CatchClauseList? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeDoKeyword: UnexpectedNodes? = nil, doKeyword: Token = Token.`do`, unexpectedBetweenDoKeywordAndBody: UnexpectedNodes? = nil, unexpectedBetweenBodyAndCatchClauses: UnexpectedNodes? = nil, catchClauses: CatchClauseList? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
     CodeBlockItemListSyntax([])
-  }) {
-    self.init (unexpectedBeforeDoKeyword, doKeyword: doKeyword, unexpectedBetweenDoKeywordAndBody, body: CodeBlockSyntax(statements: bodyBuilder()), unexpectedBetweenBodyAndCatchClauses, catchClauses: catchClauses)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeDoKeyword, doKeyword: doKeyword, unexpectedBetweenDoKeywordAndBody, body: CodeBlockSyntax(statements: bodyBuilder()), unexpectedBetweenBodyAndCatchClauses, catchClauses: catchClauses, trailingTrivia: trailingTrivia)
   }
 }
 
 extension EditorPlaceholderExpr {
-  /// Creates a `EditorPlaceholderExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeIdentifier: 
-  ///   - identifier: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIdentifier: UnexpectedNodes? = nil, identifier: Token) {
-    self = EditorPlaceholderExprSyntax(unexpectedBeforeIdentifier, identifier: identifier)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeIdentifier: UnexpectedNodes? = nil, identifier: String) {
-    self.init (unexpectedBeforeIdentifier, identifier: Token.`identifier`(identifier))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeIdentifier: UnexpectedNodes? = nil, identifier: String, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeIdentifier, identifier: Token.`identifier`(identifier), trailingTrivia: trailingTrivia)
   }
 }
 
 /// A `case` declaration of a Swift `enum`. It can have 1 or more`EnumCaseElement`s inside, each declaring a different case of theenum.
 extension EnumCaseDecl {
-  /// Creates a `EnumCaseDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: The attributes applied to the case declaration.
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: The declaration modifiers applied to the case declaration.
-  ///   - unexpectedBetweenModifiersAndCaseKeyword: 
-  ///   - caseKeyword: The `case` keyword for this case.
-  ///   - unexpectedBetweenCaseKeywordAndElements: 
-  ///   - elements: The elements this case declares.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndCaseKeyword: UnexpectedNodes? = nil, caseKeyword: Token = Token.`case`, unexpectedBetweenCaseKeywordAndElements: UnexpectedNodes? = nil, elements: EnumCaseElementList) {
-    assert(caseKeyword.text == "case")
-    self = EnumCaseDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndCaseKeyword, caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndElements, elements: elements)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndCaseKeyword: UnexpectedNodes? = nil, caseKeyword: Token = Token.`case`, unexpectedBetweenCaseKeywordAndElements: UnexpectedNodes? = nil, @EnumCaseElementListBuilder elementsBuilder: () -> EnumCaseElementListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndCaseKeyword: UnexpectedNodes? = nil, caseKeyword: Token = Token.`case`, unexpectedBetweenCaseKeywordAndElements: UnexpectedNodes? = nil, @EnumCaseElementListBuilder elementsBuilder: () -> EnumCaseElementListSyntax = {
     EnumCaseElementListSyntax([])
-  }) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndCaseKeyword, caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndElements, elements: elementsBuilder())
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndCaseKeyword, caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndElements, elements: elementsBuilder(), trailingTrivia: trailingTrivia)
   }
 }
 
 /// An element of an enum case, containing the name of the case and,optionally, either associated values or an assignment to a raw value.
 extension EnumCaseElement: HasTrailingComma {
-  /// Creates a `EnumCaseElement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeIdentifier: 
-  ///   - identifier: The name of this case.
-  ///   - unexpectedBetweenIdentifierAndAssociatedValue: 
-  ///   - associatedValue: The set of associated values of the case.
-  ///   - unexpectedBetweenAssociatedValueAndRawValue: 
-  ///   - rawValue: The raw value of this enum element, if present.
-  ///   - unexpectedBetweenRawValueAndTrailingComma: 
-  ///   - trailingComma: The trailing comma of this element, if the case hasmultiple elements.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndAssociatedValue: UnexpectedNodes? = nil, associatedValue: ParameterClause? = nil, unexpectedBetweenAssociatedValueAndRawValue: UnexpectedNodes? = nil, rawValue: InitializerClause? = nil, unexpectedBetweenRawValueAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = EnumCaseElementSyntax(unexpectedBeforeIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndAssociatedValue, associatedValue: associatedValue, unexpectedBetweenAssociatedValueAndRawValue, rawValue: rawValue, unexpectedBetweenRawValueAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndAssociatedValue: UnexpectedNodes? = nil, associatedValue: ParameterClause? = nil, unexpectedBetweenAssociatedValueAndRawValue: UnexpectedNodes? = nil, rawValue: InitializerClause? = nil, unexpectedBetweenRawValueAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    self.init (unexpectedBeforeIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndAssociatedValue, associatedValue: associatedValue, unexpectedBetweenAssociatedValueAndRawValue, rawValue: rawValue, unexpectedBetweenRawValueAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndAssociatedValue: UnexpectedNodes? = nil, associatedValue: ParameterClause? = nil, unexpectedBetweenAssociatedValueAndRawValue: UnexpectedNodes? = nil, rawValue: InitializerClause? = nil, unexpectedBetweenRawValueAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndAssociatedValue, associatedValue: associatedValue, unexpectedBetweenAssociatedValueAndRawValue, rawValue: rawValue, unexpectedBetweenRawValueAndTrailingComma, trailingComma: trailingComma, trailingTrivia: trailingTrivia)
   }
   
   var hasTrailingComma: Bool {
@@ -1708,377 +507,97 @@ extension EnumCaseElement: HasTrailingComma {
 }
 
 extension EnumCasePattern {
-  /// Creates a `EnumCasePattern` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeType: 
-  ///   - type: 
-  ///   - unexpectedBetweenTypeAndPeriod: 
-  ///   - period: 
-  ///   - unexpectedBetweenPeriodAndCaseName: 
-  ///   - caseName: 
-  ///   - unexpectedBetweenCaseNameAndAssociatedTuple: 
-  ///   - associatedTuple: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeType: UnexpectedNodes? = nil, type: TypeSyntaxProtocol? = nil, unexpectedBetweenTypeAndPeriod: UnexpectedNodes? = nil, period: Token = Token.`period`, unexpectedBetweenPeriodAndCaseName: UnexpectedNodes? = nil, caseName: Token, unexpectedBetweenCaseNameAndAssociatedTuple: UnexpectedNodes? = nil, associatedTuple: TuplePattern? = nil) {
-    assert(period.text == ".")
-    self = EnumCasePatternSyntax(unexpectedBeforeType, type: TypeSyntax(fromProtocol: type), unexpectedBetweenTypeAndPeriod, period: period, unexpectedBetweenPeriodAndCaseName, caseName: caseName, unexpectedBetweenCaseNameAndAssociatedTuple, associatedTuple: associatedTuple)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeType: UnexpectedNodes? = nil, type: TypeSyntaxProtocol? = nil, unexpectedBetweenTypeAndPeriod: UnexpectedNodes? = nil, period: Token = Token.`period`, unexpectedBetweenPeriodAndCaseName: UnexpectedNodes? = nil, caseName: String, unexpectedBetweenCaseNameAndAssociatedTuple: UnexpectedNodes? = nil, associatedTuple: TuplePattern? = nil) {
-    self.init (unexpectedBeforeType, type: TypeSyntax(fromProtocol: type), unexpectedBetweenTypeAndPeriod, period: period, unexpectedBetweenPeriodAndCaseName, caseName: Token.`identifier`(caseName), unexpectedBetweenCaseNameAndAssociatedTuple, associatedTuple: associatedTuple)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeType: UnexpectedNodes? = nil, type: TypeSyntaxProtocol? = nil, unexpectedBetweenTypeAndPeriod: UnexpectedNodes? = nil, period: Token = Token.`period`, unexpectedBetweenPeriodAndCaseName: UnexpectedNodes? = nil, caseName: String, unexpectedBetweenCaseNameAndAssociatedTuple: UnexpectedNodes? = nil, associatedTuple: TuplePattern? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeType, type: TypeSyntax(fromProtocol: type), unexpectedBetweenTypeAndPeriod, period: period, unexpectedBetweenPeriodAndCaseName, caseName: Token.`identifier`(caseName), unexpectedBetweenCaseNameAndAssociatedTuple, associatedTuple: associatedTuple, trailingTrivia: trailingTrivia)
   }
 }
 
 /// A Swift `enum` declaration.
 extension EnumDecl {
-  /// Creates a `EnumDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: The attributes applied to the enum declaration.
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: The declaration modifiers applied to the enum declaration.
-  ///   - unexpectedBetweenModifiersAndEnumKeyword: 
-  ///   - enumKeyword: The `enum` keyword for this declaration.
-  ///   - unexpectedBetweenEnumKeywordAndIdentifier: 
-  ///   - identifier: The name of this enum.
-  ///   - unexpectedBetweenIdentifierAndGenericParameters: 
-  ///   - genericParameters: The generic parameters, if any, for this enum.
-  ///   - unexpectedBetweenGenericParametersAndInheritanceClause: 
-  ///   - inheritanceClause: The inheritance clause describing conformances or rawvalues for this enum.
-  ///   - unexpectedBetweenInheritanceClauseAndGenericWhereClause: 
-  ///   - genericWhereClause: The `where` clause that applies to the generic parameters ofthis enum.
-  ///   - unexpectedBetweenGenericWhereClauseAndMembers: 
-  ///   - members: The cases and other members of this enum.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndEnumKeyword: UnexpectedNodes? = nil, enumKeyword: Token = Token.`enum`, unexpectedBetweenEnumKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameters: UnexpectedNodes? = nil, genericParameters: GenericParameterClause? = nil, unexpectedBetweenGenericParametersAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, members: MemberDeclBlock) {
-    assert(enumKeyword.text == "enum")
-    self = EnumDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndEnumKeyword, enumKeyword: enumKeyword, unexpectedBetweenEnumKeywordAndIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndGenericParameters, genericParameters: genericParameters, unexpectedBetweenGenericParametersAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: members)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndEnumKeyword: UnexpectedNodes? = nil, enumKeyword: Token = Token.`enum`, unexpectedBetweenEnumKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameters: UnexpectedNodes? = nil, genericParameters: GenericParameterClause? = nil, unexpectedBetweenGenericParametersAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndEnumKeyword: UnexpectedNodes? = nil, enumKeyword: Token = Token.`enum`, unexpectedBetweenEnumKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameters: UnexpectedNodes? = nil, genericParameters: GenericParameterClause? = nil, unexpectedBetweenGenericParametersAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
     MemberDeclListSyntax([])
-  }) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndEnumKeyword, enumKeyword: enumKeyword, unexpectedBetweenEnumKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameters, genericParameters: genericParameters, unexpectedBetweenGenericParametersAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: MemberDeclBlockSyntax(members: membersBuilder()))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension ExpressionPattern {
-  /// Creates a `ExpressionPattern` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeExpression: 
-  ///   - expression: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol) {
-    self = ExpressionPatternSyntax(unexpectedBeforeExpression, expression: ExprSyntax(fromProtocol: expression))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndEnumKeyword, enumKeyword: enumKeyword, unexpectedBetweenEnumKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameters, genericParameters: genericParameters, unexpectedBetweenGenericParametersAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: MemberDeclBlockSyntax(members: membersBuilder()), trailingTrivia: trailingTrivia)
   }
 }
 
 extension ExpressionSegment {
-  /// Creates a `ExpressionSegment` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeBackslash: 
-  ///   - backslash: 
-  ///   - unexpectedBetweenBackslashAndDelimiter: 
-  ///   - delimiter: 
-  ///   - unexpectedBetweenDelimiterAndLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndExpressions: 
-  ///   - expressions: 
-  ///   - unexpectedBetweenExpressionsAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBackslash: UnexpectedNodes? = nil, backslash: Token = Token.`backslash`, unexpectedBetweenBackslashAndDelimiter: UnexpectedNodes? = nil, delimiter: Token? = nil, unexpectedBetweenDelimiterAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndExpressions: UnexpectedNodes? = nil, expressions: TupleExprElementList, unexpectedBetweenExpressionsAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`stringInterpolationAnchor`) {
-    assert(backslash.text == #"\"#)
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = ExpressionSegmentSyntax(unexpectedBeforeBackslash, backslash: backslash, unexpectedBetweenBackslashAndDelimiter, delimiter: delimiter, unexpectedBetweenDelimiterAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndExpressions, expressions: expressions, unexpectedBetweenExpressionsAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeBackslash: UnexpectedNodes? = nil, backslash: Token = Token.`backslash`, unexpectedBetweenBackslashAndDelimiter: UnexpectedNodes? = nil, delimiter: String?, unexpectedBetweenDelimiterAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndExpressions: UnexpectedNodes? = nil, unexpectedBetweenExpressionsAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`stringInterpolationAnchor`, @TupleExprElementListBuilder expressionsBuilder: () -> TupleExprElementListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeBackslash: UnexpectedNodes? = nil, backslash: Token = Token.`backslash`, unexpectedBetweenBackslashAndDelimiter: UnexpectedNodes? = nil, delimiter: String?, unexpectedBetweenDelimiterAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndExpressions: UnexpectedNodes? = nil, unexpectedBetweenExpressionsAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`stringInterpolationAnchor`, @TupleExprElementListBuilder expressionsBuilder: () -> TupleExprElementListSyntax = {
     TupleExprElementListSyntax([])
-  }) {
-    self.init (unexpectedBeforeBackslash, backslash: backslash, unexpectedBetweenBackslashAndDelimiter, delimiter: delimiter.map { 
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeBackslash, backslash: backslash, unexpectedBetweenBackslashAndDelimiter, delimiter: delimiter.map { 
       Token.`rawStringDelimiter`($0) 
-    }, unexpectedBetweenDelimiterAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndExpressions, expressions: expressionsBuilder(), unexpectedBetweenExpressionsAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension ExpressionStmt {
-  /// Creates a `ExpressionStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeExpression: 
-  ///   - expression: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol) {
-    self = ExpressionStmtSyntax(unexpectedBeforeExpression, expression: ExprSyntax(fromProtocol: expression))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+    }, unexpectedBetweenDelimiterAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndExpressions, expressions: expressionsBuilder(), unexpectedBetweenExpressionsAndRightParen, rightParen: rightParen, trailingTrivia: trailingTrivia)
   }
 }
 
 extension ExtensionDecl {
-  /// Creates a `ExtensionDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: 
-  ///   - unexpectedBetweenModifiersAndExtensionKeyword: 
-  ///   - extensionKeyword: 
-  ///   - unexpectedBetweenExtensionKeywordAndExtendedType: 
-  ///   - extendedType: 
-  ///   - unexpectedBetweenExtendedTypeAndInheritanceClause: 
-  ///   - inheritanceClause: 
-  ///   - unexpectedBetweenInheritanceClauseAndGenericWhereClause: 
-  ///   - genericWhereClause: 
-  ///   - unexpectedBetweenGenericWhereClauseAndMembers: 
-  ///   - members: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndExtensionKeyword: UnexpectedNodes? = nil, extensionKeyword: Token = Token.`extension`, unexpectedBetweenExtensionKeywordAndExtendedType: UnexpectedNodes? = nil, extendedType: TypeSyntaxProtocol, unexpectedBetweenExtendedTypeAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, members: MemberDeclBlock) {
-    assert(extensionKeyword.text == "extension")
-    self = ExtensionDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndExtensionKeyword, extensionKeyword: extensionKeyword, unexpectedBetweenExtensionKeywordAndExtendedType, extendedType: TypeSyntax(fromProtocol: extendedType), unexpectedBetweenExtendedTypeAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: members)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndExtensionKeyword: UnexpectedNodes? = nil, extensionKeyword: Token = Token.`extension`, unexpectedBetweenExtensionKeywordAndExtendedType: UnexpectedNodes? = nil, extendedType: TypeSyntaxProtocol, unexpectedBetweenExtendedTypeAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndExtensionKeyword: UnexpectedNodes? = nil, extensionKeyword: Token = Token.`extension`, unexpectedBetweenExtensionKeywordAndExtendedType: UnexpectedNodes? = nil, extendedType: TypeSyntaxProtocol, unexpectedBetweenExtendedTypeAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
     MemberDeclListSyntax([])
-  }) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndExtensionKeyword, extensionKeyword: extensionKeyword, unexpectedBetweenExtensionKeywordAndExtendedType, extendedType: TypeSyntax(fromProtocol: extendedType), unexpectedBetweenExtendedTypeAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: MemberDeclBlockSyntax(members: membersBuilder()))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension FallthroughStmt {
-  /// Creates a `FallthroughStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeFallthroughKeyword: 
-  ///   - fallthroughKeyword: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeFallthroughKeyword: UnexpectedNodes? = nil, fallthroughKeyword: Token = Token.`fallthrough`) {
-    assert(fallthroughKeyword.text == "fallthrough")
-    self = FallthroughStmtSyntax(unexpectedBeforeFallthroughKeyword, fallthroughKeyword: fallthroughKeyword)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndExtensionKeyword, extensionKeyword: extensionKeyword, unexpectedBetweenExtensionKeywordAndExtendedType, extendedType: TypeSyntax(fromProtocol: extendedType), unexpectedBetweenExtendedTypeAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: MemberDeclBlockSyntax(members: membersBuilder()), trailingTrivia: trailingTrivia)
   }
 }
 
 extension FloatLiteralExpr {
-  /// Creates a `FloatLiteralExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeFloatingDigits: 
-  ///   - floatingDigits: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeFloatingDigits: UnexpectedNodes? = nil, floatingDigits: Token) {
-    self = FloatLiteralExprSyntax(unexpectedBeforeFloatingDigits, floatingDigits: floatingDigits)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeFloatingDigits: UnexpectedNodes? = nil, floatingDigits: String) {
-    self.init (unexpectedBeforeFloatingDigits, floatingDigits: Token.`floatingLiteral`(floatingDigits))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeFloatingDigits: UnexpectedNodes? = nil, floatingDigits: String, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeFloatingDigits, floatingDigits: Token.`floatingLiteral`(floatingDigits), trailingTrivia: trailingTrivia)
   }
 }
 
 extension ForInStmt {
-  /// Creates a `ForInStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeForKeyword: 
-  ///   - forKeyword: 
-  ///   - unexpectedBetweenForKeywordAndTryKeyword: 
-  ///   - tryKeyword: 
-  ///   - unexpectedBetweenTryKeywordAndAwaitKeyword: 
-  ///   - awaitKeyword: 
-  ///   - unexpectedBetweenAwaitKeywordAndCaseKeyword: 
-  ///   - caseKeyword: 
-  ///   - unexpectedBetweenCaseKeywordAndPattern: 
-  ///   - pattern: 
-  ///   - unexpectedBetweenPatternAndTypeAnnotation: 
-  ///   - typeAnnotation: 
-  ///   - unexpectedBetweenTypeAnnotationAndInKeyword: 
-  ///   - inKeyword: 
-  ///   - unexpectedBetweenInKeywordAndSequenceExpr: 
-  ///   - sequenceExpr: 
-  ///   - unexpectedBetweenSequenceExprAndWhereClause: 
-  ///   - whereClause: 
-  ///   - unexpectedBetweenWhereClauseAndBody: 
-  ///   - body: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeForKeyword: UnexpectedNodes? = nil, forKeyword: Token = Token.`for`, unexpectedBetweenForKeywordAndTryKeyword: UnexpectedNodes? = nil, tryKeyword: Token? = nil, unexpectedBetweenTryKeywordAndAwaitKeyword: UnexpectedNodes? = nil, awaitKeyword: Token? = nil, unexpectedBetweenAwaitKeywordAndCaseKeyword: UnexpectedNodes? = nil, caseKeyword: Token? = nil, unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodes? = nil, pattern: PatternSyntaxProtocol, unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodes? = nil, typeAnnotation: TypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInKeyword: UnexpectedNodes? = nil, inKeyword: Token = Token.`in`, unexpectedBetweenInKeywordAndSequenceExpr: UnexpectedNodes? = nil, sequenceExpr: ExprSyntaxProtocol, unexpectedBetweenSequenceExprAndWhereClause: UnexpectedNodes? = nil, whereClause: WhereClause? = nil, unexpectedBetweenWhereClauseAndBody: UnexpectedNodes? = nil, body: CodeBlock) {
-    assert(forKeyword.text == "for")
-    assert(tryKeyword == nil || tryKeyword!.text == "try")
-    assert(awaitKeyword == nil || awaitKeyword!.text == "await")
-    assert(caseKeyword == nil || caseKeyword!.text == "case")
-    assert(inKeyword.text == "in")
-    self = ForInStmtSyntax(unexpectedBeforeForKeyword, forKeyword: forKeyword, unexpectedBetweenForKeywordAndTryKeyword, tryKeyword: tryKeyword, unexpectedBetweenTryKeywordAndAwaitKeyword, awaitKeyword: awaitKeyword, unexpectedBetweenAwaitKeywordAndCaseKeyword, caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndPattern, pattern: PatternSyntax(fromProtocol: pattern), unexpectedBetweenPatternAndTypeAnnotation, typeAnnotation: typeAnnotation, unexpectedBetweenTypeAnnotationAndInKeyword, inKeyword: inKeyword, unexpectedBetweenInKeywordAndSequenceExpr, sequenceExpr: ExprSyntax(fromProtocol: sequenceExpr), unexpectedBetweenSequenceExprAndWhereClause, whereClause: whereClause, unexpectedBetweenWhereClauseAndBody, body: body)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeForKeyword: UnexpectedNodes? = nil, forKeyword: Token = Token.`for`, unexpectedBetweenForKeywordAndTryKeyword: UnexpectedNodes? = nil, tryKeyword: Token? = nil, unexpectedBetweenTryKeywordAndAwaitKeyword: UnexpectedNodes? = nil, awaitKeyword: String?, unexpectedBetweenAwaitKeywordAndCaseKeyword: UnexpectedNodes? = nil, caseKeyword: Token? = nil, unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodes? = nil, pattern: PatternSyntaxProtocol, unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodes? = nil, typeAnnotation: TypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInKeyword: UnexpectedNodes? = nil, inKeyword: Token = Token.`in`, unexpectedBetweenInKeywordAndSequenceExpr: UnexpectedNodes? = nil, sequenceExpr: ExprSyntaxProtocol, unexpectedBetweenSequenceExprAndWhereClause: UnexpectedNodes? = nil, whereClause: WhereClause? = nil, unexpectedBetweenWhereClauseAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeForKeyword: UnexpectedNodes? = nil, forKeyword: Token = Token.`for`, unexpectedBetweenForKeywordAndTryKeyword: UnexpectedNodes? = nil, tryKeyword: Token? = nil, unexpectedBetweenTryKeywordAndAwaitKeyword: UnexpectedNodes? = nil, awaitKeyword: String?, unexpectedBetweenAwaitKeywordAndCaseKeyword: UnexpectedNodes? = nil, caseKeyword: Token? = nil, unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodes? = nil, pattern: PatternSyntaxProtocol, unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodes? = nil, typeAnnotation: TypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInKeyword: UnexpectedNodes? = nil, inKeyword: Token = Token.`in`, unexpectedBetweenInKeywordAndSequenceExpr: UnexpectedNodes? = nil, sequenceExpr: ExprSyntaxProtocol, unexpectedBetweenSequenceExprAndWhereClause: UnexpectedNodes? = nil, whereClause: WhereClause? = nil, unexpectedBetweenWhereClauseAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
     CodeBlockItemListSyntax([])
-  }) {
-    self.init (unexpectedBeforeForKeyword, forKeyword: forKeyword, unexpectedBetweenForKeywordAndTryKeyword, tryKeyword: tryKeyword, unexpectedBetweenTryKeywordAndAwaitKeyword, awaitKeyword: awaitKeyword.map { 
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeForKeyword, forKeyword: forKeyword, unexpectedBetweenForKeywordAndTryKeyword, tryKeyword: tryKeyword, unexpectedBetweenTryKeywordAndAwaitKeyword, awaitKeyword: awaitKeyword.map { 
       Token.`identifier`($0) 
-    }, unexpectedBetweenAwaitKeywordAndCaseKeyword, caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndPattern, pattern: PatternSyntax(fromProtocol: pattern), unexpectedBetweenPatternAndTypeAnnotation, typeAnnotation: typeAnnotation, unexpectedBetweenTypeAnnotationAndInKeyword, inKeyword: inKeyword, unexpectedBetweenInKeywordAndSequenceExpr, sequenceExpr: ExprSyntax(fromProtocol: sequenceExpr), unexpectedBetweenSequenceExprAndWhereClause, whereClause: whereClause, unexpectedBetweenWhereClauseAndBody, body: CodeBlockSyntax(statements: bodyBuilder()))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension ForcedValueExpr {
-  /// Creates a `ForcedValueExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeExpression: 
-  ///   - expression: 
-  ///   - unexpectedBetweenExpressionAndExclamationMark: 
-  ///   - exclamationMark: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndExclamationMark: UnexpectedNodes? = nil, exclamationMark: Token = Token.`exclamationMark`) {
-    assert(exclamationMark.text == "!")
-    self = ForcedValueExprSyntax(unexpectedBeforeExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndExclamationMark, exclamationMark: exclamationMark)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+    }, unexpectedBetweenAwaitKeywordAndCaseKeyword, caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndPattern, pattern: PatternSyntax(fromProtocol: pattern), unexpectedBetweenPatternAndTypeAnnotation, typeAnnotation: typeAnnotation, unexpectedBetweenTypeAnnotationAndInKeyword, inKeyword: inKeyword, unexpectedBetweenInKeywordAndSequenceExpr, sequenceExpr: ExprSyntax(fromProtocol: sequenceExpr), unexpectedBetweenSequenceExprAndWhereClause, whereClause: whereClause, unexpectedBetweenWhereClauseAndBody, body: CodeBlockSyntax(statements: bodyBuilder()), trailingTrivia: trailingTrivia)
   }
 }
 
 extension FunctionCallExpr {
-  /// Creates a `FunctionCallExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeCalledExpression: 
-  ///   - calledExpression: 
-  ///   - unexpectedBetweenCalledExpressionAndLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndArgumentList: 
-  ///   - argumentList: 
-  ///   - unexpectedBetweenArgumentListAndRightParen: 
-  ///   - rightParen: 
-  ///   - unexpectedBetweenRightParenAndTrailingClosure: 
-  ///   - trailingClosure: 
-  ///   - unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: 
-  ///   - additionalTrailingClosures: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeCalledExpression: UnexpectedNodes? = nil, calledExpression: ExprSyntaxProtocol, unexpectedBetweenCalledExpressionAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodes? = nil, argumentList: TupleExprElementList, unexpectedBetweenArgumentListAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodes? = nil, trailingClosure: ClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodes? = nil, additionalTrailingClosures: MultipleTrailingClosureElementList? = nil) {
-    assert(leftParen == nil || leftParen!.text == "(")
-    assert(rightParen == nil || rightParen!.text == ")")
-    self = FunctionCallExprSyntax(unexpectedBeforeCalledExpression, calledExpression: ExprSyntax(fromProtocol: calledExpression), unexpectedBetweenCalledExpressionAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList: argumentList, unexpectedBetweenArgumentListAndRightParen, rightParen: rightParen, unexpectedBetweenRightParenAndTrailingClosure, trailingClosure: trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures: additionalTrailingClosures)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeCalledExpression: UnexpectedNodes? = nil, calledExpression: ExprSyntaxProtocol, unexpectedBetweenCalledExpressionAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodes? = nil, unexpectedBetweenArgumentListAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodes? = nil, trailingClosure: ClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodes? = nil, additionalTrailingClosures: MultipleTrailingClosureElementList? = nil, @TupleExprElementListBuilder argumentListBuilder: () -> TupleExprElementListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeCalledExpression: UnexpectedNodes? = nil, calledExpression: ExprSyntaxProtocol, unexpectedBetweenCalledExpressionAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodes? = nil, unexpectedBetweenArgumentListAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodes? = nil, trailingClosure: ClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodes? = nil, additionalTrailingClosures: MultipleTrailingClosureElementList? = nil, @TupleExprElementListBuilder argumentListBuilder: () -> TupleExprElementListSyntax = {
     TupleExprElementListSyntax([])
-  }) {
-    self.init (unexpectedBeforeCalledExpression, calledExpression: ExprSyntax(fromProtocol: calledExpression), unexpectedBetweenCalledExpressionAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList: argumentListBuilder(), unexpectedBetweenArgumentListAndRightParen, rightParen: rightParen, unexpectedBetweenRightParenAndTrailingClosure, trailingClosure: trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures: additionalTrailingClosures)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-/// A function declaration name (e.g. `foo(_:_:)`).
-extension FunctionDeclName {
-  /// Creates a `FunctionDeclName` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeName: 
-  ///   - name: The base name of the referenced function.
-  ///   - unexpectedBetweenNameAndArguments: 
-  ///   - arguments: The argument labels of the referenced function, optionallyspecified.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndArguments: UnexpectedNodes? = nil, arguments: DeclNameArguments? = nil) {
-    self = FunctionDeclNameSyntax(unexpectedBeforeName, name: name, unexpectedBetweenNameAndArguments, arguments: arguments)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeCalledExpression, calledExpression: ExprSyntax(fromProtocol: calledExpression), unexpectedBetweenCalledExpressionAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList: argumentListBuilder(), unexpectedBetweenArgumentListAndRightParen, rightParen: rightParen, unexpectedBetweenRightParenAndTrailingClosure, trailingClosure: trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures: additionalTrailingClosures, trailingTrivia: trailingTrivia)
   }
 }
 
 extension FunctionDecl {
-  /// Creates a `FunctionDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: 
-  ///   - unexpectedBetweenModifiersAndFuncKeyword: 
-  ///   - funcKeyword: 
-  ///   - unexpectedBetweenFuncKeywordAndIdentifier: 
-  ///   - identifier: 
-  ///   - unexpectedBetweenIdentifierAndGenericParameterClause: 
-  ///   - genericParameterClause: 
-  ///   - unexpectedBetweenGenericParameterClauseAndSignature: 
-  ///   - signature: 
-  ///   - unexpectedBetweenSignatureAndGenericWhereClause: 
-  ///   - genericWhereClause: 
-  ///   - unexpectedBetweenGenericWhereClauseAndBody: 
-  ///   - body: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndFuncKeyword: UnexpectedNodes? = nil, funcKeyword: Token = Token.`func`, unexpectedBetweenFuncKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodes? = nil, signature: FunctionSignature, unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodes? = nil, body: CodeBlock? = nil) {
-    assert(funcKeyword.text == "func")
-    self = FunctionDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndFuncKeyword, funcKeyword: funcKeyword, unexpectedBetweenFuncKeywordAndIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature, signature: signature, unexpectedBetweenSignatureAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndBody, body: body)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndFuncKeyword: UnexpectedNodes? = nil, funcKeyword: Token = Token.`func`, unexpectedBetweenFuncKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodes? = nil, signature: FunctionSignature, unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax? = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndFuncKeyword: UnexpectedNodes? = nil, funcKeyword: Token = Token.`func`, unexpectedBetweenFuncKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodes? = nil, signature: FunctionSignature, unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax? = {
     nil
-  }) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndFuncKeyword, funcKeyword: funcKeyword, unexpectedBetweenFuncKeywordAndIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature, signature: signature, unexpectedBetweenSignatureAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndBody, body: bodyBuilder().map { 
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndFuncKeyword, funcKeyword: funcKeyword, unexpectedBetweenFuncKeywordAndIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature, signature: signature, unexpectedBetweenSignatureAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndBody, body: bodyBuilder().map { 
       CodeBlockSyntax(statements: $0) 
-    })
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    }, trailingTrivia: trailingTrivia)
   }
 }
 
 extension FunctionParameter: HasTrailingComma {
-  /// Creates a `FunctionParameter` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: 
-  ///   - unexpectedBetweenModifiersAndFirstName: 
-  ///   - firstName: 
-  ///   - unexpectedBetweenFirstNameAndSecondName: 
-  ///   - secondName: 
-  ///   - unexpectedBetweenSecondNameAndColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndType: 
-  ///   - type: 
-  ///   - unexpectedBetweenTypeAndEllipsis: 
-  ///   - ellipsis: 
-  ///   - unexpectedBetweenEllipsisAndDefaultArgument: 
-  ///   - defaultArgument: 
-  ///   - unexpectedBetweenDefaultArgumentAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndFirstName: UnexpectedNodes? = nil, firstName: Token? = nil, unexpectedBetweenFirstNameAndSecondName: UnexpectedNodes? = nil, secondName: Token? = nil, unexpectedBetweenSecondNameAndColon: UnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndType: UnexpectedNodes? = nil, type: TypeSyntaxProtocol? = nil, unexpectedBetweenTypeAndEllipsis: UnexpectedNodes? = nil, ellipsis: Token? = nil, unexpectedBetweenEllipsisAndDefaultArgument: UnexpectedNodes? = nil, defaultArgument: InitializerClause? = nil, unexpectedBetweenDefaultArgumentAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(colon == nil || colon!.text == ":")
-    assert(ellipsis == nil || ellipsis!.text == "...")
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = FunctionParameterSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndFirstName, firstName: firstName, unexpectedBetweenFirstNameAndSecondName, secondName: secondName, unexpectedBetweenSecondNameAndColon, colon: colon, unexpectedBetweenColonAndType, type: TypeSyntax(fromProtocol: type), unexpectedBetweenTypeAndEllipsis, ellipsis: ellipsis, unexpectedBetweenEllipsisAndDefaultArgument, defaultArgument: defaultArgument, unexpectedBetweenDefaultArgumentAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
@@ -2090,106 +609,28 @@ extension FunctionParameter: HasTrailingComma {
 }
 
 extension FunctionSignature {
-  /// Creates a `FunctionSignature` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeInput: 
-  ///   - input: 
-  ///   - unexpectedBetweenInputAndAsyncOrReasyncKeyword: 
-  ///   - asyncOrReasyncKeyword: 
-  ///   - unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: 
-  ///   - throwsOrRethrowsKeyword: 
-  ///   - unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: 
-  ///   - output: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeInput: UnexpectedNodes? = nil, input: ParameterClause, unexpectedBetweenInputAndAsyncOrReasyncKeyword: UnexpectedNodes? = nil, asyncOrReasyncKeyword: Token? = nil, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodes? = nil, throwsOrRethrowsKeyword: Token? = nil, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: UnexpectedNodes? = nil, output: ReturnClause? = nil) {
-    assert(asyncOrReasyncKeyword == nil || asyncOrReasyncKeyword!.text == "async" || asyncOrReasyncKeyword!.text == "reasync")
-    assert(throwsOrRethrowsKeyword == nil || throwsOrRethrowsKeyword!.text == "throws" || throwsOrRethrowsKeyword!.text == "rethrows")
-    self = FunctionSignatureSyntax(unexpectedBeforeInput, input: input, unexpectedBetweenInputAndAsyncOrReasyncKeyword, asyncOrReasyncKeyword: asyncOrReasyncKeyword, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword, throwsOrRethrowsKeyword: throwsOrRethrowsKeyword, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput, output: output)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeInput: UnexpectedNodes? = nil, input: ParameterClause, unexpectedBetweenInputAndAsyncOrReasyncKeyword: UnexpectedNodes? = nil, asyncOrReasyncKeyword: String?, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodes? = nil, throwsOrRethrowsKeyword: Token? = nil, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: UnexpectedNodes? = nil, output: ReturnClause? = nil) {
-    self.init (unexpectedBeforeInput, input: input, unexpectedBetweenInputAndAsyncOrReasyncKeyword, asyncOrReasyncKeyword: asyncOrReasyncKeyword.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeInput: UnexpectedNodes? = nil, input: ParameterClause, unexpectedBetweenInputAndAsyncOrReasyncKeyword: UnexpectedNodes? = nil, asyncOrReasyncKeyword: String?, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodes? = nil, throwsOrRethrowsKeyword: Token? = nil, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: UnexpectedNodes? = nil, output: ReturnClause? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeInput, input: input, unexpectedBetweenInputAndAsyncOrReasyncKeyword, asyncOrReasyncKeyword: asyncOrReasyncKeyword.map { 
       Token.`contextualKeyword`($0) 
-    }, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword, throwsOrRethrowsKeyword: throwsOrRethrowsKeyword, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput, output: output)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension FunctionType {
-  /// Creates a `FunctionType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndArguments: 
-  ///   - arguments: 
-  ///   - unexpectedBetweenArgumentsAndRightParen: 
-  ///   - rightParen: 
-  ///   - unexpectedBetweenRightParenAndAsyncKeyword: 
-  ///   - asyncKeyword: 
-  ///   - unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword: 
-  ///   - throwsOrRethrowsKeyword: 
-  ///   - unexpectedBetweenThrowsOrRethrowsKeywordAndArrow: 
-  ///   - arrow: 
-  ///   - unexpectedBetweenArrowAndReturnType: 
-  ///   - returnType: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndArguments: UnexpectedNodes? = nil, arguments: TupleTypeElementList, unexpectedBetweenArgumentsAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`, unexpectedBetweenRightParenAndAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: Token? = nil, unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodes? = nil, throwsOrRethrowsKeyword: Token? = nil, unexpectedBetweenThrowsOrRethrowsKeywordAndArrow: UnexpectedNodes? = nil, arrow: Token = Token.`arrow`, unexpectedBetweenArrowAndReturnType: UnexpectedNodes? = nil, returnType: TypeSyntaxProtocol) {
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    assert(asyncKeyword == nil || asyncKeyword!.text == "async")
-    assert(throwsOrRethrowsKeyword == nil || throwsOrRethrowsKeyword!.text == "throws" || throwsOrRethrowsKeyword!.text == "rethrows" || throwsOrRethrowsKeyword!.text == "throw")
-    assert(arrow.text == "->")
-    self = FunctionTypeSyntax(unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArguments, arguments: arguments, unexpectedBetweenArgumentsAndRightParen, rightParen: rightParen, unexpectedBetweenRightParenAndAsyncKeyword, asyncKeyword: asyncKeyword, unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword, throwsOrRethrowsKeyword: throwsOrRethrowsKeyword, unexpectedBetweenThrowsOrRethrowsKeywordAndArrow, arrow: arrow, unexpectedBetweenArrowAndReturnType, returnType: TypeSyntax(fromProtocol: returnType))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+    }, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword, throwsOrRethrowsKeyword: throwsOrRethrowsKeyword, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput, output: output, trailingTrivia: trailingTrivia)
   }
 }
 
 extension GenericArgumentClause {
-  /// Creates a `GenericArgumentClause` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftAngleBracket: 
-  ///   - leftAngleBracket: 
-  ///   - unexpectedBetweenLeftAngleBracketAndArguments: 
-  ///   - arguments: 
-  ///   - unexpectedBetweenArgumentsAndRightAngleBracket: 
-  ///   - rightAngleBracket: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftAngleBracket: UnexpectedNodes? = nil, leftAngleBracket: Token = Token.`leftAngle`, unexpectedBetweenLeftAngleBracketAndArguments: UnexpectedNodes? = nil, arguments: GenericArgumentList, unexpectedBetweenArgumentsAndRightAngleBracket: UnexpectedNodes? = nil, rightAngleBracket: Token = Token.`rightAngle`) {
-    assert(leftAngleBracket.text == "<")
-    assert(rightAngleBracket.text == ">")
-    self = GenericArgumentClauseSyntax(unexpectedBeforeLeftAngleBracket, leftAngleBracket: leftAngleBracket, unexpectedBetweenLeftAngleBracketAndArguments, arguments: arguments, unexpectedBetweenArgumentsAndRightAngleBracket, rightAngleBracket: rightAngleBracket)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftAngleBracket: UnexpectedNodes? = nil, leftAngleBracket: Token = Token.`leftAngle`, unexpectedBetweenLeftAngleBracketAndArguments: UnexpectedNodes? = nil, unexpectedBetweenArgumentsAndRightAngleBracket: UnexpectedNodes? = nil, rightAngleBracket: Token = Token.`rightAngle`, @GenericArgumentListBuilder argumentsBuilder: () -> GenericArgumentListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLeftAngleBracket: UnexpectedNodes? = nil, leftAngleBracket: Token = Token.`leftAngle`, unexpectedBetweenLeftAngleBracketAndArguments: UnexpectedNodes? = nil, unexpectedBetweenArgumentsAndRightAngleBracket: UnexpectedNodes? = nil, rightAngleBracket: Token = Token.`rightAngle`, @GenericArgumentListBuilder argumentsBuilder: () -> GenericArgumentListSyntax = {
     GenericArgumentListSyntax([])
-  }) {
-    self.init (unexpectedBeforeLeftAngleBracket, leftAngleBracket: leftAngleBracket, unexpectedBetweenLeftAngleBracketAndArguments, arguments: argumentsBuilder(), unexpectedBetweenArgumentsAndRightAngleBracket, rightAngleBracket: rightAngleBracket)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLeftAngleBracket, leftAngleBracket: leftAngleBracket, unexpectedBetweenLeftAngleBracketAndArguments, arguments: argumentsBuilder(), unexpectedBetweenArgumentsAndRightAngleBracket, rightAngleBracket: rightAngleBracket, trailingTrivia: trailingTrivia)
   }
 }
 
 extension GenericArgument: HasTrailingComma {
-  /// Creates a `GenericArgument` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeArgumentType: 
-  ///   - argumentType: 
-  ///   - unexpectedBetweenArgumentTypeAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeArgumentType: UnexpectedNodes? = nil, argumentType: TypeSyntaxProtocol, unexpectedBetweenArgumentTypeAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = GenericArgumentSyntax(unexpectedBeforeArgumentType, argumentType: TypeSyntax(fromProtocol: argumentType), unexpectedBetweenArgumentTypeAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
@@ -2201,65 +642,22 @@ extension GenericArgument: HasTrailingComma {
 }
 
 extension GenericParameterClause {
-  /// Creates a `GenericParameterClause` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftAngleBracket: 
-  ///   - leftAngleBracket: 
-  ///   - unexpectedBetweenLeftAngleBracketAndGenericParameterList: 
-  ///   - genericParameterList: 
-  ///   - unexpectedBetweenGenericParameterListAndGenericWhereClause: 
-  ///   - genericWhereClause: 
-  ///   - unexpectedBetweenGenericWhereClauseAndRightAngleBracket: 
-  ///   - rightAngleBracket: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftAngleBracket: UnexpectedNodes? = nil, leftAngleBracket: Token = Token.`leftAngle`, unexpectedBetweenLeftAngleBracketAndGenericParameterList: UnexpectedNodes? = nil, genericParameterList: GenericParameterList, unexpectedBetweenGenericParameterListAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndRightAngleBracket: UnexpectedNodes? = nil, rightAngleBracket: Token = Token.`rightAngle`) {
-    assert(leftAngleBracket.text == "<")
-    assert(rightAngleBracket.text == ">")
-    self = GenericParameterClauseSyntax(unexpectedBeforeLeftAngleBracket, leftAngleBracket: leftAngleBracket, unexpectedBetweenLeftAngleBracketAndGenericParameterList, genericParameterList: genericParameterList, unexpectedBetweenGenericParameterListAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndRightAngleBracket, rightAngleBracket: rightAngleBracket)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftAngleBracket: UnexpectedNodes? = nil, leftAngleBracket: Token = Token.`leftAngle`, unexpectedBetweenLeftAngleBracketAndGenericParameterList: UnexpectedNodes? = nil, unexpectedBetweenGenericParameterListAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndRightAngleBracket: UnexpectedNodes? = nil, rightAngleBracket: Token = Token.`rightAngle`, @GenericParameterListBuilder genericParameterListBuilder: () -> GenericParameterListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLeftAngleBracket: UnexpectedNodes? = nil, leftAngleBracket: Token = Token.`leftAngle`, unexpectedBetweenLeftAngleBracketAndGenericParameterList: UnexpectedNodes? = nil, unexpectedBetweenGenericParameterListAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndRightAngleBracket: UnexpectedNodes? = nil, rightAngleBracket: Token = Token.`rightAngle`, @GenericParameterListBuilder genericParameterListBuilder: () -> GenericParameterListSyntax = {
     GenericParameterListSyntax([])
-  }) {
-    self.init (unexpectedBeforeLeftAngleBracket, leftAngleBracket: leftAngleBracket, unexpectedBetweenLeftAngleBracketAndGenericParameterList, genericParameterList: genericParameterListBuilder(), unexpectedBetweenGenericParameterListAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndRightAngleBracket, rightAngleBracket: rightAngleBracket)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLeftAngleBracket, leftAngleBracket: leftAngleBracket, unexpectedBetweenLeftAngleBracketAndGenericParameterList, genericParameterList: genericParameterListBuilder(), unexpectedBetweenGenericParameterListAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndRightAngleBracket, rightAngleBracket: rightAngleBracket, trailingTrivia: trailingTrivia)
   }
 }
 
 extension GenericParameter: HasTrailingComma {
-  /// Creates a `GenericParameter` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndName: 
-  ///   - name: 
-  ///   - unexpectedBetweenNameAndEllipsis: 
-  ///   - ellipsis: 
-  ///   - unexpectedBetweenEllipsisAndColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndInheritedType: 
-  ///   - inheritedType: 
-  ///   - unexpectedBetweenInheritedTypeAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndName: UnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndEllipsis: UnexpectedNodes? = nil, ellipsis: Token? = nil, unexpectedBetweenEllipsisAndColon: UnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndInheritedType: UnexpectedNodes? = nil, inheritedType: TypeSyntaxProtocol? = nil, unexpectedBetweenInheritedTypeAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(ellipsis == nil || ellipsis!.text == "...")
-    assert(colon == nil || colon!.text == ":")
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = GenericParameterSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndName, name: name, unexpectedBetweenNameAndEllipsis, ellipsis: ellipsis, unexpectedBetweenEllipsisAndColon, colon: colon, unexpectedBetweenColonAndInheritedType, inheritedType: TypeSyntax(fromProtocol: inheritedType), unexpectedBetweenInheritedTypeAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndName: UnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndEllipsis: UnexpectedNodes? = nil, ellipsis: Token? = nil, unexpectedBetweenEllipsisAndColon: UnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndInheritedType: UnexpectedNodes? = nil, inheritedType: TypeSyntaxProtocol? = nil, unexpectedBetweenInheritedTypeAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndName, name: Token.`identifier`(name), unexpectedBetweenNameAndEllipsis, ellipsis: ellipsis, unexpectedBetweenEllipsisAndColon, colon: colon, unexpectedBetweenColonAndInheritedType, inheritedType: TypeSyntax(fromProtocol: inheritedType), unexpectedBetweenInheritedTypeAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndName: UnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndEllipsis: UnexpectedNodes? = nil, ellipsis: Token? = nil, unexpectedBetweenEllipsisAndColon: UnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndInheritedType: UnexpectedNodes? = nil, inheritedType: TypeSyntaxProtocol? = nil, unexpectedBetweenInheritedTypeAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndName, name: Token.`identifier`(name), unexpectedBetweenNameAndEllipsis, ellipsis: ellipsis, unexpectedBetweenEllipsisAndColon, colon: colon, unexpectedBetweenColonAndInheritedType, inheritedType: TypeSyntax(fromProtocol: inheritedType), unexpectedBetweenInheritedTypeAndTrailingComma, trailingComma: trailingComma, trailingTrivia: trailingTrivia)
   }
   
   var hasTrailingComma: Bool {
@@ -2273,19 +671,6 @@ extension GenericParameter: HasTrailingComma {
 }
 
 extension GenericRequirement: HasTrailingComma {
-  /// Creates a `GenericRequirement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeBody: 
-  ///   - body: 
-  ///   - unexpectedBetweenBodyAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBody: UnexpectedNodes? = nil, body: Body, unexpectedBetweenBodyAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = GenericRequirementSyntax(unexpectedBeforeBody, body: body, unexpectedBetweenBodyAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
@@ -2297,272 +682,39 @@ extension GenericRequirement: HasTrailingComma {
 }
 
 extension GenericWhereClause {
-  /// Creates a `GenericWhereClause` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeWhereKeyword: 
-  ///   - whereKeyword: 
-  ///   - unexpectedBetweenWhereKeywordAndRequirementList: 
-  ///   - requirementList: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWhereKeyword: UnexpectedNodes? = nil, whereKeyword: Token = Token.`where`, unexpectedBetweenWhereKeywordAndRequirementList: UnexpectedNodes? = nil, requirementList: GenericRequirementList) {
-    assert(whereKeyword.text == "where")
-    self = GenericWhereClauseSyntax(unexpectedBeforeWhereKeyword, whereKeyword: whereKeyword, unexpectedBetweenWhereKeywordAndRequirementList, requirementList: requirementList)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeWhereKeyword: UnexpectedNodes? = nil, whereKeyword: Token = Token.`where`, unexpectedBetweenWhereKeywordAndRequirementList: UnexpectedNodes? = nil, @GenericRequirementListBuilder requirementListBuilder: () -> GenericRequirementListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeWhereKeyword: UnexpectedNodes? = nil, whereKeyword: Token = Token.`where`, unexpectedBetweenWhereKeywordAndRequirementList: UnexpectedNodes? = nil, @GenericRequirementListBuilder requirementListBuilder: () -> GenericRequirementListSyntax = {
     GenericRequirementListSyntax([])
-  }) {
-    self.init (unexpectedBeforeWhereKeyword, whereKeyword: whereKeyword, unexpectedBetweenWhereKeywordAndRequirementList, requirementList: requirementListBuilder())
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeWhereKeyword, whereKeyword: whereKeyword, unexpectedBetweenWhereKeywordAndRequirementList, requirementList: requirementListBuilder(), trailingTrivia: trailingTrivia)
   }
 }
 
 extension GuardStmt {
-  /// Creates a `GuardStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeGuardKeyword: 
-  ///   - guardKeyword: 
-  ///   - unexpectedBetweenGuardKeywordAndConditions: 
-  ///   - conditions: 
-  ///   - unexpectedBetweenConditionsAndElseKeyword: 
-  ///   - elseKeyword: 
-  ///   - unexpectedBetweenElseKeywordAndBody: 
-  ///   - body: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeGuardKeyword: UnexpectedNodes? = nil, guardKeyword: Token = Token.`guard`, unexpectedBetweenGuardKeywordAndConditions: UnexpectedNodes? = nil, conditions: ConditionElementList, unexpectedBetweenConditionsAndElseKeyword: UnexpectedNodes? = nil, elseKeyword: Token = Token.`else`, unexpectedBetweenElseKeywordAndBody: UnexpectedNodes? = nil, body: CodeBlock) {
-    assert(guardKeyword.text == "guard")
-    assert(elseKeyword.text == "else")
-    self = GuardStmtSyntax(unexpectedBeforeGuardKeyword, guardKeyword: guardKeyword, unexpectedBetweenGuardKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndElseKeyword, elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndBody, body: body)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeGuardKeyword: UnexpectedNodes? = nil, guardKeyword: Token = Token.`guard`, unexpectedBetweenGuardKeywordAndConditions: UnexpectedNodes? = nil, conditions: ConditionElementList, unexpectedBetweenConditionsAndElseKeyword: UnexpectedNodes? = nil, elseKeyword: Token = Token.`else`, unexpectedBetweenElseKeywordAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeGuardKeyword: UnexpectedNodes? = nil, guardKeyword: Token = Token.`guard`, unexpectedBetweenGuardKeywordAndConditions: UnexpectedNodes? = nil, conditions: ConditionElementList, unexpectedBetweenConditionsAndElseKeyword: UnexpectedNodes? = nil, elseKeyword: Token = Token.`else`, unexpectedBetweenElseKeywordAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
     CodeBlockItemListSyntax([])
-  }) {
-    self.init (unexpectedBeforeGuardKeyword, guardKeyword: guardKeyword, unexpectedBetweenGuardKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndElseKeyword, elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndBody, body: CodeBlockSyntax(statements: bodyBuilder()))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension HasSymbolCondition {
-  /// Creates a `HasSymbolCondition` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeHasSymbolKeyword: 
-  ///   - hasSymbolKeyword: 
-  ///   - unexpectedBetweenHasSymbolKeywordAndLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndExpression: 
-  ///   - expression: 
-  ///   - unexpectedBetweenExpressionAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeHasSymbolKeyword: UnexpectedNodes? = nil, hasSymbolKeyword: Token, unexpectedBetweenHasSymbolKeywordAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = HasSymbolConditionSyntax(unexpectedBeforeHasSymbolKeyword, hasSymbolKeyword: hasSymbolKeyword, unexpectedBetweenHasSymbolKeywordAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension IdentifierExpr {
-  /// Creates a `IdentifierExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeIdentifier: 
-  ///   - identifier: 
-  ///   - unexpectedBetweenIdentifierAndDeclNameArguments: 
-  ///   - declNameArguments: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodes? = nil, declNameArguments: DeclNameArguments? = nil) {
-    self = IdentifierExprSyntax(unexpectedBeforeIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndDeclNameArguments, declNameArguments: declNameArguments)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension IdentifierPattern {
-  /// Creates a `IdentifierPattern` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeIdentifier: 
-  ///   - identifier: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIdentifier: UnexpectedNodes? = nil, identifier: Token) {
-    self = IdentifierPatternSyntax(unexpectedBeforeIdentifier, identifier: identifier)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension IfConfigClause {
-  /// Creates a `IfConfigClause` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePoundKeyword: 
-  ///   - poundKeyword: 
-  ///   - unexpectedBetweenPoundKeywordAndCondition: 
-  ///   - condition: 
-  ///   - unexpectedBetweenConditionAndElements: 
-  ///   - elements: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundKeyword: UnexpectedNodes? = nil, poundKeyword: Token, unexpectedBetweenPoundKeywordAndCondition: UnexpectedNodes? = nil, condition: ExprSyntaxProtocol? = nil, unexpectedBetweenConditionAndElements: UnexpectedNodes? = nil, elements: Elements? = nil) {
-    assert(poundKeyword.text == "#if" || poundKeyword.text == "#elseif" || poundKeyword.text == "#else")
-    self = IfConfigClauseSyntax(unexpectedBeforePoundKeyword, poundKeyword: poundKeyword, unexpectedBetweenPoundKeywordAndCondition, condition: ExprSyntax(fromProtocol: condition), unexpectedBetweenConditionAndElements, elements: elements)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension IfConfigDecl {
-  /// Creates a `IfConfigDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeClauses: 
-  ///   - clauses: 
-  ///   - unexpectedBetweenClausesAndPoundEndif: 
-  ///   - poundEndif: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeClauses: UnexpectedNodes? = nil, clauses: IfConfigClauseList, unexpectedBetweenClausesAndPoundEndif: UnexpectedNodes? = nil, poundEndif: Token = Token.`poundEndif`) {
-    assert(poundEndif.text == "#endif")
-    self = IfConfigDeclSyntax(unexpectedBeforeClauses, clauses: clauses, unexpectedBetweenClausesAndPoundEndif, poundEndif: poundEndif)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeGuardKeyword, guardKeyword: guardKeyword, unexpectedBetweenGuardKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndElseKeyword, elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndBody, body: CodeBlockSyntax(statements: bodyBuilder()), trailingTrivia: trailingTrivia)
   }
 }
 
 extension IfStmt {
-  /// Creates a `IfStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeIfKeyword: 
-  ///   - ifKeyword: 
-  ///   - unexpectedBetweenIfKeywordAndConditions: 
-  ///   - conditions: 
-  ///   - unexpectedBetweenConditionsAndBody: 
-  ///   - body: 
-  ///   - unexpectedBetweenBodyAndElseKeyword: 
-  ///   - elseKeyword: 
-  ///   - unexpectedBetweenElseKeywordAndElseBody: 
-  ///   - elseBody: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIfKeyword: UnexpectedNodes? = nil, ifKeyword: Token = Token.`if`, unexpectedBetweenIfKeywordAndConditions: UnexpectedNodes? = nil, conditions: ConditionElementList, unexpectedBetweenConditionsAndBody: UnexpectedNodes? = nil, body: CodeBlock, unexpectedBetweenBodyAndElseKeyword: UnexpectedNodes? = nil, elseKeyword: Token? = nil, unexpectedBetweenElseKeywordAndElseBody: UnexpectedNodes? = nil, elseBody: ElseBody? = nil) {
-    assert(ifKeyword.text == "if")
-    assert(elseKeyword == nil || elseKeyword!.text == "else")
-    self = IfStmtSyntax(unexpectedBeforeIfKeyword, ifKeyword: ifKeyword, unexpectedBetweenIfKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndBody, body: body, unexpectedBetweenBodyAndElseKeyword, elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndElseBody, elseBody: elseBody)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeIfKeyword: UnexpectedNodes? = nil, ifKeyword: Token = Token.`if`, unexpectedBetweenIfKeywordAndConditions: UnexpectedNodes? = nil, conditions: ConditionElementList, unexpectedBetweenConditionsAndBody: UnexpectedNodes? = nil, unexpectedBetweenBodyAndElseKeyword: UnexpectedNodes? = nil, elseKeyword: Token? = nil, unexpectedBetweenElseKeywordAndElseBody: UnexpectedNodes? = nil, elseBody: ElseBody? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeIfKeyword: UnexpectedNodes? = nil, ifKeyword: Token = Token.`if`, unexpectedBetweenIfKeywordAndConditions: UnexpectedNodes? = nil, conditions: ConditionElementList, unexpectedBetweenConditionsAndBody: UnexpectedNodes? = nil, unexpectedBetweenBodyAndElseKeyword: UnexpectedNodes? = nil, elseKeyword: Token? = nil, unexpectedBetweenElseKeywordAndElseBody: UnexpectedNodes? = nil, elseBody: ElseBody? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
     CodeBlockItemListSyntax([])
-  }) {
-    self.init (unexpectedBeforeIfKeyword, ifKeyword: ifKeyword, unexpectedBetweenIfKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndBody, body: CodeBlockSyntax(statements: bodyBuilder()), unexpectedBetweenBodyAndElseKeyword, elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndElseBody, elseBody: elseBody)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-/// The arguments for the `@_implements` attribute of the form`Type, methodName(arg1Label:arg2Label:)`
-extension ImplementsAttributeArguments {
-  /// Creates a `ImplementsAttributeArguments` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeType: 
-  ///   - type: The type for which the method with this attributeimplements a requirement.
-  ///   - unexpectedBetweenTypeAndComma: 
-  ///   - comma: The comma separating the type and method name
-  ///   - unexpectedBetweenCommaAndDeclBaseName: 
-  ///   - declBaseName: The base name of the protocol's requirement.
-  ///   - unexpectedBetweenDeclBaseNameAndDeclNameArguments: 
-  ///   - declNameArguments: The argument labels of the protocol's requirement if itis a function requirement.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeType: UnexpectedNodes? = nil, type: TypeSyntaxProtocol, unexpectedBetweenTypeAndComma: UnexpectedNodes? = nil, comma: Token = Token.`comma`, unexpectedBetweenCommaAndDeclBaseName: UnexpectedNodes? = nil, declBaseName: Token, unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodes? = nil, declNameArguments: DeclNameArguments? = nil) {
-    assert(comma.text == ",")
-    self = ImplementsAttributeArgumentsSyntax(unexpectedBeforeType, type: TypeSyntax(fromProtocol: type), unexpectedBetweenTypeAndComma, comma: comma, unexpectedBetweenCommaAndDeclBaseName, declBaseName: declBaseName, unexpectedBetweenDeclBaseNameAndDeclNameArguments, declNameArguments: declNameArguments)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension ImplicitlyUnwrappedOptionalType {
-  /// Creates a `ImplicitlyUnwrappedOptionalType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeWrappedType: 
-  ///   - wrappedType: 
-  ///   - unexpectedBetweenWrappedTypeAndExclamationMark: 
-  ///   - exclamationMark: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWrappedType: UnexpectedNodes? = nil, wrappedType: TypeSyntaxProtocol, unexpectedBetweenWrappedTypeAndExclamationMark: UnexpectedNodes? = nil, exclamationMark: Token = Token.`exclamationMark`) {
-    assert(exclamationMark.text == "!")
-    self = ImplicitlyUnwrappedOptionalTypeSyntax(unexpectedBeforeWrappedType, wrappedType: TypeSyntax(fromProtocol: wrappedType), unexpectedBetweenWrappedTypeAndExclamationMark, exclamationMark: exclamationMark)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension ImportDecl {
-  /// Creates a `ImportDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: 
-  ///   - unexpectedBetweenModifiersAndImportTok: 
-  ///   - importTok: 
-  ///   - unexpectedBetweenImportTokAndImportKind: 
-  ///   - importKind: 
-  ///   - unexpectedBetweenImportKindAndPath: 
-  ///   - path: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndImportTok: UnexpectedNodes? = nil, importTok: Token = Token.`import`, unexpectedBetweenImportTokAndImportKind: UnexpectedNodes? = nil, importKind: Token? = nil, unexpectedBetweenImportKindAndPath: UnexpectedNodes? = nil, path: AccessPath) {
-    assert(importTok.text == "import")
-    assert(importKind == nil || importKind!.text == "typealias" || importKind!.text == "struct" || importKind!.text == "class" || importKind!.text == "enum" || importKind!.text == "protocol" || importKind!.text == "var" || importKind!.text == "let" || importKind!.text == "func")
-    self = ImportDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndImportTok, importTok: importTok, unexpectedBetweenImportTokAndImportKind, importKind: importKind, unexpectedBetweenImportKindAndPath, path: path)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension InOutExpr {
-  /// Creates a `InOutExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAmpersand: 
-  ///   - ampersand: 
-  ///   - unexpectedBetweenAmpersandAndExpression: 
-  ///   - expression: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAmpersand: UnexpectedNodes? = nil, ampersand: Token = Token.`prefixAmpersand`, unexpectedBetweenAmpersandAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol) {
-    assert(ampersand.text == "&")
-    self = InOutExprSyntax(unexpectedBeforeAmpersand, ampersand: ampersand, unexpectedBetweenAmpersandAndExpression, expression: ExprSyntax(fromProtocol: expression))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension InfixOperatorExpr {
-  /// Creates a `InfixOperatorExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftOperand: 
-  ///   - leftOperand: 
-  ///   - unexpectedBetweenLeftOperandAndOperatorOperand: 
-  ///   - operatorOperand: 
-  ///   - unexpectedBetweenOperatorOperandAndRightOperand: 
-  ///   - rightOperand: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftOperand: UnexpectedNodes? = nil, leftOperand: ExprSyntaxProtocol, unexpectedBetweenLeftOperandAndOperatorOperand: UnexpectedNodes? = nil, operatorOperand: ExprSyntaxProtocol, unexpectedBetweenOperatorOperandAndRightOperand: UnexpectedNodes? = nil, rightOperand: ExprSyntaxProtocol) {
-    self = InfixOperatorExprSyntax(unexpectedBeforeLeftOperand, leftOperand: ExprSyntax(fromProtocol: leftOperand), unexpectedBetweenLeftOperandAndOperatorOperand, operatorOperand: ExprSyntax(fromProtocol: operatorOperand), unexpectedBetweenOperatorOperandAndRightOperand, rightOperand: ExprSyntax(fromProtocol: rightOperand))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeIfKeyword, ifKeyword: ifKeyword, unexpectedBetweenIfKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndBody, body: CodeBlockSyntax(statements: bodyBuilder()), unexpectedBetweenBodyAndElseKeyword, elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndElseBody, elseBody: elseBody, trailingTrivia: trailingTrivia)
   }
 }
 
 extension InheritedType: HasTrailingComma {
-  /// Creates a `InheritedType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeTypeName: 
-  ///   - typeName: 
-  ///   - unexpectedBetweenTypeNameAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeTypeName: UnexpectedNodes? = nil, typeName: TypeSyntaxProtocol, unexpectedBetweenTypeNameAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = InheritedTypeSyntax(unexpectedBeforeTypeName, typeName: TypeSyntax(fromProtocol: typeName), unexpectedBetweenTypeNameAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
@@ -2573,228 +725,46 @@ extension InheritedType: HasTrailingComma {
   }
 }
 
-extension InitializerClause {
-  /// Creates a `InitializerClause` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeEqual: 
-  ///   - equal: 
-  ///   - unexpectedBetweenEqualAndValue: 
-  ///   - value: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeEqual: UnexpectedNodes? = nil, equal: Token = Token.`equal`, unexpectedBetweenEqualAndValue: UnexpectedNodes? = nil, value: ExprSyntaxProtocol) {
-    assert(equal.text == "=")
-    self = InitializerClauseSyntax(unexpectedBeforeEqual, equal: equal, unexpectedBetweenEqualAndValue, value: ExprSyntax(fromProtocol: value))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
 extension InitializerDecl {
-  /// Creates a `InitializerDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: 
-  ///   - unexpectedBetweenModifiersAndInitKeyword: 
-  ///   - initKeyword: 
-  ///   - unexpectedBetweenInitKeywordAndOptionalMark: 
-  ///   - optionalMark: 
-  ///   - unexpectedBetweenOptionalMarkAndGenericParameterClause: 
-  ///   - genericParameterClause: 
-  ///   - unexpectedBetweenGenericParameterClauseAndSignature: 
-  ///   - signature: 
-  ///   - unexpectedBetweenSignatureAndGenericWhereClause: 
-  ///   - genericWhereClause: 
-  ///   - unexpectedBetweenGenericWhereClauseAndBody: 
-  ///   - body: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndInitKeyword: UnexpectedNodes? = nil, initKeyword: Token = Token.`init`, unexpectedBetweenInitKeywordAndOptionalMark: UnexpectedNodes? = nil, optionalMark: Token? = nil, unexpectedBetweenOptionalMarkAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodes? = nil, signature: FunctionSignature, unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodes? = nil, body: CodeBlock? = nil) {
-    assert(initKeyword.text == "init")
-    assert(optionalMark == nil || optionalMark!.text == "?" || optionalMark!.text == "?" || optionalMark!.text == "!")
-    self = InitializerDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndInitKeyword, initKeyword: initKeyword, unexpectedBetweenInitKeywordAndOptionalMark, optionalMark: optionalMark, unexpectedBetweenOptionalMarkAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature, signature: signature, unexpectedBetweenSignatureAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndBody, body: body)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndInitKeyword: UnexpectedNodes? = nil, initKeyword: Token = Token.`init`, unexpectedBetweenInitKeywordAndOptionalMark: UnexpectedNodes? = nil, optionalMark: Token? = nil, unexpectedBetweenOptionalMarkAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodes? = nil, signature: FunctionSignature, unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax? = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndInitKeyword: UnexpectedNodes? = nil, initKeyword: Token = Token.`init`, unexpectedBetweenInitKeywordAndOptionalMark: UnexpectedNodes? = nil, optionalMark: Token? = nil, unexpectedBetweenOptionalMarkAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodes? = nil, signature: FunctionSignature, unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax? = {
     nil
-  }) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndInitKeyword, initKeyword: initKeyword, unexpectedBetweenInitKeywordAndOptionalMark, optionalMark: optionalMark, unexpectedBetweenOptionalMarkAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature, signature: signature, unexpectedBetweenSignatureAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndBody, body: bodyBuilder().map { 
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndInitKeyword, initKeyword: initKeyword, unexpectedBetweenInitKeywordAndOptionalMark, optionalMark: optionalMark, unexpectedBetweenOptionalMarkAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature, signature: signature, unexpectedBetweenSignatureAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndBody, body: bodyBuilder().map { 
       CodeBlockSyntax(statements: $0) 
-    })
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    }, trailingTrivia: trailingTrivia)
   }
 }
 
 extension IntegerLiteralExpr {
-  /// Creates a `IntegerLiteralExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeDigits: 
-  ///   - digits: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDigits: UnexpectedNodes? = nil, digits: Token) {
-    self = IntegerLiteralExprSyntax(unexpectedBeforeDigits, digits: digits)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeDigits: UnexpectedNodes? = nil, digits: String) {
-    self.init (unexpectedBeforeDigits, digits: Token.`integerLiteral`(digits))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension IsExpr {
-  /// Creates a `IsExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeExpression: 
-  ///   - expression: 
-  ///   - unexpectedBetweenExpressionAndIsTok: 
-  ///   - isTok: 
-  ///   - unexpectedBetweenIsTokAndTypeName: 
-  ///   - typeName: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndIsTok: UnexpectedNodes? = nil, isTok: Token = Token.`is`, unexpectedBetweenIsTokAndTypeName: UnexpectedNodes? = nil, typeName: TypeSyntaxProtocol) {
-    assert(isTok.text == "is")
-    self = IsExprSyntax(unexpectedBeforeExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndIsTok, isTok: isTok, unexpectedBetweenIsTokAndTypeName, typeName: TypeSyntax(fromProtocol: typeName))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension IsTypePattern {
-  /// Creates a `IsTypePattern` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeIsKeyword: 
-  ///   - isKeyword: 
-  ///   - unexpectedBetweenIsKeywordAndType: 
-  ///   - type: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIsKeyword: UnexpectedNodes? = nil, isKeyword: Token = Token.`is`, unexpectedBetweenIsKeywordAndType: UnexpectedNodes? = nil, type: TypeSyntaxProtocol) {
-    assert(isKeyword.text == "is")
-    self = IsTypePatternSyntax(unexpectedBeforeIsKeyword, isKeyword: isKeyword, unexpectedBetweenIsKeywordAndType, type: TypeSyntax(fromProtocol: type))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension KeyPathComponent {
-  /// Creates a `KeyPathComponent` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePeriod: 
-  ///   - period: 
-  ///   - unexpectedBetweenPeriodAndComponent: 
-  ///   - component: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePeriod: UnexpectedNodes? = nil, period: Token? = nil, unexpectedBetweenPeriodAndComponent: UnexpectedNodes? = nil, component: Component) {
-    assert(period == nil || period!.text == "." || period!.text == ".")
-    self = KeyPathComponentSyntax(unexpectedBeforePeriod, period: period, unexpectedBetweenPeriodAndComponent, component: component)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension KeyPathExpr {
-  /// Creates a `KeyPathExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeBackslash: 
-  ///   - backslash: 
-  ///   - unexpectedBetweenBackslashAndRoot: 
-  ///   - root: 
-  ///   - unexpectedBetweenRootAndComponents: 
-  ///   - components: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBackslash: UnexpectedNodes? = nil, backslash: Token = Token.`backslash`, unexpectedBetweenBackslashAndRoot: UnexpectedNodes? = nil, root: TypeSyntaxProtocol? = nil, unexpectedBetweenRootAndComponents: UnexpectedNodes? = nil, components: KeyPathComponentList) {
-    assert(backslash.text == #"\"#)
-    self = KeyPathExprSyntax(unexpectedBeforeBackslash, backslash: backslash, unexpectedBetweenBackslashAndRoot, root: TypeSyntax(fromProtocol: root), unexpectedBetweenRootAndComponents, components: components)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension KeyPathOptionalComponent {
-  /// Creates a `KeyPathOptionalComponent` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeQuestionOrExclamationMark: 
-  ///   - questionOrExclamationMark: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeQuestionOrExclamationMark: UnexpectedNodes? = nil, questionOrExclamationMark: Token) {
-    assert(questionOrExclamationMark.text == "?" || questionOrExclamationMark.text == "!")
-    self = KeyPathOptionalComponentSyntax(unexpectedBeforeQuestionOrExclamationMark, questionOrExclamationMark: questionOrExclamationMark)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension KeyPathPropertyComponent {
-  /// Creates a `KeyPathPropertyComponent` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeIdentifier: 
-  ///   - identifier: 
-  ///   - unexpectedBetweenIdentifierAndDeclNameArguments: 
-  ///   - declNameArguments: 
-  ///   - unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause: 
-  ///   - genericArgumentClause: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodes? = nil, declNameArguments: DeclNameArguments? = nil, unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause: UnexpectedNodes? = nil, genericArgumentClause: GenericArgumentClause? = nil) {
-    self = KeyPathPropertyComponentSyntax(unexpectedBeforeIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndDeclNameArguments, declNameArguments: declNameArguments, unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause, genericArgumentClause: genericArgumentClause)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeDigits: UnexpectedNodes? = nil, digits: String, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeDigits, digits: Token.`integerLiteral`(digits), trailingTrivia: trailingTrivia)
   }
 }
 
 extension KeyPathSubscriptComponent {
-  /// Creates a `KeyPathSubscriptComponent` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftBracket: 
-  ///   - leftBracket: 
-  ///   - unexpectedBetweenLeftBracketAndArgumentList: 
-  ///   - argumentList: 
-  ///   - unexpectedBetweenArgumentListAndRightBracket: 
-  ///   - rightBracket: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftBracket: UnexpectedNodes? = nil, leftBracket: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodes? = nil, argumentList: TupleExprElementList, unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodes? = nil, rightBracket: Token = Token.`rightSquareBracket`) {
-    assert(leftBracket.text == "[")
-    assert(rightBracket.text == "]")
-    self = KeyPathSubscriptComponentSyntax(unexpectedBeforeLeftBracket, leftBracket: leftBracket, unexpectedBetweenLeftBracketAndArgumentList, argumentList: argumentList, unexpectedBetweenArgumentListAndRightBracket, rightBracket: rightBracket)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftBracket: UnexpectedNodes? = nil, leftBracket: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodes? = nil, unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodes? = nil, rightBracket: Token = Token.`rightSquareBracket`, @TupleExprElementListBuilder argumentListBuilder: () -> TupleExprElementListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLeftBracket: UnexpectedNodes? = nil, leftBracket: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodes? = nil, unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodes? = nil, rightBracket: Token = Token.`rightSquareBracket`, @TupleExprElementListBuilder argumentListBuilder: () -> TupleExprElementListSyntax = {
     TupleExprElementListSyntax([])
-  }) {
-    self.init (unexpectedBeforeLeftBracket, leftBracket: leftBracket, unexpectedBetweenLeftBracketAndArgumentList, argumentList: argumentListBuilder(), unexpectedBetweenArgumentListAndRightBracket, rightBracket: rightBracket)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLeftBracket, leftBracket: leftBracket, unexpectedBetweenLeftBracketAndArgumentList, argumentList: argumentListBuilder(), unexpectedBetweenArgumentListAndRightBracket, rightBracket: rightBracket, trailingTrivia: trailingTrivia)
   }
 }
 
 /// A labeled argument for the `@_specialize` attribute like`exported: true`
 extension LabeledSpecializeEntry: HasTrailingComma {
-  /// Creates a `LabeledSpecializeEntry` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLabel: 
-  ///   - label: The label of the argument
-  ///   - unexpectedBetweenLabelAndColon: 
-  ///   - colon: The colon separating the label and the value
-  ///   - unexpectedBetweenColonAndValue: 
-  ///   - value: The value for this argument
-  ///   - unexpectedBetweenValueAndTrailingComma: 
-  ///   - trailingComma: A trailing comma if this argument is followed by another one
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabel: UnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: UnexpectedNodes? = nil, value: Token, unexpectedBetweenValueAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(colon.text == ":")
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = LabeledSpecializeEntrySyntax(unexpectedBeforeLabel, label: label, unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndValue, value: value, unexpectedBetweenValueAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: UnexpectedNodes? = nil, label: String, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: UnexpectedNodes? = nil, value: Token, unexpectedBetweenValueAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    self.init (unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndValue, value: value, unexpectedBetweenValueAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLabel: UnexpectedNodes? = nil, label: String, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: UnexpectedNodes? = nil, value: Token, unexpectedBetweenValueAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndValue, value: value, unexpectedBetweenValueAndTrailingComma, trailingComma: trailingComma, trailingTrivia: trailingTrivia)
   }
   
   var hasTrailingComma: Bool {
@@ -2808,639 +778,131 @@ extension LabeledSpecializeEntry: HasTrailingComma {
 }
 
 extension LabeledStmt {
-  /// Creates a `LabeledStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLabelName: 
-  ///   - labelName: 
-  ///   - unexpectedBetweenLabelNameAndLabelColon: 
-  ///   - labelColon: 
-  ///   - unexpectedBetweenLabelColonAndStatement: 
-  ///   - statement: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabelName: UnexpectedNodes? = nil, labelName: Token, unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodes? = nil, labelColon: Token = Token.`colon`, unexpectedBetweenLabelColonAndStatement: UnexpectedNodes? = nil, statement: StmtSyntaxProtocol) {
-    assert(labelColon.text == ":")
-    self = LabeledStmtSyntax(unexpectedBeforeLabelName, labelName: labelName, unexpectedBetweenLabelNameAndLabelColon, labelColon: labelColon, unexpectedBetweenLabelColonAndStatement, statement: StmtSyntax(fromProtocol: statement))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLabelName: UnexpectedNodes? = nil, labelName: String, unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodes? = nil, labelColon: Token = Token.`colon`, unexpectedBetweenLabelColonAndStatement: UnexpectedNodes? = nil, statement: StmtSyntaxProtocol) {
-    self.init (unexpectedBeforeLabelName, labelName: Token.`identifier`(labelName), unexpectedBetweenLabelNameAndLabelColon, labelColon: labelColon, unexpectedBetweenLabelColonAndStatement, statement: StmtSyntax(fromProtocol: statement))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLabelName: UnexpectedNodes? = nil, labelName: String, unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodes? = nil, labelColon: Token = Token.`colon`, unexpectedBetweenLabelColonAndStatement: UnexpectedNodes? = nil, statement: StmtSyntaxProtocol, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLabelName, labelName: Token.`identifier`(labelName), unexpectedBetweenLabelNameAndLabelColon, labelColon: labelColon, unexpectedBetweenLabelColonAndStatement, statement: StmtSyntax(fromProtocol: statement), trailingTrivia: trailingTrivia)
   }
 }
 
 extension LayoutRequirement {
-  /// Creates a `LayoutRequirement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeTypeIdentifier: 
-  ///   - typeIdentifier: 
-  ///   - unexpectedBetweenTypeIdentifierAndColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndLayoutConstraint: 
-  ///   - layoutConstraint: 
-  ///   - unexpectedBetweenLayoutConstraintAndLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndSize: 
-  ///   - size: 
-  ///   - unexpectedBetweenSizeAndComma: 
-  ///   - comma: 
-  ///   - unexpectedBetweenCommaAndAlignment: 
-  ///   - alignment: 
-  ///   - unexpectedBetweenAlignmentAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeTypeIdentifier: UnexpectedNodes? = nil, typeIdentifier: TypeSyntaxProtocol, unexpectedBetweenTypeIdentifierAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndLayoutConstraint: UnexpectedNodes? = nil, layoutConstraint: Token, unexpectedBetweenLayoutConstraintAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndSize: UnexpectedNodes? = nil, size: Token? = nil, unexpectedBetweenSizeAndComma: UnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndAlignment: UnexpectedNodes? = nil, alignment: Token? = nil, unexpectedBetweenAlignmentAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil) {
-    assert(colon.text == ":")
-    assert(leftParen == nil || leftParen!.text == "(")
-    assert(comma == nil || comma!.text == ",")
-    assert(rightParen == nil || rightParen!.text == ")")
-    self = LayoutRequirementSyntax(unexpectedBeforeTypeIdentifier, typeIdentifier: TypeSyntax(fromProtocol: typeIdentifier), unexpectedBetweenTypeIdentifierAndColon, colon: colon, unexpectedBetweenColonAndLayoutConstraint, layoutConstraint: layoutConstraint, unexpectedBetweenLayoutConstraintAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndSize, size: size, unexpectedBetweenSizeAndComma, comma: comma, unexpectedBetweenCommaAndAlignment, alignment: alignment, unexpectedBetweenAlignmentAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeTypeIdentifier: UnexpectedNodes? = nil, typeIdentifier: TypeSyntaxProtocol, unexpectedBetweenTypeIdentifierAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndLayoutConstraint: UnexpectedNodes? = nil, layoutConstraint: String, unexpectedBetweenLayoutConstraintAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndSize: UnexpectedNodes? = nil, size: String?, unexpectedBetweenSizeAndComma: UnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndAlignment: UnexpectedNodes? = nil, alignment: String?, unexpectedBetweenAlignmentAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil) {
-    self.init (unexpectedBeforeTypeIdentifier, typeIdentifier: TypeSyntax(fromProtocol: typeIdentifier), unexpectedBetweenTypeIdentifierAndColon, colon: colon, unexpectedBetweenColonAndLayoutConstraint, layoutConstraint: Token.`identifier`(layoutConstraint), unexpectedBetweenLayoutConstraintAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndSize, size: size.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeTypeIdentifier: UnexpectedNodes? = nil, typeIdentifier: TypeSyntaxProtocol, unexpectedBetweenTypeIdentifierAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndLayoutConstraint: UnexpectedNodes? = nil, layoutConstraint: String, unexpectedBetweenLayoutConstraintAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndSize: UnexpectedNodes? = nil, size: String?, unexpectedBetweenSizeAndComma: UnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndAlignment: UnexpectedNodes? = nil, alignment: String?, unexpectedBetweenAlignmentAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeTypeIdentifier, typeIdentifier: TypeSyntax(fromProtocol: typeIdentifier), unexpectedBetweenTypeIdentifierAndColon, colon: colon, unexpectedBetweenColonAndLayoutConstraint, layoutConstraint: Token.`identifier`(layoutConstraint), unexpectedBetweenLayoutConstraintAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndSize, size: size.map { 
       Token.`integerLiteral`($0) 
     }, unexpectedBetweenSizeAndComma, comma: comma, unexpectedBetweenCommaAndAlignment, alignment: alignment.map { 
       Token.`integerLiteral`($0) 
-    }, unexpectedBetweenAlignmentAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    }, unexpectedBetweenAlignmentAndRightParen, rightParen: rightParen, trailingTrivia: trailingTrivia)
   }
 }
 
 extension MacroDecl {
-  /// Creates a `MacroDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: 
-  ///   - unexpectedBetweenModifiersAndMacroKeyword: 
-  ///   - macroKeyword: 
-  ///   - unexpectedBetweenMacroKeywordAndIdentifier: 
-  ///   - identifier: 
-  ///   - unexpectedBetweenIdentifierAndGenericParameterClause: 
-  ///   - genericParameterClause: 
-  ///   - unexpectedBetweenGenericParameterClauseAndSignature: 
-  ///   - signature: 
-  ///   - unexpectedBetweenSignatureAndDefinition: 
-  ///   - definition: 
-  ///   - unexpectedBetweenDefinitionAndGenericWhereClause: 
-  ///   - genericWhereClause: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndMacroKeyword: UnexpectedNodes? = nil, macroKeyword: Token, unexpectedBetweenMacroKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodes? = nil, signature: Signature, unexpectedBetweenSignatureAndDefinition: UnexpectedNodes? = nil, definition: InitializerClause? = nil, unexpectedBetweenDefinitionAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil) {
-    assert(macroKeyword.text == "macro")
-    self = MacroDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndMacroKeyword, macroKeyword: macroKeyword, unexpectedBetweenMacroKeywordAndIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature, signature: signature, unexpectedBetweenSignatureAndDefinition, definition: definition, unexpectedBetweenDefinitionAndGenericWhereClause, genericWhereClause: genericWhereClause)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndMacroKeyword: UnexpectedNodes? = nil, macroKeyword: String, unexpectedBetweenMacroKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodes? = nil, signature: Signature, unexpectedBetweenSignatureAndDefinition: UnexpectedNodes? = nil, definition: InitializerClause? = nil, unexpectedBetweenDefinitionAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndMacroKeyword, macroKeyword: Token.`contextualKeyword`(macroKeyword), unexpectedBetweenMacroKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature, signature: signature, unexpectedBetweenSignatureAndDefinition, definition: definition, unexpectedBetweenDefinitionAndGenericWhereClause, genericWhereClause: genericWhereClause)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndMacroKeyword: UnexpectedNodes? = nil, macroKeyword: String, unexpectedBetweenMacroKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodes? = nil, signature: Signature, unexpectedBetweenSignatureAndDefinition: UnexpectedNodes? = nil, definition: InitializerClause? = nil, unexpectedBetweenDefinitionAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndMacroKeyword, macroKeyword: Token.`contextualKeyword`(macroKeyword), unexpectedBetweenMacroKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature, signature: signature, unexpectedBetweenSignatureAndDefinition, definition: definition, unexpectedBetweenDefinitionAndGenericWhereClause, genericWhereClause: genericWhereClause, trailingTrivia: trailingTrivia)
   }
 }
 
 extension MacroExpansionDecl {
-  /// Creates a `MacroExpansionDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePoundToken: 
-  ///   - poundToken: The `#` sign.
-  ///   - unexpectedBetweenPoundTokenAndMacro: 
-  ///   - macro: 
-  ///   - unexpectedBetweenMacroAndGenericArguments: 
-  ///   - genericArguments: 
-  ///   - unexpectedBetweenGenericArgumentsAndLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndArgumentList: 
-  ///   - argumentList: 
-  ///   - unexpectedBetweenArgumentListAndRightParen: 
-  ///   - rightParen: 
-  ///   - unexpectedBetweenRightParenAndTrailingClosure: 
-  ///   - trailingClosure: 
-  ///   - unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: 
-  ///   - additionalTrailingClosures: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundToken: UnexpectedNodes? = nil, poundToken: Token = Token.`pound`, unexpectedBetweenPoundTokenAndMacro: UnexpectedNodes? = nil, macro: Token, unexpectedBetweenMacroAndGenericArguments: UnexpectedNodes? = nil, genericArguments: GenericArgumentClause? = nil, unexpectedBetweenGenericArgumentsAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodes? = nil, argumentList: TupleExprElementList, unexpectedBetweenArgumentListAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodes? = nil, trailingClosure: ClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodes? = nil, additionalTrailingClosures: MultipleTrailingClosureElementList? = nil) {
-    assert(poundToken.text == "#")
-    assert(leftParen == nil || leftParen!.text == "(")
-    assert(rightParen == nil || rightParen!.text == ")")
-    self = MacroExpansionDeclSyntax(unexpectedBeforePoundToken, poundToken: poundToken, unexpectedBetweenPoundTokenAndMacro, macro: macro, unexpectedBetweenMacroAndGenericArguments, genericArguments: genericArguments, unexpectedBetweenGenericArgumentsAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList: argumentList, unexpectedBetweenArgumentListAndRightParen, rightParen: rightParen, unexpectedBetweenRightParenAndTrailingClosure, trailingClosure: trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures: additionalTrailingClosures)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforePoundToken: UnexpectedNodes? = nil, poundToken: Token = Token.`pound`, unexpectedBetweenPoundTokenAndMacro: UnexpectedNodes? = nil, macro: String, unexpectedBetweenMacroAndGenericArguments: UnexpectedNodes? = nil, genericArguments: GenericArgumentClause? = nil, unexpectedBetweenGenericArgumentsAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodes? = nil, unexpectedBetweenArgumentListAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodes? = nil, trailingClosure: ClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodes? = nil, additionalTrailingClosures: MultipleTrailingClosureElementList? = nil, @TupleExprElementListBuilder argumentListBuilder: () -> TupleExprElementListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforePoundToken: UnexpectedNodes? = nil, poundToken: Token = Token.`pound`, unexpectedBetweenPoundTokenAndMacro: UnexpectedNodes? = nil, macro: String, unexpectedBetweenMacroAndGenericArguments: UnexpectedNodes? = nil, genericArguments: GenericArgumentClause? = nil, unexpectedBetweenGenericArgumentsAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodes? = nil, unexpectedBetweenArgumentListAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodes? = nil, trailingClosure: ClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodes? = nil, additionalTrailingClosures: MultipleTrailingClosureElementList? = nil, @TupleExprElementListBuilder argumentListBuilder: () -> TupleExprElementListSyntax = {
     TupleExprElementListSyntax([])
-  }) {
-    self.init (unexpectedBeforePoundToken, poundToken: poundToken, unexpectedBetweenPoundTokenAndMacro, macro: Token.`identifier`(macro), unexpectedBetweenMacroAndGenericArguments, genericArguments: genericArguments, unexpectedBetweenGenericArgumentsAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList: argumentListBuilder(), unexpectedBetweenArgumentListAndRightParen, rightParen: rightParen, unexpectedBetweenRightParenAndTrailingClosure, trailingClosure: trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures: additionalTrailingClosures)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforePoundToken, poundToken: poundToken, unexpectedBetweenPoundTokenAndMacro, macro: Token.`identifier`(macro), unexpectedBetweenMacroAndGenericArguments, genericArguments: genericArguments, unexpectedBetweenGenericArgumentsAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList: argumentListBuilder(), unexpectedBetweenArgumentListAndRightParen, rightParen: rightParen, unexpectedBetweenRightParenAndTrailingClosure, trailingClosure: trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures: additionalTrailingClosures, trailingTrivia: trailingTrivia)
   }
 }
 
 extension MacroExpansionExpr {
-  /// Creates a `MacroExpansionExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePoundToken: 
-  ///   - poundToken: The `#` sign.
-  ///   - unexpectedBetweenPoundTokenAndMacro: 
-  ///   - macro: 
-  ///   - unexpectedBetweenMacroAndGenericArguments: 
-  ///   - genericArguments: 
-  ///   - unexpectedBetweenGenericArgumentsAndLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndArgumentList: 
-  ///   - argumentList: 
-  ///   - unexpectedBetweenArgumentListAndRightParen: 
-  ///   - rightParen: 
-  ///   - unexpectedBetweenRightParenAndTrailingClosure: 
-  ///   - trailingClosure: 
-  ///   - unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: 
-  ///   - additionalTrailingClosures: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundToken: UnexpectedNodes? = nil, poundToken: Token = Token.`pound`, unexpectedBetweenPoundTokenAndMacro: UnexpectedNodes? = nil, macro: Token, unexpectedBetweenMacroAndGenericArguments: UnexpectedNodes? = nil, genericArguments: GenericArgumentClause? = nil, unexpectedBetweenGenericArgumentsAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodes? = nil, argumentList: TupleExprElementList, unexpectedBetweenArgumentListAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodes? = nil, trailingClosure: ClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodes? = nil, additionalTrailingClosures: MultipleTrailingClosureElementList? = nil) {
-    assert(poundToken.text == "#")
-    assert(leftParen == nil || leftParen!.text == "(")
-    assert(rightParen == nil || rightParen!.text == ")")
-    self = MacroExpansionExprSyntax(unexpectedBeforePoundToken, poundToken: poundToken, unexpectedBetweenPoundTokenAndMacro, macro: macro, unexpectedBetweenMacroAndGenericArguments, genericArguments: genericArguments, unexpectedBetweenGenericArgumentsAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList: argumentList, unexpectedBetweenArgumentListAndRightParen, rightParen: rightParen, unexpectedBetweenRightParenAndTrailingClosure, trailingClosure: trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures: additionalTrailingClosures)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforePoundToken: UnexpectedNodes? = nil, poundToken: Token = Token.`pound`, unexpectedBetweenPoundTokenAndMacro: UnexpectedNodes? = nil, macro: String, unexpectedBetweenMacroAndGenericArguments: UnexpectedNodes? = nil, genericArguments: GenericArgumentClause? = nil, unexpectedBetweenGenericArgumentsAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodes? = nil, unexpectedBetweenArgumentListAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodes? = nil, trailingClosure: ClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodes? = nil, additionalTrailingClosures: MultipleTrailingClosureElementList? = nil, @TupleExprElementListBuilder argumentListBuilder: () -> TupleExprElementListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforePoundToken: UnexpectedNodes? = nil, poundToken: Token = Token.`pound`, unexpectedBetweenPoundTokenAndMacro: UnexpectedNodes? = nil, macro: String, unexpectedBetweenMacroAndGenericArguments: UnexpectedNodes? = nil, genericArguments: GenericArgumentClause? = nil, unexpectedBetweenGenericArgumentsAndLeftParen: UnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodes? = nil, unexpectedBetweenArgumentListAndRightParen: UnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodes? = nil, trailingClosure: ClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodes? = nil, additionalTrailingClosures: MultipleTrailingClosureElementList? = nil, @TupleExprElementListBuilder argumentListBuilder: () -> TupleExprElementListSyntax = {
     TupleExprElementListSyntax([])
-  }) {
-    self.init (unexpectedBeforePoundToken, poundToken: poundToken, unexpectedBetweenPoundTokenAndMacro, macro: Token.`identifier`(macro), unexpectedBetweenMacroAndGenericArguments, genericArguments: genericArguments, unexpectedBetweenGenericArgumentsAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList: argumentListBuilder(), unexpectedBetweenArgumentListAndRightParen, rightParen: rightParen, unexpectedBetweenRightParenAndTrailingClosure, trailingClosure: trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures: additionalTrailingClosures)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension MatchingPatternCondition {
-  /// Creates a `MatchingPatternCondition` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeCaseKeyword: 
-  ///   - caseKeyword: 
-  ///   - unexpectedBetweenCaseKeywordAndPattern: 
-  ///   - pattern: 
-  ///   - unexpectedBetweenPatternAndTypeAnnotation: 
-  ///   - typeAnnotation: 
-  ///   - unexpectedBetweenTypeAnnotationAndInitializer: 
-  ///   - initializer: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeCaseKeyword: UnexpectedNodes? = nil, caseKeyword: Token = Token.`case`, unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodes? = nil, pattern: PatternSyntaxProtocol, unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodes? = nil, typeAnnotation: TypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodes? = nil, initializer: InitializerClause) {
-    assert(caseKeyword.text == "case")
-    self = MatchingPatternConditionSyntax(unexpectedBeforeCaseKeyword, caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndPattern, pattern: PatternSyntax(fromProtocol: pattern), unexpectedBetweenPatternAndTypeAnnotation, typeAnnotation: typeAnnotation, unexpectedBetweenTypeAnnotationAndInitializer, initializer: initializer)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension MemberAccessExpr {
-  /// Creates a `MemberAccessExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeBase: 
-  ///   - base: 
-  ///   - unexpectedBetweenBaseAndDot: 
-  ///   - dot: 
-  ///   - unexpectedBetweenDotAndName: 
-  ///   - name: 
-  ///   - unexpectedBetweenNameAndDeclNameArguments: 
-  ///   - declNameArguments: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBase: UnexpectedNodes? = nil, base: ExprSyntaxProtocol? = nil, unexpectedBetweenBaseAndDot: UnexpectedNodes? = nil, dot: Token, unexpectedBetweenDotAndName: UnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndDeclNameArguments: UnexpectedNodes? = nil, declNameArguments: DeclNameArguments? = nil) {
-    assert(dot.text == "." || dot.text == ".")
-    self = MemberAccessExprSyntax(unexpectedBeforeBase, base: ExprSyntax(fromProtocol: base), unexpectedBetweenBaseAndDot, dot: dot, unexpectedBetweenDotAndName, name: name, unexpectedBetweenNameAndDeclNameArguments, declNameArguments: declNameArguments)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforePoundToken, poundToken: poundToken, unexpectedBetweenPoundTokenAndMacro, macro: Token.`identifier`(macro), unexpectedBetweenMacroAndGenericArguments, genericArguments: genericArguments, unexpectedBetweenGenericArgumentsAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList: argumentListBuilder(), unexpectedBetweenArgumentListAndRightParen, rightParen: rightParen, unexpectedBetweenRightParenAndTrailingClosure, trailingClosure: trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures: additionalTrailingClosures, trailingTrivia: trailingTrivia)
   }
 }
 
 extension MemberDeclBlock {
-  /// Creates a `MemberDeclBlock` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftBrace: 
-  ///   - leftBrace: 
-  ///   - unexpectedBetweenLeftBraceAndMembers: 
-  ///   - members: 
-  ///   - unexpectedBetweenMembersAndRightBrace: 
-  ///   - rightBrace: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndMembers: UnexpectedNodes? = nil, members: MemberDeclList, unexpectedBetweenMembersAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
-    assert(leftBrace.text == "{")
-    assert(rightBrace.text == "}")
-    self = MemberDeclBlockSyntax(unexpectedBeforeLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndMembers, members: members, unexpectedBetweenMembersAndRightBrace, rightBrace: rightBrace)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndMembers: UnexpectedNodes? = nil, unexpectedBetweenMembersAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndMembers: UnexpectedNodes? = nil, unexpectedBetweenMembersAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
     MemberDeclListSyntax([])
-  }) {
-    self.init (unexpectedBeforeLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndMembers, members: membersBuilder(), unexpectedBetweenMembersAndRightBrace, rightBrace: rightBrace)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-/// A member declaration of a type consisting of a declaration and anoptional semicolon;
-extension MemberDeclListItem {
-  /// Creates a `MemberDeclListItem` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeDecl: 
-  ///   - decl: The declaration of the type member.
-  ///   - unexpectedBetweenDeclAndSemicolon: 
-  ///   - semicolon: An optional trailing semicolon.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDecl: UnexpectedNodes? = nil, decl: DeclSyntaxProtocol, unexpectedBetweenDeclAndSemicolon: UnexpectedNodes? = nil, semicolon: Token? = nil) {
-    assert(semicolon == nil || semicolon!.text == ";")
-    self = MemberDeclListItemSyntax(unexpectedBeforeDecl, decl: DeclSyntax(fromProtocol: decl), unexpectedBetweenDeclAndSemicolon, semicolon: semicolon)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension MemberTypeIdentifier {
-  /// Creates a `MemberTypeIdentifier` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeBaseType: 
-  ///   - baseType: 
-  ///   - unexpectedBetweenBaseTypeAndPeriod: 
-  ///   - period: 
-  ///   - unexpectedBetweenPeriodAndName: 
-  ///   - name: 
-  ///   - unexpectedBetweenNameAndGenericArgumentClause: 
-  ///   - genericArgumentClause: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBaseType: UnexpectedNodes? = nil, baseType: TypeSyntaxProtocol, unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodes? = nil, period: Token, unexpectedBetweenPeriodAndName: UnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodes? = nil, genericArgumentClause: GenericArgumentClause? = nil) {
-    assert(period.text == "." || period.text == ".")
-    self = MemberTypeIdentifierSyntax(unexpectedBeforeBaseType, baseType: TypeSyntax(fromProtocol: baseType), unexpectedBetweenBaseTypeAndPeriod, period: period, unexpectedBetweenPeriodAndName, name: name, unexpectedBetweenNameAndGenericArgumentClause, genericArgumentClause: genericArgumentClause)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndMembers, members: membersBuilder(), unexpectedBetweenMembersAndRightBrace, rightBrace: rightBrace, trailingTrivia: trailingTrivia)
   }
 }
 
 extension MetatypeType {
-  /// Creates a `MetatypeType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeBaseType: 
-  ///   - baseType: 
-  ///   - unexpectedBetweenBaseTypeAndPeriod: 
-  ///   - period: 
-  ///   - unexpectedBetweenPeriodAndTypeOrProtocol: 
-  ///   - typeOrProtocol: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBaseType: UnexpectedNodes? = nil, baseType: TypeSyntaxProtocol, unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodes? = nil, period: Token = Token.`period`, unexpectedBetweenPeriodAndTypeOrProtocol: UnexpectedNodes? = nil, typeOrProtocol: Token) {
-    assert(period.text == ".")
-    assert(typeOrProtocol.text == "Type" || typeOrProtocol.text == "Protocol")
-    self = MetatypeTypeSyntax(unexpectedBeforeBaseType, baseType: TypeSyntax(fromProtocol: baseType), unexpectedBetweenBaseTypeAndPeriod, period: period, unexpectedBetweenPeriodAndTypeOrProtocol, typeOrProtocol: typeOrProtocol)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeBaseType: UnexpectedNodes? = nil, baseType: TypeSyntaxProtocol, unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodes? = nil, period: Token = Token.`period`, unexpectedBetweenPeriodAndTypeOrProtocol: UnexpectedNodes? = nil, typeOrProtocol: String) {
-    self.init (unexpectedBeforeBaseType, baseType: TypeSyntax(fromProtocol: baseType), unexpectedBetweenBaseTypeAndPeriod, period: period, unexpectedBetweenPeriodAndTypeOrProtocol, typeOrProtocol: Token.`identifier`(typeOrProtocol))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeBaseType: UnexpectedNodes? = nil, baseType: TypeSyntaxProtocol, unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodes? = nil, period: Token = Token.`period`, unexpectedBetweenPeriodAndTypeOrProtocol: UnexpectedNodes? = nil, typeOrProtocol: String, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeBaseType, baseType: TypeSyntax(fromProtocol: baseType), unexpectedBetweenBaseTypeAndPeriod, period: period, unexpectedBetweenPeriodAndTypeOrProtocol, typeOrProtocol: Token.`identifier`(typeOrProtocol), trailingTrivia: trailingTrivia)
   }
 }
 
 extension MoveExpr {
-  /// Creates a `MoveExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeMoveKeyword: 
-  ///   - moveKeyword: 
-  ///   - unexpectedBetweenMoveKeywordAndExpression: 
-  ///   - expression: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeMoveKeyword: UnexpectedNodes? = nil, moveKeyword: Token, unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol) {
-    assert(moveKeyword.text == "_move")
-    self = MoveExprSyntax(unexpectedBeforeMoveKeyword, moveKeyword: moveKeyword, unexpectedBetweenMoveKeywordAndExpression, expression: ExprSyntax(fromProtocol: expression))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeMoveKeyword: UnexpectedNodes? = nil, moveKeyword: String, unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol) {
-    self.init (unexpectedBeforeMoveKeyword, moveKeyword: Token.`contextualKeyword`(moveKeyword), unexpectedBetweenMoveKeywordAndExpression, expression: ExprSyntax(fromProtocol: expression))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension MultipleTrailingClosureElement {
-  /// Creates a `MultipleTrailingClosureElement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLabel: 
-  ///   - label: 
-  ///   - unexpectedBetweenLabelAndColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndClosure: 
-  ///   - closure: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabel: UnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndClosure: UnexpectedNodes? = nil, closure: ClosureExpr) {
-    assert(colon.text == ":")
-    self = MultipleTrailingClosureElementSyntax(unexpectedBeforeLabel, label: label, unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndClosure, closure: closure)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-/// The argument for the `@_dynamic_replacement` or `@_private`attribute of the form `for: "function()"` or `sourceFile:"Src.swift"`
-extension NamedAttributeStringArgument {
-  /// Creates a `NamedAttributeStringArgument` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeNameTok: 
-  ///   - nameTok: The label of the argument
-  ///   - unexpectedBetweenNameTokAndColon: 
-  ///   - colon: The colon separating the label and the value
-  ///   - unexpectedBetweenColonAndStringOrDeclname: 
-  ///   - stringOrDeclname: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeNameTok: UnexpectedNodes? = nil, nameTok: Token, unexpectedBetweenNameTokAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndStringOrDeclname: UnexpectedNodes? = nil, stringOrDeclname: StringOrDeclname) {
-    assert(colon.text == ":")
-    self = NamedAttributeStringArgumentSyntax(unexpectedBeforeNameTok, nameTok: nameTok, unexpectedBetweenNameTokAndColon, colon: colon, unexpectedBetweenColonAndStringOrDeclname, stringOrDeclname: stringOrDeclname)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension NamedOpaqueReturnType {
-  /// Creates a `NamedOpaqueReturnType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeGenericParameters: 
-  ///   - genericParameters: 
-  ///   - unexpectedBetweenGenericParametersAndBaseType: 
-  ///   - baseType: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeGenericParameters: UnexpectedNodes? = nil, genericParameters: GenericParameterClause, unexpectedBetweenGenericParametersAndBaseType: UnexpectedNodes? = nil, baseType: TypeSyntaxProtocol) {
-    self = NamedOpaqueReturnTypeSyntax(unexpectedBeforeGenericParameters, genericParameters: genericParameters, unexpectedBetweenGenericParametersAndBaseType, baseType: TypeSyntax(fromProtocol: baseType))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension NilLiteralExpr {
-  /// Creates a `NilLiteralExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeNilKeyword: 
-  ///   - nilKeyword: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeNilKeyword: UnexpectedNodes? = nil, nilKeyword: Token = Token.`nil`) {
-    assert(nilKeyword.text == "nil")
-    self = NilLiteralExprSyntax(unexpectedBeforeNilKeyword, nilKeyword: nilKeyword)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeMoveKeyword: UnexpectedNodes? = nil, moveKeyword: String, unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeMoveKeyword, moveKeyword: Token.`contextualKeyword`(moveKeyword), unexpectedBetweenMoveKeywordAndExpression, expression: ExprSyntax(fromProtocol: expression), trailingTrivia: trailingTrivia)
   }
 }
 
 /// A piece of an Objective-C selector. Either consisting of just anidentifier for a nullary selector, an identifier and a colon for alabeled argument or just a colon for an unlabeled argument
 extension ObjCSelectorPiece {
-  /// Creates a `ObjCSelectorPiece` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeName: 
-  ///   - name: 
-  ///   - unexpectedBetweenNameAndColon: 
-  ///   - colon: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: Token? = nil, unexpectedBetweenNameAndColon: UnexpectedNodes? = nil, colon: Token? = nil) {
-    assert(colon == nil || colon!.text == ":")
-    self = ObjCSelectorPieceSyntax(unexpectedBeforeName, name: name, unexpectedBetweenNameAndColon, colon: colon)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: String?, unexpectedBetweenNameAndColon: UnexpectedNodes? = nil, colon: Token? = nil) {
-    self.init (unexpectedBeforeName, name: name.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeName: UnexpectedNodes? = nil, name: String?, unexpectedBetweenNameAndColon: UnexpectedNodes? = nil, colon: Token? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeName, name: name.map { 
       Token.`identifier`($0) 
-    }, unexpectedBetweenNameAndColon, colon: colon)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    }, unexpectedBetweenNameAndColon, colon: colon, trailingTrivia: trailingTrivia)
   }
 }
 
 /// The arguments for the '@_opaqueReturnTypeOf()'.
 extension OpaqueReturnTypeOfAttributeArguments {
-  /// Creates a `OpaqueReturnTypeOfAttributeArguments` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeMangledName: 
-  ///   - mangledName: The mangled name of a declaration.
-  ///   - unexpectedBetweenMangledNameAndComma: 
-  ///   - comma: 
-  ///   - unexpectedBetweenCommaAndOrdinal: 
-  ///   - ordinal: The ordinal corresponding to the 'some' keyword that introduced this opaque type.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeMangledName: UnexpectedNodes? = nil, mangledName: Token, unexpectedBetweenMangledNameAndComma: UnexpectedNodes? = nil, comma: Token = Token.`comma`, unexpectedBetweenCommaAndOrdinal: UnexpectedNodes? = nil, ordinal: Token) {
-    assert(comma.text == ",")
-    self = OpaqueReturnTypeOfAttributeArgumentsSyntax(unexpectedBeforeMangledName, mangledName: mangledName, unexpectedBetweenMangledNameAndComma, comma: comma, unexpectedBetweenCommaAndOrdinal, ordinal: ordinal)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeMangledName: UnexpectedNodes? = nil, mangledName: String, unexpectedBetweenMangledNameAndComma: UnexpectedNodes? = nil, comma: Token = Token.`comma`, unexpectedBetweenCommaAndOrdinal: UnexpectedNodes? = nil, ordinal: String) {
-    self.init (unexpectedBeforeMangledName, mangledName: Token.`stringLiteral`(mangledName), unexpectedBetweenMangledNameAndComma, comma: comma, unexpectedBetweenCommaAndOrdinal, ordinal: Token.`integerLiteral`(ordinal))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-/// A Swift `operator` declaration.
-extension OperatorDecl {
-  /// Creates a `OperatorDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: The attributes applied to the 'operator' declaration.
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: The declaration modifiers applied to the 'operator'declaration.
-  ///   - unexpectedBetweenModifiersAndOperatorKeyword: 
-  ///   - operatorKeyword: 
-  ///   - unexpectedBetweenOperatorKeywordAndIdentifier: 
-  ///   - identifier: 
-  ///   - unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes: 
-  ///   - operatorPrecedenceAndTypes: Optionally specify a precedence group and designated types.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndOperatorKeyword: UnexpectedNodes? = nil, operatorKeyword: Token = Token.`operator`, unexpectedBetweenOperatorKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes: UnexpectedNodes? = nil, operatorPrecedenceAndTypes: OperatorPrecedenceAndTypes? = nil) {
-    assert(operatorKeyword.text == "operator")
-    self = OperatorDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndOperatorKeyword, operatorKeyword: operatorKeyword, unexpectedBetweenOperatorKeywordAndIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes, operatorPrecedenceAndTypes: operatorPrecedenceAndTypes)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeMangledName: UnexpectedNodes? = nil, mangledName: String, unexpectedBetweenMangledNameAndComma: UnexpectedNodes? = nil, comma: Token = Token.`comma`, unexpectedBetweenCommaAndOrdinal: UnexpectedNodes? = nil, ordinal: String, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeMangledName, mangledName: Token.`stringLiteral`(mangledName), unexpectedBetweenMangledNameAndComma, comma: comma, unexpectedBetweenCommaAndOrdinal, ordinal: Token.`integerLiteral`(ordinal), trailingTrivia: trailingTrivia)
   }
 }
 
 /// A clause to specify precedence group in infix operator declarations, and designated types in any operator declaration.
 extension OperatorPrecedenceAndTypes {
-  /// Creates a `OperatorPrecedenceAndTypes` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndPrecedenceGroup: 
-  ///   - precedenceGroup: The precedence group for this operator
-  ///   - unexpectedBetweenPrecedenceGroupAndDesignatedTypes: 
-  ///   - designatedTypes: The designated types associated with this operator.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndPrecedenceGroup: UnexpectedNodes? = nil, precedenceGroup: Token, unexpectedBetweenPrecedenceGroupAndDesignatedTypes: UnexpectedNodes? = nil, designatedTypes: DesignatedTypeList) {
-    assert(colon.text == ":")
-    self = OperatorPrecedenceAndTypesSyntax(unexpectedBeforeColon, colon: colon, unexpectedBetweenColonAndPrecedenceGroup, precedenceGroup: precedenceGroup, unexpectedBetweenPrecedenceGroupAndDesignatedTypes, designatedTypes: designatedTypes)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndPrecedenceGroup: UnexpectedNodes? = nil, precedenceGroup: String, unexpectedBetweenPrecedenceGroupAndDesignatedTypes: UnexpectedNodes? = nil, designatedTypes: DesignatedTypeList) {
-    self.init (unexpectedBeforeColon, colon: colon, unexpectedBetweenColonAndPrecedenceGroup, precedenceGroup: Token.`identifier`(precedenceGroup), unexpectedBetweenPrecedenceGroupAndDesignatedTypes, designatedTypes: designatedTypes)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension OptionalBindingCondition {
-  /// Creates a `OptionalBindingCondition` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLetOrVarKeyword: 
-  ///   - letOrVarKeyword: 
-  ///   - unexpectedBetweenLetOrVarKeywordAndPattern: 
-  ///   - pattern: 
-  ///   - unexpectedBetweenPatternAndTypeAnnotation: 
-  ///   - typeAnnotation: 
-  ///   - unexpectedBetweenTypeAnnotationAndInitializer: 
-  ///   - initializer: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLetOrVarKeyword: UnexpectedNodes? = nil, letOrVarKeyword: Token, unexpectedBetweenLetOrVarKeywordAndPattern: UnexpectedNodes? = nil, pattern: PatternSyntaxProtocol, unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodes? = nil, typeAnnotation: TypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodes? = nil, initializer: InitializerClause? = nil) {
-    assert(letOrVarKeyword.text == "let" || letOrVarKeyword.text == "var")
-    self = OptionalBindingConditionSyntax(unexpectedBeforeLetOrVarKeyword, letOrVarKeyword: letOrVarKeyword, unexpectedBetweenLetOrVarKeywordAndPattern, pattern: PatternSyntax(fromProtocol: pattern), unexpectedBetweenPatternAndTypeAnnotation, typeAnnotation: typeAnnotation, unexpectedBetweenTypeAnnotationAndInitializer, initializer: initializer)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension OptionalChainingExpr {
-  /// Creates a `OptionalChainingExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeExpression: 
-  ///   - expression: 
-  ///   - unexpectedBetweenExpressionAndQuestionMark: 
-  ///   - questionMark: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndQuestionMark: UnexpectedNodes? = nil, questionMark: Token = Token.`postfixQuestionMark`) {
-    assert(questionMark.text == "?")
-    self = OptionalChainingExprSyntax(unexpectedBeforeExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndQuestionMark, questionMark: questionMark)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension OptionalPattern {
-  /// Creates a `OptionalPattern` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeSubPattern: 
-  ///   - subPattern: 
-  ///   - unexpectedBetweenSubPatternAndQuestionMark: 
-  ///   - questionMark: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeSubPattern: UnexpectedNodes? = nil, subPattern: PatternSyntaxProtocol, unexpectedBetweenSubPatternAndQuestionMark: UnexpectedNodes? = nil, questionMark: Token = Token.`postfixQuestionMark`) {
-    assert(questionMark.text == "?")
-    self = OptionalPatternSyntax(unexpectedBeforeSubPattern, subPattern: PatternSyntax(fromProtocol: subPattern), unexpectedBetweenSubPatternAndQuestionMark, questionMark: questionMark)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension OptionalType {
-  /// Creates a `OptionalType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeWrappedType: 
-  ///   - wrappedType: 
-  ///   - unexpectedBetweenWrappedTypeAndQuestionMark: 
-  ///   - questionMark: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWrappedType: UnexpectedNodes? = nil, wrappedType: TypeSyntaxProtocol, unexpectedBetweenWrappedTypeAndQuestionMark: UnexpectedNodes? = nil, questionMark: Token = Token.`postfixQuestionMark`) {
-    assert(questionMark.text == "?")
-    self = OptionalTypeSyntax(unexpectedBeforeWrappedType, wrappedType: TypeSyntax(fromProtocol: wrappedType), unexpectedBetweenWrappedTypeAndQuestionMark, questionMark: questionMark)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension PackExpansionType {
-  /// Creates a `PackExpansionType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePatternType: 
-  ///   - patternType: 
-  ///   - unexpectedBetweenPatternTypeAndEllipsis: 
-  ///   - ellipsis: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePatternType: UnexpectedNodes? = nil, patternType: TypeSyntaxProtocol, unexpectedBetweenPatternTypeAndEllipsis: UnexpectedNodes? = nil, ellipsis: Token = Token.`ellipsis`) {
-    assert(ellipsis.text == "...")
-    self = PackExpansionTypeSyntax(unexpectedBeforePatternType, patternType: TypeSyntax(fromProtocol: patternType), unexpectedBetweenPatternTypeAndEllipsis, ellipsis: ellipsis)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension PackReferenceType {
-  /// Creates a `PackReferenceType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeEachKeyword: 
-  ///   - eachKeyword: 
-  ///   - unexpectedBetweenEachKeywordAndPackType: 
-  ///   - packType: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeEachKeyword: UnexpectedNodes? = nil, eachKeyword: Token, unexpectedBetweenEachKeywordAndPackType: UnexpectedNodes? = nil, packType: TypeSyntaxProtocol) {
-    assert(eachKeyword.text == "each")
-    self = PackReferenceTypeSyntax(unexpectedBeforeEachKeyword, eachKeyword: eachKeyword, unexpectedBetweenEachKeywordAndPackType, packType: TypeSyntax(fromProtocol: packType))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndPrecedenceGroup: UnexpectedNodes? = nil, precedenceGroup: String, unexpectedBetweenPrecedenceGroupAndDesignatedTypes: UnexpectedNodes? = nil, designatedTypes: DesignatedTypeList, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeColon, colon: colon, unexpectedBetweenColonAndPrecedenceGroup, precedenceGroup: Token.`identifier`(precedenceGroup), unexpectedBetweenPrecedenceGroupAndDesignatedTypes, designatedTypes: designatedTypes, trailingTrivia: trailingTrivia)
   }
 }
 
 extension ParameterClause {
-  /// Creates a `ParameterClause` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndParameterList: 
-  ///   - parameterList: 
-  ///   - unexpectedBetweenParameterListAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndParameterList: UnexpectedNodes? = nil, parameterList: FunctionParameterList, unexpectedBetweenParameterListAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = ParameterClauseSyntax(unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndParameterList, parameterList: parameterList, unexpectedBetweenParameterListAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndParameterList: UnexpectedNodes? = nil, unexpectedBetweenParameterListAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`, @FunctionParameterListBuilder parameterListBuilder: () -> FunctionParameterListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndParameterList: UnexpectedNodes? = nil, unexpectedBetweenParameterListAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`, @FunctionParameterListBuilder parameterListBuilder: () -> FunctionParameterListSyntax = {
     FunctionParameterListSyntax([])
-  }) {
-    self.init (unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndParameterList, parameterList: parameterListBuilder(), unexpectedBetweenParameterListAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndParameterList, parameterList: parameterListBuilder(), unexpectedBetweenParameterListAndRightParen, rightParen: rightParen, trailingTrivia: trailingTrivia)
   }
 }
 
 extension PatternBinding: HasTrailingComma {
-  /// Creates a `PatternBinding` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePattern: 
-  ///   - pattern: 
-  ///   - unexpectedBetweenPatternAndTypeAnnotation: 
-  ///   - typeAnnotation: 
-  ///   - unexpectedBetweenTypeAnnotationAndInitializer: 
-  ///   - initializer: 
-  ///   - unexpectedBetweenInitializerAndAccessor: 
-  ///   - accessor: 
-  ///   - unexpectedBetweenAccessorAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePattern: UnexpectedNodes? = nil, pattern: PatternSyntaxProtocol, unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodes? = nil, typeAnnotation: TypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodes? = nil, initializer: InitializerClause? = nil, unexpectedBetweenInitializerAndAccessor: UnexpectedNodes? = nil, accessor: Accessor? = nil, unexpectedBetweenAccessorAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = PatternBindingSyntax(unexpectedBeforePattern, pattern: PatternSyntax(fromProtocol: pattern), unexpectedBetweenPatternAndTypeAnnotation, typeAnnotation: typeAnnotation, unexpectedBetweenTypeAnnotationAndInitializer, initializer: initializer, unexpectedBetweenInitializerAndAccessor, accessor: accessor, unexpectedBetweenAccessorAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
@@ -3451,395 +913,101 @@ extension PatternBinding: HasTrailingComma {
   }
 }
 
-extension PostfixIfConfigExpr {
-  /// Creates a `PostfixIfConfigExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeBase: 
-  ///   - base: 
-  ///   - unexpectedBetweenBaseAndConfig: 
-  ///   - config: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBase: UnexpectedNodes? = nil, base: ExprSyntaxProtocol? = nil, unexpectedBetweenBaseAndConfig: UnexpectedNodes? = nil, config: IfConfigDecl) {
-    self = PostfixIfConfigExprSyntax(unexpectedBeforeBase, base: ExprSyntax(fromProtocol: base), unexpectedBetweenBaseAndConfig, config: config)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
 extension PostfixUnaryExpr {
-  /// Creates a `PostfixUnaryExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeExpression: 
-  ///   - expression: 
-  ///   - unexpectedBetweenExpressionAndOperatorToken: 
-  ///   - operatorToken: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndOperatorToken: UnexpectedNodes? = nil, operatorToken: Token) {
-    self = PostfixUnaryExprSyntax(unexpectedBeforeExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndOperatorToken, operatorToken: operatorToken)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndOperatorToken: UnexpectedNodes? = nil, operatorToken: String) {
-    self.init (unexpectedBeforeExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndOperatorToken, operatorToken: Token.`postfixOperator`(operatorToken))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndOperatorToken: UnexpectedNodes? = nil, operatorToken: String, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndOperatorToken, operatorToken: Token.`postfixOperator`(operatorToken), trailingTrivia: trailingTrivia)
   }
 }
 
 extension PoundAssertStmt {
-  /// Creates a `PoundAssertStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePoundAssert: 
-  ///   - poundAssert: 
-  ///   - unexpectedBetweenPoundAssertAndLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndCondition: 
-  ///   - condition: The assertion condition.
-  ///   - unexpectedBetweenConditionAndComma: 
-  ///   - comma: The comma after the assertion condition.
-  ///   - unexpectedBetweenCommaAndMessage: 
-  ///   - message: The assertion message.
-  ///   - unexpectedBetweenMessageAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundAssert: UnexpectedNodes? = nil, poundAssert: Token = Token.`poundAssert`, unexpectedBetweenPoundAssertAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndCondition: UnexpectedNodes? = nil, condition: ExprSyntaxProtocol, unexpectedBetweenConditionAndComma: UnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndMessage: UnexpectedNodes? = nil, message: Token? = nil, unexpectedBetweenMessageAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(poundAssert.text == "#assert")
-    assert(leftParen.text == "(")
-    assert(comma == nil || comma!.text == ",")
-    assert(rightParen.text == ")")
-    self = PoundAssertStmtSyntax(unexpectedBeforePoundAssert, poundAssert: poundAssert, unexpectedBetweenPoundAssertAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndCondition, condition: ExprSyntax(fromProtocol: condition), unexpectedBetweenConditionAndComma, comma: comma, unexpectedBetweenCommaAndMessage, message: message, unexpectedBetweenMessageAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforePoundAssert: UnexpectedNodes? = nil, poundAssert: Token = Token.`poundAssert`, unexpectedBetweenPoundAssertAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndCondition: UnexpectedNodes? = nil, condition: ExprSyntaxProtocol, unexpectedBetweenConditionAndComma: UnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndMessage: UnexpectedNodes? = nil, message: String?, unexpectedBetweenMessageAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    self.init (unexpectedBeforePoundAssert, poundAssert: poundAssert, unexpectedBetweenPoundAssertAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndCondition, condition: ExprSyntax(fromProtocol: condition), unexpectedBetweenConditionAndComma, comma: comma, unexpectedBetweenCommaAndMessage, message: message.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforePoundAssert: UnexpectedNodes? = nil, poundAssert: Token = Token.`poundAssert`, unexpectedBetweenPoundAssertAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndCondition: UnexpectedNodes? = nil, condition: ExprSyntaxProtocol, unexpectedBetweenConditionAndComma: UnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndMessage: UnexpectedNodes? = nil, message: String?, unexpectedBetweenMessageAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforePoundAssert, poundAssert: poundAssert, unexpectedBetweenPoundAssertAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndCondition, condition: ExprSyntax(fromProtocol: condition), unexpectedBetweenConditionAndComma, comma: comma, unexpectedBetweenCommaAndMessage, message: message.map { 
       Token.`stringLiteral`($0) 
-    }, unexpectedBetweenMessageAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension PoundColumnExpr {
-  /// Creates a `PoundColumnExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePoundColumn: 
-  ///   - poundColumn: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundColumn: UnexpectedNodes? = nil, poundColumn: Token = Token.`poundColumn`) {
-    assert(poundColumn.text == "#column")
-    self = PoundColumnExprSyntax(unexpectedBeforePoundColumn, poundColumn: poundColumn)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension PoundErrorDecl {
-  /// Creates a `PoundErrorDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePoundError: 
-  ///   - poundError: 
-  ///   - unexpectedBetweenPoundErrorAndLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndMessage: 
-  ///   - message: 
-  ///   - unexpectedBetweenMessageAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundError: UnexpectedNodes? = nil, poundError: Token = Token.`poundError`, unexpectedBetweenPoundErrorAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndMessage: UnexpectedNodes? = nil, message: StringLiteralExpr, unexpectedBetweenMessageAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(poundError.text == "#error")
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = PoundErrorDeclSyntax(unexpectedBeforePoundError, poundError: poundError, unexpectedBetweenPoundErrorAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndMessage, message: message, unexpectedBetweenMessageAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+    }, unexpectedBetweenMessageAndRightParen, rightParen: rightParen, trailingTrivia: trailingTrivia)
   }
 }
 
 extension PoundSourceLocationArgs {
-  /// Creates a `PoundSourceLocationArgs` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeFileArgLabel: 
-  ///   - fileArgLabel: 
-  ///   - unexpectedBetweenFileArgLabelAndFileArgColon: 
-  ///   - fileArgColon: 
-  ///   - unexpectedBetweenFileArgColonAndFileName: 
-  ///   - fileName: 
-  ///   - unexpectedBetweenFileNameAndComma: 
-  ///   - comma: 
-  ///   - unexpectedBetweenCommaAndLineArgLabel: 
-  ///   - lineArgLabel: 
-  ///   - unexpectedBetweenLineArgLabelAndLineArgColon: 
-  ///   - lineArgColon: 
-  ///   - unexpectedBetweenLineArgColonAndLineNumber: 
-  ///   - lineNumber: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeFileArgLabel: UnexpectedNodes? = nil, fileArgLabel: Token, unexpectedBetweenFileArgLabelAndFileArgColon: UnexpectedNodes? = nil, fileArgColon: Token = Token.`colon`, unexpectedBetweenFileArgColonAndFileName: UnexpectedNodes? = nil, fileName: Token, unexpectedBetweenFileNameAndComma: UnexpectedNodes? = nil, comma: Token = Token.`comma`, unexpectedBetweenCommaAndLineArgLabel: UnexpectedNodes? = nil, lineArgLabel: Token, unexpectedBetweenLineArgLabelAndLineArgColon: UnexpectedNodes? = nil, lineArgColon: Token = Token.`colon`, unexpectedBetweenLineArgColonAndLineNumber: UnexpectedNodes? = nil, lineNumber: Token) {
-    assert(fileArgLabel.text == "file")
-    assert(fileArgColon.text == ":")
-    assert(comma.text == ",")
-    assert(lineArgLabel.text == "line")
-    assert(lineArgColon.text == ":")
-    self = PoundSourceLocationArgsSyntax(unexpectedBeforeFileArgLabel, fileArgLabel: fileArgLabel, unexpectedBetweenFileArgLabelAndFileArgColon, fileArgColon: fileArgColon, unexpectedBetweenFileArgColonAndFileName, fileName: fileName, unexpectedBetweenFileNameAndComma, comma: comma, unexpectedBetweenCommaAndLineArgLabel, lineArgLabel: lineArgLabel, unexpectedBetweenLineArgLabelAndLineArgColon, lineArgColon: lineArgColon, unexpectedBetweenLineArgColonAndLineNumber, lineNumber: lineNumber)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeFileArgLabel: UnexpectedNodes? = nil, fileArgLabel: String, unexpectedBetweenFileArgLabelAndFileArgColon: UnexpectedNodes? = nil, fileArgColon: Token = Token.`colon`, unexpectedBetweenFileArgColonAndFileName: UnexpectedNodes? = nil, fileName: String, unexpectedBetweenFileNameAndComma: UnexpectedNodes? = nil, comma: Token = Token.`comma`, unexpectedBetweenCommaAndLineArgLabel: UnexpectedNodes? = nil, lineArgLabel: String, unexpectedBetweenLineArgLabelAndLineArgColon: UnexpectedNodes? = nil, lineArgColon: Token = Token.`colon`, unexpectedBetweenLineArgColonAndLineNumber: UnexpectedNodes? = nil, lineNumber: String) {
-    self.init (unexpectedBeforeFileArgLabel, fileArgLabel: Token.`identifier`(fileArgLabel), unexpectedBetweenFileArgLabelAndFileArgColon, fileArgColon: fileArgColon, unexpectedBetweenFileArgColonAndFileName, fileName: Token.`stringLiteral`(fileName), unexpectedBetweenFileNameAndComma, comma: comma, unexpectedBetweenCommaAndLineArgLabel, lineArgLabel: Token.`identifier`(lineArgLabel), unexpectedBetweenLineArgLabelAndLineArgColon, lineArgColon: lineArgColon, unexpectedBetweenLineArgColonAndLineNumber, lineNumber: Token.`integerLiteral`(lineNumber))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension PoundSourceLocation {
-  /// Creates a `PoundSourceLocation` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePoundSourceLocation: 
-  ///   - poundSourceLocation: 
-  ///   - unexpectedBetweenPoundSourceLocationAndLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndArgs: 
-  ///   - args: 
-  ///   - unexpectedBetweenArgsAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundSourceLocation: UnexpectedNodes? = nil, poundSourceLocation: Token = Token.`poundSourceLocation`, unexpectedBetweenPoundSourceLocationAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndArgs: UnexpectedNodes? = nil, args: PoundSourceLocationArgs? = nil, unexpectedBetweenArgsAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(poundSourceLocation.text == "#sourceLocation")
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = PoundSourceLocationSyntax(unexpectedBeforePoundSourceLocation, poundSourceLocation: poundSourceLocation, unexpectedBetweenPoundSourceLocationAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgs, args: args, unexpectedBetweenArgsAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension PoundWarningDecl {
-  /// Creates a `PoundWarningDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePoundWarning: 
-  ///   - poundWarning: 
-  ///   - unexpectedBetweenPoundWarningAndLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndMessage: 
-  ///   - message: 
-  ///   - unexpectedBetweenMessageAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundWarning: UnexpectedNodes? = nil, poundWarning: Token = Token.`poundWarning`, unexpectedBetweenPoundWarningAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndMessage: UnexpectedNodes? = nil, message: StringLiteralExpr, unexpectedBetweenMessageAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(poundWarning.text == "#warning")
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = PoundWarningDeclSyntax(unexpectedBeforePoundWarning, poundWarning: poundWarning, unexpectedBetweenPoundWarningAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndMessage, message: message, unexpectedBetweenMessageAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeFileArgLabel: UnexpectedNodes? = nil, fileArgLabel: String, unexpectedBetweenFileArgLabelAndFileArgColon: UnexpectedNodes? = nil, fileArgColon: Token = Token.`colon`, unexpectedBetweenFileArgColonAndFileName: UnexpectedNodes? = nil, fileName: String, unexpectedBetweenFileNameAndComma: UnexpectedNodes? = nil, comma: Token = Token.`comma`, unexpectedBetweenCommaAndLineArgLabel: UnexpectedNodes? = nil, lineArgLabel: String, unexpectedBetweenLineArgLabelAndLineArgColon: UnexpectedNodes? = nil, lineArgColon: Token = Token.`colon`, unexpectedBetweenLineArgColonAndLineNumber: UnexpectedNodes? = nil, lineNumber: String, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeFileArgLabel, fileArgLabel: Token.`identifier`(fileArgLabel), unexpectedBetweenFileArgLabelAndFileArgColon, fileArgColon: fileArgColon, unexpectedBetweenFileArgColonAndFileName, fileName: Token.`stringLiteral`(fileName), unexpectedBetweenFileNameAndComma, comma: comma, unexpectedBetweenCommaAndLineArgLabel, lineArgLabel: Token.`identifier`(lineArgLabel), unexpectedBetweenLineArgLabelAndLineArgColon, lineArgColon: lineArgColon, unexpectedBetweenLineArgColonAndLineNumber, lineNumber: Token.`integerLiteral`(lineNumber), trailingTrivia: trailingTrivia)
   }
 }
 
 /// Specifies the precedence of an operator when used in an operationthat includes optional chaining.
 extension PrecedenceGroupAssignment {
-  /// Creates a `PrecedenceGroupAssignment` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAssignmentKeyword: 
-  ///   - assignmentKeyword: 
-  ///   - unexpectedBetweenAssignmentKeywordAndColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndFlag: 
-  ///   - flag: When true, an operator in the corresponding precedence groupuses the same grouping rules during optional chaining as theassignment operators from the standard library. Otherwise,operators in the precedence group follows the same optionalchaining rules as operators that don't perform assignment.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAssignmentKeyword: UnexpectedNodes? = nil, assignmentKeyword: Token, unexpectedBetweenAssignmentKeywordAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndFlag: UnexpectedNodes? = nil, flag: Token) {
-    assert(assignmentKeyword.text == "assignment")
-    assert(colon.text == ":")
-    assert(flag.text == "true" || flag.text == "false")
-    self = PrecedenceGroupAssignmentSyntax(unexpectedBeforeAssignmentKeyword, assignmentKeyword: assignmentKeyword, unexpectedBetweenAssignmentKeywordAndColon, colon: colon, unexpectedBetweenColonAndFlag, flag: flag)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAssignmentKeyword: UnexpectedNodes? = nil, assignmentKeyword: String, unexpectedBetweenAssignmentKeywordAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndFlag: UnexpectedNodes? = nil, flag: Token) {
-    self.init (unexpectedBeforeAssignmentKeyword, assignmentKeyword: Token.`identifier`(assignmentKeyword), unexpectedBetweenAssignmentKeywordAndColon, colon: colon, unexpectedBetweenColonAndFlag, flag: flag)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAssignmentKeyword: UnexpectedNodes? = nil, assignmentKeyword: String, unexpectedBetweenAssignmentKeywordAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndFlag: UnexpectedNodes? = nil, flag: Token, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAssignmentKeyword, assignmentKeyword: Token.`identifier`(assignmentKeyword), unexpectedBetweenAssignmentKeywordAndColon, colon: colon, unexpectedBetweenColonAndFlag, flag: flag, trailingTrivia: trailingTrivia)
   }
 }
 
 /// Specifies how a sequence of operators with the same precedence levelare grouped together in the absence of grouping parentheses.
 extension PrecedenceGroupAssociativity {
-  /// Creates a `PrecedenceGroupAssociativity` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAssociativityKeyword: 
-  ///   - associativityKeyword: 
-  ///   - unexpectedBetweenAssociativityKeywordAndColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndValue: 
-  ///   - value: Operators that are `left`-associative group left-to-right.Operators that are `right`-associative group right-to-left.Operators that are specified with an associativity of `none`don't associate at all
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAssociativityKeyword: UnexpectedNodes? = nil, associativityKeyword: Token, unexpectedBetweenAssociativityKeywordAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: UnexpectedNodes? = nil, value: Token) {
-    assert(associativityKeyword.text == "associativity")
-    assert(colon.text == ":")
-    assert(value.text == "left" || value.text == "right" || value.text == "none")
-    self = PrecedenceGroupAssociativitySyntax(unexpectedBeforeAssociativityKeyword, associativityKeyword: associativityKeyword, unexpectedBetweenAssociativityKeywordAndColon, colon: colon, unexpectedBetweenColonAndValue, value: value)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAssociativityKeyword: UnexpectedNodes? = nil, associativityKeyword: String, unexpectedBetweenAssociativityKeywordAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: UnexpectedNodes? = nil, value: String) {
-    self.init (unexpectedBeforeAssociativityKeyword, associativityKeyword: Token.`identifier`(associativityKeyword), unexpectedBetweenAssociativityKeywordAndColon, colon: colon, unexpectedBetweenColonAndValue, value: Token.`identifier`(value))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAssociativityKeyword: UnexpectedNodes? = nil, associativityKeyword: String, unexpectedBetweenAssociativityKeywordAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: UnexpectedNodes? = nil, value: String, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAssociativityKeyword, associativityKeyword: Token.`identifier`(associativityKeyword), unexpectedBetweenAssociativityKeywordAndColon, colon: colon, unexpectedBetweenColonAndValue, value: Token.`identifier`(value), trailingTrivia: trailingTrivia)
   }
 }
 
 /// A Swift `precedencegroup` declaration.
 extension PrecedenceGroupDecl {
-  /// Creates a `PrecedenceGroupDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: The attributes applied to the 'precedencegroup' declaration.
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: The declaration modifiers applied to the 'precedencegroup'declaration.
-  ///   - unexpectedBetweenModifiersAndPrecedencegroupKeyword: 
-  ///   - precedencegroupKeyword: 
-  ///   - unexpectedBetweenPrecedencegroupKeywordAndIdentifier: 
-  ///   - identifier: The name of this precedence group.
-  ///   - unexpectedBetweenIdentifierAndLeftBrace: 
-  ///   - leftBrace: 
-  ///   - unexpectedBetweenLeftBraceAndGroupAttributes: 
-  ///   - groupAttributes: The characteristics of this precedence group.
-  ///   - unexpectedBetweenGroupAttributesAndRightBrace: 
-  ///   - rightBrace: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndPrecedencegroupKeyword: UnexpectedNodes? = nil, precedencegroupKeyword: Token = Token.`precedencegroup`, unexpectedBetweenPrecedencegroupKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndGroupAttributes: UnexpectedNodes? = nil, groupAttributes: PrecedenceGroupAttributeList, unexpectedBetweenGroupAttributesAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
-    assert(precedencegroupKeyword.text == "precedencegroup")
-    assert(leftBrace.text == "{")
-    assert(rightBrace.text == "}")
-    self = PrecedenceGroupDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndPrecedencegroupKeyword, precedencegroupKeyword: precedencegroupKeyword, unexpectedBetweenPrecedencegroupKeywordAndIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndGroupAttributes, groupAttributes: groupAttributes, unexpectedBetweenGroupAttributesAndRightBrace, rightBrace: rightBrace)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndPrecedencegroupKeyword: UnexpectedNodes? = nil, precedencegroupKeyword: Token = Token.`precedencegroup`, unexpectedBetweenPrecedencegroupKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndGroupAttributes: UnexpectedNodes? = nil, groupAttributes: PrecedenceGroupAttributeList, unexpectedBetweenGroupAttributesAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndPrecedencegroupKeyword, precedencegroupKeyword: precedencegroupKeyword, unexpectedBetweenPrecedencegroupKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndGroupAttributes, groupAttributes: groupAttributes, unexpectedBetweenGroupAttributesAndRightBrace, rightBrace: rightBrace)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndPrecedencegroupKeyword: UnexpectedNodes? = nil, precedencegroupKeyword: Token = Token.`precedencegroup`, unexpectedBetweenPrecedencegroupKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndGroupAttributes: UnexpectedNodes? = nil, groupAttributes: PrecedenceGroupAttributeList, unexpectedBetweenGroupAttributesAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndPrecedencegroupKeyword, precedencegroupKeyword: precedencegroupKeyword, unexpectedBetweenPrecedencegroupKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndGroupAttributes, groupAttributes: groupAttributes, unexpectedBetweenGroupAttributesAndRightBrace, rightBrace: rightBrace, trailingTrivia: trailingTrivia)
   }
 }
 
 extension PrecedenceGroupNameElement {
-  /// Creates a `PrecedenceGroupNameElement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeName: 
-  ///   - name: 
-  ///   - unexpectedBetweenNameAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = PrecedenceGroupNameElementSyntax(unexpectedBeforeName, name: name, unexpectedBetweenNameAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    self.init (unexpectedBeforeName, name: Token.`identifier`(name), unexpectedBetweenNameAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeName: UnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeName, name: Token.`identifier`(name), unexpectedBetweenNameAndTrailingComma, trailingComma: trailingComma, trailingTrivia: trailingTrivia)
   }
 }
 
 /// Specify the new precedence group's relation to existing precedencegroups.
 extension PrecedenceGroupRelation {
-  /// Creates a `PrecedenceGroupRelation` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeHigherThanOrLowerThan: 
-  ///   - higherThanOrLowerThan: The relation to specified other precedence groups.
-  ///   - unexpectedBetweenHigherThanOrLowerThanAndColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndOtherNames: 
-  ///   - otherNames: The name of other precedence group to which this precedencegroup relates.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeHigherThanOrLowerThan: UnexpectedNodes? = nil, higherThanOrLowerThan: Token, unexpectedBetweenHigherThanOrLowerThanAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndOtherNames: UnexpectedNodes? = nil, otherNames: PrecedenceGroupNameList) {
-    assert(higherThanOrLowerThan.text == "higherThan" || higherThanOrLowerThan.text == "lowerThan")
-    assert(colon.text == ":")
-    self = PrecedenceGroupRelationSyntax(unexpectedBeforeHigherThanOrLowerThan, higherThanOrLowerThan: higherThanOrLowerThan, unexpectedBetweenHigherThanOrLowerThanAndColon, colon: colon, unexpectedBetweenColonAndOtherNames, otherNames: otherNames)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeHigherThanOrLowerThan: UnexpectedNodes? = nil, higherThanOrLowerThan: String, unexpectedBetweenHigherThanOrLowerThanAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndOtherNames: UnexpectedNodes? = nil, otherNames: PrecedenceGroupNameList) {
-    self.init (unexpectedBeforeHigherThanOrLowerThan, higherThanOrLowerThan: Token.`identifier`(higherThanOrLowerThan), unexpectedBetweenHigherThanOrLowerThanAndColon, colon: colon, unexpectedBetweenColonAndOtherNames, otherNames: otherNames)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeHigherThanOrLowerThan: UnexpectedNodes? = nil, higherThanOrLowerThan: String, unexpectedBetweenHigherThanOrLowerThanAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndOtherNames: UnexpectedNodes? = nil, otherNames: PrecedenceGroupNameList, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeHigherThanOrLowerThan, higherThanOrLowerThan: Token.`identifier`(higherThanOrLowerThan), unexpectedBetweenHigherThanOrLowerThanAndColon, colon: colon, unexpectedBetweenColonAndOtherNames, otherNames: otherNames, trailingTrivia: trailingTrivia)
   }
 }
 
 extension PrefixOperatorExpr {
-  /// Creates a `PrefixOperatorExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeOperatorToken: 
-  ///   - operatorToken: 
-  ///   - unexpectedBetweenOperatorTokenAndPostfixExpression: 
-  ///   - postfixExpression: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeOperatorToken: UnexpectedNodes? = nil, operatorToken: Token? = nil, unexpectedBetweenOperatorTokenAndPostfixExpression: UnexpectedNodes? = nil, postfixExpression: ExprSyntaxProtocol) {
-    self = PrefixOperatorExprSyntax(unexpectedBeforeOperatorToken, operatorToken: operatorToken, unexpectedBetweenOperatorTokenAndPostfixExpression, postfixExpression: ExprSyntax(fromProtocol: postfixExpression))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeOperatorToken: UnexpectedNodes? = nil, operatorToken: String?, unexpectedBetweenOperatorTokenAndPostfixExpression: UnexpectedNodes? = nil, postfixExpression: ExprSyntaxProtocol) {
-    self.init (unexpectedBeforeOperatorToken, operatorToken: operatorToken.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeOperatorToken: UnexpectedNodes? = nil, operatorToken: String?, unexpectedBetweenOperatorTokenAndPostfixExpression: UnexpectedNodes? = nil, postfixExpression: ExprSyntaxProtocol, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeOperatorToken, operatorToken: operatorToken.map { 
       Token.`prefixOperator`($0) 
-    }, unexpectedBetweenOperatorTokenAndPostfixExpression, postfixExpression: ExprSyntax(fromProtocol: postfixExpression))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension PrimaryAssociatedTypeClause {
-  /// Creates a `PrimaryAssociatedTypeClause` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftAngleBracket: 
-  ///   - leftAngleBracket: 
-  ///   - unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList: 
-  ///   - primaryAssociatedTypeList: 
-  ///   - unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket: 
-  ///   - rightAngleBracket: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftAngleBracket: UnexpectedNodes? = nil, leftAngleBracket: Token = Token.`leftAngle`, unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList: UnexpectedNodes? = nil, primaryAssociatedTypeList: PrimaryAssociatedTypeList, unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket: UnexpectedNodes? = nil, rightAngleBracket: Token = Token.`rightAngle`) {
-    assert(leftAngleBracket.text == "<")
-    assert(rightAngleBracket.text == ">")
-    self = PrimaryAssociatedTypeClauseSyntax(unexpectedBeforeLeftAngleBracket, leftAngleBracket: leftAngleBracket, unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList, primaryAssociatedTypeList: primaryAssociatedTypeList, unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket, rightAngleBracket: rightAngleBracket)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+    }, unexpectedBetweenOperatorTokenAndPostfixExpression, postfixExpression: ExprSyntax(fromProtocol: postfixExpression), trailingTrivia: trailingTrivia)
   }
 }
 
 extension PrimaryAssociatedType: HasTrailingComma {
-  /// Creates a `PrimaryAssociatedType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeName: 
-  ///   - name: 
-  ///   - unexpectedBetweenNameAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = PrimaryAssociatedTypeSyntax(unexpectedBeforeName, name: name, unexpectedBetweenNameAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    self.init (unexpectedBeforeName, name: Token.`identifier`(name), unexpectedBetweenNameAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeName: UnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeName, name: Token.`identifier`(name), unexpectedBetweenNameAndTrailingComma, trailingComma: trailingComma, trailingTrivia: trailingTrivia)
   }
   
   var hasTrailingComma: Bool {
@@ -3853,548 +1021,151 @@ extension PrimaryAssociatedType: HasTrailingComma {
 }
 
 extension ProtocolDecl {
-  /// Creates a `ProtocolDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: 
-  ///   - unexpectedBetweenModifiersAndProtocolKeyword: 
-  ///   - protocolKeyword: 
-  ///   - unexpectedBetweenProtocolKeywordAndIdentifier: 
-  ///   - identifier: 
-  ///   - unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause: 
-  ///   - primaryAssociatedTypeClause: 
-  ///   - unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause: 
-  ///   - inheritanceClause: 
-  ///   - unexpectedBetweenInheritanceClauseAndGenericWhereClause: 
-  ///   - genericWhereClause: 
-  ///   - unexpectedBetweenGenericWhereClauseAndMembers: 
-  ///   - members: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndProtocolKeyword: UnexpectedNodes? = nil, protocolKeyword: Token = Token.`protocol`, unexpectedBetweenProtocolKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause: UnexpectedNodes? = nil, primaryAssociatedTypeClause: PrimaryAssociatedTypeClause? = nil, unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, members: MemberDeclBlock) {
-    assert(protocolKeyword.text == "protocol")
-    self = ProtocolDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndProtocolKeyword, protocolKeyword: protocolKeyword, unexpectedBetweenProtocolKeywordAndIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause, primaryAssociatedTypeClause: primaryAssociatedTypeClause, unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: members)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndProtocolKeyword: UnexpectedNodes? = nil, protocolKeyword: Token = Token.`protocol`, unexpectedBetweenProtocolKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause: UnexpectedNodes? = nil, primaryAssociatedTypeClause: PrimaryAssociatedTypeClause? = nil, unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndProtocolKeyword: UnexpectedNodes? = nil, protocolKeyword: Token = Token.`protocol`, unexpectedBetweenProtocolKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause: UnexpectedNodes? = nil, primaryAssociatedTypeClause: PrimaryAssociatedTypeClause? = nil, unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
     MemberDeclListSyntax([])
-  }) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndProtocolKeyword, protocolKeyword: protocolKeyword, unexpectedBetweenProtocolKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause, primaryAssociatedTypeClause: primaryAssociatedTypeClause, unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: MemberDeclBlockSyntax(members: membersBuilder()))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-/// An optionally qualified function declaration name (e.g. `+(_:_:)`,`A.B.C.foo(_:_:)`).
-extension QualifiedDeclName {
-  /// Creates a `QualifiedDeclName` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeBaseType: 
-  ///   - baseType: The base type of the qualified name, optionally specified.
-  ///   - unexpectedBetweenBaseTypeAndDot: 
-  ///   - dot: 
-  ///   - unexpectedBetweenDotAndName: 
-  ///   - name: The base name of the referenced function.
-  ///   - unexpectedBetweenNameAndArguments: 
-  ///   - arguments: The argument labels of the referenced function, optionallyspecified.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBaseType: UnexpectedNodes? = nil, baseType: TypeSyntaxProtocol? = nil, unexpectedBetweenBaseTypeAndDot: UnexpectedNodes? = nil, dot: Token? = nil, unexpectedBetweenDotAndName: UnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndArguments: UnexpectedNodes? = nil, arguments: DeclNameArguments? = nil) {
-    assert(dot == nil || dot!.text == "." || dot!.text == ".")
-    self = QualifiedDeclNameSyntax(unexpectedBeforeBaseType, baseType: TypeSyntax(fromProtocol: baseType), unexpectedBetweenBaseTypeAndDot, dot: dot, unexpectedBetweenDotAndName, name: name, unexpectedBetweenNameAndArguments, arguments: arguments)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndProtocolKeyword, protocolKeyword: protocolKeyword, unexpectedBetweenProtocolKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause, primaryAssociatedTypeClause: primaryAssociatedTypeClause, unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: MemberDeclBlockSyntax(members: membersBuilder()), trailingTrivia: trailingTrivia)
   }
 }
 
 extension RegexLiteralExpr {
-  /// Creates a `RegexLiteralExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeRegex: 
-  ///   - regex: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeRegex: UnexpectedNodes? = nil, regex: Token) {
-    self = RegexLiteralExprSyntax(unexpectedBeforeRegex, regex: regex)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeRegex: UnexpectedNodes? = nil, regex: String) {
-    self.init (unexpectedBeforeRegex, regex: Token.`regexLiteral`(regex))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeRegex: UnexpectedNodes? = nil, regex: String, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeRegex, regex: Token.`regexLiteral`(regex), trailingTrivia: trailingTrivia)
   }
 }
 
 extension RepeatWhileStmt {
-  /// Creates a `RepeatWhileStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeRepeatKeyword: 
-  ///   - repeatKeyword: 
-  ///   - unexpectedBetweenRepeatKeywordAndBody: 
-  ///   - body: 
-  ///   - unexpectedBetweenBodyAndWhileKeyword: 
-  ///   - whileKeyword: 
-  ///   - unexpectedBetweenWhileKeywordAndCondition: 
-  ///   - condition: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeRepeatKeyword: UnexpectedNodes? = nil, repeatKeyword: Token = Token.`repeat`, unexpectedBetweenRepeatKeywordAndBody: UnexpectedNodes? = nil, body: CodeBlock, unexpectedBetweenBodyAndWhileKeyword: UnexpectedNodes? = nil, whileKeyword: Token = Token.`while`, unexpectedBetweenWhileKeywordAndCondition: UnexpectedNodes? = nil, condition: ExprSyntaxProtocol) {
-    assert(repeatKeyword.text == "repeat")
-    assert(whileKeyword.text == "while")
-    self = RepeatWhileStmtSyntax(unexpectedBeforeRepeatKeyword, repeatKeyword: repeatKeyword, unexpectedBetweenRepeatKeywordAndBody, body: body, unexpectedBetweenBodyAndWhileKeyword, whileKeyword: whileKeyword, unexpectedBetweenWhileKeywordAndCondition, condition: ExprSyntax(fromProtocol: condition))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeRepeatKeyword: UnexpectedNodes? = nil, repeatKeyword: Token = Token.`repeat`, unexpectedBetweenRepeatKeywordAndBody: UnexpectedNodes? = nil, unexpectedBetweenBodyAndWhileKeyword: UnexpectedNodes? = nil, whileKeyword: Token = Token.`while`, unexpectedBetweenWhileKeywordAndCondition: UnexpectedNodes? = nil, condition: ExprSyntaxProtocol, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeRepeatKeyword: UnexpectedNodes? = nil, repeatKeyword: Token = Token.`repeat`, unexpectedBetweenRepeatKeywordAndBody: UnexpectedNodes? = nil, unexpectedBetweenBodyAndWhileKeyword: UnexpectedNodes? = nil, whileKeyword: Token = Token.`while`, unexpectedBetweenWhileKeywordAndCondition: UnexpectedNodes? = nil, condition: ExprSyntaxProtocol, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
     CodeBlockItemListSyntax([])
-  }) {
-    self.init (unexpectedBeforeRepeatKeyword, repeatKeyword: repeatKeyword, unexpectedBetweenRepeatKeywordAndBody, body: CodeBlockSyntax(statements: bodyBuilder()), unexpectedBetweenBodyAndWhileKeyword, whileKeyword: whileKeyword, unexpectedBetweenWhileKeywordAndCondition, condition: ExprSyntax(fromProtocol: condition))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension ReturnClause {
-  /// Creates a `ReturnClause` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeArrow: 
-  ///   - arrow: 
-  ///   - unexpectedBetweenArrowAndReturnType: 
-  ///   - returnType: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeArrow: UnexpectedNodes? = nil, arrow: Token = Token.`arrow`, unexpectedBetweenArrowAndReturnType: UnexpectedNodes? = nil, returnType: TypeSyntaxProtocol) {
-    assert(arrow.text == "->")
-    self = ReturnClauseSyntax(unexpectedBeforeArrow, arrow: arrow, unexpectedBetweenArrowAndReturnType, returnType: TypeSyntax(fromProtocol: returnType))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension ReturnStmt {
-  /// Creates a `ReturnStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeReturnKeyword: 
-  ///   - returnKeyword: 
-  ///   - unexpectedBetweenReturnKeywordAndExpression: 
-  ///   - expression: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeReturnKeyword: UnexpectedNodes? = nil, returnKeyword: Token = Token.`return`, unexpectedBetweenReturnKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol? = nil) {
-    assert(returnKeyword.text == "return")
-    self = ReturnStmtSyntax(unexpectedBeforeReturnKeyword, returnKeyword: returnKeyword, unexpectedBetweenReturnKeywordAndExpression, expression: ExprSyntax(fromProtocol: expression))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension SameTypeRequirement {
-  /// Creates a `SameTypeRequirement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftTypeIdentifier: 
-  ///   - leftTypeIdentifier: 
-  ///   - unexpectedBetweenLeftTypeIdentifierAndEqualityToken: 
-  ///   - equalityToken: 
-  ///   - unexpectedBetweenEqualityTokenAndRightTypeIdentifier: 
-  ///   - rightTypeIdentifier: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftTypeIdentifier: UnexpectedNodes? = nil, leftTypeIdentifier: TypeSyntaxProtocol, unexpectedBetweenLeftTypeIdentifierAndEqualityToken: UnexpectedNodes? = nil, equalityToken: Token, unexpectedBetweenEqualityTokenAndRightTypeIdentifier: UnexpectedNodes? = nil, rightTypeIdentifier: TypeSyntaxProtocol) {
-    self = SameTypeRequirementSyntax(unexpectedBeforeLeftTypeIdentifier, leftTypeIdentifier: TypeSyntax(fromProtocol: leftTypeIdentifier), unexpectedBetweenLeftTypeIdentifierAndEqualityToken, equalityToken: equalityToken, unexpectedBetweenEqualityTokenAndRightTypeIdentifier, rightTypeIdentifier: TypeSyntax(fromProtocol: rightTypeIdentifier))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeRepeatKeyword, repeatKeyword: repeatKeyword, unexpectedBetweenRepeatKeywordAndBody, body: CodeBlockSyntax(statements: bodyBuilder()), unexpectedBetweenBodyAndWhileKeyword, whileKeyword: whileKeyword, unexpectedBetweenWhileKeywordAndCondition, condition: ExprSyntax(fromProtocol: condition), trailingTrivia: trailingTrivia)
   }
 }
 
 extension SequenceExpr {
-  /// Creates a `SequenceExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeElements: 
-  ///   - elements: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeElements: UnexpectedNodes? = nil, elements: ExprList) {
-    self = SequenceExprSyntax(unexpectedBeforeElements, elements: elements)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeElements: UnexpectedNodes? = nil, @ExprListBuilder elementsBuilder: () -> ExprListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeElements: UnexpectedNodes? = nil, @ExprListBuilder elementsBuilder: () -> ExprListSyntax = {
     ExprListSyntax([])
-  }) {
-    self.init (unexpectedBeforeElements, elements: elementsBuilder())
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension SimpleTypeIdentifier {
-  /// Creates a `SimpleTypeIdentifier` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeName: 
-  ///   - name: 
-  ///   - unexpectedBetweenNameAndGenericArgumentClause: 
-  ///   - genericArgumentClause: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: UnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodes? = nil, genericArgumentClause: GenericArgumentClause? = nil) {
-    self = SimpleTypeIdentifierSyntax(unexpectedBeforeName, name: name, unexpectedBetweenNameAndGenericArgumentClause, genericArgumentClause: genericArgumentClause)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeElements, elements: elementsBuilder(), trailingTrivia: trailingTrivia)
   }
 }
 
 extension SourceFile {
-  /// Creates a `SourceFile` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeStatements: 
-  ///   - statements: 
-  ///   - unexpectedBetweenStatementsAndEOFToken: 
-  ///   - eofToken: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeStatements: UnexpectedNodes? = nil, statements: CodeBlockItemList, unexpectedBetweenStatementsAndEOFToken: UnexpectedNodes? = nil, eofToken: Token = Token.eof) {
-    self = SourceFileSyntax(unexpectedBeforeStatements, statements: statements, unexpectedBetweenStatementsAndEOFToken, eofToken: eofToken)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeStatements: UnexpectedNodes? = nil, unexpectedBetweenStatementsAndEOFToken: UnexpectedNodes? = nil, eofToken: Token = Token.eof, @CodeBlockItemListBuilder statementsBuilder: () -> CodeBlockItemListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeStatements: UnexpectedNodes? = nil, unexpectedBetweenStatementsAndEOFToken: UnexpectedNodes? = nil, eofToken: Token = Token.eof, @CodeBlockItemListBuilder statementsBuilder: () -> CodeBlockItemListSyntax = {
     CodeBlockItemListSyntax([])
-  }) {
-    self.init (unexpectedBeforeStatements, statements: statementsBuilder(), unexpectedBetweenStatementsAndEOFToken, eofToken: eofToken)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension SpecializeExpr {
-  /// Creates a `SpecializeExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeExpression: 
-  ///   - expression: 
-  ///   - unexpectedBetweenExpressionAndGenericArgumentClause: 
-  ///   - genericArgumentClause: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndGenericArgumentClause: UnexpectedNodes? = nil, genericArgumentClause: GenericArgumentClause) {
-    self = SpecializeExprSyntax(unexpectedBeforeExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndGenericArgumentClause, genericArgumentClause: genericArgumentClause)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeStatements, statements: statementsBuilder(), unexpectedBetweenStatementsAndEOFToken, eofToken: eofToken, trailingTrivia: trailingTrivia)
   }
 }
 
 extension StringLiteralExpr {
-  /// Creates a `StringLiteralExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeOpenDelimiter: 
-  ///   - openDelimiter: 
-  ///   - unexpectedBetweenOpenDelimiterAndOpenQuote: 
-  ///   - openQuote: 
-  ///   - unexpectedBetweenOpenQuoteAndSegments: 
-  ///   - segments: 
-  ///   - unexpectedBetweenSegmentsAndCloseQuote: 
-  ///   - closeQuote: 
-  ///   - unexpectedBetweenCloseQuoteAndCloseDelimiter: 
-  ///   - closeDelimiter: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeOpenDelimiter: UnexpectedNodes? = nil, openDelimiter: Token? = nil, unexpectedBetweenOpenDelimiterAndOpenQuote: UnexpectedNodes? = nil, openQuote: Token, unexpectedBetweenOpenQuoteAndSegments: UnexpectedNodes? = nil, segments: StringLiteralSegments, unexpectedBetweenSegmentsAndCloseQuote: UnexpectedNodes? = nil, closeQuote: Token, unexpectedBetweenCloseQuoteAndCloseDelimiter: UnexpectedNodes? = nil, closeDelimiter: Token? = nil) {
-    assert(openQuote.text == #"""# || openQuote.text == #"""""#)
-    assert(closeQuote.text == #"""# || closeQuote.text == #"""""#)
-    self = StringLiteralExprSyntax(unexpectedBeforeOpenDelimiter, openDelimiter: openDelimiter, unexpectedBetweenOpenDelimiterAndOpenQuote, openQuote: openQuote, unexpectedBetweenOpenQuoteAndSegments, segments: segments, unexpectedBetweenSegmentsAndCloseQuote, closeQuote: closeQuote, unexpectedBetweenCloseQuoteAndCloseDelimiter, closeDelimiter: closeDelimiter)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeOpenDelimiter: UnexpectedNodes? = nil, openDelimiter: String?, unexpectedBetweenOpenDelimiterAndOpenQuote: UnexpectedNodes? = nil, openQuote: Token, unexpectedBetweenOpenQuoteAndSegments: UnexpectedNodes? = nil, segments: StringLiteralSegments, unexpectedBetweenSegmentsAndCloseQuote: UnexpectedNodes? = nil, closeQuote: Token, unexpectedBetweenCloseQuoteAndCloseDelimiter: UnexpectedNodes? = nil, closeDelimiter: String?) {
-    self.init (unexpectedBeforeOpenDelimiter, openDelimiter: openDelimiter.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeOpenDelimiter: UnexpectedNodes? = nil, openDelimiter: String?, unexpectedBetweenOpenDelimiterAndOpenQuote: UnexpectedNodes? = nil, openQuote: Token, unexpectedBetweenOpenQuoteAndSegments: UnexpectedNodes? = nil, segments: StringLiteralSegments, unexpectedBetweenSegmentsAndCloseQuote: UnexpectedNodes? = nil, closeQuote: Token, unexpectedBetweenCloseQuoteAndCloseDelimiter: UnexpectedNodes? = nil, closeDelimiter: String?, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeOpenDelimiter, openDelimiter: openDelimiter.map { 
       Token.`rawStringDelimiter`($0) 
     }, unexpectedBetweenOpenDelimiterAndOpenQuote, openQuote: openQuote, unexpectedBetweenOpenQuoteAndSegments, segments: segments, unexpectedBetweenSegmentsAndCloseQuote, closeQuote: closeQuote, unexpectedBetweenCloseQuoteAndCloseDelimiter, closeDelimiter: closeDelimiter.map { 
       Token.`rawStringDelimiter`($0) 
-    })
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    }, trailingTrivia: trailingTrivia)
   }
 }
 
 extension StringSegment {
-  /// Creates a `StringSegment` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeContent: 
-  ///   - content: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeContent: UnexpectedNodes? = nil, content: Token) {
-    self = StringSegmentSyntax(unexpectedBeforeContent, content: content)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeContent: UnexpectedNodes? = nil, content: String) {
-    self.init (unexpectedBeforeContent, content: Token.`stringSegment`(content))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeContent: UnexpectedNodes? = nil, content: String, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeContent, content: Token.`stringSegment`(content), trailingTrivia: trailingTrivia)
   }
 }
 
 extension StructDecl {
-  /// Creates a `StructDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: 
-  ///   - unexpectedBetweenModifiersAndStructKeyword: 
-  ///   - structKeyword: 
-  ///   - unexpectedBetweenStructKeywordAndIdentifier: 
-  ///   - identifier: 
-  ///   - unexpectedBetweenIdentifierAndGenericParameterClause: 
-  ///   - genericParameterClause: 
-  ///   - unexpectedBetweenGenericParameterClauseAndInheritanceClause: 
-  ///   - inheritanceClause: 
-  ///   - unexpectedBetweenInheritanceClauseAndGenericWhereClause: 
-  ///   - genericWhereClause: 
-  ///   - unexpectedBetweenGenericWhereClauseAndMembers: 
-  ///   - members: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndStructKeyword: UnexpectedNodes? = nil, structKeyword: Token = Token.`struct`, unexpectedBetweenStructKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, members: MemberDeclBlock) {
-    assert(structKeyword.text == "struct")
-    self = StructDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndStructKeyword, structKeyword: structKeyword, unexpectedBetweenStructKeywordAndIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: members)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndStructKeyword: UnexpectedNodes? = nil, structKeyword: Token = Token.`struct`, unexpectedBetweenStructKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndStructKeyword: UnexpectedNodes? = nil, structKeyword: Token = Token.`struct`, unexpectedBetweenStructKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
     MemberDeclListSyntax([])
-  }) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndStructKeyword, structKeyword: structKeyword, unexpectedBetweenStructKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: MemberDeclBlockSyntax(members: membersBuilder()))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension SubscriptDecl {
-  /// Creates a `SubscriptDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: 
-  ///   - unexpectedBetweenModifiersAndSubscriptKeyword: 
-  ///   - subscriptKeyword: 
-  ///   - unexpectedBetweenSubscriptKeywordAndGenericParameterClause: 
-  ///   - genericParameterClause: 
-  ///   - unexpectedBetweenGenericParameterClauseAndIndices: 
-  ///   - indices: 
-  ///   - unexpectedBetweenIndicesAndResult: 
-  ///   - result: 
-  ///   - unexpectedBetweenResultAndGenericWhereClause: 
-  ///   - genericWhereClause: 
-  ///   - unexpectedBetweenGenericWhereClauseAndAccessor: 
-  ///   - accessor: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndSubscriptKeyword: UnexpectedNodes? = nil, subscriptKeyword: Token = Token.`subscript`, unexpectedBetweenSubscriptKeywordAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndIndices: UnexpectedNodes? = nil, indices: ParameterClause, unexpectedBetweenIndicesAndResult: UnexpectedNodes? = nil, result: ReturnClause, unexpectedBetweenResultAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndAccessor: UnexpectedNodes? = nil, accessor: Accessor? = nil) {
-    assert(subscriptKeyword.text == "subscript")
-    self = SubscriptDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndSubscriptKeyword, subscriptKeyword: subscriptKeyword, unexpectedBetweenSubscriptKeywordAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndIndices, indices: indices, unexpectedBetweenIndicesAndResult, result: result, unexpectedBetweenResultAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndAccessor, accessor: accessor)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndStructKeyword, structKeyword: structKeyword, unexpectedBetweenStructKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: MemberDeclBlockSyntax(members: membersBuilder()), trailingTrivia: trailingTrivia)
   }
 }
 
 extension SubscriptExpr {
-  /// Creates a `SubscriptExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeCalledExpression: 
-  ///   - calledExpression: 
-  ///   - unexpectedBetweenCalledExpressionAndLeftBracket: 
-  ///   - leftBracket: 
-  ///   - unexpectedBetweenLeftBracketAndArgumentList: 
-  ///   - argumentList: 
-  ///   - unexpectedBetweenArgumentListAndRightBracket: 
-  ///   - rightBracket: 
-  ///   - unexpectedBetweenRightBracketAndTrailingClosure: 
-  ///   - trailingClosure: 
-  ///   - unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: 
-  ///   - additionalTrailingClosures: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeCalledExpression: UnexpectedNodes? = nil, calledExpression: ExprSyntaxProtocol, unexpectedBetweenCalledExpressionAndLeftBracket: UnexpectedNodes? = nil, leftBracket: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodes? = nil, argumentList: TupleExprElementList, unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodes? = nil, rightBracket: Token = Token.`rightSquareBracket`, unexpectedBetweenRightBracketAndTrailingClosure: UnexpectedNodes? = nil, trailingClosure: ClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodes? = nil, additionalTrailingClosures: MultipleTrailingClosureElementList? = nil) {
-    assert(leftBracket.text == "[")
-    assert(rightBracket.text == "]")
-    self = SubscriptExprSyntax(unexpectedBeforeCalledExpression, calledExpression: ExprSyntax(fromProtocol: calledExpression), unexpectedBetweenCalledExpressionAndLeftBracket, leftBracket: leftBracket, unexpectedBetweenLeftBracketAndArgumentList, argumentList: argumentList, unexpectedBetweenArgumentListAndRightBracket, rightBracket: rightBracket, unexpectedBetweenRightBracketAndTrailingClosure, trailingClosure: trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures: additionalTrailingClosures)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeCalledExpression: UnexpectedNodes? = nil, calledExpression: ExprSyntaxProtocol, unexpectedBetweenCalledExpressionAndLeftBracket: UnexpectedNodes? = nil, leftBracket: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodes? = nil, unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodes? = nil, rightBracket: Token = Token.`rightSquareBracket`, unexpectedBetweenRightBracketAndTrailingClosure: UnexpectedNodes? = nil, trailingClosure: ClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodes? = nil, additionalTrailingClosures: MultipleTrailingClosureElementList? = nil, @TupleExprElementListBuilder argumentListBuilder: () -> TupleExprElementListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeCalledExpression: UnexpectedNodes? = nil, calledExpression: ExprSyntaxProtocol, unexpectedBetweenCalledExpressionAndLeftBracket: UnexpectedNodes? = nil, leftBracket: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodes? = nil, unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodes? = nil, rightBracket: Token = Token.`rightSquareBracket`, unexpectedBetweenRightBracketAndTrailingClosure: UnexpectedNodes? = nil, trailingClosure: ClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodes? = nil, additionalTrailingClosures: MultipleTrailingClosureElementList? = nil, @TupleExprElementListBuilder argumentListBuilder: () -> TupleExprElementListSyntax = {
     TupleExprElementListSyntax([])
-  }) {
-    self.init (unexpectedBeforeCalledExpression, calledExpression: ExprSyntax(fromProtocol: calledExpression), unexpectedBetweenCalledExpressionAndLeftBracket, leftBracket: leftBracket, unexpectedBetweenLeftBracketAndArgumentList, argumentList: argumentListBuilder(), unexpectedBetweenArgumentListAndRightBracket, rightBracket: rightBracket, unexpectedBetweenRightBracketAndTrailingClosure, trailingClosure: trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures: additionalTrailingClosures)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension SuperRefExpr {
-  /// Creates a `SuperRefExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeSuperKeyword: 
-  ///   - superKeyword: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeSuperKeyword: UnexpectedNodes? = nil, superKeyword: Token = Token.`super`) {
-    assert(superKeyword.text == "super")
-    self = SuperRefExprSyntax(unexpectedBeforeSuperKeyword, superKeyword: superKeyword)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeCalledExpression, calledExpression: ExprSyntax(fromProtocol: calledExpression), unexpectedBetweenCalledExpressionAndLeftBracket, leftBracket: leftBracket, unexpectedBetweenLeftBracketAndArgumentList, argumentList: argumentListBuilder(), unexpectedBetweenArgumentListAndRightBracket, rightBracket: rightBracket, unexpectedBetweenRightBracketAndTrailingClosure, trailingClosure: trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures: additionalTrailingClosures, trailingTrivia: trailingTrivia)
   }
 }
 
 extension SwitchCaseLabel {
-  /// Creates a `SwitchCaseLabel` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeCaseKeyword: 
-  ///   - caseKeyword: 
-  ///   - unexpectedBetweenCaseKeywordAndCaseItems: 
-  ///   - caseItems: 
-  ///   - unexpectedBetweenCaseItemsAndColon: 
-  ///   - colon: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeCaseKeyword: UnexpectedNodes? = nil, caseKeyword: Token = Token.`case`, unexpectedBetweenCaseKeywordAndCaseItems: UnexpectedNodes? = nil, caseItems: CaseItemList, unexpectedBetweenCaseItemsAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`) {
-    assert(caseKeyword.text == "case")
-    assert(colon.text == ":")
-    self = SwitchCaseLabelSyntax(unexpectedBeforeCaseKeyword, caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndCaseItems, caseItems: caseItems, unexpectedBetweenCaseItemsAndColon, colon: colon)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeCaseKeyword: UnexpectedNodes? = nil, caseKeyword: Token = Token.`case`, unexpectedBetweenCaseKeywordAndCaseItems: UnexpectedNodes? = nil, unexpectedBetweenCaseItemsAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, @CaseItemListBuilder caseItemsBuilder: () -> CaseItemListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeCaseKeyword: UnexpectedNodes? = nil, caseKeyword: Token = Token.`case`, unexpectedBetweenCaseKeywordAndCaseItems: UnexpectedNodes? = nil, unexpectedBetweenCaseItemsAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, @CaseItemListBuilder caseItemsBuilder: () -> CaseItemListSyntax = {
     CaseItemListSyntax([])
-  }) {
-    self.init (unexpectedBeforeCaseKeyword, caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndCaseItems, caseItems: caseItemsBuilder(), unexpectedBetweenCaseItemsAndColon, colon: colon)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeCaseKeyword, caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndCaseItems, caseItems: caseItemsBuilder(), unexpectedBetweenCaseItemsAndColon, colon: colon, trailingTrivia: trailingTrivia)
   }
 }
 
 extension SwitchCase {
-  /// Creates a `SwitchCase` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeUnknownAttr: 
-  ///   - unknownAttr: 
-  ///   - unexpectedBetweenUnknownAttrAndLabel: 
-  ///   - label: 
-  ///   - unexpectedBetweenLabelAndStatements: 
-  ///   - statements: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeUnknownAttr: UnexpectedNodes? = nil, unknownAttr: Attribute? = nil, unexpectedBetweenUnknownAttrAndLabel: UnexpectedNodes? = nil, label: Label, unexpectedBetweenLabelAndStatements: UnexpectedNodes? = nil, statements: CodeBlockItemList) {
-    self = SwitchCaseSyntax(unexpectedBeforeUnknownAttr, unknownAttr: unknownAttr, unexpectedBetweenUnknownAttrAndLabel, label: label, unexpectedBetweenLabelAndStatements, statements: statements)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeUnknownAttr: UnexpectedNodes? = nil, unknownAttr: Attribute? = nil, unexpectedBetweenUnknownAttrAndLabel: UnexpectedNodes? = nil, label: Label, unexpectedBetweenLabelAndStatements: UnexpectedNodes? = nil, @CodeBlockItemListBuilder statementsBuilder: () -> CodeBlockItemListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeUnknownAttr: UnexpectedNodes? = nil, unknownAttr: Attribute? = nil, unexpectedBetweenUnknownAttrAndLabel: UnexpectedNodes? = nil, label: Label, unexpectedBetweenLabelAndStatements: UnexpectedNodes? = nil, @CodeBlockItemListBuilder statementsBuilder: () -> CodeBlockItemListSyntax = {
     CodeBlockItemListSyntax([])
-  }) {
-    self.init (unexpectedBeforeUnknownAttr, unknownAttr: unknownAttr, unexpectedBetweenUnknownAttrAndLabel, label: label, unexpectedBetweenLabelAndStatements, statements: statementsBuilder())
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension SwitchDefaultLabel {
-  /// Creates a `SwitchDefaultLabel` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeDefaultKeyword: 
-  ///   - defaultKeyword: 
-  ///   - unexpectedBetweenDefaultKeywordAndColon: 
-  ///   - colon: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDefaultKeyword: UnexpectedNodes? = nil, defaultKeyword: Token = Token.`default`, unexpectedBetweenDefaultKeywordAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`) {
-    assert(defaultKeyword.text == "default")
-    assert(colon.text == ":")
-    self = SwitchDefaultLabelSyntax(unexpectedBeforeDefaultKeyword, defaultKeyword: defaultKeyword, unexpectedBetweenDefaultKeywordAndColon, colon: colon)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeUnknownAttr, unknownAttr: unknownAttr, unexpectedBetweenUnknownAttrAndLabel, label: label, unexpectedBetweenLabelAndStatements, statements: statementsBuilder(), trailingTrivia: trailingTrivia)
   }
 }
 
 extension SwitchStmt {
-  /// Creates a `SwitchStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeSwitchKeyword: 
-  ///   - switchKeyword: 
-  ///   - unexpectedBetweenSwitchKeywordAndExpression: 
-  ///   - expression: 
-  ///   - unexpectedBetweenExpressionAndLeftBrace: 
-  ///   - leftBrace: 
-  ///   - unexpectedBetweenLeftBraceAndCases: 
-  ///   - cases: 
-  ///   - unexpectedBetweenCasesAndRightBrace: 
-  ///   - rightBrace: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeSwitchKeyword: UnexpectedNodes? = nil, switchKeyword: Token = Token.`switch`, unexpectedBetweenSwitchKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndCases: UnexpectedNodes? = nil, cases: SwitchCaseList, unexpectedBetweenCasesAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
-    assert(switchKeyword.text == "switch")
-    assert(leftBrace.text == "{")
-    assert(rightBrace.text == "}")
-    self = SwitchStmtSyntax(unexpectedBeforeSwitchKeyword, switchKeyword: switchKeyword, unexpectedBetweenSwitchKeywordAndExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndCases, cases: cases, unexpectedBetweenCasesAndRightBrace, rightBrace: rightBrace)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeSwitchKeyword: UnexpectedNodes? = nil, switchKeyword: Token = Token.`switch`, unexpectedBetweenSwitchKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndCases: UnexpectedNodes? = nil, unexpectedBetweenCasesAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`, @SwitchCaseListBuilder casesBuilder: () -> SwitchCaseListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeSwitchKeyword: UnexpectedNodes? = nil, switchKeyword: Token = Token.`switch`, unexpectedBetweenSwitchKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndLeftBrace: UnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndCases: UnexpectedNodes? = nil, unexpectedBetweenCasesAndRightBrace: UnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`, @SwitchCaseListBuilder casesBuilder: () -> SwitchCaseListSyntax = {
     SwitchCaseListSyntax([])
-  }) {
-    self.init (unexpectedBeforeSwitchKeyword, switchKeyword: switchKeyword, unexpectedBetweenSwitchKeywordAndExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndCases, cases: casesBuilder(), unexpectedBetweenCasesAndRightBrace, rightBrace: rightBrace)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeSwitchKeyword, switchKeyword: switchKeyword, unexpectedBetweenSwitchKeywordAndExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndCases, cases: casesBuilder(), unexpectedBetweenCasesAndRightBrace, rightBrace: rightBrace, trailingTrivia: trailingTrivia)
   }
 }
 
 extension SymbolicReferenceExpr {
-  /// Creates a `SymbolicReferenceExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeIdentifier: 
-  ///   - identifier: 
-  ///   - unexpectedBetweenIdentifierAndGenericArgumentClause: 
-  ///   - genericArgumentClause: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericArgumentClause: UnexpectedNodes? = nil, genericArgumentClause: GenericArgumentClause? = nil) {
-    self = SymbolicReferenceExprSyntax(unexpectedBeforeIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndGenericArgumentClause, genericArgumentClause: genericArgumentClause)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericArgumentClause: UnexpectedNodes? = nil, genericArgumentClause: GenericArgumentClause? = nil) {
-    self.init (unexpectedBeforeIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericArgumentClause, genericArgumentClause: genericArgumentClause)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericArgumentClause: UnexpectedNodes? = nil, genericArgumentClause: GenericArgumentClause? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericArgumentClause, genericArgumentClause: genericArgumentClause, trailingTrivia: trailingTrivia)
   }
 }
 
 /// A labeled argument for the `@_specialize` attribute with a functiondecl value like`target: myFunc(_:)`
 extension TargetFunctionEntry: HasTrailingComma {
-  /// Creates a `TargetFunctionEntry` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLabel: 
-  ///   - label: The label of the argument
-  ///   - unexpectedBetweenLabelAndColon: 
-  ///   - colon: The colon separating the label and the value
-  ///   - unexpectedBetweenColonAndDeclname: 
-  ///   - declname: The value for this argument
-  ///   - unexpectedBetweenDeclnameAndTrailingComma: 
-  ///   - trailingComma: A trailing comma if this argument is followed by another one
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabel: UnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndDeclname: UnexpectedNodes? = nil, declname: DeclName, unexpectedBetweenDeclnameAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(colon.text == ":")
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = TargetFunctionEntrySyntax(unexpectedBeforeLabel, label: label, unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndDeclname, declname: declname, unexpectedBetweenDeclnameAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: UnexpectedNodes? = nil, label: String, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndDeclname: UnexpectedNodes? = nil, declname: DeclName, unexpectedBetweenDeclnameAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    self.init (unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndDeclname, declname: declname, unexpectedBetweenDeclnameAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLabel: UnexpectedNodes? = nil, label: String, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndDeclname: UnexpectedNodes? = nil, declname: DeclName, unexpectedBetweenDeclnameAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndDeclname, declname: declname, unexpectedBetweenDeclnameAndTrailingComma, trailingComma: trailingComma, trailingTrivia: trailingTrivia)
   }
   
   var hasTrailingComma: Bool {
@@ -4407,80 +1178,7 @@ extension TargetFunctionEntry: HasTrailingComma {
   }
 }
 
-extension TernaryExpr {
-  /// Creates a `TernaryExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeConditionExpression: 
-  ///   - conditionExpression: 
-  ///   - unexpectedBetweenConditionExpressionAndQuestionMark: 
-  ///   - questionMark: 
-  ///   - unexpectedBetweenQuestionMarkAndFirstChoice: 
-  ///   - firstChoice: 
-  ///   - unexpectedBetweenFirstChoiceAndColonMark: 
-  ///   - colonMark: 
-  ///   - unexpectedBetweenColonMarkAndSecondChoice: 
-  ///   - secondChoice: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeConditionExpression: UnexpectedNodes? = nil, conditionExpression: ExprSyntaxProtocol, unexpectedBetweenConditionExpressionAndQuestionMark: UnexpectedNodes? = nil, questionMark: Token = Token.`infixQuestionMark`, unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodes? = nil, firstChoice: ExprSyntaxProtocol, unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodes? = nil, colonMark: Token = Token.`colon`, unexpectedBetweenColonMarkAndSecondChoice: UnexpectedNodes? = nil, secondChoice: ExprSyntaxProtocol) {
-    assert(questionMark.text == "?")
-    assert(colonMark.text == ":")
-    self = TernaryExprSyntax(unexpectedBeforeConditionExpression, conditionExpression: ExprSyntax(fromProtocol: conditionExpression), unexpectedBetweenConditionExpressionAndQuestionMark, questionMark: questionMark, unexpectedBetweenQuestionMarkAndFirstChoice, firstChoice: ExprSyntax(fromProtocol: firstChoice), unexpectedBetweenFirstChoiceAndColonMark, colonMark: colonMark, unexpectedBetweenColonMarkAndSecondChoice, secondChoice: ExprSyntax(fromProtocol: secondChoice))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension ThrowStmt {
-  /// Creates a `ThrowStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeThrowKeyword: 
-  ///   - throwKeyword: 
-  ///   - unexpectedBetweenThrowKeywordAndExpression: 
-  ///   - expression: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeThrowKeyword: UnexpectedNodes? = nil, throwKeyword: Token = Token.`throw`, unexpectedBetweenThrowKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol) {
-    assert(throwKeyword.text == "throw")
-    self = ThrowStmtSyntax(unexpectedBeforeThrowKeyword, throwKeyword: throwKeyword, unexpectedBetweenThrowKeywordAndExpression, expression: ExprSyntax(fromProtocol: expression))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension TryExpr {
-  /// Creates a `TryExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeTryKeyword: 
-  ///   - tryKeyword: 
-  ///   - unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: 
-  ///   - questionOrExclamationMark: 
-  ///   - unexpectedBetweenQuestionOrExclamationMarkAndExpression: 
-  ///   - expression: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeTryKeyword: UnexpectedNodes? = nil, tryKeyword: Token = Token.`try`, unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: UnexpectedNodes? = nil, questionOrExclamationMark: Token? = nil, unexpectedBetweenQuestionOrExclamationMarkAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol) {
-    assert(tryKeyword.text == "try")
-    assert(questionOrExclamationMark == nil || questionOrExclamationMark!.text == "?" || questionOrExclamationMark!.text == "!")
-    self = TryExprSyntax(unexpectedBeforeTryKeyword, tryKeyword: tryKeyword, unexpectedBetweenTryKeywordAndQuestionOrExclamationMark, questionOrExclamationMark: questionOrExclamationMark, unexpectedBetweenQuestionOrExclamationMarkAndExpression, expression: ExprSyntax(fromProtocol: expression))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
 extension TupleExprElement: HasTrailingComma {
-  /// Creates a `TupleExprElement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLabel: 
-  ///   - label: 
-  ///   - unexpectedBetweenLabelAndColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndExpression: 
-  ///   - expression: 
-  ///   - unexpectedBetweenExpressionAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabel: UnexpectedNodes? = nil, label: Token? = nil, unexpectedBetweenLabelAndColon: UnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(colon == nil || colon!.text == ":")
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = TupleExprElementSyntax(unexpectedBeforeLabel, label: label, unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
@@ -4492,60 +1190,24 @@ extension TupleExprElement: HasTrailingComma {
 }
 
 extension TupleExpr {
-  /// Creates a `TupleExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndElementList: 
-  ///   - elementList: 
-  ///   - unexpectedBetweenElementListAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElementList: UnexpectedNodes? = nil, elementList: TupleExprElementList, unexpectedBetweenElementListAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = TupleExprSyntax(unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndElementList, elementList: elementList, unexpectedBetweenElementListAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElementList: UnexpectedNodes? = nil, unexpectedBetweenElementListAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`, @TupleExprElementListBuilder elementListBuilder: () -> TupleExprElementListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElementList: UnexpectedNodes? = nil, unexpectedBetweenElementListAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`, @TupleExprElementListBuilder elementListBuilder: () -> TupleExprElementListSyntax = {
     TupleExprElementListSyntax([])
-  }) {
-    self.init (unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndElementList, elementList: elementListBuilder(), unexpectedBetweenElementListAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndElementList, elementList: elementListBuilder(), unexpectedBetweenElementListAndRightParen, rightParen: rightParen, trailingTrivia: trailingTrivia)
   }
 }
 
 extension TuplePatternElement: HasTrailingComma {
-  /// Creates a `TuplePatternElement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLabelName: 
-  ///   - labelName: 
-  ///   - unexpectedBetweenLabelNameAndLabelColon: 
-  ///   - labelColon: 
-  ///   - unexpectedBetweenLabelColonAndPattern: 
-  ///   - pattern: 
-  ///   - unexpectedBetweenPatternAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabelName: UnexpectedNodes? = nil, labelName: Token? = nil, unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodes? = nil, labelColon: Token? = nil, unexpectedBetweenLabelColonAndPattern: UnexpectedNodes? = nil, pattern: PatternSyntaxProtocol, unexpectedBetweenPatternAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(labelColon == nil || labelColon!.text == ":")
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = TuplePatternElementSyntax(unexpectedBeforeLabelName, labelName: labelName, unexpectedBetweenLabelNameAndLabelColon, labelColon: labelColon, unexpectedBetweenLabelColonAndPattern, pattern: PatternSyntax(fromProtocol: pattern), unexpectedBetweenPatternAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLabelName: UnexpectedNodes? = nil, labelName: String?, unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodes? = nil, labelColon: Token? = nil, unexpectedBetweenLabelColonAndPattern: UnexpectedNodes? = nil, pattern: PatternSyntaxProtocol, unexpectedBetweenPatternAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    self.init (unexpectedBeforeLabelName, labelName: labelName.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLabelName: UnexpectedNodes? = nil, labelName: String?, unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodes? = nil, labelColon: Token? = nil, unexpectedBetweenLabelColonAndPattern: UnexpectedNodes? = nil, pattern: PatternSyntaxProtocol, unexpectedBetweenPatternAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLabelName, labelName: labelName.map { 
       Token.`identifier`($0) 
-    }, unexpectedBetweenLabelNameAndLabelColon, labelColon: labelColon, unexpectedBetweenLabelColonAndPattern, pattern: PatternSyntax(fromProtocol: pattern), unexpectedBetweenPatternAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    }, unexpectedBetweenLabelNameAndLabelColon, labelColon: labelColon, unexpectedBetweenLabelColonAndPattern, pattern: PatternSyntax(fromProtocol: pattern), unexpectedBetweenPatternAndTrailingComma, trailingComma: trailingComma, trailingTrivia: trailingTrivia)
   }
   
   var hasTrailingComma: Bool {
@@ -4559,62 +1221,17 @@ extension TuplePatternElement: HasTrailingComma {
 }
 
 extension TuplePattern {
-  /// Creates a `TuplePattern` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndElements: 
-  ///   - elements: 
-  ///   - unexpectedBetweenElementsAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElements: UnexpectedNodes? = nil, elements: TuplePatternElementList, unexpectedBetweenElementsAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = TuplePatternSyntax(unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndElements, elements: elements, unexpectedBetweenElementsAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElements: UnexpectedNodes? = nil, unexpectedBetweenElementsAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`, @TuplePatternElementListBuilder elementsBuilder: () -> TuplePatternElementListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElements: UnexpectedNodes? = nil, unexpectedBetweenElementsAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`, @TuplePatternElementListBuilder elementsBuilder: () -> TuplePatternElementListSyntax = {
     TuplePatternElementListSyntax([])
-  }) {
-    self.init (unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndElements, elements: elementsBuilder(), unexpectedBetweenElementsAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndElements, elements: elementsBuilder(), unexpectedBetweenElementsAndRightParen, rightParen: rightParen, trailingTrivia: trailingTrivia)
   }
 }
 
 extension TupleTypeElement: HasTrailingComma {
-  /// Creates a `TupleTypeElement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeInOut: 
-  ///   - inOut: 
-  ///   - unexpectedBetweenInOutAndName: 
-  ///   - name: 
-  ///   - unexpectedBetweenNameAndSecondName: 
-  ///   - secondName: 
-  ///   - unexpectedBetweenSecondNameAndColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndType: 
-  ///   - type: 
-  ///   - unexpectedBetweenTypeAndEllipsis: 
-  ///   - ellipsis: 
-  ///   - unexpectedBetweenEllipsisAndInitializer: 
-  ///   - initializer: 
-  ///   - unexpectedBetweenInitializerAndTrailingComma: 
-  ///   - trailingComma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeInOut: UnexpectedNodes? = nil, inOut: Token? = nil, unexpectedBetweenInOutAndName: UnexpectedNodes? = nil, name: Token? = nil, unexpectedBetweenNameAndSecondName: UnexpectedNodes? = nil, secondName: Token? = nil, unexpectedBetweenSecondNameAndColon: UnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndType: UnexpectedNodes? = nil, type: TypeSyntaxProtocol, unexpectedBetweenTypeAndEllipsis: UnexpectedNodes? = nil, ellipsis: Token? = nil, unexpectedBetweenEllipsisAndInitializer: UnexpectedNodes? = nil, initializer: InitializerClause? = nil, unexpectedBetweenInitializerAndTrailingComma: UnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    assert(inOut == nil || inOut!.text == "inout")
-    assert(colon == nil || colon!.text == ":")
-    assert(ellipsis == nil || ellipsis!.text == "...")
-    assert(trailingComma == nil || trailingComma!.text == ",")
-    self = TupleTypeElementSyntax(unexpectedBeforeInOut, inOut: inOut, unexpectedBetweenInOutAndName, name: name, unexpectedBetweenNameAndSecondName, secondName: secondName, unexpectedBetweenSecondNameAndColon, colon: colon, unexpectedBetweenColonAndType, type: TypeSyntax(fromProtocol: type), unexpectedBetweenTypeAndEllipsis, ellipsis: ellipsis, unexpectedBetweenEllipsisAndInitializer, initializer: initializer, unexpectedBetweenInitializerAndTrailingComma, trailingComma: trailingComma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
@@ -4625,377 +1242,56 @@ extension TupleTypeElement: HasTrailingComma {
   }
 }
 
-extension TupleType {
-  /// Creates a `TupleType` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndElements: 
-  ///   - elements: 
-  ///   - unexpectedBetweenElementsAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElements: UnexpectedNodes? = nil, elements: TupleTypeElementList, unexpectedBetweenElementsAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = TupleTypeSyntax(unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndElements, elements: elements, unexpectedBetweenElementsAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension TypeAnnotation {
-  /// Creates a `TypeAnnotation` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndType: 
-  ///   - type: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndType: UnexpectedNodes? = nil, type: TypeSyntaxProtocol) {
-    assert(colon.text == ":")
-    self = TypeAnnotationSyntax(unexpectedBeforeColon, colon: colon, unexpectedBetweenColonAndType, type: TypeSyntax(fromProtocol: type))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension TypeExpr {
-  /// Creates a `TypeExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeType: 
-  ///   - type: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeType: UnexpectedNodes? = nil, type: TypeSyntaxProtocol) {
-    self = TypeExprSyntax(unexpectedBeforeType, type: TypeSyntax(fromProtocol: type))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
 extension TypeInheritanceClause {
-  /// Creates a `TypeInheritanceClause` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeColon: 
-  ///   - colon: 
-  ///   - unexpectedBetweenColonAndInheritedTypeCollection: 
-  ///   - inheritedTypeCollection: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndInheritedTypeCollection: UnexpectedNodes? = nil, inheritedTypeCollection: InheritedTypeList) {
-    assert(colon.text == ":")
-    self = TypeInheritanceClauseSyntax(unexpectedBeforeColon, colon: colon, unexpectedBetweenColonAndInheritedTypeCollection, inheritedTypeCollection: inheritedTypeCollection)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndInheritedTypeCollection: UnexpectedNodes? = nil, @InheritedTypeListBuilder inheritedTypeCollectionBuilder: () -> InheritedTypeListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeColon: UnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndInheritedTypeCollection: UnexpectedNodes? = nil, @InheritedTypeListBuilder inheritedTypeCollectionBuilder: () -> InheritedTypeListSyntax = {
     InheritedTypeListSyntax([])
-  }) {
-    self.init (unexpectedBeforeColon, colon: colon, unexpectedBetweenColonAndInheritedTypeCollection, inheritedTypeCollection: inheritedTypeCollectionBuilder())
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension TypeInitializerClause {
-  /// Creates a `TypeInitializerClause` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeEqual: 
-  ///   - equal: 
-  ///   - unexpectedBetweenEqualAndValue: 
-  ///   - value: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeEqual: UnexpectedNodes? = nil, equal: Token = Token.`equal`, unexpectedBetweenEqualAndValue: UnexpectedNodes? = nil, value: TypeSyntaxProtocol) {
-    assert(equal.text == "=")
-    self = TypeInitializerClauseSyntax(unexpectedBeforeEqual, equal: equal, unexpectedBetweenEqualAndValue, value: TypeSyntax(fromProtocol: value))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeColon, colon: colon, unexpectedBetweenColonAndInheritedTypeCollection, inheritedTypeCollection: inheritedTypeCollectionBuilder(), trailingTrivia: trailingTrivia)
   }
 }
 
 extension TypealiasDecl {
-  /// Creates a `TypealiasDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: 
-  ///   - unexpectedBetweenModifiersAndTypealiasKeyword: 
-  ///   - typealiasKeyword: 
-  ///   - unexpectedBetweenTypealiasKeywordAndIdentifier: 
-  ///   - identifier: 
-  ///   - unexpectedBetweenIdentifierAndGenericParameterClause: 
-  ///   - genericParameterClause: 
-  ///   - unexpectedBetweenGenericParameterClauseAndInitializer: 
-  ///   - initializer: 
-  ///   - unexpectedBetweenInitializerAndGenericWhereClause: 
-  ///   - genericWhereClause: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndTypealiasKeyword: UnexpectedNodes? = nil, typealiasKeyword: Token = Token.`typealias`, unexpectedBetweenTypealiasKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInitializer: UnexpectedNodes? = nil, initializer: TypeInitializerClause, unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil) {
-    assert(typealiasKeyword.text == "typealias")
-    self = TypealiasDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndTypealiasKeyword, typealiasKeyword: typealiasKeyword, unexpectedBetweenTypealiasKeywordAndIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInitializer, initializer: initializer, unexpectedBetweenInitializerAndGenericWhereClause, genericWhereClause: genericWhereClause)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndTypealiasKeyword: UnexpectedNodes? = nil, typealiasKeyword: Token = Token.`typealias`, unexpectedBetweenTypealiasKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInitializer: UnexpectedNodes? = nil, initializer: TypeInitializerClause, unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndTypealiasKeyword, typealiasKeyword: typealiasKeyword, unexpectedBetweenTypealiasKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInitializer, initializer: initializer, unexpectedBetweenInitializerAndGenericWhereClause, genericWhereClause: genericWhereClause)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension UnavailabilityCondition {
-  /// Creates a `UnavailabilityCondition` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePoundUnavailableKeyword: 
-  ///   - poundUnavailableKeyword: 
-  ///   - unexpectedBetweenPoundUnavailableKeywordAndLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndAvailabilitySpec: 
-  ///   - availabilitySpec: 
-  ///   - unexpectedBetweenAvailabilitySpecAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundUnavailableKeyword: UnexpectedNodes? = nil, poundUnavailableKeyword: Token = Token.`poundUnavailable`, unexpectedBetweenPoundUnavailableKeywordAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodes? = nil, availabilitySpec: AvailabilitySpecList, unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(poundUnavailableKeyword.text == "#unavailable")
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = UnavailabilityConditionSyntax(unexpectedBeforePoundUnavailableKeyword, poundUnavailableKeyword: poundUnavailableKeyword, unexpectedBetweenPoundUnavailableKeywordAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndAvailabilitySpec, availabilitySpec: availabilitySpec, unexpectedBetweenAvailabilitySpecAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension UnresolvedAsExpr {
-  /// Creates a `UnresolvedAsExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAsTok: 
-  ///   - asTok: 
-  ///   - unexpectedBetweenAsTokAndQuestionOrExclamationMark: 
-  ///   - questionOrExclamationMark: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAsTok: UnexpectedNodes? = nil, asTok: Token = Token.`as`, unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodes? = nil, questionOrExclamationMark: Token? = nil) {
-    assert(asTok.text == "as")
-    assert(questionOrExclamationMark == nil || questionOrExclamationMark!.text == "?" || questionOrExclamationMark!.text == "!")
-    self = UnresolvedAsExprSyntax(unexpectedBeforeAsTok, asTok: asTok, unexpectedBetweenAsTokAndQuestionOrExclamationMark, questionOrExclamationMark: questionOrExclamationMark)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension UnresolvedIsExpr {
-  /// Creates a `UnresolvedIsExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeIsTok: 
-  ///   - isTok: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIsTok: UnexpectedNodes? = nil, isTok: Token = Token.`is`) {
-    assert(isTok.text == "is")
-    self = UnresolvedIsExprSyntax(unexpectedBeforeIsTok, isTok: isTok)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension UnresolvedPatternExpr {
-  /// Creates a `UnresolvedPatternExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePattern: 
-  ///   - pattern: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePattern: UnexpectedNodes? = nil, pattern: PatternSyntaxProtocol) {
-    self = UnresolvedPatternExprSyntax(unexpectedBeforePattern, pattern: PatternSyntax(fromProtocol: pattern))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension UnresolvedTernaryExpr {
-  /// Creates a `UnresolvedTernaryExpr` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeQuestionMark: 
-  ///   - questionMark: 
-  ///   - unexpectedBetweenQuestionMarkAndFirstChoice: 
-  ///   - firstChoice: 
-  ///   - unexpectedBetweenFirstChoiceAndColonMark: 
-  ///   - colonMark: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeQuestionMark: UnexpectedNodes? = nil, questionMark: Token = Token.`infixQuestionMark`, unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodes? = nil, firstChoice: ExprSyntaxProtocol, unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodes? = nil, colonMark: Token = Token.`colon`) {
-    assert(questionMark.text == "?")
-    assert(colonMark.text == ":")
-    self = UnresolvedTernaryExprSyntax(unexpectedBeforeQuestionMark, questionMark: questionMark, unexpectedBetweenQuestionMarkAndFirstChoice, firstChoice: ExprSyntax(fromProtocol: firstChoice), unexpectedBetweenFirstChoiceAndColonMark, colonMark: colonMark)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension ValueBindingPattern {
-  /// Creates a `ValueBindingPattern` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLetOrVarKeyword: 
-  ///   - letOrVarKeyword: 
-  ///   - unexpectedBetweenLetOrVarKeywordAndValuePattern: 
-  ///   - valuePattern: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLetOrVarKeyword: UnexpectedNodes? = nil, letOrVarKeyword: Token, unexpectedBetweenLetOrVarKeywordAndValuePattern: UnexpectedNodes? = nil, valuePattern: PatternSyntaxProtocol) {
-    assert(letOrVarKeyword.text == "let" || letOrVarKeyword.text == "var")
-    self = ValueBindingPatternSyntax(unexpectedBeforeLetOrVarKeyword, letOrVarKeyword: letOrVarKeyword, unexpectedBetweenLetOrVarKeywordAndValuePattern, valuePattern: PatternSyntax(fromProtocol: valuePattern))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndTypealiasKeyword: UnexpectedNodes? = nil, typealiasKeyword: Token = Token.`typealias`, unexpectedBetweenTypealiasKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInitializer: UnexpectedNodes? = nil, initializer: TypeInitializerClause, unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndTypealiasKeyword, typealiasKeyword: typealiasKeyword, unexpectedBetweenTypealiasKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInitializer, initializer: initializer, unexpectedBetweenInitializerAndGenericWhereClause, genericWhereClause: genericWhereClause, trailingTrivia: trailingTrivia)
   }
 }
 
 extension VariableDecl {
-  /// Creates a `VariableDecl` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeAttributes: 
-  ///   - attributes: 
-  ///   - unexpectedBetweenAttributesAndModifiers: 
-  ///   - modifiers: 
-  ///   - unexpectedBetweenModifiersAndLetOrVarKeyword: 
-  ///   - letOrVarKeyword: 
-  ///   - unexpectedBetweenLetOrVarKeywordAndBindings: 
-  ///   - bindings: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndLetOrVarKeyword: UnexpectedNodes? = nil, letOrVarKeyword: Token, unexpectedBetweenLetOrVarKeywordAndBindings: UnexpectedNodes? = nil, bindings: PatternBindingList) {
-    assert(letOrVarKeyword.text == "let" || letOrVarKeyword.text == "var")
-    self = VariableDeclSyntax(unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndLetOrVarKeyword, letOrVarKeyword: letOrVarKeyword, unexpectedBetweenLetOrVarKeywordAndBindings, bindings: bindings)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndLetOrVarKeyword: UnexpectedNodes? = nil, letOrVarKeyword: Token, unexpectedBetweenLetOrVarKeywordAndBindings: UnexpectedNodes? = nil, @PatternBindingListBuilder bindingsBuilder: () -> PatternBindingListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndLetOrVarKeyword: UnexpectedNodes? = nil, letOrVarKeyword: Token, unexpectedBetweenLetOrVarKeywordAndBindings: UnexpectedNodes? = nil, @PatternBindingListBuilder bindingsBuilder: () -> PatternBindingListSyntax = {
     PatternBindingListSyntax([])
-  }) {
-    self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndLetOrVarKeyword, letOrVarKeyword: letOrVarKeyword, unexpectedBetweenLetOrVarKeywordAndBindings, bindings: bindingsBuilder())
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndLetOrVarKeyword, letOrVarKeyword: letOrVarKeyword, unexpectedBetweenLetOrVarKeywordAndBindings, bindings: bindingsBuilder(), trailingTrivia: trailingTrivia)
   }
 }
 
 /// A version number of the form major.minor.patch in which the minorand patch part may be omitted.
 extension VersionTuple {
-  /// Creates a `VersionTuple` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeMajorMinor: 
-  ///   - majorMinor: In case the version consists only of the major version, aninteger literal that specifies the major version. In casethe version consists of major and minor version number, afloating literal in which the decimal part is interpretedas the minor version.
-  ///   - unexpectedBetweenMajorMinorAndPatchPeriod: 
-  ///   - patchPeriod: If the version contains a patch number, the periodseparating the minor from the patch number.
-  ///   - unexpectedBetweenPatchPeriodAndPatchVersion: 
-  ///   - patchVersion: The patch version if specified.
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeMajorMinor: UnexpectedNodes? = nil, majorMinor: Token, unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodes? = nil, patchPeriod: Token? = nil, unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodes? = nil, patchVersion: Token? = nil) {
-    assert(patchPeriod == nil || patchPeriod!.text == ".")
-    self = VersionTupleSyntax(unexpectedBeforeMajorMinor, majorMinor: majorMinor, unexpectedBetweenMajorMinorAndPatchPeriod, patchPeriod: patchPeriod, unexpectedBetweenPatchPeriodAndPatchVersion, patchVersion: patchVersion)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeMajorMinor: UnexpectedNodes? = nil, majorMinor: Token, unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodes? = nil, patchPeriod: Token? = nil, unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodes? = nil, patchVersion: String?) {
-    self.init (unexpectedBeforeMajorMinor, majorMinor: majorMinor, unexpectedBetweenMajorMinorAndPatchPeriod, patchPeriod: patchPeriod, unexpectedBetweenPatchPeriodAndPatchVersion, patchVersion: patchVersion.map { 
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeMajorMinor: UnexpectedNodes? = nil, majorMinor: Token, unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodes? = nil, patchPeriod: Token? = nil, unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodes? = nil, patchVersion: String?, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeMajorMinor, majorMinor: majorMinor, unexpectedBetweenMajorMinorAndPatchPeriod, patchPeriod: patchPeriod, unexpectedBetweenPatchPeriodAndPatchVersion, patchVersion: patchVersion.map { 
       Token.`integerLiteral`($0) 
-    })
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension WhereClause {
-  /// Creates a `WhereClause` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeWhereKeyword: 
-  ///   - whereKeyword: 
-  ///   - unexpectedBetweenWhereKeywordAndGuardResult: 
-  ///   - guardResult: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWhereKeyword: UnexpectedNodes? = nil, whereKeyword: Token = Token.`where`, unexpectedBetweenWhereKeywordAndGuardResult: UnexpectedNodes? = nil, guardResult: ExprSyntaxProtocol) {
-    assert(whereKeyword.text == "where")
-    self = WhereClauseSyntax(unexpectedBeforeWhereKeyword, whereKeyword: whereKeyword, unexpectedBetweenWhereKeywordAndGuardResult, guardResult: ExprSyntax(fromProtocol: guardResult))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+    }, trailingTrivia: trailingTrivia)
   }
 }
 
 extension WhileStmt {
-  /// Creates a `WhileStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeWhileKeyword: 
-  ///   - whileKeyword: 
-  ///   - unexpectedBetweenWhileKeywordAndConditions: 
-  ///   - conditions: 
-  ///   - unexpectedBetweenConditionsAndBody: 
-  ///   - body: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWhileKeyword: UnexpectedNodes? = nil, whileKeyword: Token = Token.`while`, unexpectedBetweenWhileKeywordAndConditions: UnexpectedNodes? = nil, conditions: ConditionElementList, unexpectedBetweenConditionsAndBody: UnexpectedNodes? = nil, body: CodeBlock) {
-    assert(whileKeyword.text == "while")
-    self = WhileStmtSyntax(unexpectedBeforeWhileKeyword, whileKeyword: whileKeyword, unexpectedBetweenWhileKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndBody, body: body)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeWhileKeyword: UnexpectedNodes? = nil, whileKeyword: Token = Token.`while`, unexpectedBetweenWhileKeywordAndConditions: UnexpectedNodes? = nil, conditions: ConditionElementList, unexpectedBetweenConditionsAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeWhileKeyword: UnexpectedNodes? = nil, whileKeyword: Token = Token.`while`, unexpectedBetweenWhileKeywordAndConditions: UnexpectedNodes? = nil, conditions: ConditionElementList, unexpectedBetweenConditionsAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax = {
     CodeBlockItemListSyntax([])
-  }) {
-    self.init (unexpectedBeforeWhileKeyword, whileKeyword: whileKeyword, unexpectedBetweenWhileKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndBody, body: CodeBlockSyntax(statements: bodyBuilder()))
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension WildcardPattern {
-  /// Creates a `WildcardPattern` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeWildcard: 
-  ///   - wildcard: 
-  ///   - unexpectedBetweenWildcardAndTypeAnnotation: 
-  ///   - typeAnnotation: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWildcard: UnexpectedNodes? = nil, wildcard: Token = Token.`wildcard`, unexpectedBetweenWildcardAndTypeAnnotation: UnexpectedNodes? = nil, typeAnnotation: TypeAnnotation? = nil) {
-    assert(wildcard.text == "_")
-    self = WildcardPatternSyntax(unexpectedBeforeWildcard, wildcard: wildcard, unexpectedBetweenWildcardAndTypeAnnotation, typeAnnotation: typeAnnotation)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension YieldExprListElement {
-  /// Creates a `YieldExprListElement` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeExpression: 
-  ///   - expression: 
-  ///   - unexpectedBetweenExpressionAndComma: 
-  ///   - comma: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, unexpectedBetweenExpressionAndComma: UnexpectedNodes? = nil, comma: Token? = nil) {
-    assert(comma == nil || comma!.text == ",")
-    self = YieldExprListElementSyntax(unexpectedBeforeExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndComma, comma: comma)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension YieldList {
-  /// Creates a `YieldList` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndElementList: 
-  ///   - elementList: 
-  ///   - unexpectedBetweenElementListAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElementList: UnexpectedNodes? = nil, elementList: YieldExprList, unexpectedBetweenElementListAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = YieldListSyntax(unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndElementList, elementList: elementList, unexpectedBetweenElementListAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
-  }
-}
-
-extension YieldStmt {
-  /// Creates a `YieldStmt` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforeYieldKeyword: 
-  ///   - yieldKeyword: 
-  ///   - unexpectedBetweenYieldKeywordAndYields: 
-  ///   - yields: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeYieldKeyword: UnexpectedNodes? = nil, yieldKeyword: Token = Token.`yield`, unexpectedBetweenYieldKeywordAndYields: UnexpectedNodes? = nil, yields: Yields) {
-    assert(yieldKeyword.text == "yield")
-    self = YieldStmtSyntax(unexpectedBeforeYieldKeyword, yieldKeyword: yieldKeyword, unexpectedBetweenYieldKeywordAndYields, yields: yields)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeWhileKeyword, whileKeyword: whileKeyword, unexpectedBetweenWhileKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndBody, body: CodeBlockSyntax(statements: bodyBuilder()), trailingTrivia: trailingTrivia)
   }
 }

--- a/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
@@ -68,7 +68,12 @@ extension BooleanLiteralExprSyntax: SyntaxExpressibleByStringInterpolation {
 extension BreakStmtSyntax: SyntaxExpressibleByStringInterpolation { 
 }
 
-extension CatchClauseSyntax: SyntaxExpressibleByStringInterpolation { 
+extension CatchClauseSyntax: SyntaxExpressibleByStringInterpolation {
+  public init (stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in 
+      return Self.parse(from: &parser)
+    })
+  }
 }
 
 extension ClassDeclSyntax: SyntaxExpressibleByStringInterpolation { 
@@ -192,7 +197,12 @@ extension FunctionDeclSyntax: SyntaxExpressibleByStringInterpolation {
 extension FunctionTypeSyntax: SyntaxExpressibleByStringInterpolation { 
 }
 
-extension GenericParameterClauseSyntax: SyntaxExpressibleByStringInterpolation { 
+extension GenericParameterClauseSyntax: SyntaxExpressibleByStringInterpolation {
+  public init (stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in 
+      return Self.parse(from: &parser)
+    })
+  }
 }
 
 extension GuardStmtSyntax: SyntaxExpressibleByStringInterpolation { 
@@ -252,28 +262,18 @@ extension MacroExpansionExprSyntax: SyntaxExpressibleByStringInterpolation {
 extension MemberAccessExprSyntax: SyntaxExpressibleByStringInterpolation { 
 }
 
-extension MemberDeclBlockSyntax: SyntaxExpressibleByStringInterpolation { 
+extension MemberDeclBlockSyntax: SyntaxExpressibleByStringInterpolation {
+  public init (stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in 
+      return Self.parse(from: &parser)
+    })
+  }
 }
 
 extension MemberTypeIdentifierSyntax: SyntaxExpressibleByStringInterpolation { 
 }
 
 extension MetatypeTypeSyntax: SyntaxExpressibleByStringInterpolation { 
-}
-
-extension MissingDeclSyntax: SyntaxExpressibleByStringInterpolation { 
-}
-
-extension MissingExprSyntax: SyntaxExpressibleByStringInterpolation { 
-}
-
-extension MissingPatternSyntax: SyntaxExpressibleByStringInterpolation { 
-}
-
-extension MissingStmtSyntax: SyntaxExpressibleByStringInterpolation { 
-}
-
-extension MissingTypeSyntax: SyntaxExpressibleByStringInterpolation { 
 }
 
 extension MoveExprSyntax: SyntaxExpressibleByStringInterpolation { 
@@ -368,7 +368,12 @@ extension SequenceExprSyntax: SyntaxExpressibleByStringInterpolation {
 extension SimpleTypeIdentifierSyntax: SyntaxExpressibleByStringInterpolation { 
 }
 
-extension SourceFileSyntax: SyntaxExpressibleByStringInterpolation { 
+extension SourceFileSyntax: SyntaxExpressibleByStringInterpolation {
+  public init (stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in 
+      return Self.parse(from: &parser)
+    })
+  }
 }
 
 extension SpecializeExprSyntax: SyntaxExpressibleByStringInterpolation { 
@@ -409,7 +414,12 @@ extension SubscriptExprSyntax: SyntaxExpressibleByStringInterpolation {
 extension SuperRefExprSyntax: SyntaxExpressibleByStringInterpolation { 
 }
 
-extension SwitchCaseSyntax: SyntaxExpressibleByStringInterpolation { 
+extension SwitchCaseSyntax: SyntaxExpressibleByStringInterpolation {
+  public init (stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
+    self = try performParse(source: stringInterpolation.sourceText, parse: { parser in 
+      return Self.parse(from: &parser)
+    })
+  }
 }
 
 extension SwitchStmtSyntax: SyntaxExpressibleByStringInterpolation { 

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -79,15 +79,10 @@ final class DeclarationTests: XCTestCase {
       func name(_ default: Int) {}
       """,
       substructure: Syntax(FunctionParameterSyntax(
-        attributes: nil,
-        modifiers: nil,
         firstName: .wildcardKeyword(),
         secondName: .identifier("default"),
-        colon: TokenSyntax.colonToken(),
-        type: TypeSyntax(SimpleTypeIdentifierSyntax(name: TokenSyntax.identifier("Int"), genericArgumentClause: nil)),
-        ellipsis: nil,
-        defaultArgument: nil,
-        trailingComma: nil))
+        colon: .colonToken(),
+        type: SimpleTypeIdentifierSyntax(name: .identifier("Int"))))
     )
   }
 
@@ -643,23 +638,15 @@ final class DeclarationTests: XCTestCase {
       }
       """,
       substructure: Syntax(FunctionDeclSyntax(
-        attributes: nil,
-        modifiers: nil,
         funcKeyword: .funcKeyword(),
         identifier: .identifier("withoutParameters"),
-        genericParameterClause: nil,
         signature: FunctionSignatureSyntax(
           input: ParameterClauseSyntax(
             leftParen: .leftParenToken(presence: .missing),
             parameterList: FunctionParameterListSyntax([]),
             rightParen: .rightParenToken(presence: .missing)
-          ),
-          asyncOrReasyncKeyword: nil,
-          throwsOrRethrowsKeyword: nil,
-          output: nil
-        ),
-        genericWhereClause: nil,
-        body: nil
+          )
+        )
       )),
       diagnostics: [
         DiagnosticSpec(message: "expected parameter clause in function signature")
@@ -785,16 +772,11 @@ final class DeclarationTests: XCTestCase {
     AssertParse(
       "func test(first second 1️⃣third: Int)",
       substructure: Syntax(FunctionParameterSyntax(
-        attributes: nil,
-        modifiers: nil,
-        firstName: TokenSyntax.identifier("first"),
-        secondName: TokenSyntax.identifier("second"),
-        UnexpectedNodesSyntax([Syntax(TokenSyntax.identifier("third"))]),
-        colon: TokenSyntax.colonToken(),
-        type: TypeSyntax(SimpleTypeIdentifierSyntax(name: TokenSyntax.identifier("Int"), genericArgumentClause: nil)),
-        ellipsis: nil,
-        defaultArgument: nil,
-        trailingComma: nil
+        firstName: .identifier("first"),
+        secondName: .identifier("second"),
+        UnexpectedNodesSyntax([TokenSyntax.identifier("third")]),
+        colon: .colonToken(),
+        type: SimpleTypeIdentifierSyntax(name: .identifier("Int"))
       )),
       diagnostics: [
         DiagnosticSpec(message: "unexpected code 'third' in parameter")
@@ -806,16 +788,11 @@ final class DeclarationTests: XCTestCase {
     AssertParse(
       "func test(first second 1️⃣third fourth: Int)",
       substructure: Syntax(FunctionParameterSyntax(
-        attributes: nil,
-        modifiers: nil,
-        firstName: TokenSyntax.identifier("first"),
-        secondName: TokenSyntax.identifier("second"),
-        UnexpectedNodesSyntax([Syntax(TokenSyntax.identifier("third")), Syntax(TokenSyntax.identifier("fourth"))]),
-        colon: TokenSyntax.colonToken(),
-        type: TypeSyntax(SimpleTypeIdentifierSyntax(name: TokenSyntax.identifier("Int"), genericArgumentClause: nil)),
-        ellipsis: nil,
-        defaultArgument: nil,
-        trailingComma: nil
+        firstName: .identifier("first"),
+        secondName: .identifier("second"),
+        UnexpectedNodesSyntax([TokenSyntax.identifier("third"), TokenSyntax.identifier("fourth")]),
+        colon: .colonToken(),
+        type: SimpleTypeIdentifierSyntax(name: .identifier("Int"))
       )),
       diagnostics: [
         DiagnosticSpec(message: "unexpected code 'third fourth' in parameter")
@@ -827,15 +804,10 @@ final class DeclarationTests: XCTestCase {
     AssertParse(
       "func foo(first second 1️⃣third 2️⃣struct3️⃣: Int4️⃣) {}",
       substructure: Syntax(FunctionParameterSyntax(
-        attributes: nil,
-        modifiers: nil,
         firstName: .identifier("first"),
         secondName: .identifier("second"),
         colon: .colonToken(presence: .missing),
-        type: TypeSyntax(SimpleTypeIdentifierSyntax(name: .identifier("third"), genericArgumentClause: nil)),
-        ellipsis: nil,
-        defaultArgument: nil,
-        trailingComma: nil
+        type: SimpleTypeIdentifierSyntax(name: .identifier("third"))
       )),
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in parameter"),
@@ -850,21 +822,16 @@ final class DeclarationTests: XCTestCase {
     AssertParse(
       "func test(first second 1️⃣[third fourth]: Int)",
       substructure: Syntax(FunctionParameterSyntax(
-        attributes: nil,
-        modifiers: nil,
-        firstName: TokenSyntax.identifier("first"),
-        secondName: TokenSyntax.identifier("second"),
+        firstName: .identifier("first"),
+        secondName: .identifier("second"),
         UnexpectedNodesSyntax([
-          Syntax(TokenSyntax.leftSquareBracketToken()),
-          Syntax(TokenSyntax.identifier("third")),
-          Syntax(TokenSyntax.identifier("fourth")),
-          Syntax(TokenSyntax.rightSquareBracketToken())
+          TokenSyntax.leftSquareBracketToken(),
+          TokenSyntax.identifier("third"),
+          TokenSyntax.identifier("fourth"),
+          TokenSyntax.rightSquareBracketToken()
         ]),
-        colon: TokenSyntax.colonToken(),
-        type: TypeSyntax(SimpleTypeIdentifierSyntax(name: TokenSyntax.identifier("Int"), genericArgumentClause: nil)),
-        ellipsis: nil,
-        defaultArgument: nil,
-        trailingComma: nil
+        colon: .colonToken(),
+        type: SimpleTypeIdentifierSyntax(name: .identifier("Int"))
       )),
       diagnostics: [
         DiagnosticSpec(message: "unexpected code '[third fourth]' in parameter")
@@ -876,19 +843,14 @@ final class DeclarationTests: XCTestCase {
     AssertParse(
       "func foo(first second 1️⃣[third 2️⃣fourth: Int) {}",
       substructure: Syntax(FunctionParameterSyntax(
-        attributes: nil,
-        modifiers: nil,
-        firstName: TokenSyntax.identifier("first"),
-        secondName: TokenSyntax.identifier("second"),
-        colon: TokenSyntax(.colon, presence: .missing),
-        type: TypeSyntax(ArrayTypeSyntax(
-          leftSquareBracket: TokenSyntax.leftSquareBracketToken(),
-          elementType: TypeSyntax(SimpleTypeIdentifierSyntax(name: TokenSyntax.identifier("third"), genericArgumentClause: nil)),
-          rightSquareBracket: TokenSyntax(.rightSquareBracket, presence: .missing)
-        )),
-        ellipsis: nil,
-        defaultArgument: nil,
-        trailingComma: nil
+        firstName: .identifier("first"),
+        secondName: .identifier("second"),
+        colon: .colonToken(presence: .missing),
+        type: ArrayTypeSyntax(
+          leftSquareBracket: .leftSquareBracketToken(),
+          elementType: SimpleTypeIdentifierSyntax(name: .identifier("third")),
+          rightSquareBracket: .rightSquareBracketToken(presence: .missing)
+        )
       )),
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in parameter"),
@@ -905,15 +867,10 @@ final class DeclarationTests: XCTestCase {
       3️⃣: Int) {}
       """,
       substructure: Syntax(FunctionParameterSyntax(
-        attributes: nil,
-        modifiers: nil,
-        firstName: TokenSyntax.identifier("first"),
-        secondName: TokenSyntax.identifier("second"),
-        colon: TokenSyntax(.colon, presence: .missing),
-        type: TypeSyntax(SimpleTypeIdentifierSyntax(name: TokenSyntax.identifier("third"), genericArgumentClause: nil)),
-        ellipsis: nil,
-        defaultArgument: nil,
-        trailingComma: nil
+        firstName: .identifier("first"),
+        secondName: .identifier("second"),
+        colon: .colonToken(presence: .missing),
+        type: SimpleTypeIdentifierSyntax(name: .identifier("third"))
       )),
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in parameter"),
@@ -1238,62 +1195,39 @@ final class DeclarationTests: XCTestCase {
       substructure: Syntax(CodeBlockItemListSyntax([
           CodeBlockItemSyntax(
             item: .init(ClassDeclSyntax(
-              attributes: nil,
-              modifiers: nil,
               classKeyword: .classKeyword(),
               identifier: .identifier("A"),
-              genericParameterClause: nil,
-              inheritanceClause: nil,
-              genericWhereClause: nil,
               members: MemberDeclBlockSyntax(
                 leftBrace: .leftBraceToken(),
                 members: MemberDeclListSyntax([
                   MemberDeclListItemSyntax(
                     decl: Decl(FunctionDeclSyntax(
-                      attributes: nil,
-                      modifiers: nil,
                       funcKeyword: .funcKeyword(presence: .missing),
                       identifier: .spacedBinaryOperator("^"),
-                      genericParameterClause: nil,
                       signature: FunctionSignatureSyntax(
                         input: ParameterClauseSyntax(
                           leftParen: .leftParenToken(presence: .missing),
                           parameterList: FunctionParameterListSyntax([]),
                           rightParen: .rightParenToken(presence: .missing)
-                        ),
-                        asyncOrReasyncKeyword: nil,
-                        throwsOrRethrowsKeyword: nil,
-                        output: nil
-                      ),
-                      genericWhereClause: nil,
-                      body: nil
-                    )),
-                    semicolon: nil
+                        )
+                      )
+                    ))
                   )
                 ]),
                 rightBrace: .rightBraceToken()
               )
-            )),
-            semicolon: nil,
-            errorTokens: nil
+            ))
           ),
           CodeBlockItemSyntax(
             item: .init(ClassDeclSyntax(
-              attributes: nil,
-              modifiers: nil,
               classKeyword: .classKeyword(),
               identifier: .identifier("B"),
-              genericParameterClause: nil,
-              inheritanceClause: nil,
-              genericWhereClause: nil,
               members: MemberDeclBlockSyntax(
                 leftBrace: .leftBraceToken(),
                 members: MemberDeclListSyntax([]),
                 rightBrace: .rightBraceToken()
               )
-            )),
-            semicolon: nil,
-            errorTokens: nil
+            ))
           )
         ])
       ),

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -112,7 +112,6 @@ final class ExpressionTests: XCTestCase {
             item: .init(
               KeyPathExprSyntax(
               backslash: .backslashToken(),
-              root: nil,
               components: KeyPathComponentListSyntax([
                 KeyPathComponentSyntax(
                   period: .periodToken(),
@@ -126,16 +125,12 @@ final class ExpressionTests: XCTestCase {
                   period: .periodToken(),
                   component: .init(
                     KeyPathPropertyComponentSyntax(
-                      identifier: .identifier("foo"),
-                      declNameArguments: nil,
-                      genericArgumentClause: nil
+                      identifier: .identifier("foo")
                     )
                   )
                 )
               ])
-            )),
-            semicolon: nil,
-            errorTokens: nil
+            ))
           )
         ])
       )
@@ -317,30 +312,21 @@ final class ExpressionTests: XCTestCase {
       ]
       """,
       substructure: Syntax(DictionaryElementSyntax.init(
-        keyExpression: ExprSyntax(
-          MacroExpansionExprSyntax(
-            poundToken: .poundToken(), macro: .identifier("line"),
-            leftParen: nil, argumentList: TupleExprElementListSyntax([]),
-            rightParen: nil, trailingClosure: nil,
-            additionalTrailingClosures: nil)),
+        keyExpression: MacroExpansionExprSyntax(
+            poundToken: .poundToken(), macro: .identifier("line"), argumentList: TupleExprElementListSyntax([])),
         colon: .colonToken(),
-        valueExpression: ExprSyntax(FunctionCallExprSyntax(
-          calledExpression: ExprSyntax(IdentifierExprSyntax(identifier: .identifier("Calendar"), declNameArguments: nil)),
+        valueExpression: FunctionCallExprSyntax(
+          calledExpression: IdentifierExprSyntax(identifier: .identifier("Calendar")),
           leftParen: .leftParenToken(),
           argumentList: TupleExprElementListSyntax([
             TupleExprElementSyntax(
               label: .identifier("identifier"),
               colon: .colonToken(),
-              expression: ExprSyntax(MemberAccessExprSyntax(
-                base: nil,
+              expression: MemberAccessExprSyntax(
                 dot: .prefixPeriodToken(),
-                name: .identifier("buddhist"),
-                declNameArguments: nil)),
-              trailingComma: nil)
+                name: .identifier("buddhist")))
           ]),
-          rightParen: .rightParenToken(),
-          trailingClosure: nil,
-          additionalTrailingClosures: nil)),
+          rightParen: .rightParenToken()),
         trailingComma: .commaToken())),
     substructureAfterMarker: "1️⃣")
 

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -19,34 +19,32 @@ final class StatementTests: XCTestCase {
     AssertParse("""
                 if let baz {}
                 """,
-                substructure: Syntax(IfStmtSyntax(ifKeyword: .ifKeyword(),
-                                                  conditions: ConditionElementListSyntax([
-                                                    ConditionElementSyntax(condition: .init(OptionalBindingConditionSyntax(
-                                                      letOrVarKeyword: .letKeyword(),
-                                                      pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("baz"))),
-                                                      typeAnnotation: nil,
-                                                      initializer: nil)), trailingComma: nil)
-                                                  ]),
-                                                  body: .init(leftBrace: .leftBraceToken(),
-                                                              statements: .init([]),
-                                                              rightBrace: .rightBraceToken()),
-                                                  elseKeyword: nil, elseBody: nil)))
+                substructure: Syntax(IfStmtSyntax(
+                  ifKeyword: .ifKeyword(),
+                  conditions: ConditionElementListSyntax([
+                    ConditionElementSyntax(condition: .init(OptionalBindingConditionSyntax(
+                      letOrVarKeyword: .letKeyword(),
+                      pattern: IdentifierPatternSyntax(identifier: .identifier("baz"))
+                      )))
+                  ]),
+                  body: .init(leftBrace: .leftBraceToken(),
+                              statements: .init([]),
+                              rightBrace: .rightBraceToken()))))
 
     AssertParse("""
                 if let self = self {}
                 """,
-                substructure: Syntax(IfStmtSyntax(ifKeyword: .ifKeyword(),
-                                                  conditions: ConditionElementListSyntax([
-                                                    ConditionElementSyntax(condition: .init(OptionalBindingConditionSyntax(
-                                                      letOrVarKeyword: .letKeyword(),
-                                                      pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .selfKeyword())),
-                                                      typeAnnotation: nil,
-                                                      initializer: InitializerClauseSyntax(equal: .equalToken(), value: ExprSyntax(IdentifierExprSyntax(identifier: .selfKeyword(), declNameArguments: nil))))), trailingComma: nil)
-                                                  ]),
-                                                  body: .init(leftBrace: .leftBraceToken(),
-                                                              statements: .init([]),
-                                                              rightBrace: .rightBraceToken()),
-                                                  elseKeyword: nil, elseBody: nil)))
+                substructure: Syntax(IfStmtSyntax(
+                  ifKeyword: .ifKeyword(),
+                  conditions: ConditionElementListSyntax([
+                    ConditionElementSyntax(condition: .init(OptionalBindingConditionSyntax(
+                      letOrVarKeyword: .letKeyword(),
+                      pattern: IdentifierPatternSyntax(identifier: .selfKeyword()),
+                      initializer: InitializerClauseSyntax(equal: .equalToken(), value: IdentifierExprSyntax(identifier: .selfKeyword())))))
+                  ]),
+                  body: .init(leftBrace: .leftBraceToken(),
+                              statements: .init([]),
+                              rightBrace: .rightBraceToken()))))
 
     AssertParse("if let x { }")
 
@@ -119,8 +117,9 @@ final class StatementTests: XCTestCase {
     AssertParse(
       "{ 1️⃣return 0 }",
       { ExprSyntax.parse(from: &$0) },
-      substructure: Syntax(ReturnStmtSyntax(returnKeyword: .returnKeyword(),
-                                            expression: ExprSyntax(IntegerLiteralExprSyntax(digits: .integerLiteral("0"))))),
+      substructure: Syntax(ReturnStmtSyntax(
+        returnKeyword: .returnKeyword(),
+        expression: IntegerLiteralExprSyntax(digits: .integerLiteral("0")))),
       substructureAfterMarker: "1️⃣"
     )
 
@@ -319,21 +318,16 @@ final class StatementTests: XCTestCase {
       graphQLMap["clientMutationId"] as? 1️⃣Swift.Optional<String?> ?? Swift.Optional<String?>.none
       """,
     substructure: Syntax(MemberTypeIdentifierSyntax(
-      baseType: TypeSyntax(SimpleTypeIdentifierSyntax(
-        name: .identifier("Swift"),
-        genericArgumentClause: nil)),
+      baseType: SimpleTypeIdentifierSyntax(name: .identifier("Swift")),
       period: .periodToken(),
       name: .identifier("Optional"),
       genericArgumentClause: GenericArgumentClauseSyntax(
         leftAngleBracket: .leftAngleToken(),
         arguments: GenericArgumentListSyntax([
           GenericArgumentSyntax(
-            argumentType: TypeSyntax(OptionalTypeSyntax(
-              wrappedType: TypeSyntax(SimpleTypeIdentifierSyntax(
-                name: .identifier("String"),
-                genericArgumentClause: nil)),
-              questionMark: .postfixQuestionMarkToken())),
-            trailingComma: nil)
+            argumentType: OptionalTypeSyntax(
+              wrappedType: SimpleTypeIdentifierSyntax(name: .identifier("String")),
+              questionMark: .postfixQuestionMarkToken()))
         ]),
         rightAngleBracket: .rightAngleToken()))),
     substructureAfterMarker: "1️⃣")
@@ -343,14 +337,11 @@ final class StatementTests: XCTestCase {
       if case 1️⃣Optional<Any>.none = object["anyCol"] { }
       """,
       substructure: Syntax(SpecializeExprSyntax(
-        expression: ExprSyntax(IdentifierExprSyntax(
-          identifier: .identifier("Optional"), declNameArguments: nil)),
+        expression: IdentifierExprSyntax(identifier: .identifier("Optional")),
         genericArgumentClause: GenericArgumentClauseSyntax(
           leftAngleBracket: .leftAngleToken(), arguments: GenericArgumentListSyntax([
         GenericArgumentSyntax(
-          argumentType: TypeSyntax(SimpleTypeIdentifierSyntax(
-            name: .anyKeyword(), genericArgumentClause: nil)),
-          trailingComma: nil)
+          argumentType: SimpleTypeIdentifierSyntax(name: .anyKeyword()))
       ]), rightAngleBracket: .rightAngleToken()))),
       substructureAfterMarker: "1️⃣")
   }
@@ -361,7 +352,7 @@ final class StatementTests: XCTestCase {
       1️⃣yield
       print("huh")
       """,
-      substructure: Syntax(IdentifierExprSyntax(identifier: .identifier("yield"), declNameArguments: nil)),
+      substructure: Syntax(IdentifierExprSyntax(identifier: .identifier("yield"))),
     substructureAfterMarker: "1️⃣")
   }
 
@@ -379,9 +370,7 @@ final class StatementTests: XCTestCase {
         yieldKeyword: .contextualKeyword("yield"),
         yields: .init(InOutExprSyntax(
           ampersand: .prefixAmpersandToken(),
-          expression: ExprSyntax(IdentifierExprSyntax(
-            identifier: .identifier("x"),
-            declNameArguments: nil)))))),
+          expression: IdentifierExprSyntax(identifier: .identifier("x")))))),
       substructureAfterMarker: "1️⃣")
 
     AssertParse(
@@ -408,24 +397,19 @@ final class StatementTests: XCTestCase {
         yieldKeyword: .contextualKeyword("yield"),
         yields: .init(InOutExprSyntax(
           ampersand: .prefixAmpersandToken(),
-          expression: ExprSyntax(SubscriptExprSyntax(
-            calledExpression: ExprSyntax(IdentifierExprSyntax(identifier: .identifier("native"), declNameArguments: nil)),
+          expression: SubscriptExprSyntax(
+            calledExpression: IdentifierExprSyntax(identifier: .identifier("native")),
             leftBracket: .leftSquareBracketToken(),
             argumentList: TupleExprElementListSyntax([
               TupleExprElementSyntax(
-                label: nil,
-                colon: nil,
-                expression: ExprSyntax(IdentifierExprSyntax(identifier: .identifier("key"), declNameArguments: nil)),
+                expression: IdentifierExprSyntax(identifier: .identifier("key")),
                 trailingComma: .commaToken()),
               TupleExprElementSyntax(
                 label: .identifier("isUnique"),
                 colon: .colonToken(),
-                expression: ExprSyntax(BooleanLiteralExprSyntax(booleanLiteral: .trueKeyword())),
-                trailingComma: nil),
+                expression: BooleanLiteralExprSyntax(booleanLiteral: .trueKeyword())),
             ]),
-            rightBracket: .rightSquareBracketToken(),
-            trailingClosure: nil,
-            additionalTrailingClosures: nil)))))),
+            rightBracket: .rightSquareBracketToken()))))),
       substructureAfterMarker: "1️⃣")
 
     // Make sure these are not.
@@ -438,14 +422,10 @@ final class StatementTests: XCTestCase {
       }
       """,
       substructure: Syntax(FunctionCallExprSyntax(
-        calledExpression: ExprSyntax(IdentifierExprSyntax(
-          identifier: .identifier("yield"),
-          declNameArguments: nil)),
+        calledExpression: IdentifierExprSyntax(identifier: .identifier("yield")),
         leftParen: .leftParenToken(),
         argumentList: TupleExprElementListSyntax([]),
-        rightParen: .rightParenToken(),
-        trailingClosure: nil,
-        additionalTrailingClosures: nil)),
+        rightParen: .rightParenToken())),
     substructureAfterMarker: "1️⃣")
 
     AssertParse(
@@ -457,14 +437,10 @@ final class StatementTests: XCTestCase {
       }
       """,
       substructure: Syntax(FunctionCallExprSyntax(
-        calledExpression: ExprSyntax(IdentifierExprSyntax(
-          identifier: .identifier("yield"),
-          declNameArguments: nil)),
+        calledExpression: IdentifierExprSyntax(identifier: .identifier("yield")),
         leftParen: .leftParenToken(),
         argumentList: TupleExprElementListSyntax([]),
-        rightParen: .rightParenToken(),
-        trailingClosure: nil,
-        additionalTrailingClosures: nil)),
+        rightParen: .rightParenToken())),
     substructureAfterMarker: "1️⃣")
 
     AssertParse(
@@ -472,23 +448,16 @@ final class StatementTests: XCTestCase {
       yield([])
       """,
       substructure: Syntax(FunctionCallExprSyntax(
-        calledExpression: ExprSyntax(IdentifierExprSyntax(
-          identifier: .identifier("yield"),
-          declNameArguments: nil)),
+        calledExpression: IdentifierExprSyntax(identifier: .identifier("yield")),
         leftParen: .leftParenToken(),
         argumentList: TupleExprElementListSyntax([
           TupleExprElementSyntax(
-            label: nil,
-            colon: nil,
-            expression: ExprSyntax(ArrayExprSyntax(
+            expression: ArrayExprSyntax(
               leftSquare: .leftSquareBracketToken(),
               elements: ArrayElementListSyntax([]),
               rightSquare: .rightSquareBracketToken())),
-            trailingComma: nil),
         ]),
-        rightParen: .rightParenToken(),
-        trailingClosure: nil,
-        additionalTrailingClosures: nil)))
+        rightParen: .rightParenToken())))
 
     AssertParse(
       """
@@ -497,7 +466,7 @@ final class StatementTests: XCTestCase {
       }
       """,
       substructure: Syntax(SequenceExprSyntax(elements: ExprListSyntax([
-        IdentifierExprSyntax(identifier: .identifier("yield"), declNameArguments: nil),
+        IdentifierExprSyntax(identifier: .identifier("yield")),
         BinaryOperatorExprSyntax(operatorToken: .spacedBinaryOperator("&")),
         IntegerLiteralExprSyntax(5)
       ]))),
@@ -510,7 +479,7 @@ final class StatementTests: XCTestCase {
       }
       """,
       substructure: Syntax(SequenceExprSyntax(elements: ExprListSyntax([
-        IdentifierExprSyntax(identifier: .identifier("yield"), declNameArguments: nil),
+        IdentifierExprSyntax(identifier: .identifier("yield")),
         BinaryOperatorExprSyntax(operatorToken: .unspacedBinaryOperator("&")),
         IntegerLiteralExprSyntax(5)
       ]))),
@@ -526,24 +495,19 @@ final class StatementTests: XCTestCase {
          """
          data[position, default: 0]
          """,
-         substructure: Syntax(ExprSyntax(SubscriptExprSyntax(
-          calledExpression: ExprSyntax(IdentifierExprSyntax(identifier: .identifier("data"), declNameArguments: nil)),
+         substructure: Syntax(SubscriptExprSyntax(
+          calledExpression: IdentifierExprSyntax(identifier: .identifier("data")),
           leftBracket: .leftSquareBracketToken(),
           argumentList: TupleExprElementListSyntax([
             TupleExprElementSyntax(
-              label: nil,
-              colon: nil,
-              expression: ExprSyntax(IdentifierExprSyntax(identifier: .identifier("position"), declNameArguments: nil)),
+              expression: IdentifierExprSyntax(identifier: .identifier("position")),
               trailingComma: .commaToken()),
             TupleExprElementSyntax(
               label: .identifier("default"),
               colon: .colonToken(),
-              expression: ExprSyntax(IntegerLiteralExprSyntax(0)),
-              trailingComma: nil),
+              expression: IntegerLiteralExprSyntax(0)),
           ]),
-          rightBracket: .rightSquareBracketToken(),
-          trailingClosure: nil,
-          additionalTrailingClosures: nil)))
+          rightBracket: .rightSquareBracketToken()))
     )
   }
 }

--- a/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
+++ b/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
@@ -92,18 +92,11 @@ final class GenericDisambiguationTests: XCTestCase {
       """,
       substructure: Syntax(GenericArgumentListSyntax([
         GenericArgumentSyntax(
-          argumentType: TypeSyntax(SimpleTypeIdentifierSyntax(
-            name: .identifier("b"),
-            genericArgumentClause: nil
-          )),
+          argumentType: SimpleTypeIdentifierSyntax(name: .identifier("b")),
           trailingComma: .commaToken()
         ),
         GenericArgumentSyntax(
-          argumentType: TypeSyntax(SimpleTypeIdentifierSyntax(
-            name: .identifier("c"),
-            genericArgumentClause: nil
-          )),
-          trailingComma: nil
+          argumentType: SimpleTypeIdentifierSyntax(name: .identifier("c"))
         )
       ]))
     )
@@ -117,18 +110,11 @@ final class GenericDisambiguationTests: XCTestCase {
       """,
       substructure: Syntax(GenericArgumentListSyntax([
         GenericArgumentSyntax(
-          argumentType: TypeSyntax(SimpleTypeIdentifierSyntax(
-            name: .identifier("b"),
-            genericArgumentClause: nil
-          )),
+          argumentType: SimpleTypeIdentifierSyntax(name: .identifier("b")),
           trailingComma: .commaToken()
         ),
         GenericArgumentSyntax(
-          argumentType: TypeSyntax(SimpleTypeIdentifierSyntax(
-            name: .identifier("c"),
-            genericArgumentClause: nil
-          )),
-          trailingComma: nil
+          argumentType: SimpleTypeIdentifierSyntax(name: .identifier("c"))
         )
       ]))
     )

--- a/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
+++ b/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
@@ -455,25 +455,17 @@ final class IfconfigExprTests: XCTestCase {
       #endif
       """,
       substructure: Syntax(FunctionCallExprSyntax(
-        calledExpression: ExprSyntax(IdentifierExprSyntax(
-          identifier: .identifier("compiler"),
-          declNameArguments: nil
-        )),
+        calledExpression: IdentifierExprSyntax(identifier: .identifier("compiler")),
         leftParen: .leftParenToken(),
         argumentList: TupleExprElementListSyntax([
           TupleExprElementSyntax(
-            label: nil,
-            colon: nil,
-            expression: ExprSyntax(PrefixOperatorExprSyntax(
+            expression: PrefixOperatorExprSyntax(
               operatorToken: .prefixOperator("<"),
-              postfixExpression: ExprSyntax(FloatLiteralExprSyntax(floatingDigits: .floatingLiteral("10.0")))
-            )),
-            trailingComma: nil
+              postfixExpression: FloatLiteralExprSyntax(floatingDigits: .floatingLiteral("10.0"))
+            )
           )
         ]),
-        rightParen: .rightParenToken(trailingTrivia: .space),
-        trailingClosure: nil,
-        additionalTrailingClosures: nil
+        rightParen: .rightParenToken(trailingTrivia: .space)
       ))
     )
   }
@@ -516,21 +508,16 @@ final class IfconfigExprTests: XCTestCase {
       """,
       substructure: Syntax(IfConfigClauseSyntax(
         poundKeyword: .poundIfKeyword(),
-        condition: ExprSyntax(FunctionCallExprSyntax(
-          calledExpression: ExprSyntax(IdentifierExprSyntax(identifier: .identifier("hasFeature"), declNameArguments: nil)),
+        condition: FunctionCallExprSyntax(
+          calledExpression: IdentifierExprSyntax(identifier: .identifier("hasFeature")),
           leftParen: .leftParenToken(),
           argumentList: TupleExprElementListSyntax([
             TupleExprElementSyntax(
-              label: nil,
-              colon: nil,
-              expression: ExprSyntax(IntegerLiteralExprSyntax(digits: .integerLiteral("17"))),
-              trailingComma: nil
+              expression: IntegerLiteralExprSyntax(digits: .integerLiteral("17"))
             )
           ]),
-          rightParen: .rightParenToken(),
-          trailingClosure: nil,
-          additionalTrailingClosures: nil
-        )),
+          rightParen: .rightParenToken()
+        ),
         elements: .init(CodeBlockItemListSyntax([]))
       ))
     )

--- a/Tests/SwiftParserTest/translated/InitDeinitTests.swift
+++ b/Tests/SwiftParserTest/translated/InitDeinitTests.swift
@@ -395,12 +395,7 @@ final class InitDeinitTests: XCTestCase {
         final func foo()
       }
       """,
-      substructure: Syntax(DeinitializerDeclSyntax(
-        attributes: nil,
-        modifiers: nil,
-        deinitKeyword: .deinitKeyword(),
-        body: nil
-      ))
+      substructure: Syntax(DeinitializerDeclSyntax())
     )
   }
 }

--- a/Tests/SwiftParserTest/translated/OptionalTests.swift
+++ b/Tests/SwiftParserTest/translated/OptionalTests.swift
@@ -44,10 +44,7 @@ final class OptionalTests: XCTestCase {
       var c = a?  
       """,
       substructure: Syntax(OptionalChainingExprSyntax(
-        expression: ExprSyntax(IdentifierExprSyntax(
-          identifier: .identifier("a"),
-          declNameArguments: nil
-        )),
+        expression: IdentifierExprSyntax(identifier: .identifier("a")),
         questionMark: .postfixQuestionMarkToken()
       ))
     )

--- a/Tests/SwiftParserTest/translated/SuperTests.swift
+++ b/Tests/SwiftParserTest/translated/SuperTests.swift
@@ -130,19 +130,14 @@ final class SuperTests: XCTestCase {
       }
       """#,
       substructure: Syntax(FunctionCallExprSyntax(
-        calledExpression: ExprSyntax(SuperRefExprSyntax(superKeyword: .superKeyword())),
+        calledExpression: SuperRefExprSyntax(superKeyword: .superKeyword()),
         leftParen: .leftParenToken(),
         argumentList: TupleExprElementListSyntax([
           TupleExprElementSyntax(
-            label: nil,
-            colon: nil,
-            expression: ExprSyntax(IntegerLiteralExprSyntax(digits: .integerLiteral("0"))),
-            trailingComma: nil
+            expression: IntegerLiteralExprSyntax(digits: .integerLiteral("0"))
           )
         ]),
-        rightParen: .rightParenToken(),
-        trailingClosure: nil,
-        additionalTrailingClosures: nil
+        rightParen: .rightParenToken()
       ))
     )
   }
@@ -161,8 +156,7 @@ final class SuperTests: XCTestCase {
         leftSquare: .leftSquareBracketToken(),
         elements: ArrayElementListSyntax([
           ArrayElementSyntax(
-            expression: ExprSyntax(IntegerLiteralExprSyntax(digits: .integerLiteral("1"))),
-            trailingComma: nil
+            expression: IntegerLiteralExprSyntax(digits: .integerLiteral("1"))
           )
         ]),
         rightSquare: .rightSquareBracketToken()

--- a/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
+++ b/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
@@ -183,12 +183,9 @@ final class TrailingClosuresTests: XCTestCase {
         colon: .colonToken(trailingTrivia: .space),
         closure: ClosureExprSyntax(
           leftBrace: .leftBraceToken(presence: .missing),
-          signature: nil,
           statements: CodeBlockItemListSyntax([
             CodeBlockItemSyntax(
-              item: .init(EditorPlaceholderExprSyntax(identifier: .identifier("<#T##() -> Void#>"))),
-              semicolon: nil,
-              errorTokens: nil
+              item: .init(EditorPlaceholderExprSyntax(identifier: .identifier("<#T##() -> Void#>")))
             )
           ]),
           rightBrace: .rightBraceToken(presence: .missing)

--- a/Tests/SwiftSyntaxBuilderTest/CollectionNodeFlatteningTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/CollectionNodeFlatteningTests.swift
@@ -21,18 +21,18 @@ final class CollectionNodeFlatteningTests: XCTestCase {
     
     @CodeBlockItemListBuilder
     func buildInnerCodeBlockItemList() -> CodeBlockItemList {
-      FunctionCallExpr(callee: "innerBuilder")
+      FunctionCallExpr(callee: ExprSyntax("innerBuilder"))
     }
     
     @CodeBlockItemListBuilder
     func buildOuterCodeBlockItemList() -> CodeBlockItemList {
-      FunctionCallExpr(callee: "outerBuilder")
+      FunctionCallExpr(callee: ExprSyntax("outerBuilder"))
       
       buildInnerCodeBlockItemList()
     }
     
     let codeBlock = CodeBlock(leadingTrivia: leadingTrivia) {
-      FunctionCallExpr(callee: "outsideBuilder")
+      FunctionCallExpr(callee: ExprSyntax("outsideBuilder"))
       buildOuterCodeBlockItemList()
     }
 

--- a/Tests/SwiftSyntaxBuilderTest/DoStmtTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/DoStmtTests.swift
@@ -18,14 +18,14 @@ final class DoStmtTests: XCTestCase {
   func testDoStmt() {
     let buildable = DoStmt(
       body: CodeBlock(statementsBuilder: {
-        TryExpr(expression: FunctionCallExpr(callee: "a.b"))
+        TryExpr(expression: FunctionCallExpr(callee: ExprSyntax("a.b")))
       }),
       catchClauses: [
         CatchClause(CatchItemList {
           CatchItem(pattern: PatternSyntax("Error1"))
           CatchItem(pattern: PatternSyntax("Error2"))
         }) {
-          FunctionCallExpr(callee: "print") {
+          FunctionCallExpr(callee: ExprSyntax("print")) {
             TupleExprElement(expression: StringLiteralExpr(content: "Known error"))
           }
         },
@@ -36,7 +36,7 @@ final class DoStmtTests: XCTestCase {
           ThrowStmt(expression: MemberAccessExpr(base: "Error4", name: "error3"))
         },
         CatchClause {
-          FunctionCallExpr(callee: "print") {
+          FunctionCallExpr(callee: ExprSyntax("print")) {
             TupleExprElement(expression: "error")
           }
         }

--- a/Tests/SwiftSyntaxBuilderTest/ExtensionDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ExtensionDeclTests.swift
@@ -19,7 +19,7 @@ final class ExtensionDeclTests: XCTestCase {
     let keywords = ["associatedtype", "class"].map { keyword -> VariableDecl in
       // We need to use `CodeBlock` here to ensure there is braces around.
       let body = CodeBlock {
-        FunctionCallExpr(callee: "TokenSyntax.\(raw: keyword)Keyword")
+        FunctionCallExpr(callee: MemberAccessExpr(base: "TokenSyntax", name: "\(keyword)Keyword"))
       }
 
       return VariableDecl(
@@ -28,14 +28,12 @@ final class ExtensionDeclTests: XCTestCase {
       ) {
         PatternBinding(pattern: PatternSyntax("`\(raw: keyword)`"),
                        typeAnnotation: TypeAnnotation(type: Type("TokenSyntax")),
-                       initializer: nil,
                        accessor: .getter(body))
 
       }
     }
     let members = MemberDeclList(keywords.map { MemberDeclListItem(decl: $0) })
-    let buildable = ExtensionDecl(modifiers: nil,
-                                  extendedType: Type("TokenSyntax"),
+    let buildable = ExtensionDecl(extendedType: Type("TokenSyntax"),
                                   members: MemberDeclBlock(members: members))
 
     AssertBuildResult(buildable, """

--- a/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
@@ -35,7 +35,7 @@ final class FunctionTests: XCTestCase {
   }
 
   func testArguments() {
-    let buildable = FunctionCallExpr(callee: "test") {
+    let buildable = FunctionCallExpr(callee: ExprSyntax("test")) {
       for param in (1...5) {
         TupleExprElement(label: param.isMultiple(of: 2) ? "p\(param)" : nil, expression: "value\(raw: param)")
       }
@@ -44,12 +44,12 @@ final class FunctionTests: XCTestCase {
   }
 
   func testParensEmittedForNoArgumentsAndNoTrailingClosure() {
-    let buildable = FunctionCallExpr(callee: "test")
+    let buildable = FunctionCallExpr(callee: ExprSyntax("test"))
     AssertBuildResult(buildable, "test()")
   }
 
   func testParensEmittedForArgumentAndTrailingClosure() {
-    let buildable = FunctionCallExpr(callee: "test", trailingClosure: ClosureExpr()) {
+    let buildable = FunctionCallExpr(callee: ExprSyntax("test"), trailingClosure: ClosureExpr()) {
       TupleExprElement(expression: "42")
     }
     AssertBuildResult(buildable, "test(42) {\n}")
@@ -57,11 +57,11 @@ final class FunctionTests: XCTestCase {
 
   func testParensOmittedForNoArgumentsAndTrailingClosure() {
     let closure = ClosureExpr(statementsBuilder: {
-      FunctionCallExpr(callee: "f") {
+      FunctionCallExpr(callee: ExprSyntax("f")) {
         TupleExprElement(expression: "a")
       }
     })
-    let buildable = FunctionCallExpr(callee: "test", trailingClosure: closure)
+    let buildable = FunctionCallExpr(callee: ExprSyntax("test"), trailingClosure: closure)
 
     AssertBuildResult(
       buildable,

--- a/Tests/SwiftSyntaxBuilderTest/IfStmtTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/IfStmtTests.swift
@@ -30,11 +30,11 @@ final class IfStmtTests: XCTestCase {
     // Use the convenience initializer from IfStmtConvenienceInitializers
     // with an else branch expressed by a second trailing closure.
     let buildable = IfStmt(conditions: ConditionElementList { BooleanLiteralExpr(true) }) {
-      FunctionCallExpr(callee: "print") {
+      FunctionCallExpr(callee: ExprSyntax("print")) {
         TupleExprElement(expression: StringLiteralExpr(content: "Hello from the if-branch!"))
       }
     } elseBody: {
-      FunctionCallExpr(callee: "print") {
+      FunctionCallExpr(callee: ExprSyntax("print")) {
         TupleExprElement(expression: StringLiteralExpr(content: "Hello from the else-branch!"))
       }
     }

--- a/Tests/SwiftSyntaxBuilderTest/SwitchTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/SwitchTests.swift
@@ -18,7 +18,7 @@ final class SwitchTests: XCTestCase {
   func testSwitch() {
     let syntax = SwitchStmt(expression: Expr("count")) {
       for num in 1..<3 {
-        SwitchCase("case \(raw: num):") {
+        SwitchCase("case \(literal: num):") {
           Expr("print(count)")
         }
       }

--- a/Tests/SwiftSyntaxBuilderTest/TriviaTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/TriviaTests.swift
@@ -17,8 +17,8 @@ import SwiftSyntaxBuilder
 final class TriviaTests: XCTestCase {
   func testLeadingTrivia() {
     let decl = VariableDecl(
-      leadingTrivia: .docLineComment("/// A doc comment") + .newline,
-      modifiers: [DeclModifier(name: .static.withLeadingTrivia(.blockComment("/* An inline comment */") + .space))],
+      leadingTrivia: .docLineComment("/// A doc comment") + .newline + .blockComment("/* An inline comment */") + .space,
+      modifiers: [DeclModifier(name: .static)],
       letOrVarKeyword: .var
     ) {
       PatternBinding(

--- a/Tests/SwiftSyntaxParserTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftSyntaxParserTest/AbsolutePositionTests.swift
@@ -82,12 +82,9 @@ public class AbsolutePositionTests: XCTestCase {
       l.append(CodeBlockItemSyntax(
         item: .init(
           ReturnStmtSyntax(
-            returnKeyword: .returnKeyword(trailingTrivia: .newline),
-            expression: nil
+            returnKeyword: .returnKeyword(trailingTrivia: .newline)
           )
-        ),
-        semicolon: nil, 
-        errorTokens: nil)
+        ))
       )
     }
     let root = SourceFileSyntax(
@@ -116,11 +113,8 @@ public class AbsolutePositionTests: XCTestCase {
         returnKeyword: .returnKeyword(
           leadingTrivia: AbsolutePositionTests.leadingTrivia,
           trailingTrivia: AbsolutePositionTests.trailingTrivia
-        ),
-        expression: nil
-      )),
-      semicolon: nil,
-      errorTokens: nil
+        )
+      ))
     ), count: count)
     return SourceFileSyntax(
       statements: CodeBlockItemListSyntax(items),
@@ -184,11 +178,8 @@ public class AbsolutePositionTests: XCTestCase {
     let item = CodeBlockItemSyntax(
       item: .init(
         ReturnStmtSyntax(
-          returnKeyword: .returnKeyword(leadingTrivia: .newline, trailingTrivia: .newline),
-          expression: nil)
-      ),
-      semicolon: nil,
-      errorTokens: nil)
+          returnKeyword: .returnKeyword(leadingTrivia: .newline, trailingTrivia: .newline))
+      ))
      XCTAssertEqual(0, item.position.utf8Offset)
      XCTAssertEqual(1, item.positionAfterSkippingLeadingTrivia.utf8Offset)
   }

--- a/Tests/SwiftSyntaxParserTest/SyntaxComparisonTests.swift
+++ b/Tests/SwiftSyntaxParserTest/SyntaxComparisonTests.swift
@@ -181,16 +181,11 @@ public class SyntaxComparisonTests: XCTestCase {
       input: ParameterClauseSyntax(
         leftParen: .leftParenToken(),
         parameterList: FunctionParameterListSyntax([]),
-        rightParen: .rightParenToken()),
-      asyncOrReasyncKeyword: nil, throwsOrRethrowsKeyword: nil, output: nil)
+        rightParen: .rightParenToken()))
     let fd = FunctionDeclSyntax(
-      attributes: nil,
-      modifiers: nil,
       funcKeyword: keyword,
       identifier: identifier,
-      genericParameterClause: nil,
       signature: emptySignature,
-      genericWhereClause: nil,
       body: funcBody
     )
     if indent > 0 {
@@ -212,7 +207,7 @@ public class SyntaxComparisonTests: XCTestCase {
     var items = [CodeBlockItemSyntax]()
     for i in 0..<statementCount {
       let literal = IntegerLiteralExprSyntax(digits: .integerLiteral(String(i)))
-      items.append(CodeBlockItemSyntax(item: .init(literal), semicolon: nil, errorTokens: nil))
+      items.append(CodeBlockItemSyntax(item: .init(literal)))
     }
     let block = CodeBlockItemListSyntax(items)
     return CodeBlockSyntax(

--- a/Tests/SwiftSyntaxTest/CustomReflectableTests.swift
+++ b/Tests/SwiftSyntaxTest/CustomReflectableTests.swift
@@ -106,18 +106,8 @@ public class CustomReflectableTests: XCTestCase {
         let token2 = TokenSyntax.integerLiteral("2")
         let expr2 = IntegerLiteralExprSyntax(digits: token2)
         let elements = [
-          TupleExprElementSyntax(
-            label: nil,
-            colon: nil,
-            expression: ExprSyntax(expr1),
-            trailingComma: nil
-          ),
-          TupleExprElementSyntax(
-            label: nil,
-            colon: nil,
-            expression: ExprSyntax(expr2),
-            trailingComma: nil
-          )
+          TupleExprElementSyntax(expression: expr1),
+          TupleExprElementSyntax(expression: expr2)
         ]
         let tuples = TupleExprElementListSyntax(elements)
         return .init(syntax: tuples,
@@ -171,14 +161,10 @@ public class CustomReflectableTests: XCTestCase {
         let expr1 = IntegerLiteralExprSyntax(digits: token1)
         let token2 = TokenSyntax.integerLiteral("2")
         let expr2 = IntegerLiteralExprSyntax(digits: token2)
-        let elements = [TupleExprElementSyntax(label: nil,
-                                                       colon: nil,
-                                                       expression: ExprSyntax(expr1),
-                                                       trailingComma: nil),
-          TupleExprElementSyntax(label: nil,
-                                         colon: nil,
-                                         expression: ExprSyntax(expr2),
-                                         trailingComma: nil)]
+        let elements = [
+          TupleExprElementSyntax(expression: expr1),
+          TupleExprElementSyntax(expression: expr2)
+        ]
         let tuples = TupleExprElementListSyntax(elements)
         return .init(syntax: tuples.reversed(),
                      expectedDumped: """

--- a/Tests/SwiftSyntaxTest/MultithreadingTests.swift
+++ b/Tests/SwiftSyntaxTest/MultithreadingTests.swift
@@ -39,16 +39,12 @@ public class MultithreadingTests: XCTestCase {
     let methodCall = FunctionCallExprSyntax(
       calledExpression: MemberAccessExprSyntax(
         base: IdentifierExprSyntax(
-          identifier: .identifier("base"),
-          declNameArguments: nil),
+          identifier: .identifier("base")),
         dot: .periodToken(),
-        name: .identifier("member"),
-        declNameArguments: nil),
+        name: .identifier("member")),
       leftParen: .leftParenToken(),
       argumentList: TupleExprElementListSyntax([]),
-      rightParen: .rightParenToken(),
-      trailingClosure: nil,
-      additionalTrailingClosures: nil)
+      rightParen: .rightParenToken())
 
     DispatchQueue.concurrentPerform(iterations: 100) { i in
       var copied = methodCall

--- a/Tests/SwiftSyntaxTest/SyntaxChildrenTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxChildrenTests.swift
@@ -29,8 +29,7 @@ public class SyntaxChildrenTests: XCTestCase {
 
   public func testIterateWithSomeMissing() throws {
     let returnStmt = ReturnStmtSyntax(
-      returnKeyword: .returnKeyword(),
-      expression: nil)
+      returnKeyword: .returnKeyword())
 
     var iterator = returnStmt.children(viewMode: .sourceAccurate).makeIterator()
     try XCTAssertNext(&iterator) { $0.as(TokenSyntax.self)?.tokenKind == .returnKeyword }
@@ -39,8 +38,7 @@ public class SyntaxChildrenTests: XCTestCase {
 
   public func testIterateWithAllMissing() {
     let returnStmt = ReturnStmtSyntax(
-      returnKeyword: TokenSyntax.returnKeyword(presence: .missing),
-      expression: nil
+      returnKeyword: TokenSyntax.returnKeyword(presence: .missing)
     )
 
     var iterator = returnStmt.children(viewMode: .sourceAccurate).makeIterator()
@@ -49,8 +47,7 @@ public class SyntaxChildrenTests: XCTestCase {
 
   public func testMissingTokens() throws {
     let returnStmt = ReturnStmtSyntax(
-      returnKeyword: .returnKeyword(presence: .missing),
-      expression: nil
+      returnKeyword: .returnKeyword(presence: .missing)
     )
 
     var sourceAccurateIterator = returnStmt.children(viewMode: .sourceAccurate).makeIterator()
@@ -62,10 +59,7 @@ public class SyntaxChildrenTests: XCTestCase {
   }
 
   public func testMissingNodes() throws {
-    let node = DeclarationStmtSyntax(declaration: DeclSyntax(MissingDeclSyntax(
-      attributes: nil,
-      modifiers: nil
-    )))
+    let node = DeclarationStmtSyntax(declaration: MissingDeclSyntax())
 
     var sourceAccurateIt = node.children(viewMode: .sourceAccurate).makeIterator()
     try XCTAssertNext(&sourceAccurateIt) { $0.is(MissingDeclSyntax.self) }

--- a/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
@@ -17,8 +17,7 @@ import _SwiftSyntaxTestSupport
 fileprivate func integerLiteralElement(_ int: Int) -> ArrayElementSyntax {
     let literal = TokenSyntax.integerLiteral("\(int)")
     return ArrayElementSyntax(
-        expression: ExprSyntax(IntegerLiteralExprSyntax(digits: literal)),
-        trailingComma: nil)
+        expression: IntegerLiteralExprSyntax(digits: literal))
 }
 
 public class SyntaxCollectionsTests: XCTestCase {

--- a/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
@@ -23,13 +23,8 @@ fileprivate func cannedStructDecl() -> StructDeclSyntax {
     rightBrace: rBrace
   )
   return StructDeclSyntax(
-    attributes: nil,
-    modifiers: nil,
     structKeyword: structKW,
     identifier: fooID,
-    genericParameterClause: nil,
-    inheritanceClause: nil,
-    genericWhereClause: nil,
     members: members
   )
 }
@@ -105,41 +100,29 @@ public class SyntaxCreationTests: XCTestCase {
 
   public func testFunctionCallSyntaxBuilder() {
     let string = StringLiteralExprSyntax(
-      openDelimiter: nil,
       openQuote: .stringQuoteToken(),
       segments: StringLiteralSegmentsSyntax([.stringSegment(StringSegmentSyntax(content: .stringSegment("Hello, world!")))]),
-      closeQuote: .stringQuoteToken(),
-      closeDelimiter: nil
+      closeQuote: .stringQuoteToken()
     )
-    let printID = ExprSyntax(IdentifierExprSyntax(identifier: .identifier("print"), declNameArguments: nil))
-    let arg = TupleExprElementSyntax(
-      label: nil,
-      colon: nil,
-      expression: ExprSyntax(string),
-      trailingComma: nil
-    )
+    let printID = IdentifierExprSyntax(identifier: .identifier("print"))
+    let arg = TupleExprElementSyntax(expression: string)
     let call = FunctionCallExprSyntax(
-      calledExpression: ExprSyntax(printID),
+      calledExpression: printID,
       leftParen: .leftParenToken(),
       argumentList: TupleExprElementListSyntax([arg]),
-      rightParen: .rightParenToken(),
-      trailingClosure: nil,
-      additionalTrailingClosures: nil
+      rightParen: .rightParenToken()
     )
     XCTAssertEqual("\(call)", "print(\"Hello, world!\")")
 
     let emptyString = StringLiteralExprSyntax(
-      openDelimiter: nil,
       openQuote: .stringQuoteToken(),
       segments: StringLiteralSegmentsSyntax([.stringSegment(StringSegmentSyntax(content: .stringSegment(" ")))]),
-      closeQuote: .stringQuoteToken(),
-      closeDelimiter: nil
+      closeQuote: .stringQuoteToken()
     )
     let terminatorArg = TupleExprElementSyntax(
-      label: TokenSyntax.identifier("terminator"),
-      colon: TokenSyntax.colonToken(trailingTrivia: .space),
-      expression: ExprSyntax(emptyString),
-      trailingComma: nil
+      label: .identifier("terminator"),
+      colon: .colonToken(trailingTrivia: .space),
+      expression: emptyString
     )
     let callWithTerminator = call.withArgumentList(
       TupleExprElementListSyntax([
@@ -161,20 +144,13 @@ public class SyntaxCreationTests: XCTestCase {
       closeQuote: .stringQuoteToken(),
       closeDelimiter: nil
     )
-    let printID = IdentifierExprSyntax(identifier: .identifier("print"), declNameArguments: nil)
-    let arg = TupleExprElementSyntax(
-      label: nil,
-      colon: nil,
-      expression: ExprSyntax(string),
-      trailingComma: nil
-    )
+    let printID = IdentifierExprSyntax(identifier: .identifier("print"))
+    let arg = TupleExprElementSyntax(expression: string)
     let call1 = FunctionCallExprSyntax(
-      calledExpression: ExprSyntax(printID),
-      leftParen: TokenSyntax.leftParenToken(),
+      calledExpression: printID,
+      leftParen: .leftParenToken(),
       argumentList: TupleExprElementListSyntax([arg]),
-      rightParen: TokenSyntax.rightParenToken(),
-      trailingClosure: nil,
-      additionalTrailingClosures: nil
+      rightParen: .rightParenToken()
     )
     XCTAssertNotNil(call1.leftParen)
     XCTAssertNotNil(call1.rightParen)
@@ -184,12 +160,8 @@ public class SyntaxCreationTests: XCTestCase {
     XCTAssertNil(call2.rightParen)
 
     let call3 = FunctionCallExprSyntax(
-      calledExpression: ExprSyntax(printID),
-      leftParen: nil,
-      argumentList: TupleExprElementListSyntax([arg]),
-      rightParen: nil,
-      trailingClosure: nil,
-      additionalTrailingClosures: nil
+      calledExpression: printID,
+      argumentList: TupleExprElementListSyntax([arg])
     )
     XCTAssertNil(call3.leftParen)
     XCTAssertNil(call3.rightParen)
@@ -197,11 +169,9 @@ public class SyntaxCreationTests: XCTestCase {
 
   public func testMakeStringLiteralExpr() {
     let expr = StringLiteralExprSyntax(
-      openDelimiter: nil,
       openQuote: .stringQuoteToken(leadingTrivia: [.lineComment("// hello"), .newlines(1)]),
       segments: StringLiteralSegmentsSyntax([.stringSegment(StringSegmentSyntax(content: .stringSegment("Hello, world!")))]),
-      closeQuote: .stringQuoteToken(),
-      closeDelimiter: nil
+      closeQuote: .stringQuoteToken()
     )
     let expected = """
 // hello

--- a/Tests/SwiftSyntaxTest/SyntaxTreeModifierTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTreeModifierTests.swift
@@ -15,17 +15,14 @@ import SwiftSyntax
 
 fileprivate func cannedVarDecl() -> VariableDeclSyntax {
   let identifierPattern = IdentifierPatternSyntax(
-    identifier: TokenSyntax.identifier("a")
+    identifier: .identifier("a")
   )
   let pattern = PatternBindingSyntax(
-    pattern: PatternSyntax(identifierPattern),
+    pattern: identifierPattern,
     typeAnnotation: TypeAnnotationSyntax(
-      colon: TokenSyntax.colonToken(trailingTrivia: .space),
-      type: TypeSyntax(SimpleTypeIdentifierSyntax(name: .identifier("Int"), genericArgumentClause: nil))),
-    initializer: nil, accessor: nil, trailingComma: nil)
+      colon: .colonToken(trailingTrivia: .space),
+      type: SimpleTypeIdentifierSyntax(name: .identifier("Int"))))
   return VariableDeclSyntax(
-    attributes: nil,
-    modifiers: nil,
     letOrVarKeyword: .letKeyword(trailingTrivia: .space),
     bindings: PatternBindingListSyntax([pattern])
   )

--- a/Tests/SwiftSyntaxTest/VisitorTests.swift
+++ b/Tests/SwiftSyntaxTest/VisitorTests.swift
@@ -15,10 +15,7 @@ import SwiftSyntax
 
 public class VisitorTests: XCTestCase {
   public func testVisitMissingNodes() {
-    let node = DeclarationStmtSyntax(declaration: DeclSyntax(MissingDeclSyntax(
-      attributes: nil,
-      modifiers: nil
-    )))
+    let node = DeclarationStmtSyntax(declaration: MissingDeclSyntax())
 
     class MissingDeclChecker: SyntaxVisitor {
       var didSeeMissingDeclSyntax = false
@@ -41,8 +38,7 @@ public class VisitorTests: XCTestCase {
 
   public func testVisitMissingToken() {
     let node = ReturnStmtSyntax(
-      returnKeyword: .returnKeyword(presence: .missing),
-      expression: nil
+      returnKeyword: .returnKeyword(presence: .missing)
     )
 
     class MissingTokenChecker: SyntaxVisitor {


### PR DESCRIPTION
Use generics rather than existentials, add `nil` defaults for *all*
optional nodes, and add a default for tokens where there's only a single
choice. Allows removing the default initializer in SwiftSyntaxBuilder,
since the regular initializer covers it entirely.

There's a small hack that adds a second initializer when a parameter
with a generic type has a empty default, since a
`Optional<BaseType>.none` default doesn't work in Swift 5.6. This can be
removed and the property initializer updated once 5.7 is our minimum
version.
