### PR TITLE
Rename expression macro expansion to `expansion(of:in:).`

### DIFF
--- a/Sources/_SwiftSyntaxMacros/ExpressionMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/ExpressionMacro.swift
@@ -18,8 +18,8 @@ import SwiftDiagnostics
 public protocol ExpressionMacro: Macro {
   /// Expand a macro described by the given macro expansion expression
   /// within the given context to produce a replacement expression.
-  static func expand(
-    _ node: MacroExpansionExprSyntax,
+  static func expansion(
+    of node: MacroExpansionExprSyntax,
     in context: inout MacroExpansionContext
   ) -> ExprSyntax
 }

--- a/Sources/_SwiftSyntaxMacros/MacroSystem+Builtin.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem+Builtin.swift
@@ -27,8 +27,8 @@ private func replaceFirstLabel(
 }
 
 public struct ColorLiteralMacro: ExpressionMacro {
-  public static func expand(
-    _ macro: MacroExpansionExprSyntax, in context: inout MacroExpansionContext
+  public static func expansion(
+    of macro: MacroExpansionExprSyntax, in context: inout MacroExpansionContext
   ) -> ExprSyntax {
     let argList = replaceFirstLabel(
       of: macro.argumentList, with: "_colorLiteralRed"
@@ -42,8 +42,8 @@ public struct ColorLiteralMacro: ExpressionMacro {
 }
 
 public struct FileLiteralMacro: ExpressionMacro {
-  public static func expand(
-    _ macro: MacroExpansionExprSyntax, in context: inout MacroExpansionContext
+  public static func expansion(
+    of macro: MacroExpansionExprSyntax, in context: inout MacroExpansionContext
   ) -> ExprSyntax {
     let argList = replaceFirstLabel(
       of: macro.argumentList, with: "fileReferenceLiteralResourceName"
@@ -57,8 +57,8 @@ public struct FileLiteralMacro: ExpressionMacro {
 }
 
 public struct ImageLiteralMacro: ExpressionMacro {
-  public static func expand(
-    _ macro: MacroExpansionExprSyntax, in context: inout MacroExpansionContext
+  public static func expansion(
+    of macro: MacroExpansionExprSyntax, in context: inout MacroExpansionContext
   ) -> ExprSyntax {
     let argList = replaceFirstLabel(
       of: macro.argumentList, with: "imageLiteralResourceName"
@@ -72,8 +72,8 @@ public struct ImageLiteralMacro: ExpressionMacro {
 }
 
 public struct FileIDMacro: ExpressionMacro {
-  public static func expand(
-    _ macro: MacroExpansionExprSyntax, in context: inout MacroExpansionContext
+  public static func expansion(
+    of macro: MacroExpansionExprSyntax, in context: inout MacroExpansionContext
   ) -> ExprSyntax {
     // FIXME: Compiler has more sophisticated file ID computation
     let fileID = "\(context.moduleName)/\(context.fileName)"

--- a/Sources/_SwiftSyntaxMacros/MacroSystem+Examples.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem+Examples.swift
@@ -15,8 +15,8 @@ import SwiftSyntaxBuilder
 
 // Macros used for testing purposes
 public struct StringifyMacro: ExpressionMacro {
-  public static func expand(
-    _ macro: MacroExpansionExprSyntax, in context: inout MacroExpansionContext
+  public static func expansion(
+    of macro: MacroExpansionExprSyntax, in context: inout MacroExpansionContext
   ) -> ExprSyntax {
     guard let argument = macro.argumentList.first?.expression else {
       // FIXME: Create a diagnostic for the missing argument?

--- a/Sources/_SwiftSyntaxMacros/Syntax+MacroEvaluation.swift
+++ b/Sources/_SwiftSyntaxMacros/Syntax+MacroEvaluation.swift
@@ -41,7 +41,7 @@ extension MacroExpansionExprSyntax {
     }
 
     // Handle the rewrite.
-    return exprMacro.expand(disconnectedCopy(), in: &context)
+    return exprMacro.expansion(of: disconnectedCopy(), in: &context)
   }
 }
 

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -19,8 +19,8 @@ import _SwiftSyntaxTestSupport
 /// Macro whose only purpose is to ensure that we cannot see "out" of the
 /// macro expansion syntax node we were given.
 struct CheckContextIndependenceMacro: ExpressionMacro {
-  static func expand(
-    _ macro: MacroExpansionExprSyntax,
+  static func expansion(
+    of macro: MacroExpansionExprSyntax,
     in context: inout MacroExpansionContext) -> ExprSyntax {
 
     // Should not have a parent.


### PR DESCRIPTION
Thanks to a suggestion from Richard Wei!