### PR TITLE
[CMake] Build with library evolution and generate Swift interfaces.

### DIFF
--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodes.swift.gyb
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodes.swift.gyb
@@ -39,6 +39,7 @@ public struct Raw${node.name}: Raw${node.name if node.is_base() else node.base_t
 %      enums.append(('Element', [(NODE_MAP[choice_name].swift_syntax_kind, NODE_MAP[choice_name].name) for choice_name in node.collection_element_choices]))
 %   end
 %   for (name, choices) in enums:
+  @frozen
   public enum ${name}: RawSyntaxNodeProtocol {
 %     for (swift_name, type_name) in choices:
     case `${swift_name}`(Raw${type_name})

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -542,6 +542,7 @@ public struct RawMissingPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxTo
 
 @_spi(RawSyntax)
 public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Item: RawSyntaxNodeProtocol {
     case `decl`(RawDeclSyntax)
     case `stmt`(RawStmtSyntax)
@@ -1047,6 +1048,7 @@ public struct RawDictionaryElementListSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
 
 @_spi(RawSyntax)
 public struct RawStringLiteralSegmentsSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Element: RawSyntaxNodeProtocol {
     case `stringSegment`(RawStringSegmentSyntax)
     case `expressionSegment`(RawExpressionSegmentSyntax)
@@ -2653,6 +2655,7 @@ public struct RawArrayExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
 
 @_spi(RawSyntax)
 public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Content: RawSyntaxNodeProtocol {
     case `colon`(RawTokenSyntax)
     case `elements`(RawDictionaryElementListSyntax)
@@ -3940,6 +3943,7 @@ public struct RawClosureParamListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
 
 @_spi(RawSyntax)
 public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Input: RawSyntaxNodeProtocol {
     case `simpleInput`(RawClosureParamListSyntax)
     case `input`(RawParameterClauseSyntax)
@@ -5165,6 +5169,7 @@ public struct RawKeyPathComponentListSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
 
 @_spi(RawSyntax)
 public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Component: RawSyntaxNodeProtocol {
     case `property`(RawKeyPathPropertyComponentSyntax)
     case `subscript`(RawKeyPathSubscriptComponentSyntax)
@@ -5453,6 +5458,7 @@ public struct RawKeyPathOptionalComponentSyntax: RawSyntaxNodeProtocol, RawSynta
 
 @_spi(RawSyntax)
 public struct RawOldKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum RootExpr: RawSyntaxNodeProtocol {
     case `identifierExpr`(RawIdentifierExprSyntax)
     case `specializeExpr`(RawSpecializeExprSyntax)
@@ -6846,6 +6852,7 @@ public struct RawFunctionSignatureSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
 
 @_spi(RawSyntax)
 public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Elements: RawSyntaxNodeProtocol {
     case `statements`(RawCodeBlockItemListSyntax)
     case `switchCases`(RawSwitchCaseListSyntax)
@@ -9099,6 +9106,7 @@ public struct RawDeinitializerDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxTo
 
 @_spi(RawSyntax)
 public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Accessor: RawSyntaxNodeProtocol {
     case `accessors`(RawAccessorBlockSyntax)
     case `getter`(RawCodeBlockSyntax)
@@ -9796,6 +9804,7 @@ public struct RawAccessorBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 
 @_spi(RawSyntax)
 public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Accessor: RawSyntaxNodeProtocol {
     case `accessors`(RawAccessorBlockSyntax)
     case `getter`(RawCodeBlockSyntax)
@@ -10736,6 +10745,7 @@ public struct RawPrecedenceGroupDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntax
 
 @_spi(RawSyntax)
 public struct RawPrecedenceGroupAttributeListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Element: RawSyntaxNodeProtocol {
     case `precedenceGroupRelation`(RawPrecedenceGroupRelationSyntax)
     case `precedenceGroupAssignment`(RawPrecedenceGroupAssignmentSyntax)
@@ -11126,6 +11136,7 @@ public struct RawPrecedenceGroupAssociativitySyntax: RawSyntaxNodeProtocol, RawS
 
 @_spi(RawSyntax)
 public struct RawMacroDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Signature: RawSyntaxNodeProtocol {
     case `functionLike`(RawFunctionSignatureSyntax)
     case `valueLike`(RawTypeAnnotationSyntax)
@@ -11650,6 +11661,7 @@ public struct RawCustomAttributeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
 
 @_spi(RawSyntax)
 public struct RawAttributeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Argument: RawSyntaxNodeProtocol {
     case `token`(RawTokenSyntax)
     case `stringExpr`(RawStringLiteralExprSyntax)
@@ -11851,6 +11863,7 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 
 @_spi(RawSyntax)
 public struct RawAttributeListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Element: RawSyntaxNodeProtocol {
     case `attribute`(RawAttributeSyntax)
     case `customAttribute`(RawCustomAttributeSyntax)
@@ -11926,6 +11939,7 @@ public struct RawAttributeListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 
 @_spi(RawSyntax)
 public struct RawSpecializeAttributeSpecListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Element: RawSyntaxNodeProtocol {
     case `labeledSpecializeEntry`(RawLabeledSpecializeEntrySyntax)
     case `availabilityEntry`(RawAvailabilityEntrySyntax)
@@ -12250,6 +12264,7 @@ public struct RawTargetFunctionEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
 
 @_spi(RawSyntax)
 public struct RawNamedAttributeStringArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum StringOrDeclname: RawSyntaxNodeProtocol {
     case `string`(RawTokenSyntax)
     case `declname`(RawDeclNameSyntax)
@@ -12684,6 +12699,7 @@ public struct RawDifferentiableAttributeArgumentsSyntax: RawSyntaxNodeProtocol, 
 
 @_spi(RawSyntax)
 public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Parameters: RawSyntaxNodeProtocol {
     case `parameter`(RawDifferentiabilityParamSyntax)
     case `parameterList`(RawDifferentiabilityParamsSyntax)
@@ -13930,6 +13946,7 @@ public struct RawExpressionStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyn
 
 @_spi(RawSyntax)
 public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Element: RawSyntaxNodeProtocol {
     case `switchCase`(RawSwitchCaseSyntax)
     case `ifConfigDecl`(RawIfConfigDeclSyntax)
@@ -14627,6 +14644,7 @@ public struct RawReturnStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax 
 
 @_spi(RawSyntax)
 public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Yields: RawSyntaxNodeProtocol {
     case `yieldList`(RawYieldListSyntax)
     case `simpleYield`(RawExprSyntax)
@@ -14981,6 +14999,7 @@ public struct RawCatchItemListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
 
 @_spi(RawSyntax)
 public struct RawConditionElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Condition: RawSyntaxNodeProtocol {
     case `expression`(RawExprSyntax)
     case `availability`(RawAvailabilityConditionSyntax)
@@ -15652,6 +15671,7 @@ public struct RawThrowStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
 
 @_spi(RawSyntax)
 public struct RawIfStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum ElseBody: RawSyntaxNodeProtocol {
     case `ifStmt`(RawIfStmtSyntax)
     case `codeBlock`(RawCodeBlockSyntax)
@@ -15771,6 +15791,7 @@ public struct RawIfStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
 
 @_spi(RawSyntax)
 public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Label: RawSyntaxNodeProtocol {
     case `default`(RawSwitchDefaultLabelSyntax)
     case `case`(RawSwitchCaseLabelSyntax)
@@ -16418,6 +16439,7 @@ public struct RawGenericRequirementListSyntax: RawSyntaxNodeProtocol, RawSyntaxT
 
 @_spi(RawSyntax)
 public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Body: RawSyntaxNodeProtocol {
     case `sameTypeRequirement`(RawSameTypeRequirementSyntax)
     case `conformanceRequirement`(RawConformanceRequirementSyntax)
@@ -19437,6 +19459,7 @@ public struct RawAvailabilitySpecListSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
 
 @_spi(RawSyntax)
 public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Entry: RawSyntaxNodeProtocol {
     case `token`(RawTokenSyntax)
     case `availabilityVersionRestriction`(RawAvailabilityVersionRestrictionSyntax)
@@ -19538,6 +19561,7 @@ public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
 
 @_spi(RawSyntax)
 public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  @frozen
   public enum Value: RawSyntaxNodeProtocol {
     case `string`(RawTokenSyntax)
     case `version`(RawVersionTupleSyntax)

--- a/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -45,6 +45,7 @@ public extension SyntaxCollection {
 % end
 public struct ${node.name}: SyntaxCollection, SyntaxHashable {
 % if node.collection_element_choices:
+  @frozen
   public enum Element: SyntaxChildChoices {
 %   for choice_name in node.collection_element_choices:
 %     choice = NODE_MAP[choice_name]

--- a/Sources/SwiftSyntax/SyntaxEnum.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxEnum.swift.gyb
@@ -20,6 +20,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Enum to exhaustively switch over all different syntax nodes.
+@frozen
 public enum SyntaxEnum {
   case unknown(UnknownSyntax)
   case token(TokenSyntax)

--- a/Sources/SwiftSyntax/SyntaxKind.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxKind.swift.gyb
@@ -19,6 +19,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Enumerates the known kinds of Syntax represented in the Syntax tree.
+@frozen
 public enum SyntaxKind {
   case token
   case unknown

--- a/Sources/SwiftSyntax/TokenKind.swift.gyb
+++ b/Sources/SwiftSyntax/TokenKind.swift.gyb
@@ -18,6 +18,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Enumerates the kinds of tokens in the Swift language.
+@frozen
 public enum TokenKind: Hashable {
   case eof
 % for token in SYNTAX_TOKENS:
@@ -143,6 +144,7 @@ extension TokenKind: Equatable {
 }
 
 /// Plain token kind value, without an associated `String` value.
+@frozen
 public enum RawTokenKind: Equatable, Hashable {
   case eof
 % for token in SYNTAX_TOKENS:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
@@ -1289,6 +1289,7 @@ extension DictionaryElementListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
+  @frozen
   public enum Element: SyntaxChildChoices {
     case `stringSegment`(StringSegmentSyntax)
     case `expressionSegment`(ExpressionSegmentSyntax)
@@ -6108,6 +6109,7 @@ extension DesignatedTypeListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashable {
+  @frozen
   public enum Element: SyntaxChildChoices {
     case `precedenceGroupRelation`(PrecedenceGroupRelationSyntax)
     case `precedenceGroupAssignment`(PrecedenceGroupAssignmentSyntax)
@@ -7160,6 +7162,7 @@ extension NonEmptyTokenListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
+  @frozen
   public enum Element: SyntaxChildChoices {
     case `attribute`(AttributeSyntax)
     case `customAttribute`(CustomAttributeSyntax)
@@ -7455,6 +7458,7 @@ extension AttributeListSyntax: BidirectionalCollection {
 /// A collection of arguments for the `@_specialize` attribute
 /// 
 public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashable {
+  @frozen
   public enum Element: SyntaxChildChoices {
     case `labeledSpecializeEntry`(LabeledSpecializeEntrySyntax)
     case `availabilityEntry`(AvailabilityEntrySyntax)
@@ -8517,6 +8521,7 @@ extension BackDeployVersionListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
+  @frozen
   public enum Element: SyntaxChildChoices {
     case `switchCase`(SwitchCaseSyntax)
     case `ifConfigDecl`(IfConfigDeclSyntax)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Enum to exhaustively switch over all different syntax nodes.
+@frozen
 public enum SyntaxEnum {
   case unknown(UnknownSyntax)
   case token(TokenSyntax)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Enumerates the known kinds of Syntax represented in the Syntax tree.
+@frozen
 public enum SyntaxKind {
   case token
   case unknown

--- a/Sources/SwiftSyntax/gyb_generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/TokenKind.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Enumerates the kinds of tokens in the Swift language.
+@frozen
 public enum TokenKind: Hashable {
   case eof
   case associatedtypeKeyword
@@ -1131,6 +1132,7 @@ extension TokenKind: Equatable {
 }
 
 /// Plain token kind value, without an associated `String` value.
+@frozen
 public enum RawTokenKind: Equatable, Hashable {
   case eof
   case associatedtypeKeyword

--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -39,8 +39,10 @@ function(add_swift_host_library name)
   target_compile_options("${name}" PRIVATE
     $<$<COMPILE_LANGUAGE:Swift>:
       -module-name;${name};
+      -enable-library-evolution;
       -emit-module-path;${module_file};
-      -emit-module-source-info-path;${module_sourceinfo_file}
+      -emit-module-source-info-path;${module_sourceinfo_file};
+      -emit-module-interface-path;${module_interface_file}
       >)
 
   # NOTE: workaround for CMake not setting up include flags yet


### PR DESCRIPTION
Enable library evolution for the CMake build of swift-syntax, so that plugins can be built with different compilers than the Swift compiler itself. Introduce `@frozen` in a few places to try to dodge what appears to be a miscompile in the older Swift 5.5 that's currently used in CI.