### PR TITLE
Don't drop token presence

### DIFF
--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -219,6 +219,7 @@ extension RawSyntax {
         kind: tokenView.formKind(),
         leadingTrivia: leadingTrivia,
         trailingTrivia: tokenView.formTrailingTrivia(),
+        presence: tokenView.presence,
         arena: arena)
     case .layout(let layoutView):
       for (index, child) in layoutView.children.enumerated() {
@@ -242,6 +243,7 @@ extension RawSyntax {
         kind: tokenView.formKind(),
         leadingTrivia: tokenView.formLeadingTrivia(),
         trailingTrivia: trailingTrivia,
+        presence: tokenView.presence,
         arena: arena)
     case .layout(let layoutView):
       for (index, child) in layoutView.children.enumerated().reversed() {
@@ -545,7 +547,7 @@ extension RawSyntax {
     kind: TokenKind,
     leadingTrivia: Trivia,
     trailingTrivia: Trivia,
-    presence: SourcePresence = .present,
+    presence: SourcePresence,
     arena: SyntaxArena
   ) -> RawSyntax {
     let decomposed = kind.decomposeToRaw()

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -153,6 +153,7 @@ public struct RawSyntaxTokenView {
         kind: newValue,
         leadingTrivia: formLeadingTrivia(),
         trailingTrivia: formTrailingTrivia(),
+        presence: presence,
         arena: arena)
     case .materializedToken(var payload):
       let decomposed = newValue.decomposeToRaw()


### PR DESCRIPTION
`with(Leading|Trailing)Trivia` was dropping the token's source presence for materialized tokens. Make sure to include it.