### PR TITLE
Fix parsing generic argument lists of variadic types in expression context

### DIFF
--- a/Tests/SwiftParserTest/TypeTests.swift
+++ b/Tests/SwiftParserTest/TypeTests.swift
@@ -374,6 +374,18 @@ final class TypeParameterPackTests: XCTestCase {
     func f1<T ...>(_ x: T ...) -> (T ...) {}
     """)
   }
+  func testVariadicTypes() {
+    AssertParse(
+    """
+    let _: G< > = G()
+    let _: G<T... > = G()
+    let _: G<Int, T... > = G()
+    let _ = G< >.self
+    let _ = G<T... >.self
+    let _ = G<Int, T... >.self
+    """)
+
+  }
   
   func testMissingCommaInType() throws {
     AssertParse(


### PR DESCRIPTION
We need to allow empty argument lists, and accept '...' in canParseType().