### PR TITLE
Verify that files generated with SwiftSyntaxBuilder match the checked-in state

### DIFF
--- a/CodeGeneration/Package.swift
+++ b/CodeGeneration/Package.swift
@@ -1,6 +1,7 @@
 // swift-tools-version:5.7
 
 import PackageDescription
+import Foundation
 
 let package = Package(
   name: "CodeGeneration",
@@ -11,10 +12,6 @@ let package = Package(
     .executable(name: "generate-swiftbasicformat", targets: ["generate-swiftbasicformat"]),
     .executable(name: "generate-swiftideutils", targets: ["generate-swiftideutils"]),
     .executable(name: "generate-swiftsyntaxbuilder", targets: ["generate-swiftsyntaxbuilder"]),
-  ],
-  dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", revision: "cdbdcbabb78d14e5e8d4915a115e3d843868ab8d"),
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.4")),
   ],
   targets: [
     .executableTarget(
@@ -78,3 +75,19 @@ let package = Package(
     ),
   ]
 )
+
+if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
+  // Building standalone.
+  package.dependencies += [
+    .package(url: "https://github.com/apple/swift-syntax.git", revision: "cdbdcbabb78d14e5e8d4915a115e3d843868ab8d"),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.4")),
+  ]
+} else {
+  guard let swiftSyntaxPath = ProcessInfo.processInfo.environment["SWIFTCI_SWIFTSYNTAX_PATH"] else {
+    fatalError("If SWIFTCI_USE_LOCAL_DEPS is specified, SWIFTCI_SWIFTSYNTAX_PATH must point to a checkout of SwiftSyntax of the same commit that's mentioned in the standalone build")
+  }
+  package.dependencies += [
+    .package(name: "swift-syntax", path: swiftSyntaxPath),
+    .package(path: "../../swift-argument-parser"),
+  ]
+}


### PR DESCRIPTION
Currently, we only verify that the gyb-generated files match the checked in source state. As more and more files are being generated using CodeGeneration, we should also verify them in CI.

rdar://103023853