### PR TITLE
Implement a few more diagnostics in SwiftParser

### DIFF
--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -150,7 +150,7 @@ extension Parser {
     introucerHandle: RecoveryConsumptionHandle
   ) -> T where T: NominalTypeDeclarationTrait {
     let (unexpectedBeforeIntroducerKeyword, introducerKeyword) = self.eat(introucerHandle)
-    let (unexpectedBeforeName, name) = self.expectIdentifier(keywordRecovery: true)
+    let (unexpectedBeforeName, name) = self.expectIdentifier(allowIdentifierLikeKeywords: false, keywordRecovery: true)
     if unexpectedBeforeName == nil && name.isMissing && self.currentToken.isAtStartOfLine {
       return T.init(
         attributes: attrs.attributes,

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -443,6 +443,7 @@ func AssertParse(
   _ markedSource: String,
   substructure expectedSubstructure: Syntax? = nil,
   substructureAfterMarker: String = "START",
+  substructureCheckTrivia: Bool = false,
   diagnostics expectedDiagnostics: [DiagnosticSpec] = [],
   applyFixIts: [String]? = nil,
   fixedSource expectedFixedSource: String? = nil,
@@ -454,6 +455,7 @@ func AssertParse(
     { SourceFileSyntax.parse(from: &$0) },
     substructure: expectedSubstructure,
     substructureAfterMarker: substructureAfterMarker,
+    substructureCheckTrivia: substructureCheckTrivia,
     diagnostics: expectedDiagnostics,
     applyFixIts: applyFixIts,
     fixedSource: expectedFixedSource,
@@ -470,6 +472,7 @@ func AssertParse<S: SyntaxProtocol>(
   _ parse: (inout Parser) -> S,
   substructure expectedSubstructure: Syntax? = nil,
   substructureAfterMarker: String = "START",
+  substructureCheckTrivia: Bool = false,
   diagnostics expectedDiagnostics: [DiagnosticSpec] = [],
   applyFixIts: [String]? = nil,
   fixedSource expectedFixedSource: String? = nil,
@@ -484,6 +487,7 @@ func AssertParse<S: SyntaxProtocol>(
     },
     substructure: expectedSubstructure,
     substructureAfterMarker: substructureAfterMarker,
+    substructureCheckTrivia: substructureCheckTrivia,
     diagnostics: expectedDiagnostics,
     applyFixIts: applyFixIts,
     fixedSource: expectedFixedSource,
@@ -515,6 +519,7 @@ func AssertParse<S: SyntaxProtocol>(
   _ parse: (String) -> S,
   substructure expectedSubstructure: Syntax? = nil,
   substructureAfterMarker: String = "START",
+  substructureCheckTrivia: Bool = false,
   diagnostics expectedDiagnostics: [DiagnosticSpec] = [],
   applyFixIts: [String]? = nil,
   fixedSource expectedFixedSource: String? = nil,
@@ -545,7 +550,7 @@ func AssertParse<S: SyntaxProtocol>(
   if let expectedSubstructure = expectedSubstructure {
     let subtreeMatcher = SubtreeMatcher(Syntax(tree), markers: markerLocations)
     do {
-      try subtreeMatcher.assertSameStructure(afterMarker: substructureAfterMarker, Syntax(expectedSubstructure), file: file, line: line)
+      try subtreeMatcher.assertSameStructure(afterMarker: substructureAfterMarker, Syntax(expectedSubstructure), includeTrivia: substructureCheckTrivia, file: file, line: line)
     } catch {
       XCTFail("Matching for a subtree failed with error: \(error)", file: file, line: line)
     }

--- a/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
+++ b/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
@@ -49,8 +49,7 @@ final class DollarIdentifierTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "'$' is not a valid identifier")
-        // TODO: Old parser expected error on line 3: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 9 - 10 = '`$`'
+        DiagnosticSpec(message: "'$' is not a valid identifier", fixIts: ["if this name is unavoidable, use backticks to escape it"])
       ]
     )
   }
@@ -118,7 +117,6 @@ final class DollarIdentifierTests: XCTestCase {
       $(1️⃣$: 24)
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 3 - 4 = '`$`'
         DiagnosticSpec(message: "'$' is not a valid identifier")
       ]
     )
@@ -171,7 +169,6 @@ final class DollarIdentifierTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: expected expression
         DiagnosticSpec(message: "unexpected code in function")
       ]
     )

--- a/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
+++ b/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
@@ -12,21 +12,47 @@
 
 // This test file has been translated from swift/test/Parse/hashbang_library.swift
 
+import SwiftSyntax
+
 import XCTest
 
 final class HashbangLibraryTests: XCTestCase {
   func testHashbangLibrary1() {
+    // Check that we diagnose and skip the hashbang at the beginning of the file
+    // when compiling in library mode.
     AssertParse(
       """
-      #!/usr/bin/swift 
+      #!/usr/bin/swift
       class Foo {}
-      // Check that we diagnose and skip the hashbang at the beginning of the file
-      // when compiling in library mode.
       """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: hashbang line is allowed only in the main file
-      ]
+      substructure: Syntax(
+        SourceFileSyntax(
+          statements: CodeBlockItemListSyntax([
+            CodeBlockItemSyntax(
+              item: .decl(
+                DeclSyntax(
+                  ClassDeclSyntax(
+                    classKeyword: .keyword(
+                      .class,
+                      leadingTrivia: [
+                        .shebang("#!/usr/bin/swift"),
+                        .newlines(1),
+                      ],
+                      trailingTrivia: .space
+                    ),
+                    identifier: .identifier("Foo", trailingTrivia: .space),
+                    members: MemberDeclBlockSyntax(
+                      members: MemberDeclListSyntax([])
+                    )
+                  )
+                )
+              )
+            )
+          ]),
+          eofToken: .eof()
+        )
+      ),
+      substructureCheckTrivia: true
     )
   }
-
 }

--- a/Tests/SwiftParserTest/translated/IdentifiersTests.swift
+++ b/Tests/SwiftParserTest/translated/IdentifiersTests.swift
@@ -110,11 +110,29 @@ final class IdentifiersTests: XCTestCase {
   func testIdentifiers8b() {
     AssertParse(
       """
-      struct Self {}
+      struct 1️⃣Self {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: keyword 'Self' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 3: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 12 = '`Self`'
+        DiagnosticSpec(message: "keyword 'Self' cannot be used as an identifier here")
+      ]
+    )
+  }
+
+  func testStructNamedLowercaseAny() {
+    AssertParse(
+      """
+      struct any {}
+      """
+    )
+  }
+
+  func testStructNamedCapitalAny() {
+    AssertParse(
+      """
+      struct 1️⃣Any {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "keyword 'Any' cannot be used as an identifier here")
       ]
     )
   }


### PR DESCRIPTION
A few unrelated commits to migrate more diagnostics from the C++ parser to SwiftParser.