### PR TITLE
Update CodeGeneration to latest SwiftSyntax version

### DIFF
--- a/CodeGeneration/Package.swift
+++ b/CodeGeneration/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     .executable(name: "generate-swiftsyntaxbuilder", targets: ["generate-swiftsyntaxbuilder"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", revision: "5e9dcce1dc5c81e48b658ced23f0848be4671a0c"),
+    .package(url: "https://github.com/apple/swift-syntax.git", revision: "6e3dfb332553ad1462f0a3d45b4d91e349ce4013"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.4")),
   ],
   targets: [

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
@@ -35,7 +35,7 @@ public extension Child {
   }
 
   var parameterType: Type {
-    return self.type.optionalWrapped(type: Type(parameterBaseType))
+    return self.type.optionalWrapped(type: SimpleTypeIdentifier(name: .identifier(parameterBaseType)))
   }
 
   /// If the child node has documentation associated with it, return it as single
@@ -74,7 +74,7 @@ public extension Child {
     }
     for textChoice in choices {
       assertChoices.append(Expr(SequenceExpr {
-        MemberAccessExpr(base: type.forceUnwrappedIfNeeded(expr: Expr(varName)), name: "text")
+        MemberAccessExpr(base: type.forceUnwrappedIfNeeded(expr: IdentifierExpr(identifier: .identifier(varName))), name: "text")
         BinaryOperatorExpr(text: "==")
         StringLiteralExpr(content: textChoice)
       }))

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
@@ -87,7 +87,7 @@ public struct SyntaxBuildableType: Hashable {
   ///  - For token: `TokenSyntax` (tokens don't have a dedicated type in SwiftSyntaxBuilder)
   /// If the type is optional, the type is wrapped in an `OptionalType`.
   public var buildable: Type {
-    optionalWrapped(type: Type(shorthandName))
+    optionalWrapped(type: SimpleTypeIdentifier(name: .identifier(shorthandName)))
   }
 
   /// Whether parameters of this type should be initializable by a result builder.
@@ -126,7 +126,7 @@ public struct SyntaxBuildableType: Hashable {
   /// which will eventually get built from `SwiftSyntaxBuilder`. If the type
   /// is optional, this terminates with a `?`.
   public var syntax: TypeSyntax {
-    return optionalWrapped(type: TypeSyntax(syntaxBaseName))
+    return optionalWrapped(type: SimpleTypeIdentifier(name: .identifier(syntaxBaseName)))
   }
 
   /// The type that is used for paramters in SwiftSyntaxBuilder that take this
@@ -140,7 +140,7 @@ public struct SyntaxBuildableType: Hashable {
   }
 
   public var parameterType: TypeSyntax {
-    return optionalWrapped(type: TypeSyntax(parameterBaseType))
+    return optionalWrapped(type: SimpleTypeIdentifier(name: .identifier(parameterBaseType)))
   }
 
   /// Assuming that this is a collection type, the non-optional type of the result builder
@@ -165,7 +165,7 @@ public struct SyntaxBuildableType: Hashable {
   }
 
   /// Wraps a type in an optional depending on whether `isOptional` is true.
-  public func optionalWrapped(type: TypeSyntaxProtocol) -> TypeSyntax {
+  public func optionalWrapped<TypeNode: TypeSyntaxProtocol>(type: TypeNode) -> TypeSyntax {
     if isOptional {
       return TypeSyntax(OptionalType(wrappedType: type))
     } else {

--- a/CodeGeneration/Sources/generate-swiftbasicformat/BasicFormatFile.swift
+++ b/CodeGeneration/Sources/generate-swiftbasicformat/BasicFormatFile.swift
@@ -80,7 +80,7 @@ let basicFormatFile = SourceFile {
       SwitchStmt(expression: Expr("keyPath")) {
         for node in SYNTAX_NODES where !node.isBase {
           for child in node.children where child.isIndented {
-            SwitchCase("case \\\(node.type.syntaxBaseName).\(child.swiftName):") {
+            SwitchCase("case \\\(raw: node.type.syntaxBaseName).\(raw: child.swiftName):") {
               ReturnStmt("return true")
             }
           }
@@ -95,7 +95,7 @@ let basicFormatFile = SourceFile {
       SwitchStmt(expression: Expr("keyPath")) {
         for node in SYNTAX_NODES where !node.isBase {
           for child in node.children where child.requiresLeadingNewline {
-            SwitchCase("case \\\(node.type.syntaxBaseName).\(child.swiftName):") {
+            SwitchCase("case \\\(raw: node.type.syntaxBaseName).\(raw: child.swiftName):") {
               ReturnStmt("return true")
             }
           }
@@ -110,7 +110,7 @@ let basicFormatFile = SourceFile {
       SwitchStmt(expression: Expr("node.as(SyntaxEnum.self)")) {
         for node in SYNTAX_NODES where !node.isBase {
           if node.elementsSeparatedByNewline {
-            SwitchCase("case .\(node.swiftSyntaxKind):") {
+            SwitchCase("case .\(raw: node.swiftSyntaxKind):") {
               ReturnStmt("return true")
             }
           }
@@ -125,7 +125,7 @@ let basicFormatFile = SourceFile {
       SwitchStmt(expression: Expr("tokenKind")) {
         for token in SYNTAX_TOKENS {
           if token.requiresLeadingSpace {
-            SwitchCase("case .\(token.swiftKind):") {
+            SwitchCase("case .\(raw: token.swiftKind):") {
               ReturnStmt("return true")
             }
           }
@@ -140,7 +140,7 @@ let basicFormatFile = SourceFile {
       SwitchStmt(expression: Expr("tokenKind")) {
         for token in SYNTAX_TOKENS {
           if token.requiresTrailingSpace {
-            SwitchCase("case .\(token.swiftKind):") {
+            SwitchCase("case .\(raw: token.swiftKind):") {
               ReturnStmt("return true")
             }
           }
@@ -178,7 +178,7 @@ private func createChildVisitCall(childType: SyntaxBuildableType, rewrittenExpr:
   }
   if childType.baseType?.baseName != "Syntax", childType.baseType?.isSyntaxCollection != true, childType.baseType != nil {
     let optionalChained = childType.optionalChained(expr: visitCall)
-    return FunctionCallExpr("\(optionalChained).cast(\(childType.syntaxBaseName).self)")
+    return FunctionCallExpr("\(optionalChained).cast(\(raw: childType.syntaxBaseName).self)")
   } else {
     return visitCall
   }
@@ -193,7 +193,7 @@ private func makeSyntaxCollectionRewriteFunc(node: Node) -> FunctionDecl {
     let formattedChildrenVarLet = node.elementsSeparatedByNewline ? "var" : "let"
     VariableDecl(
       """
-      \(formattedChildrenVarLet) formattedChildren = node.map {
+      \(raw: formattedChildrenVarLet) formattedChildren = node.map {
         \(createChildVisitCall(childType: node.collectionElementType, rewrittenExpr: IdentifierExpr(identifier: .dollarIdentifier("$0"))))
       }
       """
@@ -211,7 +211,7 @@ private func makeSyntaxCollectionRewriteFunc(node: Node) -> FunctionDecl {
         """
       )
     }
-    ReturnStmt("return \(node.type.syntaxBaseName)(formattedChildren)")
+    ReturnStmt("return \(raw: node.type.syntaxBaseName)(formattedChildren)")
   }
 }
 

--- a/CodeGeneration/Sources/generate-swiftideutils/SyntaxClassificationFile.swift
+++ b/CodeGeneration/Sources/generate-swiftideutils/SyntaxClassificationFile.swift
@@ -32,7 +32,7 @@ var node_child_classifications: [ChildClassification] {
 let syntaxClassificationFile = SourceFile {
   ImportDecl(
     """
-    \(generateCopyrightHeader(for: "generate-ideutils"))
+    \(raw: generateCopyrightHeader(for: "generate-ideutils"))
     @_spi(RawSyntax) import SwiftSyntax
     """
   )
@@ -41,8 +41,8 @@ let syntaxClassificationFile = SourceFile {
     for classification in SYNTAX_CLASSIFICATIONS {
       EnumCaseDecl(
         """
-        /// \(classification.description)
-        case \(classification.swiftName)
+        /// \(raw: classification.description)
+        case \(raw: classification.swiftName)
         """
       )
     }
@@ -70,8 +70,8 @@ let syntaxClassificationFile = SourceFile {
           ) {
             SwitchStmtSyntax(expression: ExprSyntax("(parentKind, indexInParent)")) {
               for childClassification in node_child_classifications where childClassification.isToken {
-                SwitchCaseSyntax("case (.\(childClassification.parent.swiftSyntaxKind), \(childClassification.childIndex)):") {
-                  ReturnStmt("return (.\(childClassification.classification!.swiftName), \(childClassification.force))")
+                SwitchCaseSyntax("case (.\(raw: childClassification.parent.swiftSyntaxKind), \(raw: childClassification.childIndex)):") {
+                  ReturnStmt("return (.\(raw: childClassification.classification!.swiftName), \(raw: childClassification.force))")
                 }
               }
               
@@ -80,8 +80,8 @@ let syntaxClassificationFile = SourceFile {
           } elseBody: {
             SwitchStmtSyntax(expression: ExprSyntax("(parentKind, indexInParent)")) {
               for childClassification in node_child_classifications where !childClassification.isToken {
-                SwitchCaseSyntax("case (.\(childClassification.parent.swiftSyntaxKind), \(childClassification.childIndex)):") {
-                    ReturnStmt("return (.\(childClassification.classification!.swiftName), \(childClassification.force))")
+                SwitchCaseSyntax("case (.\(raw: childClassification.parent.swiftSyntaxKind), \(raw: childClassification.childIndex)):") {
+                  ReturnStmt("return (.\(raw: childClassification.classification!.swiftName), \(raw: childClassification.force))")
                 }
               }
               
@@ -98,9 +98,9 @@ let syntaxClassificationFile = SourceFile {
       type: TypeAnnotation(type: TypeSyntax("SyntaxClassification"))) {
         SwitchStmt(expression: ExprSyntax("self")) {
           for token in SYNTAX_TOKENS {
-            SwitchCaseSyntax("case .\(token.swiftKind):") {
+            SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
               if let classification = token.classification {
-                ReturnStmt("return .\(classification.swiftName)")
+                ReturnStmt("return .\(raw: classification.swiftName)")
               } else {
                 ReturnStmt("return .none)")
               }

--- a/CodeGeneration/Sources/generate-swiftsyntaxbuilder/BuildableCollectionNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntaxbuilder/BuildableCollectionNodesFile.swift
@@ -33,7 +33,7 @@ let buildableCollectionNodesFile = SourceFile {
         InitializerDecl(
           """
           public init(_ elements: \(ArrayType(elementType: elementType.parameterType))) {
-            self = \(node.type.syntaxBaseName)(elements.map { \(elementType.syntax)(fromProtocol: $0) })
+            self = \(raw: node.type.syntaxBaseName)(elements.map { \(elementType.syntax)(fromProtocol: $0) })
           }
           """
         )

--- a/CodeGeneration/Sources/generate-swiftsyntaxbuilder/ResultBuildersFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntaxbuilder/ResultBuildersFile.swift
@@ -78,7 +78,7 @@ let resultBuildersFile = SourceFile {
             """
             /// If declared, provides contextual type information for statement
             /// expressions to translate them into partial results.
-            public static func buildExpression(_ expression: \(elementChoice)) -> Self.Component {
+            public static func buildExpression(_ expression: \(raw: elementChoice)) -> Self.Component {
               return buildExpression(.init(expression))
             }
             """
@@ -168,8 +168,8 @@ let resultBuildersFile = SourceFile {
       
     ExtensionDecl(
       """
-      public extension \(type.shorthandName) {
-        init(@\(type.resultBuilderBaseName) itemsBuilder: () -> \(type.shorthandName)) {
+      public extension \(raw: type.shorthandName) {
+        init(@\(raw: type.resultBuilderBaseName) itemsBuilder: () -> \(raw: type.shorthandName)) {
           self = itemsBuilder()
         }
       }

--- a/CodeGeneration/Sources/generate-swiftsyntaxbuilder/TokenFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntaxbuilder/TokenFile.swift
@@ -25,17 +25,17 @@ let tokenFile = SourceFile {
     for token in SYNTAX_TOKENS {
       if token.isKeyword {
         VariableDecl("""
-          /// The `\(token.text!)` keyword
-          static var \(token.name.withFirstCharacterLowercased.backticked): Token {
-            return .\(token.swiftKind)()
+          /// The `\(raw: token.text!)` keyword
+          static var \(raw: token.name.withFirstCharacterLowercased.backticked): Token {
+            return .\(raw: token.swiftKind)()
           }
           """
         )
       } else if let text = token.text {
         VariableDecl("""
-          /// The `\(text)` token
-          static var \(token.name.withFirstCharacterLowercased.backticked): TokenSyntax {
-            return .\(token.swiftKind)Token()
+          /// The `\(raw: text)` token
+          static var \(raw: token.name.withFirstCharacterLowercased.backticked): TokenSyntax {
+            return .\(raw: token.swiftKind)Token()
           }
           """
         )

--- a/CodeGeneration/Sources/generate-swiftsyntaxbuilder/TypealiasesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntaxbuilder/TypealiasesFile.swift
@@ -25,6 +25,6 @@ let typealiasesFile = SourceFile {
   TypealiasDecl("public typealias Token = TokenSyntax")
   
   for node in SYNTAX_NODES where !node.isUnknown && !node.isMissing {
-    TypealiasDecl("public typealias \(node.type.shorthandName) = \(node.type.syntaxBaseName)")
+    TypealiasDecl("public typealias \(raw: node.type.shorthandName) = \(raw: node.type.syntaxBaseName)")
   }
 }

--- a/Sources/IDEUtils/generated/SyntaxClassification.swift
+++ b/Sources/IDEUtils/generated/SyntaxClassification.swift
@@ -19,40 +19,58 @@
 public enum SyntaxClassification {
   /// The token should not receive syntax coloring.
   case none
+  
   /// A Swift keyword, including contextual keywords.
   case keyword
+  
   /// A generic identifier.
   case identifier
+  
   /// An identifier referring to a type.
   case typeIdentifier
+  
   /// An identifier referring to an operator.
   case operatorIdentifier
+  
   /// An identifier starting with `$` like `$0`.
   case dollarIdentifier
+  
   /// An integer literal.
   case integerLiteral
+  
   /// A floating point literal.
   case floatingLiteral
+  
   /// A string literal including multiline string literals.
   case stringLiteral
+  
   /// The opening and closing parenthesis of string interpolation.
   case stringInterpolationAnchor
+  
   /// A `#` keyword like `#warning`.
   case poundDirectiveKeyword
+  
   /// A build configuration directive like `#if`, `#elseif`, `#else`.
   case buildConfigId
+  
   /// An attribute starting with an `@`.
   case attribute
+  
   /// An image, color, etc. literal.
   case objectLiteral
+  
   /// An editor placeholder of the form `<#content#>`
   case editorPlaceholder
+  
   /// A line comment starting with `//`.
   case lineComment
+  
   /// A doc line comment starting with `///`.
   case docLineComment
+  
   /// A block comment starting with `/**` and ending with `*/.
   case blockComment
+  
   /// A doc block comment starting with `/**` and ending with `*/.
   case docBlockComment
 }

--- a/Sources/SwiftBasicFormat/generated/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat.swift
@@ -17,14 +17,19 @@ import SwiftSyntax
 
 open class BasicFormat: SyntaxRewriter {
   public var indentationLevel: Int = 0
+  
   open var indentation: TriviaPiece { 
     .spaces(indentationLevel * 4) 
   }
+  
   public var indentedNewline: Trivia { 
     Trivia(pieces: [.newlines(1), indentation]) 
   }
+  
   private var lastRewrittenToken: TokenSyntax?
+  
   private var putNextTokenOnNewLine: Bool = false
+  
   open override func visitPre(_ node: Syntax) {
     if let keyPath = getKeyPath(node), shouldIndent(keyPath) {
       indentationLevel += 1
@@ -33,11 +38,13 @@ open class BasicFormat: SyntaxRewriter {
       putNextTokenOnNewLine = true
     }
   }
+  
   open override func visitPost(_ node: Syntax) {
     if let keyPath = getKeyPath(node), shouldIndent(keyPath) {
       indentationLevel -= 1
     }
   }
+  
   open override func visit(_ node: TokenSyntax) -> TokenSyntax {
     var leadingTrivia = node.leadingTrivia
     var trailingTrivia = node.trailingTrivia
@@ -62,6 +69,7 @@ open class BasicFormat: SyntaxRewriter {
     putNextTokenOnNewLine = false
     return rewritten
   }
+  
   open func shouldIndent(_ keyPath: AnyKeyPath) -> Bool {
     switch keyPath {
     case \ClosureExprSyntax.statements: 
@@ -76,6 +84,7 @@ open class BasicFormat: SyntaxRewriter {
       return false
     }
   }
+  
   open func requiresLeadingNewline(_ keyPath: AnyKeyPath) -> Bool {
     switch keyPath {
     case \ClosureExprSyntax.rightBrace: 
@@ -90,6 +99,7 @@ open class BasicFormat: SyntaxRewriter {
       return putNextTokenOnNewLine
     }
   }
+  
   open func childrenSeparatedByNewline(_ node: Syntax) -> Bool {
     switch node.as(SyntaxEnum.self) {
     case .codeBlockItemList: 
@@ -102,6 +112,7 @@ open class BasicFormat: SyntaxRewriter {
       return false
     }
   }
+  
   open func requiresLeadingSpace(_ tokenKind: TokenKind) -> Bool {
     switch tokenKind {
     case .whereKeyword: 
@@ -126,6 +137,7 @@ open class BasicFormat: SyntaxRewriter {
       return false
     }
   }
+  
   open func requiresTrailingSpace(_ tokenKind: TokenKind) -> Bool {
     switch tokenKind {
     case .associatedtypeKeyword: 
@@ -296,6 +308,7 @@ open class BasicFormat: SyntaxRewriter {
       return false
     }
   }
+  
   private func getKeyPath(_ node: Syntax) -> AnyKeyPath? {
     guard let parent = node.parent else {
       return nil

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
@@ -155,6 +155,7 @@ extension ExprList: ExpressibleByArrayLiteral {
       ExprSyntax(fromProtocol: $0) 
     })
   }
+  
   public init (arrayLiteral elements: ExprSyntaxProtocol...) {
     self.init (elements)
   }
@@ -335,6 +336,7 @@ extension UnexpectedNodes: ExpressibleByArrayLiteral {
       Syntax(fromProtocol: $0) 
     })
   }
+  
   public init (arrayLiteral elements: SyntaxProtocol...) {
     self.init (elements)
   }

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -27,6 +27,7 @@ extension AccessLevelModifier {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -49,6 +50,7 @@ extension AccessPathComponent {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -101,6 +103,7 @@ extension AccessorDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -132,6 +135,7 @@ extension AccessorParameter {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -166,6 +170,7 @@ extension ActorDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -190,9 +195,11 @@ extension ArrayElement: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -215,6 +222,7 @@ extension ArrayExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -261,6 +269,7 @@ extension ArrowExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -345,6 +354,7 @@ extension AssociatedtypeDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -453,6 +463,7 @@ extension AvailabilityEntry {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -478,6 +489,7 @@ extension AvailabilityLabeledArgument {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -500,6 +512,7 @@ extension AvailabilityVersionRestriction {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -522,6 +535,7 @@ extension AwaitExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -548,6 +562,7 @@ extension BackDeployAttributeSpecList {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -611,6 +626,7 @@ extension BreakStmt {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -637,9 +653,11 @@ extension CaseItem: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -661,6 +679,7 @@ extension CatchClause {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -687,9 +706,11 @@ extension CatchItem: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -721,6 +742,7 @@ extension ClassDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -765,6 +787,7 @@ extension ClosureCaptureItem: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -774,9 +797,11 @@ extension ClosureCaptureItem: HasTrailingComma {
     }, unexpectedBetweenNameAndAssignToken, assignToken: assignToken, unexpectedBetweenAssignTokenAndExpression, expression: ExprSyntax(fromProtocol: expression), unexpectedBetweenExpressionAndTrailingComma, trailingComma: trailingComma)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -799,6 +824,7 @@ extension ClosureCaptureSignature {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -828,6 +854,7 @@ extension ClosureExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -852,9 +879,11 @@ extension ClosureParam: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -886,6 +915,7 @@ extension ClosureSignature {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -931,6 +961,7 @@ extension CodeBlock {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -982,9 +1013,11 @@ extension ConditionElement: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -1021,6 +1054,7 @@ extension ConstrainedSugarType {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1043,6 +1077,7 @@ extension ContinueStmt {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1077,6 +1112,7 @@ extension ConventionAttributeArguments {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1106,6 +1142,7 @@ extension ConventionWitnessMethodAttributeArguments {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1137,6 +1174,7 @@ extension CustomAttribute {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1164,6 +1202,7 @@ extension DeclModifierDetail {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1260,6 +1299,7 @@ extension DeferStmt {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1288,6 +1328,7 @@ extension DeinitializerDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1329,6 +1370,7 @@ extension DerivativeRegistrationAttributeArguments {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1353,6 +1395,7 @@ extension DesignatedTypeElement {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1380,9 +1423,11 @@ extension DictionaryElement: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -1444,9 +1489,11 @@ extension DifferentiabilityParam: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -1470,6 +1517,7 @@ extension DifferentiabilityParamsClause {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1520,6 +1568,7 @@ extension DifferentiableAttributeArguments {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1559,6 +1608,7 @@ extension DoStmt {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1580,6 +1630,7 @@ extension EditorPlaceholderExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1607,6 +1658,7 @@ extension EnumCaseDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1636,6 +1688,7 @@ extension EnumCaseElement: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1643,9 +1696,11 @@ extension EnumCaseElement: HasTrailingComma {
     self.init (unexpectedBeforeIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndAssociatedValue, associatedValue: associatedValue, unexpectedBetweenAssociatedValueAndRawValue, rawValue: rawValue, unexpectedBetweenRawValueAndTrailingComma, trailingComma: trailingComma)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -1669,6 +1724,7 @@ extension EnumCasePattern {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1704,6 +1760,7 @@ extension EnumDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1748,6 +1805,7 @@ extension ExpressionSegment {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1796,6 +1854,7 @@ extension ExtensionDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1822,6 +1881,7 @@ extension ExternalMacroName {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1854,6 +1914,7 @@ extension FloatLiteralExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1896,6 +1957,7 @@ extension ForInStmt {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1946,6 +2008,7 @@ extension FunctionCallExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -1997,6 +2060,7 @@ extension FunctionDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2039,9 +2103,11 @@ extension FunctionParameter: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -2066,6 +2132,7 @@ extension FunctionSignature {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2122,6 +2189,7 @@ extension GenericArgumentClause {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2146,9 +2214,11 @@ extension GenericArgument: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -2173,6 +2243,7 @@ extension GenericParameterClause {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2207,6 +2278,7 @@ extension GenericParameter: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2214,9 +2286,11 @@ extension GenericParameter: HasTrailingComma {
     self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndName, name: Token.`identifier`(name), unexpectedBetweenNameAndEllipsis, ellipsis: ellipsis, unexpectedBetweenEllipsisAndColon, colon: colon, unexpectedBetweenColonAndInheritedType, inheritedType: TypeSyntax(fromProtocol: inheritedType), unexpectedBetweenInheritedTypeAndTrailingComma, trailingComma: trailingComma)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -2236,9 +2310,11 @@ extension GenericRequirement: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -2258,6 +2334,7 @@ extension GenericWhereClause {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2287,6 +2364,7 @@ extension GuardStmt {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2396,6 +2474,7 @@ extension IfStmt {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2508,9 +2587,11 @@ extension InheritedType: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -2558,6 +2639,7 @@ extension InitializerDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2581,6 +2663,7 @@ extension IntegerLiteralExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2712,6 +2795,7 @@ extension KeyPathSubscriptComponent {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2742,6 +2826,7 @@ extension LabeledSpecializeEntry: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2749,9 +2834,11 @@ extension LabeledSpecializeEntry: HasTrailingComma {
     self.init (unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndValue, value: value, unexpectedBetweenValueAndTrailingComma, trailingComma: trailingComma)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -2773,6 +2860,7 @@ extension LabeledStmt {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2810,6 +2898,7 @@ extension LayoutRequirement {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2851,6 +2940,7 @@ extension MacroDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2887,6 +2977,7 @@ extension MacroExpansionDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2925,6 +3016,7 @@ extension MacroExpansionExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -2990,6 +3082,7 @@ extension MemberDeclBlock {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3052,6 +3145,7 @@ extension MetatypeType {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3074,6 +3168,7 @@ extension MoveExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3159,6 +3254,7 @@ extension ObjCSelectorPiece {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3204,6 +3300,7 @@ extension ObjcNamePiece {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3238,6 +3335,7 @@ extension ObjcSelectorExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3268,6 +3366,7 @@ extension ObjectLiteralExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3312,6 +3411,7 @@ extension OpaqueReturnTypeOfAttributeArguments {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3359,6 +3459,7 @@ extension OperatorPrecedenceAndTypes {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3463,6 +3564,7 @@ extension ParameterClause {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3493,9 +3595,11 @@ extension PatternBinding: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -3528,6 +3632,7 @@ extension PostfixUnaryExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3561,6 +3666,7 @@ extension PoundAssertStmt {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3711,6 +3817,7 @@ extension PoundSourceLocationArgs {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3780,6 +3887,7 @@ extension PrecedenceGroupAssignment {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3807,6 +3915,7 @@ extension PrecedenceGroupAssociativity {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3842,6 +3951,7 @@ extension PrecedenceGroupDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3864,6 +3974,7 @@ extension PrecedenceGroupNameElement {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3890,6 +4001,7 @@ extension PrecedenceGroupRelation {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3911,6 +4023,7 @@ extension PrefixOperatorExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3953,6 +4066,7 @@ extension PrimaryAssociatedType: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -3960,9 +4074,11 @@ extension PrimaryAssociatedType: HasTrailingComma {
     self.init (unexpectedBeforeName, name: Token.`identifier`(name), unexpectedBetweenNameAndTrailingComma, trailingComma: trailingComma)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -3994,6 +4110,7 @@ extension ProtocolDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4035,6 +4152,7 @@ extension RegexLiteralExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4062,6 +4180,7 @@ extension RepeatWhileStmt {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4129,6 +4248,7 @@ extension SequenceExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4166,6 +4286,7 @@ extension SourceFile {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4211,6 +4332,7 @@ extension StringLiteralExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4234,6 +4356,7 @@ extension StringSegment {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4268,6 +4391,7 @@ extension StructDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4328,6 +4452,7 @@ extension SubscriptExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4368,6 +4493,7 @@ extension SwitchCaseLabel {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4393,6 +4519,7 @@ extension SwitchCase {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4441,6 +4568,7 @@ extension SwitchStmt {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4464,6 +4592,7 @@ extension SymbolicReferenceExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4492,6 +4621,7 @@ extension TargetFunctionEntry: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4499,9 +4629,11 @@ extension TargetFunctionEntry: HasTrailingComma {
     self.init (unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndDeclname, declname: declname, unexpectedBetweenDeclnameAndTrailingComma, trailingComma: trailingComma)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -4581,9 +4713,11 @@ extension TupleExprElement: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -4606,6 +4740,7 @@ extension TupleExpr {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4635,6 +4770,7 @@ extension TuplePatternElement: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4644,9 +4780,11 @@ extension TuplePatternElement: HasTrailingComma {
     }, unexpectedBetweenLabelNameAndLabelColon, labelColon: labelColon, unexpectedBetweenLabelColonAndPattern, pattern: PatternSyntax(fromProtocol: pattern), unexpectedBetweenPatternAndTrailingComma, trailingComma: trailingComma)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -4669,6 +4807,7 @@ extension TuplePattern {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4708,9 +4847,11 @@ extension TupleTypeElement: HasTrailingComma {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   var hasTrailingComma: Bool {
     return trailingComma != nil
   }
+  
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     return withTrailingComma(withComma ? .commaToken() : nil)
@@ -4775,6 +4916,7 @@ extension TypeInheritanceClause {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4824,6 +4966,7 @@ extension TypealiasDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4945,6 +5088,7 @@ extension VariableDecl {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -4972,6 +5116,7 @@ extension VersionTuple {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
@@ -5013,6 +5158,7 @@ extension WhileStmt {
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
+  
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings

--- a/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
@@ -20,12 +20,15 @@ public struct AccessPathBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = AccessPathComponent
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = AccessPath
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -33,31 +36,37 @@ public struct AccessPathBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -65,6 +74,7 @@ public struct AccessPathBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -80,7 +90,6 @@ public struct AccessPathBuilder {
 }
 
 public extension AccessPath {
-  
   init (@AccessPathBuilder itemsBuilder: () -> AccessPath) {
     self = itemsBuilder()
   }
@@ -91,12 +100,15 @@ public struct AccessorListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = AccessorDecl
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = AccessorList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -104,31 +116,37 @@ public struct AccessorListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -136,6 +154,7 @@ public struct AccessorListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -151,7 +170,6 @@ public struct AccessorListBuilder {
 }
 
 public extension AccessorList {
-  
   init (@AccessorListBuilder itemsBuilder: () -> AccessorList) {
     self = itemsBuilder()
   }
@@ -162,12 +180,15 @@ public struct ArrayElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = ArrayElement
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ArrayElementList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -175,31 +196,37 @@ public struct ArrayElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -207,6 +234,7 @@ public struct ArrayElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -225,7 +253,6 @@ public struct ArrayElementListBuilder {
 }
 
 public extension ArrayElementList {
-  
   init (@ArrayElementListBuilder itemsBuilder: () -> ArrayElementList) {
     self = itemsBuilder()
   }
@@ -236,12 +263,15 @@ public struct AttributeListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = AttributeList.Element
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = AttributeList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -249,46 +279,55 @@ public struct AttributeListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Attribute) -> Self.Component {
     return buildExpression(.init (expression))
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: CustomAttribute) -> Self.Component {
     return buildExpression(.init (expression))
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: IfConfigDecl) -> Self.Component {
     return buildExpression(.init (expression))
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -296,6 +335,7 @@ public struct AttributeListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -311,7 +351,6 @@ public struct AttributeListBuilder {
 }
 
 public extension AttributeList {
-  
   init (@AttributeListBuilder itemsBuilder: () -> AttributeList) {
     self = itemsBuilder()
   }
@@ -322,12 +361,15 @@ public struct AvailabilitySpecListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = AvailabilityArgument
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = AvailabilitySpecList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -335,31 +377,37 @@ public struct AvailabilitySpecListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -367,6 +415,7 @@ public struct AvailabilitySpecListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -382,7 +431,6 @@ public struct AvailabilitySpecListBuilder {
 }
 
 public extension AvailabilitySpecList {
-  
   init (@AvailabilitySpecListBuilder itemsBuilder: () -> AvailabilitySpecList) {
     self = itemsBuilder()
   }
@@ -393,12 +441,15 @@ public struct BackDeployVersionListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = BackDeployVersionArgument
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = BackDeployVersionList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -406,31 +457,37 @@ public struct BackDeployVersionListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -438,6 +495,7 @@ public struct BackDeployVersionListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -453,7 +511,6 @@ public struct BackDeployVersionListBuilder {
 }
 
 public extension BackDeployVersionList {
-  
   init (@BackDeployVersionListBuilder itemsBuilder: () -> BackDeployVersionList) {
     self = itemsBuilder()
   }
@@ -464,12 +521,15 @@ public struct CaseItemListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = CaseItem
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = CaseItemList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -477,31 +537,37 @@ public struct CaseItemListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -509,6 +575,7 @@ public struct CaseItemListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -527,7 +594,6 @@ public struct CaseItemListBuilder {
 }
 
 public extension CaseItemList {
-  
   init (@CaseItemListBuilder itemsBuilder: () -> CaseItemList) {
     self = itemsBuilder()
   }
@@ -538,12 +604,15 @@ public struct CatchClauseListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = CatchClause
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = CatchClauseList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -551,31 +620,37 @@ public struct CatchClauseListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -583,6 +658,7 @@ public struct CatchClauseListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -598,7 +674,6 @@ public struct CatchClauseListBuilder {
 }
 
 public extension CatchClauseList {
-  
   init (@CatchClauseListBuilder itemsBuilder: () -> CatchClauseList) {
     self = itemsBuilder()
   }
@@ -609,12 +684,15 @@ public struct CatchItemListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = CatchItem
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = CatchItemList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -622,31 +700,37 @@ public struct CatchItemListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -654,6 +738,7 @@ public struct CatchItemListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -672,7 +757,6 @@ public struct CatchItemListBuilder {
 }
 
 public extension CatchItemList {
-  
   init (@CatchItemListBuilder itemsBuilder: () -> CatchItemList) {
     self = itemsBuilder()
   }
@@ -683,12 +767,15 @@ public struct ClosureCaptureItemListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = ClosureCaptureItem
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ClosureCaptureItemList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -696,31 +783,37 @@ public struct ClosureCaptureItemListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -728,6 +821,7 @@ public struct ClosureCaptureItemListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -746,7 +840,6 @@ public struct ClosureCaptureItemListBuilder {
 }
 
 public extension ClosureCaptureItemList {
-  
   init (@ClosureCaptureItemListBuilder itemsBuilder: () -> ClosureCaptureItemList) {
     self = itemsBuilder()
   }
@@ -757,12 +850,15 @@ public struct ClosureParamListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = ClosureParam
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ClosureParamList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -770,31 +866,37 @@ public struct ClosureParamListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -802,6 +904,7 @@ public struct ClosureParamListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -820,7 +923,6 @@ public struct ClosureParamListBuilder {
 }
 
 public extension ClosureParamList {
-  
   init (@ClosureParamListBuilder itemsBuilder: () -> ClosureParamList) {
     self = itemsBuilder()
   }
@@ -831,12 +933,15 @@ public struct CodeBlockItemListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = CodeBlockItem
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = CodeBlockItemList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -844,31 +949,37 @@ public struct CodeBlockItemListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -876,6 +987,7 @@ public struct CodeBlockItemListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -891,7 +1003,6 @@ public struct CodeBlockItemListBuilder {
 }
 
 public extension CodeBlockItemList {
-  
   init (@CodeBlockItemListBuilder itemsBuilder: () -> CodeBlockItemList) {
     self = itemsBuilder()
   }
@@ -902,12 +1013,15 @@ public struct CompositionTypeElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = CompositionTypeElement
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = CompositionTypeElementList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -915,31 +1029,37 @@ public struct CompositionTypeElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -947,6 +1067,7 @@ public struct CompositionTypeElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -962,7 +1083,6 @@ public struct CompositionTypeElementListBuilder {
 }
 
 public extension CompositionTypeElementList {
-  
   init (@CompositionTypeElementListBuilder itemsBuilder: () -> CompositionTypeElementList) {
     self = itemsBuilder()
   }
@@ -973,12 +1093,15 @@ public struct ConditionElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = ConditionElement
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ConditionElementList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -986,31 +1109,37 @@ public struct ConditionElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -1018,6 +1147,7 @@ public struct ConditionElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -1036,7 +1166,6 @@ public struct ConditionElementListBuilder {
 }
 
 public extension ConditionElementList {
-  
   init (@ConditionElementListBuilder itemsBuilder: () -> ConditionElementList) {
     self = itemsBuilder()
   }
@@ -1047,12 +1176,15 @@ public struct DeclNameArgumentListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = DeclNameArgument
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = DeclNameArgumentList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -1060,31 +1192,37 @@ public struct DeclNameArgumentListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -1092,6 +1230,7 @@ public struct DeclNameArgumentListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -1107,7 +1246,6 @@ public struct DeclNameArgumentListBuilder {
 }
 
 public extension DeclNameArgumentList {
-  
   init (@DeclNameArgumentListBuilder itemsBuilder: () -> DeclNameArgumentList) {
     self = itemsBuilder()
   }
@@ -1118,12 +1256,15 @@ public struct DesignatedTypeListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = DesignatedTypeElement
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = DesignatedTypeList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -1131,31 +1272,37 @@ public struct DesignatedTypeListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -1163,6 +1310,7 @@ public struct DesignatedTypeListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -1178,7 +1326,6 @@ public struct DesignatedTypeListBuilder {
 }
 
 public extension DesignatedTypeList {
-  
   init (@DesignatedTypeListBuilder itemsBuilder: () -> DesignatedTypeList) {
     self = itemsBuilder()
   }
@@ -1189,12 +1336,15 @@ public struct DictionaryElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = DictionaryElement
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = DictionaryElementList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -1202,31 +1352,37 @@ public struct DictionaryElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -1234,6 +1390,7 @@ public struct DictionaryElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -1252,7 +1409,6 @@ public struct DictionaryElementListBuilder {
 }
 
 public extension DictionaryElementList {
-  
   init (@DictionaryElementListBuilder itemsBuilder: () -> DictionaryElementList) {
     self = itemsBuilder()
   }
@@ -1263,12 +1419,15 @@ public struct DifferentiabilityParamListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = DifferentiabilityParam
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = DifferentiabilityParamList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -1276,31 +1435,37 @@ public struct DifferentiabilityParamListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -1308,6 +1473,7 @@ public struct DifferentiabilityParamListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -1326,7 +1492,6 @@ public struct DifferentiabilityParamListBuilder {
 }
 
 public extension DifferentiabilityParamList {
-  
   init (@DifferentiabilityParamListBuilder itemsBuilder: () -> DifferentiabilityParamList) {
     self = itemsBuilder()
   }
@@ -1337,12 +1502,15 @@ public struct EnumCaseElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = EnumCaseElement
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = EnumCaseElementList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -1350,31 +1518,37 @@ public struct EnumCaseElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -1382,6 +1556,7 @@ public struct EnumCaseElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -1400,7 +1575,6 @@ public struct EnumCaseElementListBuilder {
 }
 
 public extension EnumCaseElementList {
-  
   init (@EnumCaseElementListBuilder itemsBuilder: () -> EnumCaseElementList) {
     self = itemsBuilder()
   }
@@ -1411,12 +1585,15 @@ public struct ExprListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = ExprSyntaxProtocol
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ExprList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -1424,31 +1601,37 @@ public struct ExprListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -1456,6 +1639,7 @@ public struct ExprListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -1471,7 +1655,6 @@ public struct ExprListBuilder {
 }
 
 public extension ExprList {
-  
   init (@ExprListBuilder itemsBuilder: () -> ExprList) {
     self = itemsBuilder()
   }
@@ -1482,12 +1665,15 @@ public struct FunctionParameterListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = FunctionParameter
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = FunctionParameterList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -1495,31 +1681,37 @@ public struct FunctionParameterListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -1527,6 +1719,7 @@ public struct FunctionParameterListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -1545,7 +1738,6 @@ public struct FunctionParameterListBuilder {
 }
 
 public extension FunctionParameterList {
-  
   init (@FunctionParameterListBuilder itemsBuilder: () -> FunctionParameterList) {
     self = itemsBuilder()
   }
@@ -1556,12 +1748,15 @@ public struct GenericArgumentListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = GenericArgument
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = GenericArgumentList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -1569,31 +1764,37 @@ public struct GenericArgumentListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -1601,6 +1802,7 @@ public struct GenericArgumentListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -1619,7 +1821,6 @@ public struct GenericArgumentListBuilder {
 }
 
 public extension GenericArgumentList {
-  
   init (@GenericArgumentListBuilder itemsBuilder: () -> GenericArgumentList) {
     self = itemsBuilder()
   }
@@ -1630,12 +1831,15 @@ public struct GenericParameterListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = GenericParameter
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = GenericParameterList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -1643,31 +1847,37 @@ public struct GenericParameterListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -1675,6 +1885,7 @@ public struct GenericParameterListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -1693,7 +1904,6 @@ public struct GenericParameterListBuilder {
 }
 
 public extension GenericParameterList {
-  
   init (@GenericParameterListBuilder itemsBuilder: () -> GenericParameterList) {
     self = itemsBuilder()
   }
@@ -1704,12 +1914,15 @@ public struct GenericRequirementListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = GenericRequirement
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = GenericRequirementList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -1717,31 +1930,37 @@ public struct GenericRequirementListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -1749,6 +1968,7 @@ public struct GenericRequirementListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -1767,7 +1987,6 @@ public struct GenericRequirementListBuilder {
 }
 
 public extension GenericRequirementList {
-  
   init (@GenericRequirementListBuilder itemsBuilder: () -> GenericRequirementList) {
     self = itemsBuilder()
   }
@@ -1778,12 +1997,15 @@ public struct IfConfigClauseListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = IfConfigClause
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = IfConfigClauseList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -1791,31 +2013,37 @@ public struct IfConfigClauseListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -1823,6 +2051,7 @@ public struct IfConfigClauseListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -1838,7 +2067,6 @@ public struct IfConfigClauseListBuilder {
 }
 
 public extension IfConfigClauseList {
-  
   init (@IfConfigClauseListBuilder itemsBuilder: () -> IfConfigClauseList) {
     self = itemsBuilder()
   }
@@ -1849,12 +2077,15 @@ public struct InheritedTypeListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = InheritedType
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = InheritedTypeList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -1862,31 +2093,37 @@ public struct InheritedTypeListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -1894,6 +2131,7 @@ public struct InheritedTypeListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -1912,7 +2150,6 @@ public struct InheritedTypeListBuilder {
 }
 
 public extension InheritedTypeList {
-  
   init (@InheritedTypeListBuilder itemsBuilder: () -> InheritedTypeList) {
     self = itemsBuilder()
   }
@@ -1923,12 +2160,15 @@ public struct KeyPathComponentListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = KeyPathComponent
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = KeyPathComponentList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -1936,31 +2176,37 @@ public struct KeyPathComponentListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -1968,6 +2214,7 @@ public struct KeyPathComponentListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -1983,7 +2230,6 @@ public struct KeyPathComponentListBuilder {
 }
 
 public extension KeyPathComponentList {
-  
   init (@KeyPathComponentListBuilder itemsBuilder: () -> KeyPathComponentList) {
     self = itemsBuilder()
   }
@@ -1994,12 +2240,15 @@ public struct MemberDeclListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = MemberDeclListItem
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = MemberDeclList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -2007,31 +2256,37 @@ public struct MemberDeclListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -2039,6 +2294,7 @@ public struct MemberDeclListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -2054,7 +2310,6 @@ public struct MemberDeclListBuilder {
 }
 
 public extension MemberDeclList {
-  
   init (@MemberDeclListBuilder itemsBuilder: () -> MemberDeclList) {
     self = itemsBuilder()
   }
@@ -2065,12 +2320,15 @@ public struct ModifierListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = DeclModifier
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ModifierList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -2078,31 +2336,37 @@ public struct ModifierListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -2110,6 +2374,7 @@ public struct ModifierListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -2125,7 +2390,6 @@ public struct ModifierListBuilder {
 }
 
 public extension ModifierList {
-  
   init (@ModifierListBuilder itemsBuilder: () -> ModifierList) {
     self = itemsBuilder()
   }
@@ -2136,12 +2400,15 @@ public struct MultipleTrailingClosureElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = MultipleTrailingClosureElement
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = MultipleTrailingClosureElementList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -2149,31 +2416,37 @@ public struct MultipleTrailingClosureElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -2181,6 +2454,7 @@ public struct MultipleTrailingClosureElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -2196,7 +2470,6 @@ public struct MultipleTrailingClosureElementListBuilder {
 }
 
 public extension MultipleTrailingClosureElementList {
-  
   init (@MultipleTrailingClosureElementListBuilder itemsBuilder: () -> MultipleTrailingClosureElementList) {
     self = itemsBuilder()
   }
@@ -2207,12 +2480,15 @@ public struct NonEmptyTokenListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = Token
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = NonEmptyTokenList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -2220,31 +2496,37 @@ public struct NonEmptyTokenListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -2252,6 +2534,7 @@ public struct NonEmptyTokenListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -2267,7 +2550,6 @@ public struct NonEmptyTokenListBuilder {
 }
 
 public extension NonEmptyTokenList {
-  
   init (@NonEmptyTokenListBuilder itemsBuilder: () -> NonEmptyTokenList) {
     self = itemsBuilder()
   }
@@ -2278,12 +2560,15 @@ public struct ObjCSelectorBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = ObjCSelectorPiece
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ObjCSelector
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -2291,31 +2576,37 @@ public struct ObjCSelectorBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -2323,6 +2614,7 @@ public struct ObjCSelectorBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -2338,7 +2630,6 @@ public struct ObjCSelectorBuilder {
 }
 
 public extension ObjCSelector {
-  
   init (@ObjCSelectorBuilder itemsBuilder: () -> ObjCSelector) {
     self = itemsBuilder()
   }
@@ -2349,12 +2640,15 @@ public struct ObjcNameBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = ObjcNamePiece
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = ObjcName
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -2362,31 +2656,37 @@ public struct ObjcNameBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -2394,6 +2694,7 @@ public struct ObjcNameBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -2409,7 +2710,6 @@ public struct ObjcNameBuilder {
 }
 
 public extension ObjcName {
-  
   init (@ObjcNameBuilder itemsBuilder: () -> ObjcName) {
     self = itemsBuilder()
   }
@@ -2420,12 +2720,15 @@ public struct PatternBindingListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = PatternBinding
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = PatternBindingList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -2433,31 +2736,37 @@ public struct PatternBindingListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -2465,6 +2774,7 @@ public struct PatternBindingListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -2483,7 +2793,6 @@ public struct PatternBindingListBuilder {
 }
 
 public extension PatternBindingList {
-  
   init (@PatternBindingListBuilder itemsBuilder: () -> PatternBindingList) {
     self = itemsBuilder()
   }
@@ -2494,12 +2803,15 @@ public struct PrecedenceGroupAttributeListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = PrecedenceGroupAttributeList.Element
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = PrecedenceGroupAttributeList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -2507,46 +2819,55 @@ public struct PrecedenceGroupAttributeListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: PrecedenceGroupRelation) -> Self.Component {
     return buildExpression(.init (expression))
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: PrecedenceGroupAssignment) -> Self.Component {
     return buildExpression(.init (expression))
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: PrecedenceGroupAssociativity) -> Self.Component {
     return buildExpression(.init (expression))
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -2554,6 +2875,7 @@ public struct PrecedenceGroupAttributeListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -2569,7 +2891,6 @@ public struct PrecedenceGroupAttributeListBuilder {
 }
 
 public extension PrecedenceGroupAttributeList {
-  
   init (@PrecedenceGroupAttributeListBuilder itemsBuilder: () -> PrecedenceGroupAttributeList) {
     self = itemsBuilder()
   }
@@ -2580,12 +2901,15 @@ public struct PrecedenceGroupNameListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = PrecedenceGroupNameElement
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = PrecedenceGroupNameList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -2593,31 +2917,37 @@ public struct PrecedenceGroupNameListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -2625,6 +2955,7 @@ public struct PrecedenceGroupNameListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -2640,7 +2971,6 @@ public struct PrecedenceGroupNameListBuilder {
 }
 
 public extension PrecedenceGroupNameList {
-  
   init (@PrecedenceGroupNameListBuilder itemsBuilder: () -> PrecedenceGroupNameList) {
     self = itemsBuilder()
   }
@@ -2651,12 +2981,15 @@ public struct PrimaryAssociatedTypeListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = PrimaryAssociatedType
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = PrimaryAssociatedTypeList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -2664,31 +2997,37 @@ public struct PrimaryAssociatedTypeListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -2696,6 +3035,7 @@ public struct PrimaryAssociatedTypeListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -2714,7 +3054,6 @@ public struct PrimaryAssociatedTypeListBuilder {
 }
 
 public extension PrimaryAssociatedTypeList {
-  
   init (@PrimaryAssociatedTypeListBuilder itemsBuilder: () -> PrimaryAssociatedTypeList) {
     self = itemsBuilder()
   }
@@ -2725,12 +3064,15 @@ public struct SpecializeAttributeSpecListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = SpecializeAttributeSpecList.Element
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = SpecializeAttributeSpecList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -2738,51 +3080,61 @@ public struct SpecializeAttributeSpecListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: LabeledSpecializeEntry) -> Self.Component {
     return buildExpression(.init (expression))
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: AvailabilityEntry) -> Self.Component {
     return buildExpression(.init (expression))
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: TargetFunctionEntry) -> Self.Component {
     return buildExpression(.init (expression))
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: GenericWhereClause) -> Self.Component {
     return buildExpression(.init (expression))
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -2790,6 +3142,7 @@ public struct SpecializeAttributeSpecListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -2805,7 +3158,6 @@ public struct SpecializeAttributeSpecListBuilder {
 }
 
 public extension SpecializeAttributeSpecList {
-  
   init (@SpecializeAttributeSpecListBuilder itemsBuilder: () -> SpecializeAttributeSpecList) {
     self = itemsBuilder()
   }
@@ -2816,12 +3168,15 @@ public struct StringLiteralSegmentsBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = StringLiteralSegments.Element
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = StringLiteralSegments
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -2829,41 +3184,49 @@ public struct StringLiteralSegmentsBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: StringSegment) -> Self.Component {
     return buildExpression(.init (expression))
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: ExpressionSegment) -> Self.Component {
     return buildExpression(.init (expression))
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -2871,6 +3234,7 @@ public struct StringLiteralSegmentsBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -2886,7 +3250,6 @@ public struct StringLiteralSegmentsBuilder {
 }
 
 public extension StringLiteralSegments {
-  
   init (@StringLiteralSegmentsBuilder itemsBuilder: () -> StringLiteralSegments) {
     self = itemsBuilder()
   }
@@ -2897,12 +3260,15 @@ public struct SwitchCaseListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = SwitchCaseList.Element
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = SwitchCaseList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -2910,41 +3276,49 @@ public struct SwitchCaseListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: SwitchCase) -> Self.Component {
     return buildExpression(.init (expression))
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: IfConfigDecl) -> Self.Component {
     return buildExpression(.init (expression))
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -2952,6 +3326,7 @@ public struct SwitchCaseListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -2967,7 +3342,6 @@ public struct SwitchCaseListBuilder {
 }
 
 public extension SwitchCaseList {
-  
   init (@SwitchCaseListBuilder itemsBuilder: () -> SwitchCaseList) {
     self = itemsBuilder()
   }
@@ -2978,12 +3352,15 @@ public struct TokenListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = Token
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = TokenList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -2991,31 +3368,37 @@ public struct TokenListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -3023,6 +3406,7 @@ public struct TokenListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -3038,7 +3422,6 @@ public struct TokenListBuilder {
 }
 
 public extension TokenList {
-  
   init (@TokenListBuilder itemsBuilder: () -> TokenList) {
     self = itemsBuilder()
   }
@@ -3049,12 +3432,15 @@ public struct TupleExprElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = TupleExprElement
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = TupleExprElementList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -3062,31 +3448,37 @@ public struct TupleExprElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -3094,6 +3486,7 @@ public struct TupleExprElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -3112,7 +3505,6 @@ public struct TupleExprElementListBuilder {
 }
 
 public extension TupleExprElementList {
-  
   init (@TupleExprElementListBuilder itemsBuilder: () -> TupleExprElementList) {
     self = itemsBuilder()
   }
@@ -3123,12 +3515,15 @@ public struct TuplePatternElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = TuplePatternElement
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = TuplePatternElementList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -3136,31 +3531,37 @@ public struct TuplePatternElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -3168,6 +3569,7 @@ public struct TuplePatternElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -3186,7 +3588,6 @@ public struct TuplePatternElementListBuilder {
 }
 
 public extension TuplePatternElementList {
-  
   init (@TuplePatternElementListBuilder itemsBuilder: () -> TuplePatternElementList) {
     self = itemsBuilder()
   }
@@ -3197,12 +3598,15 @@ public struct TupleTypeElementListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = TupleTypeElement
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = TupleTypeElementList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -3210,31 +3614,37 @@ public struct TupleTypeElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -3242,6 +3652,7 @@ public struct TupleTypeElementListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -3260,7 +3671,6 @@ public struct TupleTypeElementListBuilder {
 }
 
 public extension TupleTypeElementList {
-  
   init (@TupleTypeElementListBuilder itemsBuilder: () -> TupleTypeElementList) {
     self = itemsBuilder()
   }
@@ -3271,12 +3681,15 @@ public struct UnexpectedNodesBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = SyntaxProtocol
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = UnexpectedNodes
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -3284,31 +3697,37 @@ public struct UnexpectedNodesBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -3316,6 +3735,7 @@ public struct UnexpectedNodesBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -3331,7 +3751,6 @@ public struct UnexpectedNodesBuilder {
 }
 
 public extension UnexpectedNodes {
-  
   init (@UnexpectedNodesBuilder itemsBuilder: () -> UnexpectedNodes) {
     self = itemsBuilder()
   }
@@ -3342,12 +3761,15 @@ public struct YieldExprListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
   public typealias Expression = YieldExprListElement
+  
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
   public typealias Component = [Expression]
+  
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
   public typealias FinalResult = YieldExprList
+  
   /// Required by every result builder to build combined results from
   /// statement blocks.
   public static func buildBlock(_ components: Self.Component...) -> Self.Component {
@@ -3355,31 +3777,37 @@ public struct YieldExprListBuilder {
       $0 
     }
   }
+  
   /// If declared, provides contextual type information for statement
   /// expressions to translate them into partial results.
   public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
     return [expression]
   }
+  
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
   public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
     return expression.map { 
       $0 
     }
   }
+  
   /// Enables support for `if` statements that do not have an `else`.
   public static func buildOptional(_ component: Self.Component?) -> Self.Component {
     return component ?? []
   }
+  
   /// With buildEither(second:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(first component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// With buildEither(first:), enables support for 'if-else' and 'switch'
   /// statements by folding conditional results into a single result.
   public static func buildEither(second component: Self.Component) -> Self.Component {
     return component
   }
+  
   /// Enables support for 'for..in' loops by combining the
   /// results of all iterations into a single result.
   public static func buildArray(_ components: [Self.Component]) -> Self.Component {
@@ -3387,6 +3815,7 @@ public struct YieldExprListBuilder {
       $0 
     }
   }
+  
   /// If declared, this will be called on the partial result of an 'if'
   /// #available' block to allow the result builder to erase type
   /// information.
@@ -3402,7 +3831,6 @@ public struct YieldExprListBuilder {
 }
 
 public extension YieldExprList {
-  
   init (@YieldExprListBuilder itemsBuilder: () -> YieldExprList) {
     self = itemsBuilder()
   }

--- a/Sources/SwiftSyntaxBuilder/generated/Token.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/Token.swift
@@ -20,450 +20,562 @@ public extension TokenSyntax {
   static var `associatedtype`: Token {
     return .associatedtypeKeyword()
   }
+  
   /// The `class` keyword
   static var `class`: Token {
     return .classKeyword()
   }
+  
   /// The `deinit` keyword
   static var `deinit`: Token {
     return .deinitKeyword()
   }
+  
   /// The `enum` keyword
   static var `enum`: Token {
     return .enumKeyword()
   }
+  
   /// The `extension` keyword
   static var `extension`: Token {
     return .extensionKeyword()
   }
+  
   /// The `func` keyword
   static var `func`: Token {
     return .funcKeyword()
   }
+  
   /// The `import` keyword
   static var `import`: Token {
     return .importKeyword()
   }
+  
   /// The `init` keyword
   static var `init`: Token {
     return .initKeyword()
   }
+  
   /// The `inout` keyword
   static var `inout`: Token {
     return .inoutKeyword()
   }
+  
   /// The `let` keyword
   static var `let`: Token {
     return .letKeyword()
   }
+  
   /// The `operator` keyword
   static var `operator`: Token {
     return .operatorKeyword()
   }
+  
   /// The `precedencegroup` keyword
   static var `precedencegroup`: Token {
     return .precedencegroupKeyword()
   }
+  
   /// The `protocol` keyword
   static var `protocol`: Token {
     return .protocolKeyword()
   }
+  
   /// The `struct` keyword
   static var `struct`: Token {
     return .structKeyword()
   }
+  
   /// The `subscript` keyword
   static var `subscript`: Token {
     return .subscriptKeyword()
   }
+  
   /// The `typealias` keyword
   static var `typealias`: Token {
     return .typealiasKeyword()
   }
+  
   /// The `var` keyword
   static var `var`: Token {
     return .varKeyword()
   }
+  
   /// The `fileprivate` keyword
   static var `fileprivate`: Token {
     return .fileprivateKeyword()
   }
+  
   /// The `internal` keyword
   static var `internal`: Token {
     return .internalKeyword()
   }
+  
   /// The `private` keyword
   static var `private`: Token {
     return .privateKeyword()
   }
+  
   /// The `public` keyword
   static var `public`: Token {
     return .publicKeyword()
   }
+  
   /// The `static` keyword
   static var `static`: Token {
     return .staticKeyword()
   }
+  
   /// The `defer` keyword
   static var `defer`: Token {
     return .deferKeyword()
   }
+  
   /// The `if` keyword
   static var `if`: Token {
     return .ifKeyword()
   }
+  
   /// The `guard` keyword
   static var `guard`: Token {
     return .guardKeyword()
   }
+  
   /// The `do` keyword
   static var `do`: Token {
     return .doKeyword()
   }
+  
   /// The `repeat` keyword
   static var `repeat`: Token {
     return .repeatKeyword()
   }
+  
   /// The `else` keyword
   static var `else`: Token {
     return .elseKeyword()
   }
+  
   /// The `for` keyword
   static var `for`: Token {
     return .forKeyword()
   }
+  
   /// The `in` keyword
   static var `in`: Token {
     return .inKeyword()
   }
+  
   /// The `while` keyword
   static var `while`: Token {
     return .whileKeyword()
   }
+  
   /// The `return` keyword
   static var `return`: Token {
     return .returnKeyword()
   }
+  
   /// The `break` keyword
   static var `break`: Token {
     return .breakKeyword()
   }
+  
   /// The `continue` keyword
   static var `continue`: Token {
     return .continueKeyword()
   }
+  
   /// The `fallthrough` keyword
   static var `fallthrough`: Token {
     return .fallthroughKeyword()
   }
+  
   /// The `switch` keyword
   static var `switch`: Token {
     return .switchKeyword()
   }
+  
   /// The `case` keyword
   static var `case`: Token {
     return .caseKeyword()
   }
+  
   /// The `default` keyword
   static var `default`: Token {
     return .defaultKeyword()
   }
+  
   /// The `where` keyword
   static var `where`: Token {
     return .whereKeyword()
   }
+  
   /// The `catch` keyword
   static var `catch`: Token {
     return .catchKeyword()
   }
+  
   /// The `throw` keyword
   static var `throw`: Token {
     return .throwKeyword()
   }
+  
   /// The `as` keyword
   static var `as`: Token {
     return .asKeyword()
   }
+  
   /// The `Any` keyword
   static var `any`: Token {
     return .anyKeyword()
   }
+  
   /// The `false` keyword
   static var `false`: Token {
     return .falseKeyword()
   }
+  
   /// The `is` keyword
   static var `is`: Token {
     return .isKeyword()
   }
+  
   /// The `nil` keyword
   static var `nil`: Token {
     return .nilKeyword()
   }
+  
   /// The `rethrows` keyword
   static var `rethrows`: Token {
     return .rethrowsKeyword()
   }
+  
   /// The `super` keyword
   static var `super`: Token {
     return .superKeyword()
   }
+  
   /// The `self` keyword
   static var `self`: Token {
     return .selfKeyword()
   }
+  
   /// The `Self` keyword
   static var `capitalSelf`: Token {
     return .capitalSelfKeyword()
   }
+  
   /// The `true` keyword
   static var `true`: Token {
     return .trueKeyword()
   }
+  
   /// The `try` keyword
   static var `try`: Token {
     return .tryKeyword()
   }
+  
   /// The `throws` keyword
   static var `throws`: Token {
     return .throwsKeyword()
   }
+  
   /// The `__FILE__` keyword
   static var `__FILE__`: Token {
     return .__file__Keyword()
   }
+  
   /// The `__LINE__` keyword
   static var `__LINE__`: Token {
     return .__line__Keyword()
   }
+  
   /// The `__COLUMN__` keyword
   static var `__COLUMN__`: Token {
     return .__column__Keyword()
   }
+  
   /// The `__FUNCTION__` keyword
   static var `__FUNCTION__`: Token {
     return .__function__Keyword()
   }
+  
   /// The `__DSO_HANDLE__` keyword
   static var `__DSO_HANDLE__`: Token {
     return .__dso_handle__Keyword()
   }
+  
   /// The `_` keyword
   static var `wildcard`: Token {
     return .wildcardKeyword()
   }
+  
   /// The `(` token
   static var `leftParen`: TokenSyntax {
     return .leftParenToken()
   }
+  
   /// The `)` token
   static var `rightParen`: TokenSyntax {
     return .rightParenToken()
   }
+  
   /// The `{` token
   static var `leftBrace`: TokenSyntax {
     return .leftBraceToken()
   }
+  
   /// The `}` token
   static var `rightBrace`: TokenSyntax {
     return .rightBraceToken()
   }
+  
   /// The `[` token
   static var `leftSquareBracket`: TokenSyntax {
     return .leftSquareBracketToken()
   }
+  
   /// The `]` token
   static var `rightSquareBracket`: TokenSyntax {
     return .rightSquareBracketToken()
   }
+  
   /// The `<` token
   static var `leftAngle`: TokenSyntax {
     return .leftAngleToken()
   }
+  
   /// The `>` token
   static var `rightAngle`: TokenSyntax {
     return .rightAngleToken()
   }
+  
   /// The `.` token
   static var `period`: TokenSyntax {
     return .periodToken()
   }
+  
   /// The `.` token
   static var `prefixPeriod`: TokenSyntax {
     return .prefixPeriodToken()
   }
+  
   /// The `,` token
   static var `comma`: TokenSyntax {
     return .commaToken()
   }
+  
   /// The `...` token
   static var `ellipsis`: TokenSyntax {
     return .ellipsisToken()
   }
+  
   /// The `:` token
   static var `colon`: TokenSyntax {
     return .colonToken()
   }
+  
   /// The `;` token
   static var `semicolon`: TokenSyntax {
     return .semicolonToken()
   }
+  
   /// The `=` token
   static var `equal`: TokenSyntax {
     return .equalToken()
   }
+  
   /// The `@` token
   static var `atSign`: TokenSyntax {
     return .atSignToken()
   }
+  
   /// The `#` token
   static var `pound`: TokenSyntax {
     return .poundToken()
   }
+  
   /// The `&` token
   static var `prefixAmpersand`: TokenSyntax {
     return .prefixAmpersandToken()
   }
+  
   /// The `->` token
   static var `arrow`: TokenSyntax {
     return .arrowToken()
   }
+  
   /// The ``` token
   static var `backtick`: TokenSyntax {
     return .backtickToken()
   }
+  
   /// The `\` token
   static var `backslash`: TokenSyntax {
     return .backslashToken()
   }
+  
   /// The `!` token
   static var `exclamationMark`: TokenSyntax {
     return .exclamationMarkToken()
   }
+  
   /// The `?` token
   static var `postfixQuestionMark`: TokenSyntax {
     return .postfixQuestionMarkToken()
   }
+  
   /// The `?` token
   static var `infixQuestionMark`: TokenSyntax {
     return .infixQuestionMarkToken()
   }
+  
   /// The `"` token
   static var `stringQuote`: TokenSyntax {
     return .stringQuoteToken()
   }
+  
   /// The `'` token
   static var `singleQuote`: TokenSyntax {
     return .singleQuoteToken()
   }
+  
   /// The `"""` token
   static var `multilineStringQuote`: TokenSyntax {
     return .multilineStringQuoteToken()
   }
+  
   /// The `#keyPath` keyword
   static var `poundKeyPath`: Token {
     return .poundKeyPathKeyword()
   }
+  
   /// The `#line` keyword
   static var `poundLine`: Token {
     return .poundLineKeyword()
   }
+  
   /// The `#selector` keyword
   static var `poundSelector`: Token {
     return .poundSelectorKeyword()
   }
+  
   /// The `#file` keyword
   static var `poundFile`: Token {
     return .poundFileKeyword()
   }
+  
   /// The `#fileID` keyword
   static var `poundFileID`: Token {
     return .poundFileIDKeyword()
   }
+  
   /// The `#filePath` keyword
   static var `poundFilePath`: Token {
     return .poundFilePathKeyword()
   }
+  
   /// The `#column` keyword
   static var `poundColumn`: Token {
     return .poundColumnKeyword()
   }
+  
   /// The `#function` keyword
   static var `poundFunction`: Token {
     return .poundFunctionKeyword()
   }
+  
   /// The `#dsohandle` keyword
   static var `poundDsohandle`: Token {
     return .poundDsohandleKeyword()
   }
+  
   /// The `#assert` keyword
   static var `poundAssert`: Token {
     return .poundAssertKeyword()
   }
+  
   /// The `#sourceLocation` keyword
   static var `poundSourceLocation`: Token {
     return .poundSourceLocationKeyword()
   }
+  
   /// The `#warning` keyword
   static var `poundWarning`: Token {
     return .poundWarningKeyword()
   }
+  
   /// The `#error` keyword
   static var `poundError`: Token {
     return .poundErrorKeyword()
   }
+  
   /// The `#if` keyword
   static var `poundIf`: Token {
     return .poundIfKeyword()
   }
+  
   /// The `#else` keyword
   static var `poundElse`: Token {
     return .poundElseKeyword()
   }
+  
   /// The `#elseif` keyword
   static var `poundElseif`: Token {
     return .poundElseifKeyword()
   }
+  
   /// The `#endif` keyword
   static var `poundEndif`: Token {
     return .poundEndifKeyword()
   }
+  
   /// The `#available` keyword
   static var `poundAvailable`: Token {
     return .poundAvailableKeyword()
   }
+  
   /// The `#unavailable` keyword
   static var `poundUnavailable`: Token {
     return .poundUnavailableKeyword()
   }
+  
   /// The `#fileLiteral` keyword
   static var `poundFileLiteral`: Token {
     return .poundFileLiteralKeyword()
   }
+  
   /// The `#imageLiteral` keyword
   static var `poundImageLiteral`: Token {
     return .poundImageLiteralKeyword()
   }
+  
   /// The `#colorLiteral` keyword
   static var `poundColorLiteral`: Token {
     return .poundColorLiteralKeyword()
   }
+  
   /// The `#_hasSymbol` keyword
   static var `poundHasSymbol`: Token {
     return .poundHasSymbolKeyword()
   }
+  
   /// The `)` token
   static var `stringInterpolationAnchor`: TokenSyntax {
     return .stringInterpolationAnchorToken()
   }
+  
   /// The `yield` token
   static var `yield`: TokenSyntax {
     return .yieldToken()
   }
+  
   /// The `eof` token
   static var eof: TokenSyntax {
     return .eof()
   }
+  
   /// The `open` contextual token
   static var open: TokenSyntax {
     return .contextualKeyword("open").withTrailingTrivia(.space)


### PR DESCRIPTION
This updates the version lock of CodeGeneration to the latest SwiftSyntax version.

CodeGeneration still relies quite a bit on raw string interpolation. I’m hoping that we can remove some of these if we stop generating the node definitions using gyb and can thus improve the underlying data structure in the SyntaxSupport module.