### PR TITLE
Prepare SwiftParser for Library Evolution

### DIFF
--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -20,7 +20,7 @@ extension Parser {
   /// arbitrary number of tokens ahead in the input stream. Instances of
   /// ``Lookahead`` are distinct from their parent ``Parser`` instances, so
   /// any tokens they consume will not be reflected in the parent parser.
-  public struct Lookahead: TokenConsumer {
+  public struct Lookahead {
     var lexemes: Lexer.LexemeSequence
     @_spi(RawSyntax)
     public var currentToken: Lexer.Lexeme
@@ -55,6 +55,21 @@ extension Parser {
   public func withLookahead<T>(_ body: (_: inout Lookahead) -> T) -> T {
     var lookahead = lookahead()
     return body(&lookahead)
+  }
+}
+
+@_spi(RawSyntax)
+extension Parser.Lookahead: TokenConsumer {
+  /// Consumes the current token, and asserts that the kind of token that was
+  /// consumed matches the given kind.
+  ///
+  /// If the token kind did not match, this function will abort. It is useful
+  /// to insert structural invariants during parsing.
+  ///
+  /// - Parameter kind: The kind of token to consume.
+  /// - Returns: A token of the given kind.
+  public mutating func eat(_ kind: RawTokenKind) -> Token {
+    return self.consume(if: kind)!
   }
 }
 
@@ -163,18 +178,6 @@ extension Parser.Lookahead {
 
     _ = self.canParseCustomAttribute()
     return
-  }
-
-  /// Consumes the current token, and asserts that the kind of token that was
-  /// consumed matches the given kind.
-  ///
-  /// If the token kind did not match, this function will abort. It is useful
-  /// to insert structural invariants during parsing.
-  ///
-  /// - Parameter kind: The kind of token to consume.
-  /// - Returns: A token of the given kind.
-  public mutating func eat(_ kind: RawTokenKind) -> Token {
-    return self.consume(if: kind)!
   }
 }
 

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -116,7 +116,7 @@ extension Parser {
 /// The exception to this is parser lookahead, which is allowed to skip as many
 /// tokens as needed to disambiguate a parse. However, because lookahead
 /// operates on a copy of the lexical stream, no input tokens are lost..
-public struct Parser: TokenConsumer {
+public struct Parser {
   @_spi(RawSyntax)
   public var arena: ParsingSyntaxArena
   /// A view of the sequence of lexemes in the input.
@@ -222,6 +222,9 @@ extension Parser {
 }
 
 // MARK: Consuming Tokens
+
+@_spi(RawSyntax)
+extension Parser: TokenConsumer {}
 
 extension Parser {
   /// Consumes the current token and sets its kind to the given `TokenKind`,

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -13,10 +13,10 @@
 @_spi(RawSyntax) import SwiftSyntax
 
 /// A type that consumes  instances of `TokenSyntax`.
+@_spi(RawSyntax)
 public protocol TokenConsumer {
   associatedtype Token
   /// The current token syntax being examined by the consumer
-  @_spi(RawSyntax)
   var currentToken: Lexer.Lexeme { get }
   /// Whether the current token matches the given kind.
   mutating func consumeAnyToken() -> Token
@@ -26,7 +26,6 @@ public protocol TokenConsumer {
 
   /// Synthesize a missing token with `kind`.
   /// If `text` is not `nil`, use it for the token's text, otherwise use the token's default text.
-  @_spi(RawSyntax)
   mutating func missingToken(_ kind: RawTokenKind, text: SyntaxText?) -> Token
 
   /// Return the lexeme that will be parsed next.

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -133,7 +133,7 @@ public struct RawSyntax {
   }
 
   internal var payload: RawSyntaxData.Payload {
-    _read { yield rawData.payload }
+    get { rawData.payload }
   }
 }
 


### PR DESCRIPTION
- Work around a SIL crash rdar://102247545
- Rework the @_spi restrictions on `TokenConsumer` to avoid Library Evolution restrictions.