### PR TITLE
Remove leading and trailing space from `&`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/TokenSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/TokenSpec.swift
@@ -277,7 +277,7 @@ public let SYNTAX_TOKENS: [TokenSpec] = [
   PunctuatorSpec(name: "Equal", kind: "equal", text: "=", requiresLeadingSpace: true, requiresTrailingSpace: true),
   PunctuatorSpec(name: "AtSign", kind: "at_sign", text: "@", classification: "Attribute"),
   PunctuatorSpec(name: "Pound", kind: "pound", text: "#"),
-  PunctuatorSpec(name: "PrefixAmpersand", kind: "amp_prefix", text: "&", requiresLeadingSpace: true, requiresTrailingSpace: true),
+  PunctuatorSpec(name: "PrefixAmpersand", kind: "amp_prefix", text: "&"),
   PunctuatorSpec(name: "Arrow", kind: "arrow", text: "->", requiresLeadingSpace: true, requiresTrailingSpace: true),
   PunctuatorSpec(name: "Backtick", kind: "backtick", text: "`"),
   PunctuatorSpec(name: "Backslash", kind: "backslash", text: "\\"),

--- a/Sources/SwiftBasicFormat/generated/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat.swift
@@ -116,8 +116,6 @@ open class BasicFormat: SyntaxRewriter {
       return true
     case .equal: 
       return true
-    case .prefixAmpersand: 
-      return true
     case .arrow: 
       return true
     case .spacedBinaryOperator: 
@@ -237,8 +235,6 @@ open class BasicFormat: SyntaxRewriter {
     case .colon: 
       return true
     case .equal: 
-      return true
-    case .prefixAmpersand: 
       return true
     case .arrow: 
       return true

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -9852,8 +9852,8 @@ public enum SyntaxFactory {
   }
   @available(*, deprecated, message: "Use TokenSyntax.prefixAmpersandToken instead")
   public static func makePrefixAmpersandToken(
-    leadingTrivia: Trivia = .space,
-    trailingTrivia: Trivia = .space
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
   ) -> TokenSyntax {
     return makeToken(.prefixAmpersand, presence: .present,
                      leadingTrivia: leadingTrivia,

--- a/Tests/SwiftSyntaxBuilderTest/ReturnStmsTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ReturnStmsTests.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+final class ReturnStmtTests: XCTestCase {
+
+  func testReturnStmt() {
+    let buildable = ReturnStmt("return Self.parse(from: &parser)")
+    
+    AssertBuildResult(buildable, """
+      return Self.parse(from: &parser)
+      """)
+  }
+  
+}

--- a/gyb_syntax_support/Token.py
+++ b/gyb_syntax_support/Token.py
@@ -276,8 +276,7 @@ SYNTAX_TOKENS = [
     Punctuator('AtSign', 'at_sign', text='@', classification='Attribute'),
     Punctuator('Pound', 'pound', text='#'),
 
-    Punctuator('PrefixAmpersand', 'amp_prefix', text='&',
-               requires_leading_space=True, requires_trailing_space=True),
+    Punctuator('PrefixAmpersand', 'amp_prefix', text='&'),
     Punctuator('Arrow', 'arrow', text='->', requires_leading_space=True,
                requires_trailing_space=True),
 


### PR DESCRIPTION
In #1109 `return Self.parse(from: &parser)` is parsed to `return Self.parse(from: & parser)`.