### PR TITLE
Require a version on availability version restriction entries 🚥 #1125

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/AvailabilityNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/AvailabilityNodes.swift
@@ -93,12 +93,11 @@ public let AVAILABILITY_NODES: [Node] = [
                ],
                classification: "Keyword"),
          Child(name: "Version",
-               kind: "VersionTuple",
-               isOptional: true)
+               kind: "VersionTuple")
        ]),
 
   Node(name: "VersionTuple",
-       nameForDiagnostics: "version tuple",
+       nameForDiagnostics: "version number",
        description: "A version number of the form major.minor.patch in which the minorand patch part may be omitted.",
        kind: "Syntax",
        children: [

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/AvailabilityNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/AvailabilityNodes.swift
@@ -19,7 +19,7 @@ public let AVAILABILITY_NODES: [Node] = [
        element: "AvailabilityArgument"),
 
   Node(name: "AvailabilityArgument",
-       nameForDiagnostics: "'@available' argument",
+       nameForDiagnostics: "availability argument",
        description: "A single argument to an `@available` argument like `*`, `iOS 10.1`,or `message: \"This has been deprecated\"`.",
        kind: "Syntax",
        children: [
@@ -50,7 +50,7 @@ public let AVAILABILITY_NODES: [Node] = [
        ]),
 
   Node(name: "AvailabilityLabeledArgument",
-       nameForDiagnostics: "'@available' argument",
+       nameForDiagnostics: "availability argument",
        description: "A argument to an `@available` attribute that consists of a label anda value, e.g. `message: \"This has been deprecated\"`.",
        kind: "Syntax",
        children: [
@@ -81,7 +81,7 @@ public let AVAILABILITY_NODES: [Node] = [
        ]),
 
   Node(name: "AvailabilityVersionRestriction",
-       nameForDiagnostics: "'@available' argument",
+       nameForDiagnostics: "availability argument",
        description: "An argument to `@available` that restricts the availability on acertain platform to a version, e.g. `iOS 10` or `swift 3.4`.",
        kind: "Syntax",
        children: [

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/StmtNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/StmtNodes.swift
@@ -371,8 +371,6 @@ public let STMT_NODES: [Node] = [
                        kind: "Expr"),
                  Child(name: "Availability",
                        kind: "AvailabilityCondition"),
-                 Child(name: "Unavailability",
-                       kind: "UnavailabilityCondition"),
                  Child(name: "MatchingPattern",
                        kind: "MatchingPatternCondition"),
                  Child(name: "OptionalBinding",
@@ -389,13 +387,14 @@ public let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "AvailabilityCondition",
-       nameForDiagnostics: "'#availabile' condition",
+       nameForDiagnostics: "availability condition",
        kind: "Syntax",
        children: [
-         Child(name: "PoundAvailableKeyword",
-               kind: "PoundAvailableToken",
+         Child(name: "AvailabilityKeyword",
+               kind: "Token",
                tokenChoices: [
-                 "PoundAvailable"
+                 "PoundAvailable",
+                 "PoundUnavailable"
                ]),
          Child(name: "LeftParen",
                kind: "LeftParenToken",
@@ -448,30 +447,6 @@ public let STMT_NODES: [Node] = [
          Child(name: "Initializer",
                kind: "InitializerClause",
                isOptional: true)
-       ]),
-
-  Node(name: "UnavailabilityCondition",
-       nameForDiagnostics: "'#unavailable' condition",
-       kind: "Syntax",
-       children: [
-         Child(name: "PoundUnavailableKeyword",
-               kind: "PoundUnavailableToken",
-               tokenChoices: [
-                 "PoundUnavailable"
-               ]),
-         Child(name: "LeftParen",
-               kind: "LeftParenToken",
-               tokenChoices: [
-                 "LeftParen"
-               ]),
-         Child(name: "AvailabilitySpec",
-               kind: "AvailabilitySpecList",
-               collectionElementName: "AvailabilityArgument"),
-         Child(name: "RightParen",
-               kind: "RightParenToken",
-               tokenChoices: [
-                 "RightParen"
-               ])
        ]),
 
   Node(name: "HasSymbolCondition",

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -140,9 +140,9 @@ extension Parser {
     let argument: RawAttributeSyntax.Argument
     do {
       if self.peek().tokenKind == .integerLiteral {
-        argument = .availability(self.parseAvailabilitySpecList(from: .available))
+        argument = .availability(self.parseAvailabilitySpecList())
       } else if self.peek().tokenKind  == .floatingLiteral {
-        argument = .availability(self.parseAvailabilitySpecList(from: .available))
+        argument = .availability(self.parseAvailabilitySpecList())
       } else {
         argument = .availability(self.parseExtendedAvailabilitySpecList())
       }
@@ -171,9 +171,9 @@ extension Parser {
     let argument: RawAttributeSyntax.Argument
     do {
       if self.peek().tokenKind == .integerLiteral {
-        argument = .availability(self.parseAvailabilitySpecList(from: .available))
+        argument = .availability(self.parseAvailabilitySpecList())
       } else if self.peek().tokenKind  == .floatingLiteral {
-        argument = .availability(self.parseAvailabilitySpecList(from: .available))
+        argument = .availability(self.parseAvailabilitySpecList())
       } else {
         argument = .availability(self.parseExtendedAvailabilitySpecList())
       }
@@ -561,7 +561,7 @@ extension Parser {
       case (.availability, let handle)?:
         let ident = self.eat(handle)
         let (unexpectedBeforeColon, colon) = self.expect(.colon)
-        let availability = self.parseAvailabilitySpecList(from: .available)
+        let availability = self.parseAvailabilitySpecList()
         let (unexpectedBeforeSemi, semi) = self.expect(.semicolon)
         elements.append(.availabilityEntry(RawAvailabilityEntrySyntax(
           label: ident,

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -32,9 +32,20 @@ extension Parser {
           entry = self.parseAvailabilitySpec()
         }
 
+        let unexpectedBeforeKeepGoing: RawUnexpectedNodesSyntax?
         keepGoing = self.consume(if: .comma)
+        if keepGoing == nil, let orOperator = self.consume(if: .spacedBinaryOperator, where: { $0.tokenText == "||" }) {
+          unexpectedBeforeKeepGoing = RawUnexpectedNodesSyntax([orOperator], arena: self.arena)
+          keepGoing = missingToken(.comma)
+        } else {
+          unexpectedBeforeKeepGoing = nil
+        }
         elements.append(RawAvailabilityArgumentSyntax(
-          entry: entry, trailingComma: keepGoing, arena: self.arena))
+          entry: entry,
+          unexpectedBeforeKeepGoing,
+          trailingComma: keepGoing,
+          arena: self.arena
+        ))
 
         // Before continuing to parse the next specification, we check that it's
         // also in the shorthand syntax and recover from it.

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -224,19 +224,16 @@ extension Parser {
   ///
   ///     availability-argument → macro-name platform-version
   mutating func parseAvailabilityMacro() -> RawAvailabilityVersionRestrictionSyntax {
-    let platform = self.consumeAnyToken()
+    let (unexpectedBeforePlatform, platform) = self.expect(.identifier)
 
-    let version: RawVersionTupleSyntax?
-    if self.at(.integerLiteral) {
-      version = self.parseVersionTuple()
-    } else if self.at(.floatingLiteral) {
-      version = self.parseVersionTuple()
-    } else {
-      version = nil
-    }
-
+    let version = self.parseVersionTuple()
+    
     return RawAvailabilityVersionRestrictionSyntax(
-      platform: platform, version: version, arena: self.arena)
+      unexpectedBeforePlatform,
+      platform: platform,
+      version: version,
+      arena: self.arena
+    )
   }
 
   /// Parse a dot-separated list of version numbers.

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -13,32 +13,22 @@
 @_spi(RawSyntax) import SwiftSyntax
 
 extension Parser {
-  enum AvailabilitySpecSource {
-    case available
-    case unavailable
-    case macro
-  }
-
   /// Parse a list of availability arguments.
   ///
   /// Grammar
   /// =======
   ///
   ///     availability-arguments → availability-argument | availability-argument , availability-arguments
-  mutating func parseAvailabilitySpecList(
-    from source: AvailabilitySpecSource
-  ) -> RawAvailabilitySpecListSyntax {
+  mutating func parseAvailabilitySpecList() -> RawAvailabilitySpecListSyntax {
     var elements = [RawAvailabilityArgumentSyntax]()
     do {
       var keepGoing: RawTokenSyntax? = nil
       var availablityArgumentProgress = LoopProgressCondition()
       repeat {
         let entry: RawAvailabilityArgumentSyntax.Entry
-        switch source {
-        case .available where self.at(.identifier),
-            .unavailable where self.at(.identifier):
+        if self.at(.identifier) {
           entry = .availabilityVersionRestriction(self.parseAvailabilityMacro())
-        default:
+        } else {
           entry = self.parseAvailabilitySpec()
         }
 

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1080,7 +1080,14 @@ extension Parser {
       return RawExprSyntax(
         self.parseMacroExpansionExpr(pattern: pattern, flavor: flavor)
       )
-      
+    case (.poundAvailableKeyword, _)?, (.poundUnavailableKeyword, _)?:
+      let poundAvailable = self.parsePoundAvailableConditionElement()
+      return RawExprSyntax(RawIdentifierExprSyntax(
+        RawUnexpectedNodesSyntax([poundAvailable], arena: self.arena),
+        identifier: missingToken(.identifier),
+        declNameArguments: nil,
+        arena: self.arena
+      ))
     case (.poundSelectorKeyword, _)?:
       return RawExprSyntax(self.parseObjectiveCSelectorLiteral())
     case (.poundKeyPathKeyword, _)?:

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -702,6 +702,8 @@ enum PrimaryExpressionStart: RawTokenKindSubset {
   case pound
   case poundKeyPathKeyword
   case poundSelectorKeyword
+  case poundAvailableKeyword // For recovery
+  case poundUnavailableKeyword // For recovery
   case prefixPeriod
   case regexLiteral
   case selfKeyword
@@ -731,6 +733,8 @@ enum PrimaryExpressionStart: RawTokenKindSubset {
     case .nilKeyword: self = .nilKeyword
     case .period: self = .period
     case .pound: self = .pound
+    case .poundAvailableKeyword: self = .poundAvailableKeyword
+    case .poundUnavailableKeyword: self = .poundUnavailableKeyword
     case .poundKeyPathKeyword: self = .poundKeyPathKeyword
     case .poundSelectorKeyword: self = .poundSelectorKeyword
     case .prefixPeriod: self = .prefixPeriod
@@ -765,6 +769,8 @@ enum PrimaryExpressionStart: RawTokenKindSubset {
     case .nilKeyword: return .nilKeyword
     case .period: return .period
     case .pound: return .pound
+    case .poundAvailableKeyword: return .poundAvailableKeyword
+    case .poundUnavailableKeyword: return .poundUnavailableKeyword
     case .poundKeyPathKeyword: return .poundKeyPathKeyword
     case .poundSelectorKeyword: return .poundSelectorKeyword
     case .prefixPeriod: return .prefixPeriod

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -343,24 +343,18 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parsePoundAvailableConditionElement() -> RawConditionElementSyntax.Condition {
     assert(self.at(any: [.poundAvailableKeyword, .poundUnavailableKeyword]))
-    let kind: AvailabilitySpecSource = self.at(.poundAvailableKeyword) ? .available : .unavailable
     let keyword = self.consumeAnyToken()
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
-    let spec = self.parseAvailabilitySpecList(from: kind)
+    let spec = self.parseAvailabilitySpecList()
     let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
-    switch kind {
-    case .available, .unavailable:
-      return .availability(RawAvailabilityConditionSyntax(
-        availabilityKeyword: keyword,
-        unexpectedBeforeLParen,
-        leftParen: lparen,
-        availabilitySpec: spec,
-        unexpectedBeforeRParen,
-        rightParen: rparen,
-        arena: self.arena))
-    case .macro:
-      fatalError("Macros are not allowed in this position!")
-    }
+    return .availability(RawAvailabilityConditionSyntax(
+      availabilityKeyword: keyword,
+      unexpectedBeforeLParen,
+      leftParen: lparen,
+      availabilitySpec: spec,
+      unexpectedBeforeRParen,
+      rightParen: rparen,
+      arena: self.arena))
   }
   
   /// Parse a `#_hasSymbol` condition.

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -340,18 +340,9 @@ extension Parser {
     let spec = self.parseAvailabilitySpecList(from: kind)
     let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
     switch kind {
-    case .available:
+    case .available, .unavailable:
       return .availability(RawAvailabilityConditionSyntax(
-        poundAvailableKeyword: keyword,
-        unexpectedBeforeLParen,
-        leftParen: lparen,
-        availabilitySpec: spec,
-        unexpectedBeforeRParen,
-        rightParen: rparen,
-        arena: self.arena))
-    case .unavailable:
-      return .unavailability(RawUnavailabilityConditionSyntax(
-        poundUnavailableKeyword: keyword,
+        availabilityKeyword: keyword,
         unexpectedBeforeLParen,
         leftParen: lparen,
         availabilitySpec: spec,

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -209,9 +209,18 @@ extension Parser {
     var loopProgress = LoopProgressCondition()
     repeat {
       let condition = self.parseConditionElement()
+      let unexpectedBeforeKeepGoing: RawUnexpectedNodesSyntax?
       keepGoing = self.consume(if: .comma)
+      if keepGoing == nil, let andOperator = self.consume(if: .spacedBinaryOperator, where: { $0.tokenText == "&&" }) {
+        unexpectedBeforeKeepGoing = RawUnexpectedNodesSyntax([andOperator], arena: self.arena)
+        keepGoing = missingToken(.comma)
+      } else {
+        unexpectedBeforeKeepGoing = nil
+      }
       elements.append(RawConditionElementSyntax(
-        condition: condition, trailingComma: keepGoing,
+        condition: condition,
+        unexpectedBeforeKeepGoing,
+        trailingComma: keepGoing,
         arena: self.arena))
     } while keepGoing != nil && loopProgress.evaluate(currentToken)
 

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -440,10 +440,43 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     if shouldSkip(node) {
       return .skipChildren
     }
-    if node.identifier.presence == .missing,
-       let unexpected = node.unexpectedBeforeIdentifier,
-       unexpected.first?.as(TokenSyntax.self)?.tokenKind == .pound {
-      addDiagnostic(unexpected, UnknownDirectiveError(unexpected: unexpected), handledNodes: [unexpected.id, node.identifier.id])
+    if node.identifier.presence == .missing, let unexpected = node.unexpectedBeforeIdentifier {
+      if unexpected.first?.as(TokenSyntax.self)?.tokenKind == .pound {
+        addDiagnostic(unexpected, UnknownDirectiveError(unexpected: unexpected), handledNodes: [unexpected.id, node.identifier.id])
+      } else if let availability = unexpected.first?.as(AvailabilityConditionSyntax.self) {
+        if let prefixOperatorExpr = node.parent?.as(PrefixOperatorExprSyntax.self),
+           let operatorToken = prefixOperatorExpr.operatorToken,
+            operatorToken.text == "!",
+           let conditionElement = prefixOperatorExpr.parent?.as(ConditionElementSyntax.self) {
+          // Diagnose !#available(...) and !#unavailable
+          let negatedAvailabilityKeyword: TokenSyntax
+          switch availability.availabilityKeyword.tokenKind {
+          case .poundAvailableKeyword:
+            negatedAvailabilityKeyword = availability.availabilityKeyword.withKind(.poundUnavailableKeyword)
+          case .poundUnavailableKeyword:
+            negatedAvailabilityKeyword = availability.availabilityKeyword.withKind(.poundAvailableKeyword)
+          default:
+            assertionFailure("The availability token of an AvailabilityConditionSyntax should always be #available or #unavailable")
+            negatedAvailabilityKeyword = availability.availabilityKeyword
+          }
+          let negatedCoditionElement = ConditionElementSyntax(
+            condition: .availability(availability.withAvailabilityKeyword(negatedAvailabilityKeyword)),
+            trailingComma: conditionElement.trailingComma
+          )
+          addDiagnostic(
+            unexpected,
+            NegatedAvailabilityCondition(avaialabilityCondition: availability, negatedAvailabilityKeyword: negatedAvailabilityKeyword),
+            fixIts: [
+              FixIt(message: ReplaceTokensFixIt(replaceTokens: [operatorToken, availability.availabilityKeyword], replacement: negatedAvailabilityKeyword), changes: [
+                .replace(oldNode: Syntax(conditionElement), newNode: Syntax(negatedCoditionElement))
+              ])
+            ],
+            handledNodes: [unexpected.id, node.identifier.id]
+          )
+        } else {
+          addDiagnostic(unexpected, AvailabilityConditionInExpression(avaialabilityCondition: availability), handledNodes: [unexpected.id, node.identifier.id])
+        }
+      }
     }
     return .visitChildren
   }

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -296,6 +296,22 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     return .visitChildren
   }
 
+  public override func visit(_ node: AvailabilityArgumentSyntax) -> SyntaxVisitorContinueKind {
+    if shouldSkip(node) {
+      return .skipChildren
+    }
+    if let trailingComma = node.trailingComma {
+      exchangeTokens(
+        unexpected: node.unexpectedBetweenEntryAndTrailingComma,
+        unexpectedTokenCondition: { $0.text == "||" },
+        correctTokens: [node.trailingComma],
+        message: { _ in .joinPlatformsUsingComma },
+        moveFixIt: { ReplaceTokensFixIt(replaceTokens: $0, replacement: trailingComma) }
+      )
+    }
+    return .visitChildren
+  }
+
   public override func visit(_ node: ConditionElementSyntax) -> SyntaxVisitorContinueKind {
     if shouldSkip(node) {
       return .skipChildren

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -296,6 +296,22 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     return .visitChildren
   }
 
+  public override func visit(_ node: ConditionElementSyntax) -> SyntaxVisitorContinueKind {
+    if shouldSkip(node) {
+      return .skipChildren
+    }
+    if let trailingComma = node.trailingComma {
+      exchangeTokens(
+        unexpected: node.unexpectedBetweenConditionAndTrailingComma,
+        unexpectedTokenCondition: { $0.text == "&&" },
+        correctTokens: [node.trailingComma],
+        message: { _ in .joinConditionsUsingComma },
+        moveFixIt: { ReplaceTokensFixIt(replaceTokens: $0, replacement: trailingComma) }
+      )
+    }
+    return .visitChildren
+  }
+
   public override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
     if shouldSkip(node) {
       return .skipChildren

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -168,6 +168,14 @@ extension DiagnosticMessage where Self == StaticParserError {
 
 // MARK: - Diagnostics (please sort alphabetically)
 
+public struct AvailabilityConditionInExpression: ParserError {
+  public let avaialabilityCondition: AvailabilityConditionSyntax
+
+  public var message: String {
+    return "\(nodesDescription([avaialabilityCondition], format: false)) cannot be used in an expression, only as a condition of 'if' or 'guard'"
+  }
+}
+
 public struct EffectsSpecifierAfterArrow: ParserError {
   public let effectsSpecifiersAfterArrow: [TokenSyntax]
 
@@ -219,6 +227,15 @@ public struct MissingAttributeArgument: ParserError {
 
   public var message: String {
     return "expected argument for '@\(attributeName)' attribute"
+  }
+}
+
+public struct NegatedAvailabilityCondition: ParserError {
+  public let avaialabilityCondition: AvailabilityConditionSyntax
+  public let negatedAvailabilityKeyword: TokenSyntax
+
+  public var message: String {
+    return "\(nodesDescription([avaialabilityCondition], format: false)) cannot be used in an expression; did you mean \(nodesDescription([negatedAvailabilityKeyword], format: false))?"
   }
 }
 

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -134,6 +134,9 @@ extension DiagnosticMessage where Self == StaticParserError {
   public static var joinConditionsUsingComma: Self {
     .init("expected ',' joining parts of a multi-clause condition")
   }
+  public static var joinPlatformsUsingComma: Self {
+    .init("expected ',' joining platforms in availability condition")
+  }
   public static var missingColonAndExprInTernaryExpr: Self {
     .init("expected ':' and expression after '? ...' in ternary expression")
   }

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -131,6 +131,9 @@ extension DiagnosticMessage where Self == StaticParserError {
   public static var invalidFlagAfterPrecedenceGroupAssignment: Self {
     .init("expected 'true' or 'false' after 'assignment'")
   }
+  public static var joinConditionsUsingComma: Self {
+    .init("expected ',' joining parts of a multi-clause condition")
+  }
   public static var missingColonAndExprInTernaryExpr: Self {
     .init("expected ':' and expression after '? ...' in ternary expression")
   }

--- a/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
@@ -395,7 +395,6 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/AvailabilityConditionSyntax>
 - <doc:SwiftSyntax/MatchingPatternConditionSyntax>
 - <doc:SwiftSyntax/OptionalBindingConditionSyntax>
-- <doc:SwiftSyntax/UnavailabilityConditionSyntax>
 - <doc:SwiftSyntax/HasSymbolConditionSyntax>
 - <doc:SwiftSyntax/ConditionElementListSyntax>
 - <doc:SwiftSyntax/SwitchCaseSyntax>

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -14786,20 +14786,18 @@ public struct RawConditionElementSyntax: RawSyntaxNodeProtocol {
   public enum Condition: RawSyntaxNodeProtocol {
     case `expression`(RawExprSyntax)
     case `availability`(RawAvailabilityConditionSyntax)
-    case `unavailability`(RawUnavailabilityConditionSyntax)
     case `matchingPattern`(RawMatchingPatternConditionSyntax)
     case `optionalBinding`(RawOptionalBindingConditionSyntax)
     case `hasSymbol`(RawHasSymbolConditionSyntax)
 
     public static func isKindOf(_ raw: RawSyntax) -> Bool {
-      return RawExprSyntax.isKindOf(raw) || RawAvailabilityConditionSyntax.isKindOf(raw) || RawUnavailabilityConditionSyntax.isKindOf(raw) || RawMatchingPatternConditionSyntax.isKindOf(raw) || RawOptionalBindingConditionSyntax.isKindOf(raw) || RawHasSymbolConditionSyntax.isKindOf(raw)
+      return RawExprSyntax.isKindOf(raw) || RawAvailabilityConditionSyntax.isKindOf(raw) || RawMatchingPatternConditionSyntax.isKindOf(raw) || RawOptionalBindingConditionSyntax.isKindOf(raw) || RawHasSymbolConditionSyntax.isKindOf(raw)
     }
 
     public var raw: RawSyntax {
       switch self {
       case .expression(let node): return node.raw
       case .availability(let node): return node.raw
-      case .unavailability(let node): return node.raw
       case .matchingPattern(let node): return node.raw
       case .optionalBinding(let node): return node.raw
       case .hasSymbol(let node): return node.raw
@@ -14813,10 +14811,6 @@ public struct RawConditionElementSyntax: RawSyntaxNodeProtocol {
       }
       if let node = RawAvailabilityConditionSyntax(other) {
         self = .availability(node)
-        return
-      }
-      if let node = RawUnavailabilityConditionSyntax(other) {
-        self = .unavailability(node)
         return
       }
       if let node = RawMatchingPatternConditionSyntax(other) {
@@ -14917,9 +14911,9 @@ public struct RawAvailabilityConditionSyntax: RawSyntaxNodeProtocol {
   }
 
   public init(
-    _ unexpectedBeforePoundAvailableKeyword: RawUnexpectedNodesSyntax? = nil,
-    poundAvailableKeyword: RawTokenSyntax,
-    _ unexpectedBetweenPoundAvailableKeywordAndLeftParen: RawUnexpectedNodesSyntax? = nil,
+    _ unexpectedBeforeAvailabilityKeyword: RawUnexpectedNodesSyntax? = nil,
+    availabilityKeyword: RawTokenSyntax,
+    _ unexpectedBetweenAvailabilityKeywordAndLeftParen: RawUnexpectedNodesSyntax? = nil,
     leftParen: RawTokenSyntax,
     _ unexpectedBetweenLeftParenAndAvailabilitySpec: RawUnexpectedNodesSyntax? = nil,
     availabilitySpec: RawAvailabilitySpecListSyntax,
@@ -14931,9 +14925,9 @@ public struct RawAvailabilityConditionSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .availabilityCondition, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
-      layout[0] = unexpectedBeforePoundAvailableKeyword?.raw
-      layout[1] = poundAvailableKeyword.raw
-      layout[2] = unexpectedBetweenPoundAvailableKeywordAndLeftParen?.raw
+      layout[0] = unexpectedBeforeAvailabilityKeyword?.raw
+      layout[1] = availabilityKeyword.raw
+      layout[2] = unexpectedBetweenAvailabilityKeywordAndLeftParen?.raw
       layout[3] = leftParen.raw
       layout[4] = unexpectedBetweenLeftParenAndAvailabilitySpec?.raw
       layout[5] = availabilitySpec.raw
@@ -14944,13 +14938,13 @@ public struct RawAvailabilityConditionSyntax: RawSyntaxNodeProtocol {
     self.init(raw: raw)
   }
 
-  public var unexpectedBeforePoundAvailableKeyword: RawUnexpectedNodesSyntax? {
+  public var unexpectedBeforeAvailabilityKeyword: RawUnexpectedNodesSyntax? {
     layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
   }
-  public var poundAvailableKeyword: RawTokenSyntax {
+  public var availabilityKeyword: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
   }
-  public var unexpectedBetweenPoundAvailableKeywordAndLeftParen: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenAvailabilityKeywordAndLeftParen: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   public var leftParen: RawTokenSyntax {
@@ -15129,86 +15123,6 @@ public struct RawOptionalBindingConditionSyntax: RawSyntaxNodeProtocol {
     layoutView.children[7].map(RawInitializerClauseSyntax.init(raw:))
   }
   public var unexpectedAfterInitializer: RawUnexpectedNodesSyntax? {
-    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-}
-
-@_spi(RawSyntax)
-public struct RawUnavailabilityConditionSyntax: RawSyntaxNodeProtocol {
-
-  @_spi(RawSyntax)
-  public var layoutView: RawSyntaxLayoutView {
-    return raw.layoutView!
-  }
-
-  public static func isKindOf(_ raw: RawSyntax) -> Bool {
-    return raw.kind == .unavailabilityCondition
-  }
-
-  public var raw: RawSyntax
-  init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
-    self.raw = raw
-  }
-
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
-    guard Self.isKindOf(other.raw) else { return nil }
-    self.init(raw: other.raw)
-  }
-
-  public init(
-    _ unexpectedBeforePoundUnavailableKeyword: RawUnexpectedNodesSyntax? = nil,
-    poundUnavailableKeyword: RawTokenSyntax,
-    _ unexpectedBetweenPoundUnavailableKeywordAndLeftParen: RawUnexpectedNodesSyntax? = nil,
-    leftParen: RawTokenSyntax,
-    _ unexpectedBetweenLeftParenAndAvailabilitySpec: RawUnexpectedNodesSyntax? = nil,
-    availabilitySpec: RawAvailabilitySpecListSyntax,
-    _ unexpectedBetweenAvailabilitySpecAndRightParen: RawUnexpectedNodesSyntax? = nil,
-    rightParen: RawTokenSyntax,
-    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
-    arena: __shared SyntaxArena
-  ) {
-    let raw = RawSyntax.makeLayout(
-      kind: .unavailabilityCondition, uninitializedCount: 9, arena: arena) { layout in
-      layout.initialize(repeating: nil)
-      layout[0] = unexpectedBeforePoundUnavailableKeyword?.raw
-      layout[1] = poundUnavailableKeyword.raw
-      layout[2] = unexpectedBetweenPoundUnavailableKeywordAndLeftParen?.raw
-      layout[3] = leftParen.raw
-      layout[4] = unexpectedBetweenLeftParenAndAvailabilitySpec?.raw
-      layout[5] = availabilitySpec.raw
-      layout[6] = unexpectedBetweenAvailabilitySpecAndRightParen?.raw
-      layout[7] = rightParen.raw
-      layout[8] = unexpectedAfterRightParen?.raw
-    }
-    self.init(raw: raw)
-  }
-
-  public var unexpectedBeforePoundUnavailableKeyword: RawUnexpectedNodesSyntax? {
-    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  public var poundUnavailableKeyword: RawTokenSyntax {
-    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
-  }
-  public var unexpectedBetweenPoundUnavailableKeywordAndLeftParen: RawUnexpectedNodesSyntax? {
-    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  public var leftParen: RawTokenSyntax {
-    layoutView.children[3].map(RawTokenSyntax.init(raw:))!
-  }
-  public var unexpectedBetweenLeftParenAndAvailabilitySpec: RawUnexpectedNodesSyntax? {
-    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  public var availabilitySpec: RawAvailabilitySpecListSyntax {
-    layoutView.children[5].map(RawAvailabilitySpecListSyntax.init(raw:))!
-  }
-  public var unexpectedBetweenAvailabilitySpecAndRightParen: RawUnexpectedNodesSyntax? {
-    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  public var rightParen: RawTokenSyntax {
-    layoutView.children[7].map(RawTokenSyntax.init(raw:))!
-  }
-  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
     layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -19317,7 +19317,7 @@ public struct RawAvailabilityVersionRestrictionSyntax: RawSyntaxNodeProtocol {
     _ unexpectedBeforePlatform: RawUnexpectedNodesSyntax? = nil,
     platform: RawTokenSyntax,
     _ unexpectedBetweenPlatformAndVersion: RawUnexpectedNodesSyntax? = nil,
-    version: RawVersionTupleSyntax?,
+    version: RawVersionTupleSyntax,
     _ unexpectedAfterVersion: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
@@ -19327,7 +19327,7 @@ public struct RawAvailabilityVersionRestrictionSyntax: RawSyntaxNodeProtocol {
       layout[0] = unexpectedBeforePlatform?.raw
       layout[1] = platform.raw
       layout[2] = unexpectedBetweenPlatformAndVersion?.raw
-      layout[3] = version?.raw
+      layout[3] = version.raw
       layout[4] = unexpectedAfterVersion?.raw
     }
     self.init(raw: raw)
@@ -19342,8 +19342,8 @@ public struct RawAvailabilityVersionRestrictionSyntax: RawSyntaxNodeProtocol {
   public var unexpectedBetweenPlatformAndVersion: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
-  public var version: RawVersionTupleSyntax? {
-    layoutView.children[3].map(RawVersionTupleSyntax.init(raw:))
+  public var version: RawVersionTupleSyntax {
+    layoutView.children[3].map(RawVersionTupleSyntax.init(raw:))!
   }
   public var unexpectedAfterVersion: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
@@ -2160,7 +2160,6 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
       verify(layout[1], as: RawSyntax.self),
       verify(layout[1], as: RawSyntax.self),
       verify(layout[1], as: RawSyntax.self),
-      verify(layout[1], as: RawSyntax.self),
     ])
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self))
@@ -2200,18 +2199,6 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 5, verify(layout[5], as: RawTypeAnnotationSyntax?.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 7, verify(layout[7], as: RawInitializerClauseSyntax?.self))
-    assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
-    break
-  case .unavailabilityCondition:
-    assert(layout.count == 9)
-    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self))
-    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self))
-    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawAvailabilitySpecListSyntax.self))
-    assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 7, verify(layout[7], as: RawTokenSyntax.self))
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
     break
   case .hasSymbolCondition:

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
@@ -2789,7 +2789,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 3, verify(layout[3], as: RawVersionTupleSyntax?.self))
+    assertNoError(kind, 3, verify(layout[3], as: RawVersionTupleSyntax.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
     break
   case .versionTuple:

--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -1144,11 +1144,11 @@ extension SyntaxKind {
     case .availabilitySpecList:
       return "'@availability' arguments"
     case .availabilityArgument:
-      return "'@available' argument"
+      return "availability argument"
     case .availabilityLabeledArgument:
-      return "'@available' argument"
+      return "availability argument"
     case .availabilityVersionRestriction:
-      return "'@available' argument"
+      return "availability argument"
     case .versionTuple:
       return "version tuple"
     }

--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -233,7 +233,6 @@ extension Syntax {
       .node(AvailabilityConditionSyntax.self),
       .node(MatchingPatternConditionSyntax.self),
       .node(OptionalBindingConditionSyntax.self),
-      .node(UnavailabilityConditionSyntax.self),
       .node(HasSymbolConditionSyntax.self),
       .node(ConditionElementListSyntax.self),
       .node(DeclarationStmtSyntax.self),
@@ -522,7 +521,6 @@ extension SyntaxKind {
     case .availabilityCondition: return AvailabilityConditionSyntax.self
     case .matchingPatternCondition: return MatchingPatternConditionSyntax.self
     case .optionalBindingCondition: return OptionalBindingConditionSyntax.self
-    case .unavailabilityCondition: return UnavailabilityConditionSyntax.self
     case .hasSymbolCondition: return HasSymbolConditionSyntax.self
     case .conditionElementList: return ConditionElementListSyntax.self
     case .declarationStmt: return DeclarationStmtSyntax.self
@@ -1022,13 +1020,11 @@ extension SyntaxKind {
     case .conditionElement:
       return nil
     case .availabilityCondition:
-      return "'#availabile' condition"
+      return "availability condition"
     case .matchingPatternCondition:
       return "pattern matching"
     case .optionalBindingCondition:
       return "optional binding"
-    case .unavailabilityCondition:
-      return "'#unavailable' condition"
     case .hasSymbolCondition:
       return "'#_hasSymbol' condition"
     case .conditionElementList:

--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -1150,7 +1150,7 @@ extension SyntaxKind {
     case .availabilityVersionRestriction:
       return "availability argument"
     case .versionTuple:
-      return "version tuple"
+      return "version number"
     }
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
@@ -1573,13 +1573,6 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   override open func visitPost(_ node: OptionalBindingConditionSyntax) {
     visitAnyPost(node._syntaxNode)
   }
-  override open func visit(_ node: UnavailabilityConditionSyntax) -> SyntaxVisitorContinueKind {
-    return visitAny(node._syntaxNode)
-  }
-
-  override open func visitPost(_ node: UnavailabilityConditionSyntax) {
-    visitAnyPost(node._syntaxNode)
-  }
   override open func visit(_ node: HasSymbolConditionSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -233,7 +233,6 @@ public enum SyntaxEnum {
   case availabilityCondition(AvailabilityConditionSyntax)
   case matchingPatternCondition(MatchingPatternConditionSyntax)
   case optionalBindingCondition(OptionalBindingConditionSyntax)
-  case unavailabilityCondition(UnavailabilityConditionSyntax)
   case hasSymbolCondition(HasSymbolConditionSyntax)
   case conditionElementList(ConditionElementListSyntax)
   case declarationStmt(DeclarationStmtSyntax)
@@ -739,8 +738,6 @@ public extension Syntax {
       return .matchingPatternCondition(MatchingPatternConditionSyntax(self)!)
     case .optionalBindingCondition:
       return .optionalBindingCondition(OptionalBindingConditionSyntax(self)!)
-    case .unavailabilityCondition:
-      return .unavailabilityCondition(UnavailabilityConditionSyntax(self)!)
     case .hasSymbolCondition:
       return .hasSymbolCondition(HasSymbolConditionSyntax(self)!)
     case .conditionElementList:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -9058,12 +9058,12 @@ public enum SyntaxFactory {
     }
   }
   @available(*, deprecated, message: "Use initializer on AvailabilityVersionRestrictionSyntax")
-  public static func makeAvailabilityVersionRestriction(_ unexpectedBeforePlatform: UnexpectedNodesSyntax? = nil, platform: TokenSyntax, _ unexpectedBetweenPlatformAndVersion: UnexpectedNodesSyntax? = nil, version: VersionTupleSyntax?, _ unexpectedAfterVersion: UnexpectedNodesSyntax? = nil) -> AvailabilityVersionRestrictionSyntax {
+  public static func makeAvailabilityVersionRestriction(_ unexpectedBeforePlatform: UnexpectedNodesSyntax? = nil, platform: TokenSyntax, _ unexpectedBetweenPlatformAndVersion: UnexpectedNodesSyntax? = nil, version: VersionTupleSyntax, _ unexpectedAfterVersion: UnexpectedNodesSyntax? = nil) -> AvailabilityVersionRestrictionSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePlatform?.raw,
       platform.raw,
       unexpectedBetweenPlatformAndVersion?.raw,
-      version?.raw,
+      version.raw,
       unexpectedAfterVersion?.raw,
     ]
     return withExtendedLifetime(SyntaxArena()) { arena in
@@ -9082,7 +9082,7 @@ public enum SyntaxFactory {
         nil,
         RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
         nil,
-        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.versionTuple, arena: arena),
         nil,
       ], arena: arena))
       return AvailabilityVersionRestrictionSyntax(data)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -6941,11 +6941,11 @@ public enum SyntaxFactory {
     }
   }
   @available(*, deprecated, message: "Use initializer on AvailabilityConditionSyntax")
-  public static func makeAvailabilityCondition(_ unexpectedBeforePoundAvailableKeyword: UnexpectedNodesSyntax? = nil, poundAvailableKeyword: TokenSyntax, _ unexpectedBetweenPoundAvailableKeywordAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? = nil, availabilitySpec: AvailabilitySpecListSyntax, _ unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> AvailabilityConditionSyntax {
+  public static func makeAvailabilityCondition(_ unexpectedBeforeAvailabilityKeyword: UnexpectedNodesSyntax? = nil, availabilityKeyword: TokenSyntax, _ unexpectedBetweenAvailabilityKeywordAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? = nil, availabilitySpec: AvailabilitySpecListSyntax, _ unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> AvailabilityConditionSyntax {
     let layout: [RawSyntax?] = [
-      unexpectedBeforePoundAvailableKeyword?.raw,
-      poundAvailableKeyword.raw,
-      unexpectedBetweenPoundAvailableKeywordAndLeftParen?.raw,
+      unexpectedBeforeAvailabilityKeyword?.raw,
+      availabilityKeyword.raw,
+      unexpectedBetweenAvailabilityKeywordAndLeftParen?.raw,
       leftParen.raw,
       unexpectedBetweenLeftParenAndAvailabilitySpec?.raw,
       availabilitySpec.raw,
@@ -7055,45 +7055,6 @@ public enum SyntaxFactory {
         nil,
       ], arena: arena))
       return OptionalBindingConditionSyntax(data)
-    }
-  }
-  @available(*, deprecated, message: "Use initializer on UnavailabilityConditionSyntax")
-  public static func makeUnavailabilityCondition(_ unexpectedBeforePoundUnavailableKeyword: UnexpectedNodesSyntax? = nil, poundUnavailableKeyword: TokenSyntax, _ unexpectedBetweenPoundUnavailableKeywordAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? = nil, availabilitySpec: AvailabilitySpecListSyntax, _ unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> UnavailabilityConditionSyntax {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePoundUnavailableKeyword?.raw,
-      poundUnavailableKeyword.raw,
-      unexpectedBetweenPoundUnavailableKeywordAndLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndAvailabilitySpec?.raw,
-      availabilitySpec.raw,
-      unexpectedBetweenAvailabilitySpecAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    return withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unavailabilityCondition,
-        from: layout, arena: arena)
-      let data = SyntaxData.forRoot(raw)
-      return UnavailabilityConditionSyntax(data)
-    }
-  }
-
-  @available(*, deprecated, message: "Use initializer on UnavailabilityConditionSyntax")
-  public static func makeBlankUnavailabilityCondition(presence: SourcePresence = .present) -> UnavailabilityConditionSyntax {
-    return withExtendedLifetime(SyntaxArena()) { arena in
-      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .unavailabilityCondition,
-        from: [
-        nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.poundUnavailableKeyword, arena: arena),
-        nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena),
-        nil,
-        RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: arena),
-        nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
-        nil,
-      ], arena: arena))
-      return UnavailabilityConditionSyntax(data)
     }
   }
   @available(*, deprecated, message: "Use initializer on HasSymbolConditionSyntax")

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
@@ -233,7 +233,6 @@ public enum SyntaxKind {
   case availabilityCondition
   case matchingPatternCondition
   case optionalBindingCondition
-  case unavailabilityCondition
   case hasSymbolCondition
   case conditionElementList
   case declarationStmt

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -1535,13 +1535,6 @@ open class SyntaxRewriter {
     return Syntax(visitChildren(node)).cast(OptionalBindingConditionSyntax.self)
   }
 
-  /// Visit a `UnavailabilityConditionSyntax`.
-  ///   - Parameter node: the node that is being visited
-  ///   - Returns: the rewritten node
-  open func visit(_ node: UnavailabilityConditionSyntax) -> UnavailabilityConditionSyntax {
-    return Syntax(visitChildren(node)).cast(UnavailabilityConditionSyntax.self)
-  }
-
   /// Visit a `HasSymbolConditionSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -4275,16 +4268,6 @@ open class SyntaxRewriter {
   }
 
   /// Implementation detail of visit(_:). Do not call directly.
-  private func visitImplUnavailabilityConditionSyntax(_ data: SyntaxData) -> Syntax {
-      let node = UnavailabilityConditionSyntax(data)
-      // Accessing _syntaxNode directly is faster than calling Syntax(node)
-      visitPre(node._syntaxNode)
-      defer { visitPost(node._syntaxNode) }
-      if let newNode = visitAny(node._syntaxNode) { return newNode }
-      return Syntax(visit(node))
-  }
-
-  /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplHasSymbolConditionSyntax(_ data: SyntaxData) -> Syntax {
       let node = HasSymbolConditionSyntax(data)
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
@@ -5398,8 +5381,6 @@ open class SyntaxRewriter {
       return visitImplMatchingPatternConditionSyntax
     case .optionalBindingCondition:
       return visitImplOptionalBindingConditionSyntax
-    case .unavailabilityCondition:
-      return visitImplUnavailabilityConditionSyntax
     case .hasSymbolCondition:
       return visitImplHasSymbolConditionSyntax
     case .conditionElementList:
@@ -5973,8 +5954,6 @@ open class SyntaxRewriter {
       return visitImplMatchingPatternConditionSyntax(data)
     case .optionalBindingCondition:
       return visitImplOptionalBindingConditionSyntax(data)
-    case .unavailabilityCondition:
-      return visitImplUnavailabilityConditionSyntax(data)
     case .hasSymbolCondition:
       return visitImplHasSymbolConditionSyntax(data)
     case .conditionElementList:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
@@ -884,10 +884,6 @@ public protocol SyntaxTransformVisitor {
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: OptionalBindingConditionSyntax) -> ResultType
-  /// Visiting `UnavailabilityConditionSyntax` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: the sum of whatever the child visitors return.
-  func visit(_ node: UnavailabilityConditionSyntax) -> ResultType
   /// Visiting `HasSymbolConditionSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -2447,12 +2443,6 @@ extension SyntaxTransformVisitor {
   public func visit(_ node: OptionalBindingConditionSyntax) -> ResultType {
     visitAny(Syntax(node))
   }
-  /// Visiting `UnavailabilityConditionSyntax` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: nil by default.
-  public func visit(_ node: UnavailabilityConditionSyntax) -> ResultType {
-    visitAny(Syntax(node))
-  }
   /// Visiting `HasSymbolConditionSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
@@ -3269,8 +3259,6 @@ extension SyntaxTransformVisitor {
     case .matchingPatternCondition(let derived):
       return visit(derived)
     case .optionalBindingCondition(let derived):
-      return visit(derived)
-    case .unavailabilityCondition(let derived):
       return visit(derived)
     case .hasSymbolCondition(let derived):
       return visit(derived)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -2201,16 +2201,6 @@ open class SyntaxVisitor {
   /// The function called after visiting `OptionalBindingConditionSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: OptionalBindingConditionSyntax) {}
-  /// Visiting `UnavailabilityConditionSyntax` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: how should we continue visiting.
-  open func visit(_ node: UnavailabilityConditionSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-
-  /// The function called after visiting `UnavailabilityConditionSyntax` and its descendents.
-  ///   - node: the node we just finished visiting.
-  open func visitPost(_ node: UnavailabilityConditionSyntax) {}
   /// Visiting `HasSymbolConditionSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -5296,17 +5286,6 @@ open class SyntaxVisitor {
   }
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
-  private func visitImplUnavailabilityConditionSyntax(_ data: SyntaxData) {
-      let node = UnavailabilityConditionSyntax(data)
-      let needsChildren = (visit(node) == .visitChildren)
-      // Avoid calling into visitChildren if possible.
-      if needsChildren && !node.raw.layoutView!.children.isEmpty {
-        visitChildren(node)
-      }
-      visitPost(node)
-  }
-
-  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplHasSymbolConditionSyntax(_ data: SyntaxData) {
       let node = HasSymbolConditionSyntax(data)
       let needsChildren = (visit(node) == .visitChildren)
@@ -6451,8 +6430,6 @@ open class SyntaxVisitor {
       visitImplMatchingPatternConditionSyntax(data)
     case .optionalBindingCondition:
       visitImplOptionalBindingConditionSyntax(data)
-    case .unavailabilityCondition:
-      visitImplUnavailabilityConditionSyntax(data)
     case .hasSymbolCondition:
       visitImplHasSymbolConditionSyntax(data)
     case .conditionElementList:

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -18791,7 +18791,6 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Condition: SyntaxChildChoices {
     case `expression`(ExprSyntax)
     case `availability`(AvailabilityConditionSyntax)
-    case `unavailability`(UnavailabilityConditionSyntax)
     case `matchingPattern`(MatchingPatternConditionSyntax)
     case `optionalBinding`(OptionalBindingConditionSyntax)
     case `hasSymbol`(HasSymbolConditionSyntax)
@@ -18799,7 +18798,6 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
       switch self {
       case .expression(let node): return node._syntaxNode
       case .availability(let node): return node._syntaxNode
-      case .unavailability(let node): return node._syntaxNode
       case .matchingPattern(let node): return node._syntaxNode
       case .optionalBinding(let node): return node._syntaxNode
       case .hasSymbol(let node): return node._syntaxNode
@@ -18811,9 +18809,6 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
     }
     public init(_ node: AvailabilityConditionSyntax) {
       self = .availability(node)
-    }
-    public init(_ node: UnavailabilityConditionSyntax) {
-      self = .unavailability(node)
     }
     public init(_ node: MatchingPatternConditionSyntax) {
       self = .matchingPattern(node)
@@ -18831,10 +18826,6 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
       }
       if let node = node.as(AvailabilityConditionSyntax.self) {
         self = .availability(node)
-        return
-      }
-      if let node = node.as(UnavailabilityConditionSyntax.self) {
-        self = .unavailability(node)
         return
       }
       if let node = node.as(MatchingPatternConditionSyntax.self) {
@@ -18856,7 +18847,6 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
       return .choices([
         .node(ExprSyntax.self),
         .node(AvailabilityConditionSyntax.self),
-        .node(UnavailabilityConditionSyntax.self),
         .node(MatchingPatternConditionSyntax.self),
         .node(OptionalBindingConditionSyntax.self),
         .node(HasSymbolConditionSyntax.self),
@@ -19064,9 +19054,9 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   }
 
   public init(
-    _ unexpectedBeforePoundAvailableKeyword: UnexpectedNodesSyntax? = nil,
-    poundAvailableKeyword: TokenSyntax,
-    _ unexpectedBetweenPoundAvailableKeywordAndLeftParen: UnexpectedNodesSyntax? = nil,
+    _ unexpectedBeforeAvailabilityKeyword: UnexpectedNodesSyntax? = nil,
+    availabilityKeyword: TokenSyntax,
+    _ unexpectedBetweenAvailabilityKeywordAndLeftParen: UnexpectedNodesSyntax? = nil,
     leftParen: TokenSyntax,
     _ unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? = nil,
     availabilitySpec: AvailabilitySpecListSyntax,
@@ -19075,9 +19065,9 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
-      unexpectedBeforePoundAvailableKeyword?.raw,
-      poundAvailableKeyword.raw,
-      unexpectedBetweenPoundAvailableKeywordAndLeftParen?.raw,
+      unexpectedBeforeAvailabilityKeyword?.raw,
+      availabilityKeyword.raw,
+      unexpectedBetweenAvailabilityKeywordAndLeftParen?.raw,
       leftParen.raw,
       unexpectedBetweenLeftParenAndAvailabilitySpec?.raw,
       availabilitySpec.raw,
@@ -19093,62 +19083,62 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
     self.init(data)
   }
 
-  public var unexpectedBeforePoundAvailableKeyword: UnexpectedNodesSyntax? {
+  public var unexpectedBeforeAvailabilityKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforePoundAvailableKeyword(value)
+      self = withUnexpectedBeforeAvailabilityKeyword(value)
     }
   }
 
-  /// Returns a copy of the receiver with its `unexpectedBeforePoundAvailableKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforePoundAvailableKeyword` to replace the node's
-  ///                   current `unexpectedBeforePoundAvailableKeyword`, if present.
-  public func withUnexpectedBeforePoundAvailableKeyword(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
+  /// Returns a copy of the receiver with its `unexpectedBeforeAvailabilityKeyword` replaced.
+  /// - param newChild: The new `unexpectedBeforeAvailabilityKeyword` to replace the node's
+  ///                   current `unexpectedBeforeAvailabilityKeyword`, if present.
+  public func withUnexpectedBeforeAvailabilityKeyword(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
     let arena = SyntaxArena()
     let raw = newChild?.raw
     let newData = data.replacingChild(at: 0, with: raw, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
 
-  public var poundAvailableKeyword: TokenSyntax {
+  public var availabilityKeyword: TokenSyntax {
     get {
       let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPoundAvailableKeyword(value)
+      self = withAvailabilityKeyword(value)
     }
   }
 
-  /// Returns a copy of the receiver with its `poundAvailableKeyword` replaced.
-  /// - param newChild: The new `poundAvailableKeyword` to replace the node's
-  ///                   current `poundAvailableKeyword`, if present.
-  public func withPoundAvailableKeyword(_ newChild: TokenSyntax?) -> AvailabilityConditionSyntax {
+  /// Returns a copy of the receiver with its `availabilityKeyword` replaced.
+  /// - param newChild: The new `availabilityKeyword` to replace the node's
+  ///                   current `availabilityKeyword`, if present.
+  public func withAvailabilityKeyword(_ newChild: TokenSyntax?) -> AvailabilityConditionSyntax {
     let arena = SyntaxArena()
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundAvailableKeyword, arena: arena)
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
 
-  public var unexpectedBetweenPoundAvailableKeywordAndLeftParen: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenAvailabilityKeywordAndLeftParen: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPoundAvailableKeywordAndLeftParen(value)
+      self = withUnexpectedBetweenAvailabilityKeywordAndLeftParen(value)
     }
   }
 
-  /// Returns a copy of the receiver with its `unexpectedBetweenPoundAvailableKeywordAndLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenPoundAvailableKeywordAndLeftParen` to replace the node's
-  ///                   current `unexpectedBetweenPoundAvailableKeywordAndLeftParen`, if present.
-  public func withUnexpectedBetweenPoundAvailableKeywordAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
+  /// Returns a copy of the receiver with its `unexpectedBetweenAvailabilityKeywordAndLeftParen` replaced.
+  /// - param newChild: The new `unexpectedBetweenAvailabilityKeywordAndLeftParen` to replace the node's
+  ///                   current `unexpectedBetweenAvailabilityKeywordAndLeftParen`, if present.
+  public func withUnexpectedBetweenAvailabilityKeywordAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
     let arena = SyntaxArena()
     let raw = newChild?.raw
     let newData = data.replacingChild(at: 2, with: raw, arena: arena)
@@ -19299,9 +19289,9 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
 
   public static var structure: SyntaxNodeStructure {
     return .layout([
-      \Self.unexpectedBeforePoundAvailableKeyword,
-      \Self.poundAvailableKeyword,
-      \Self.unexpectedBetweenPoundAvailableKeywordAndLeftParen,
+      \Self.unexpectedBeforeAvailabilityKeyword,
+      \Self.availabilityKeyword,
+      \Self.unexpectedBetweenAvailabilityKeywordAndLeftParen,
       \Self.leftParen,
       \Self.unexpectedBetweenLeftParenAndAvailabilitySpec,
       \Self.availabilitySpec,
@@ -19340,9 +19330,9 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
 extension AvailabilityConditionSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "unexpectedBeforePoundAvailableKeyword": unexpectedBeforePoundAvailableKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "poundAvailableKeyword": Syntax(poundAvailableKeyword).asProtocol(SyntaxProtocol.self),
-      "unexpectedBetweenPoundAvailableKeywordAndLeftParen": unexpectedBetweenPoundAvailableKeywordAndLeftParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedBeforeAvailabilityKeyword": unexpectedBeforeAvailabilityKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "availabilityKeyword": Syntax(availabilityKeyword).asProtocol(SyntaxProtocol.self),
+      "unexpectedBetweenAvailabilityKeywordAndLeftParen": unexpectedBetweenAvailabilityKeywordAndLeftParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenLeftParenAndAvailabilitySpec": unexpectedBetweenLeftParenAndAvailabilitySpec.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "availabilitySpec": Syntax(availabilitySpec).asProtocol(SyntaxProtocol.self),
@@ -19930,314 +19920,6 @@ extension OptionalBindingConditionSyntax: CustomReflectable {
       "unexpectedBetweenTypeAnnotationAndInitializer": unexpectedBetweenTypeAnnotationAndInitializer.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "initializer": initializer.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedAfterInitializer": unexpectedAfterInitializer.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-    ])
-  }
-}
-
-// MARK: - UnavailabilityConditionSyntax
-
-public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
-  public let _syntaxNode: Syntax
-
-  public init?<S: SyntaxProtocol>(_ node: S) {
-    guard node.raw.kind == .unavailabilityCondition else { return nil }
-    self._syntaxNode = node._syntaxNode
-  }
-
-  /// Creates a `UnavailabilityConditionSyntax` node from the given `SyntaxData`. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
-  internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .unavailabilityCondition)
-    self._syntaxNode = Syntax(data)
-  }
-
-  public init(
-    _ unexpectedBeforePoundUnavailableKeyword: UnexpectedNodesSyntax? = nil,
-    poundUnavailableKeyword: TokenSyntax,
-    _ unexpectedBetweenPoundUnavailableKeywordAndLeftParen: UnexpectedNodesSyntax? = nil,
-    leftParen: TokenSyntax,
-    _ unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? = nil,
-    availabilitySpec: AvailabilitySpecListSyntax,
-    _ unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax,
-    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
-  ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePoundUnavailableKeyword?.raw,
-      poundUnavailableKeyword.raw,
-      unexpectedBetweenPoundUnavailableKeywordAndLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndAvailabilitySpec?.raw,
-      availabilitySpec.raw,
-      unexpectedBetweenAvailabilitySpecAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.unavailabilityCondition,
-        from: layout, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
-  }
-
-  public var unexpectedBeforePoundUnavailableKeyword: UnexpectedNodesSyntax? {
-    get {
-      let childData = data.child(at: 0, parent: Syntax(self))
-      if childData == nil { return nil }
-      return UnexpectedNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withUnexpectedBeforePoundUnavailableKeyword(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforePoundUnavailableKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforePoundUnavailableKeyword` to replace the node's
-  ///                   current `unexpectedBeforePoundUnavailableKeyword`, if present.
-  public func withUnexpectedBeforePoundUnavailableKeyword(_ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return UnavailabilityConditionSyntax(newData)
-  }
-
-  public var poundUnavailableKeyword: TokenSyntax {
-    get {
-      let childData = data.child(at: 1, parent: Syntax(self))
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withPoundUnavailableKeyword(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `poundUnavailableKeyword` replaced.
-  /// - param newChild: The new `poundUnavailableKeyword` to replace the node's
-  ///                   current `poundUnavailableKeyword`, if present.
-  public func withPoundUnavailableKeyword(_ newChild: TokenSyntax?) -> UnavailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundUnavailableKeyword, arena: arena)
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return UnavailabilityConditionSyntax(newData)
-  }
-
-  public var unexpectedBetweenPoundUnavailableKeywordAndLeftParen: UnexpectedNodesSyntax? {
-    get {
-      let childData = data.child(at: 2, parent: Syntax(self))
-      if childData == nil { return nil }
-      return UnexpectedNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withUnexpectedBetweenPoundUnavailableKeywordAndLeftParen(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPoundUnavailableKeywordAndLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenPoundUnavailableKeywordAndLeftParen` to replace the node's
-  ///                   current `unexpectedBetweenPoundUnavailableKeywordAndLeftParen`, if present.
-  public func withUnexpectedBetweenPoundUnavailableKeywordAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return UnavailabilityConditionSyntax(newData)
-  }
-
-  public var leftParen: TokenSyntax {
-    get {
-      let childData = data.child(at: 3, parent: Syntax(self))
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withLeftParen(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> UnavailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return UnavailabilityConditionSyntax(newData)
-  }
-
-  public var unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? {
-    get {
-      let childData = data.child(at: 4, parent: Syntax(self))
-      if childData == nil { return nil }
-      return UnexpectedNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withUnexpectedBetweenLeftParenAndAvailabilitySpec(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndAvailabilitySpec` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndAvailabilitySpec` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndAvailabilitySpec`, if present.
-  public func withUnexpectedBetweenLeftParenAndAvailabilitySpec(_ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return UnavailabilityConditionSyntax(newData)
-  }
-
-  public var availabilitySpec: AvailabilitySpecListSyntax {
-    get {
-      let childData = data.child(at: 5, parent: Syntax(self))
-      return AvailabilitySpecListSyntax(childData!)
-    }
-    set(value) {
-      self = withAvailabilitySpec(value)
-    }
-  }
-
-  /// Adds the provided `AvailabilityArgument` to the node's `availabilitySpec`
-  /// collection.
-  /// - param element: The new `AvailabilityArgument` to add to the node's
-  ///                  `availabilitySpec` collection.
-  /// - returns: A copy of the receiver with the provided `AvailabilityArgument`
-  ///            appended to its `availabilitySpec` collection.
-  public func addAvailabilityArgument(_ element: AvailabilityArgumentSyntax) -> UnavailabilityConditionSyntax {
-    var collection: RawSyntax
-    let arena = SyntaxArena()
-    if let col = raw.layoutView!.children[5] {
-      collection = col.layoutView!.appending(element.raw, arena: arena)
-    } else {
-      collection = RawSyntax.makeLayout(kind: SyntaxKind.availabilitySpecList,
-        from: [element.raw], arena: arena)
-    }
-    let newData = data.replacingChild(at: 5, with: collection, arena: arena)
-    return UnavailabilityConditionSyntax(newData)
-  }
-
-  /// Returns a copy of the receiver with its `availabilitySpec` replaced.
-  /// - param newChild: The new `availabilitySpec` to replace the node's
-  ///                   current `availabilitySpec`, if present.
-  public func withAvailabilitySpec(_ newChild: AvailabilitySpecListSyntax?) -> UnavailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: arena)
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return UnavailabilityConditionSyntax(newData)
-  }
-
-  public var unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? {
-    get {
-      let childData = data.child(at: 6, parent: Syntax(self))
-      if childData == nil { return nil }
-      return UnexpectedNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withUnexpectedBetweenAvailabilitySpecAndRightParen(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAvailabilitySpecAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenAvailabilitySpecAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenAvailabilitySpecAndRightParen`, if present.
-  public func withUnexpectedBetweenAvailabilitySpecAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return UnavailabilityConditionSyntax(newData)
-  }
-
-  public var rightParen: TokenSyntax {
-    get {
-      let childData = data.child(at: 7, parent: Syntax(self))
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withRightParen(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> UnavailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return UnavailabilityConditionSyntax(newData)
-  }
-
-  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
-    get {
-      let childData = data.child(at: 8, parent: Syntax(self))
-      if childData == nil { return nil }
-      return UnexpectedNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withUnexpectedAfterRightParen(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return UnavailabilityConditionSyntax(newData)
-  }
-
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-      \Self.unexpectedBeforePoundUnavailableKeyword,
-      \Self.poundUnavailableKeyword,
-      \Self.unexpectedBetweenPoundUnavailableKeywordAndLeftParen,
-      \Self.leftParen,
-      \Self.unexpectedBetweenLeftParenAndAvailabilitySpec,
-      \Self.availabilitySpec,
-      \Self.unexpectedBetweenAvailabilitySpecAndRightParen,
-      \Self.rightParen,
-      \Self.unexpectedAfterRightParen,
-    ])
-  }
-
-  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
-    switch index.data?.indexInParent {
-    case 0:
-      return nil
-    case 1:
-      return nil
-    case 2:
-      return nil
-    case 3:
-      return nil
-    case 4:
-      return nil
-    case 5:
-      return nil
-    case 6:
-      return nil
-    case 7:
-      return nil
-    case 8:
-      return nil
-    default:
-      fatalError("Invalid index")
-    }
-  }
-}
-
-extension UnavailabilityConditionSyntax: CustomReflectable {
-  public var customMirror: Mirror {
-    return Mirror(self, children: [
-      "unexpectedBeforePoundUnavailableKeyword": unexpectedBeforePoundUnavailableKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "poundUnavailableKeyword": Syntax(poundUnavailableKeyword).asProtocol(SyntaxProtocol.self),
-      "unexpectedBetweenPoundUnavailableKeywordAndLeftParen": unexpectedBetweenPoundUnavailableKeywordAndLeftParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
-      "unexpectedBetweenLeftParenAndAvailabilitySpec": unexpectedBetweenLeftParenAndAvailabilitySpec.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "availabilitySpec": Syntax(availabilitySpec).asProtocol(SyntaxProtocol.self),
-      "unexpectedBetweenAvailabilitySpecAndRightParen": unexpectedBetweenAvailabilitySpecAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
-      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -26413,14 +26413,14 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
     _ unexpectedBeforePlatform: UnexpectedNodesSyntax? = nil,
     platform: TokenSyntax,
     _ unexpectedBetweenPlatformAndVersion: UnexpectedNodesSyntax? = nil,
-    version: VersionTupleSyntax?,
+    version: VersionTupleSyntax,
     _ unexpectedAfterVersion: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePlatform?.raw,
       platform.raw,
       unexpectedBetweenPlatformAndVersion?.raw,
-      version?.raw,
+      version.raw,
       unexpectedAfterVersion?.raw,
     ]
     let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
@@ -26498,10 +26498,9 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
     return AvailabilityVersionRestrictionSyntax(newData)
   }
 
-  public var version: VersionTupleSyntax? {
+  public var version: VersionTupleSyntax {
     get {
       let childData = data.child(at: 3, parent: Syntax(self))
-      if childData == nil { return nil }
       return VersionTupleSyntax(childData!)
     }
     set(value) {
@@ -26514,7 +26513,7 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
   ///                   current `version`, if present.
   public func withVersion(_ newChild: VersionTupleSyntax?) -> AvailabilityVersionRestrictionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.versionTuple, arena: arena)
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return AvailabilityVersionRestrictionSyntax(newData)
   }
@@ -26574,7 +26573,7 @@ extension AvailabilityVersionRestrictionSyntax: CustomReflectable {
       "unexpectedBeforePlatform": unexpectedBeforePlatform.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "platform": Syntax(platform).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenPlatformAndVersion": unexpectedBetweenPlatformAndVersion.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "version": version.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "version": Syntax(version).asProtocol(SyntaxProtocol.self),
       "unexpectedAfterVersion": unexpectedAfterVersion.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }

--- a/Sources/SwiftSyntaxBuilder/ResultBuilderExtensions.swift
+++ b/Sources/SwiftSyntaxBuilder/ResultBuilderExtensions.swift
@@ -36,10 +36,6 @@ extension ConditionElementListBuilder {
     return buildExpression(ConditionElementSyntax(condition: .availability(expression)))
   }
 
-  public static func buildExpression(_ expression: UnavailabilityConditionSyntax) -> Component {
-    return buildExpression(ConditionElementSyntax(condition: .unavailability(expression)))
-  }
-
   public static func buildExpression(_ expression: MatchingPatternConditionSyntax) -> Component {
     return buildExpression(ConditionElementSyntax(condition: .matchingPattern(expression)))
   }

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -426,19 +426,19 @@ extension AvailabilityArgument {
 extension AvailabilityCondition {
   /// Creates a `AvailabilityCondition` using the provided parameters.
   /// - Parameters:
-  ///   - unexpectedBeforePoundAvailableKeyword: 
-  ///   - poundAvailableKeyword: 
-  ///   - unexpectedBetweenPoundAvailableKeywordAndLeftParen: 
+  ///   - unexpectedBeforeAvailabilityKeyword: 
+  ///   - availabilityKeyword: 
+  ///   - unexpectedBetweenAvailabilityKeywordAndLeftParen: 
   ///   - leftParen: 
   ///   - unexpectedBetweenLeftParenAndAvailabilitySpec: 
   ///   - availabilitySpec: 
   ///   - unexpectedBetweenAvailabilitySpecAndRightParen: 
   ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundAvailableKeyword: UnexpectedNodes? = nil, poundAvailableKeyword: Token = Token.`poundAvailable`, unexpectedBetweenPoundAvailableKeywordAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodes? = nil, availabilitySpec: AvailabilitySpecList, unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(poundAvailableKeyword.text == "#available")
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAvailabilityKeyword: UnexpectedNodes? = nil, availabilityKeyword: Token, unexpectedBetweenAvailabilityKeywordAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodes? = nil, availabilitySpec: AvailabilitySpecList, unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+    assert(availabilityKeyword.text == "#available" || availabilityKeyword.text == "#unavailable")
     assert(leftParen.text == "(")
     assert(rightParen.text == ")")
-    self = AvailabilityConditionSyntax(unexpectedBeforePoundAvailableKeyword, poundAvailableKeyword: poundAvailableKeyword, unexpectedBetweenPoundAvailableKeywordAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndAvailabilitySpec, availabilitySpec: availabilitySpec, unexpectedBetweenAvailabilitySpecAndRightParen, rightParen: rightParen)
+    self = AvailabilityConditionSyntax(unexpectedBeforeAvailabilityKeyword, availabilityKeyword: availabilityKeyword, unexpectedBetweenAvailabilityKeywordAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndAvailabilitySpec, availabilitySpec: availabilitySpec, unexpectedBetweenAvailabilitySpecAndRightParen, rightParen: rightParen)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
@@ -4973,27 +4973,6 @@ extension TypealiasDecl {
   @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndTypealiasKeyword: UnexpectedNodes? = nil, typealiasKeyword: Token = Token.`typealias`, unexpectedBetweenTypealiasKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInitializer: UnexpectedNodes? = nil, initializer: TypeInitializerClause, unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil) {
     self.init (unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndTypealiasKeyword, typealiasKeyword: typealiasKeyword, unexpectedBetweenTypealiasKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInitializer, initializer: initializer, unexpectedBetweenInitializerAndGenericWhereClause, genericWhereClause: genericWhereClause)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-  }
-}
-
-extension UnavailabilityCondition {
-  /// Creates a `UnavailabilityCondition` using the provided parameters.
-  /// - Parameters:
-  ///   - unexpectedBeforePoundUnavailableKeyword: 
-  ///   - poundUnavailableKeyword: 
-  ///   - unexpectedBetweenPoundUnavailableKeywordAndLeftParen: 
-  ///   - leftParen: 
-  ///   - unexpectedBetweenLeftParenAndAvailabilitySpec: 
-  ///   - availabilitySpec: 
-  ///   - unexpectedBetweenAvailabilitySpecAndRightParen: 
-  ///   - rightParen: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundUnavailableKeyword: UnexpectedNodes? = nil, poundUnavailableKeyword: Token = Token.`poundUnavailable`, unexpectedBetweenPoundUnavailableKeywordAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodes? = nil, availabilitySpec: AvailabilitySpecList, unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    assert(poundUnavailableKeyword.text == "#unavailable")
-    assert(leftParen.text == "(")
-    assert(rightParen.text == ")")
-    self = UnavailabilityConditionSyntax(unexpectedBeforePoundUnavailableKeyword, poundUnavailableKeyword: poundUnavailableKeyword, unexpectedBetweenPoundUnavailableKeywordAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndAvailabilitySpec, availabilitySpec: availabilitySpec, unexpectedBetweenAvailabilitySpecAndRightParen, rightParen: rightParen)
-    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
-    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
   }
 }
 

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -507,7 +507,7 @@ extension AvailabilityVersionRestriction {
   ///   - platform: The name of the OS on which the availability should berestricted or 'swift' if the availability should berestricted based on a Swift version.
   ///   - unexpectedBetweenPlatformAndVersion: 
   ///   - version: 
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePlatform: UnexpectedNodes? = nil, platform: Token, unexpectedBetweenPlatformAndVersion: UnexpectedNodes? = nil, version: VersionTuple? = nil) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePlatform: UnexpectedNodes? = nil, platform: Token, unexpectedBetweenPlatformAndVersion: UnexpectedNodes? = nil, version: VersionTuple) {
     self = AvailabilityVersionRestrictionSyntax(unexpectedBeforePlatform, platform: platform, unexpectedBetweenPlatformAndVersion, version: version)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
     self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
@@ -516,7 +516,7 @@ extension AvailabilityVersionRestriction {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforePlatform: UnexpectedNodes? = nil, platform: String, unexpectedBetweenPlatformAndVersion: UnexpectedNodes? = nil, version: VersionTuple? = nil) {
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], unexpectedBeforePlatform: UnexpectedNodes? = nil, platform: String, unexpectedBetweenPlatformAndVersion: UnexpectedNodes? = nil, version: VersionTuple) {
     self.init (unexpectedBeforePlatform, platform: Token.`identifier`(platform), unexpectedBetweenPlatformAndVersion, version: version)
     self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
   }

--- a/Sources/SwiftSyntaxBuilder/generated/Typealiases.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/Typealiases.swift
@@ -533,8 +533,6 @@ public typealias Type = TypeSyntax
 
 public typealias TypealiasDecl = TypealiasDeclSyntax
 
-public typealias UnavailabilityCondition = UnavailabilityConditionSyntax
-
 public typealias UnexpectedNodes = UnexpectedNodesSyntax
 
 public typealias UnresolvedAsExpr = UnresolvedAsExprSyntax

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
@@ -92,9 +92,11 @@ final class AvailabilityQueryTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected ',' joining parts of a multi-clause condition, Fix-It replacements: 28 - 31 = ','
-        DiagnosticSpec(message: "unexpected code '&& #available(OSX 10.52, *)' in 'if' statement"),
-      ]
+        DiagnosticSpec(message: "expected ',' joining parts of a multi-clause condition", fixIts: ["replace '&&' by ','"]),
+      ], fixedSource: """
+      if #available(OSX 10.51, *) , #available(OSX 10.52, *) {
+      }
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
@@ -31,9 +31,7 @@ final class AvailabilityQueryTests: XCTestCase {
       if (1️⃣#available(OSX 10.51, *)) {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: #available may only be used as condition of an 'if', 'guard'
-        DiagnosticSpec(message: "expected value in tuple"),
-        DiagnosticSpec(message: "unexpected code '#available(OSX 10.51, *)' in tuple"),
+        DiagnosticSpec(message: "availability condition cannot be used in an expression, only as a condition of 'if' or 'guard'"),
       ]
     )
   }
@@ -44,9 +42,7 @@ final class AvailabilityQueryTests: XCTestCase {
       let x = 1️⃣#available(OSX 10.51, *)
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: #available may only be used as condition of
-        DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: "extraneous code '#available(OSX 10.51, *)' at top level"),
+        DiagnosticSpec(message: "availability condition cannot be used in an expression, only as a condition of 'if' or 'guard'"),
       ]
     )
   }
@@ -57,28 +53,34 @@ final class AvailabilityQueryTests: XCTestCase {
       (1️⃣#available(OSX 10.51, *) ? 1 : 0)
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: #available may only be used as condition of an
-        DiagnosticSpec(message: "expected value in tuple"),
-        DiagnosticSpec(message: "unexpected code '#available(OSX 10.51, *) ? 1 : 0' in tuple"),
+        DiagnosticSpec(message: "availability condition cannot be used in an expression, only as a condition of 'if' or 'guard'"),
       ]
     )
   }
 
-  func testAvailabilityQuery5() {
+  func testAvailabilityQuery5a() {
     AssertParse(
       """
       if !1️⃣#available(OSX 10.52, *) { 
       }
-      if let _ = Optional(5), !2️⃣#available(OSX 10.52, *) { 
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "availability condition cannot be used in an expression; did you mean '#unavailable'?", fixIts: ["replace '!#available' by '#unavailable'"]),
+      ], fixedSource: """
+      if #unavailable(OSX 10.52, *) {
+      }
+      """
+    )
+  }
+
+  func testAvailabilityQuery5b() {
+    AssertParse(
+      """
+      if let _ = Optional(5), !1️⃣#available(OSX 10.52, *) {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: #available cannot be used as an expression, did you mean to use '#unavailable'?, Fix-It replacements: 4 - 15 = '#unavailable'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected expression in prefix operator expression"),
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '#available(OSX 10.52, *)' in 'if' statement"),
-        // TODO: Old parser expected error on line 3: #available cannot be used as an expression, did you mean to use '#unavailable'?, Fix-It replacements: 25 - 36 = '#unavailable'
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in prefix operator expression"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '#available(OSX 10.52, *)' in 'if' statement"),
+        DiagnosticSpec(message: "availability condition cannot be used in an expression; did you mean '#unavailable'?", fixIts: ["replace '!#available' by '#unavailable'"]),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
@@ -104,13 +104,10 @@ final class AvailabilityQueryTests: XCTestCase {
     AssertParse(
       """
       if #available 1️⃣{ 
-      }2️⃣
+      }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected availability condition
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected '(' in availability condition"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end availability condition"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected code block in 'if' statement"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected '(', '@availability' arguments, and ')' in availability condition")
       ]
     )
   }
@@ -118,15 +115,12 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery8() {
     AssertParse(
       """
-      if #availableℹ️( {
-      }1️⃣
+      if #available( 1️⃣{
+      }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
-          NoteSpec(message: "to match this opening '('")
-        ]),
-        DiagnosticSpec(message: "expected code block in 'if' statement"),
+        DiagnosticSpec(message: "expected platform and version in availability argument"),
+        DiagnosticSpec(message: "expected ')' to end availability condition")
       ]
     )
   }
@@ -134,13 +128,11 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery9() {
     AssertParse(
       """
-      if #available() { 1️⃣
+      if #available(1️⃣) {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end availability condition"),
-        DiagnosticSpec(message: "expected '{' in 'if' statement"),
+        DiagnosticSpec(message: "expected platform and version in availability argument"),
       ]
     )
   }
@@ -321,15 +313,12 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery27() {
     AssertParse(
       """
-      if #availableℹ️(OSX 10.51, {
-      }1️⃣
+      if #available(OSX 10.51, 1️⃣{
+      }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
-          NoteSpec(message: "to match this opening '('")
-        ]),
-        DiagnosticSpec(message: "expected code block in 'if' statement"),
+        DiagnosticSpec(message: "expected platform and version in availability argument"),
+        DiagnosticSpec(message: "expected ')' to end availability condition"),
       ]
     )
   }
@@ -337,13 +326,11 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery28() {
     AssertParse(
       """
-      if #available(OSX 10.51,) { 1️⃣
+      if #available(OSX 10.51,1️⃣) {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end availability condition"),
-        DiagnosticSpec(message: "expected '{' in 'if' statement"),
+        DiagnosticSpec(message: "expected platform and version in availability argument"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
@@ -144,7 +144,7 @@ final class AvailabilityQueryTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected version number
+        DiagnosticSpec(message: "expected version number in availability argument"),
         DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
@@ -155,11 +155,11 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery11() {
     AssertParse(
       """
-      if #available(OSX) { 
+      if #available(OSX1️⃣) {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected version number
+        DiagnosticSpec(message: "expected version number in availability argument"),
       ]
     )
   }
@@ -270,9 +270,12 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery23() {
     AssertParse(
       """
-      if #available(iOSApplicationExtension, unavailable) { // expected-error 2{{expected version number}}
+      if #available(iOSApplicationExtension1️⃣, unavailable) {
       }
-      """
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected version number in availability argument")
+      ]
     )
   }
 
@@ -342,7 +345,7 @@ final class AvailabilityQueryTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected version number
+        DiagnosticSpec(message: "expected version number in availability argument"),
         DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
@@ -399,6 +402,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: version comparison not needed, Fix-It replacements: 19 - 22 = ''
+        DiagnosticSpec(message: "expected version number in availability argument"),
         DiagnosticSpec(message: "unexpected code '>= 10.51, *' in availability condition"),
       ]
     )

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
@@ -375,9 +375,11 @@ final class AvailabilityQueryTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: '||' cannot be used in an availability condition
-        DiagnosticSpec(message: "unexpected code '|| iOS 8.0' in availability condition"),
-      ]
+        DiagnosticSpec(message: "expected ',' joining platforms in availability condition", fixIts: ["replace '||' by ','"]),
+      ], fixedSource: """
+      if #available(OSX 10.51 , iOS 8.0) {
+      }
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
@@ -104,8 +104,8 @@ final class AvailabilityQueryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected availability condition
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected '(' in '#availabile' condition"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end '#availabile' condition"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected '(' in availability condition"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end availability condition"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected code block in 'if' statement"),
       ]
     )
@@ -119,7 +119,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end '#availabile' condition", notes: [
+        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
         DiagnosticSpec(message: "expected code block in 'if' statement"),
@@ -135,7 +135,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+        DiagnosticSpec(message: "expected ')' to end availability condition"),
         DiagnosticSpec(message: "expected '{' in 'if' statement"),
       ]
     )
@@ -149,7 +149,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected version number
-        DiagnosticSpec(message: "expected ')' to end '#availabile' condition", notes: [
+        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
       ]
@@ -176,7 +176,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected ')'
-        DiagnosticSpec(message: "expected ')' to end '#availabile' condition", notes: [
+        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
       ]
@@ -297,7 +297,7 @@ final class AvailabilityQueryTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected ')' to end '#availabile' condition", notes: [
+        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
       ]
@@ -322,7 +322,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end '#availabile' condition", notes: [
+        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
         DiagnosticSpec(message: "expected code block in 'if' statement"),
@@ -338,7 +338,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+        DiagnosticSpec(message: "expected ')' to end availability condition"),
         DiagnosticSpec(message: "expected '{' in 'if' statement"),
       ]
     )
@@ -352,7 +352,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected version number
-        DiagnosticSpec(message: "expected ')' to end '#availabile' condition", notes: [
+        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
       ]
@@ -385,7 +385,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: '||' cannot be used in an availability condition
-        DiagnosticSpec(message: "unexpected code '|| iOS 8.0' in '#availabile' condition"),
+        DiagnosticSpec(message: "unexpected code '|| iOS 8.0' in availability condition"),
       ]
     )
   }
@@ -406,7 +406,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: version comparison not needed, Fix-It replacements: 19 - 22 = ''
-        DiagnosticSpec(message: "unexpected code '>= 10.51, *' in '#availabile' condition"),
+        DiagnosticSpec(message: "unexpected code '>= 10.51, *' in availability condition"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -78,8 +78,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected ',' joining parts of a multi-clause condition, Fix-It replacements: 27 - 30 = ','
-        DiagnosticSpec(message: "unexpected code '&& #unavailable(OSX 10.52)' in 'if' statement"),
+        DiagnosticSpec(message: "expected ',' joining parts of a multi-clause condition", fixIts: ["replace '&&' by ','"]),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -86,14 +86,11 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability4() {
     AssertParse(
       """
-      if #unavailable 1️⃣{ 
-      }2️⃣
+      if #unavailable 1️⃣{
+      }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected availability condition
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected '(' in availability condition"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end availability condition"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected code block in 'if' statement"),
+        DiagnosticSpec(message: "expected '(', '@availability' arguments, and ')' in availability condition"),
       ]
     )
   }
@@ -101,15 +98,12 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability5() {
     AssertParse(
       """
-      if #unavailableℹ️( { 
-      }1️⃣
+      if #unavailable( 1️⃣{
+      }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
-          NoteSpec(message: "to match this opening '('")
-        ]),
-        DiagnosticSpec(message: "expected code block in 'if' statement"),
+        DiagnosticSpec(message: "expected platform and version in availability argument"),
+        DiagnosticSpec(message: "expected ')' to end availability condition"),
       ]
     )
   }
@@ -117,13 +111,11 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability6() {
     AssertParse(
       """
-      if #unavailable() { 1️⃣
+      if #unavailable(1️⃣) {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end availability condition"),
-        DiagnosticSpec(message: "expected '{' in 'if' statement"),
+        DiagnosticSpec(message: "expected platform and version in availability argument"),
       ]
     )
   }
@@ -255,13 +247,11 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
     AssertParse(
       """
       // Should this be a valid spelling since `#unvailable(*)` cannot be written?
-      if #unavailable() { 1️⃣
+      if #unavailable(1️⃣) {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: expected platform name
-        DiagnosticSpec(message: "expected ')' to end availability condition"),
-        DiagnosticSpec(message: "expected '{' in 'if' statement"),
+        DiagnosticSpec(message: "expected platform and version in availability argument"),
       ]
     )
   }
@@ -293,15 +283,12 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability22() {
     AssertParse(
       """
-      if #unavailableℹ️(OSX 10.51, {
-      }1️⃣
+      if #unavailable(OSX 10.51, 1️⃣{
+      }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
-          NoteSpec(message: "to match this opening '('")
-        ]),
-        DiagnosticSpec(message: "expected code block in 'if' statement"),
+        DiagnosticSpec(message: "expected platform and version in availability argument"),
+        DiagnosticSpec(message: "expected ')' to end availability condition"),
       ]
     )
   }
@@ -309,13 +296,11 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability23() {
     AssertParse(
       """
-      if #unavailable(OSX 10.51,) { 1️⃣
+      if #unavailable(OSX 10.51,1️⃣) {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end availability condition"),
-        DiagnosticSpec(message: "expected '{' in 'if' statement"),
+        DiagnosticSpec(message: "expected platform and version in availability argument"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -25,34 +25,48 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
     )
   }
 
-  func testAvailabilityQueryUnavailability2() {
+  func testAvailabilityQueryUnavailability2a() {
     AssertParse(
       """
       // Disallow explicit wildcards.
       if #unavailable(OSX 10.51, *) {} 
       // Disallow use as an expression.
-      if (1️⃣#unavailable(OSX 10.51)) {}  
-      let x = 3️⃣#unavailable(OSX 10.51)
-      (#unavailable(OSX 10.51) ? 1 : 0) 
-      if !#unavailable(OSX 10.52) { 
-      }
-      if let _ = Optional(5), 5️⃣!6️⃣#unavailable(OSX 10.52) {
+      if (1️⃣#unavailable(OSX 10.51)) {}
+      let x = 2️⃣#unavailable(OSX 10.51)
+      (3️⃣#unavailable(OSX 10.51) ? 1 : 0)
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "availability condition cannot be used in an expression, only as a condition of 'if' or 'guard'"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "availability condition cannot be used in an expression, only as a condition of 'if' or 'guard'"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "availability condition cannot be used in an expression, only as a condition of 'if' or 'guard'"),
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability2b() {
+    AssertParse(
+      """
+      if !1️⃣#unavailable(OSX 10.52) {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: platform wildcard '*' is always implicit in #unavailable, Fix-It replacements: 28 - 29 = ''
-        // TODO: Old parser expected error on line 4: #unavailable may only be used as condition of an 'if', 'guard'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected value in tuple"),
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '#unavailable(OSX 10.51)' in tuple"),
-        // TODO: Old parser expected error on line 5: #unavailable may only be used as condition of
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected expression in variable"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code before variable"),
-        // TODO: Old parser expected error on line 6: #unavailable may only be used as condition of an
-        // TODO: Old parser expected error on line 7: #unavailable may only be used as condition of an
-        // TODO: Old parser expected error on line 9: #unavailable may only be used as condition
-        DiagnosticSpec(locationMarker: "5️⃣", message: "expected pattern in variable"),
-        DiagnosticSpec(locationMarker: "6️⃣", message: "expected expression in prefix operator expression"),
-        DiagnosticSpec(locationMarker: "6️⃣", message: "extraneous code at top level"),
+        DiagnosticSpec(message: "availability condition cannot be used in an expression; did you mean '#available'?", fixIts: ["replace '!#unavailable' by '#available'"]),
+      ], fixedSource: """
+      if #available(OSX 10.52) {
+      }
+      """
+    )
+  }
+
+
+  func testAvailabilityQueryUnavailability2c() {
+    AssertParse(
+      """
+      if let _ = Optional(5), !1️⃣#unavailable(OSX 10.52) {
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "availability condition cannot be used in an expression; did you mean '#available'?", fixIts: ["replace '!#unavailable' by '#available'"]),
       ]
     )
   }
@@ -441,23 +455,30 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
     )
   }
 
-  func testAvailabilityQueryUnavailability34() {
+  func testAvailabilityQueryUnavailability34a() {
     AssertParse(
       """
       // Diagnose wrong spellings of unavailability
-      if #available(*) 1️⃣== false { 
-      }
-      if !2️⃣#available(*) { 
+      if #available(*) 1️⃣== false {
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: #available cannot be used as an expression, did you mean to use '#unavailable'?, Fix-It replacements: 4 - 14 = '#unavailable', 18 - 27 = ''
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '== false' in 'if' statement"),
-        // TODO: Old parser expected error on line 4: #available cannot be used as an expression, did you mean to use '#unavailable'?, Fix-It replacements: 4 - 15 = '#unavailable'
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in prefix operator expression"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code '#available(*)' in 'if' statement"),
+        DiagnosticSpec(message: "unexpected code '== false' in 'if' statement"),
       ]
     )
   }
 
+  func testAvailabilityQueryUnavailability34b() {
+    AssertParse(
+      """
+      if !1️⃣#available(*) {
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: #available cannot be used as an expression, did you mean to use '#unavailable'?, Fix-It replacements: 4 - 15 = '#unavailable'
+        DiagnosticSpec(message: "availability condition cannot be used in an expression; did you mean '#unavailable'?", fixIts: ["replace '!#available' by '#unavailable'"])
+      ]
+    )
+  }
 }

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -127,7 +127,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected version number
+        DiagnosticSpec(message: "expected version number in availability argument"),
         DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
@@ -138,11 +138,11 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability8() {
     AssertParse(
       """
-      if #unavailable(OSX) { 
+      if #unavailable(OSX1️⃣) {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected version number
+        DiagnosticSpec(message: "expected version number in availability argument")
       ]
     )
   }
@@ -237,9 +237,11 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability18() {
     AssertParse(
       """
-      if #unavailable(iOSApplicationExtension, unavailable) { // expected-error 2{{expected version number}}
+      if #unavailable(iOSApplicationExtension1️⃣, unavailable) {
       }
-      """
+      """, diagnostics: [
+        DiagnosticSpec(message: "expected version number in availability argument")
+      ]
     )
   }
 
@@ -312,7 +314,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected version number
+        DiagnosticSpec(message: "expected version number in availability argument"),
         DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
@@ -361,7 +363,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: version comparison not needed, Fix-It replacements: 21 - 24 = ''
+        DiagnosticSpec(message: "expected version number in availability argument"),
         DiagnosticSpec(message: "unexpected code '>= 10.51' in availability condition"),
       ]
     )

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -78,8 +78,8 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected availability condition
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected '(' in '#unavailable' condition"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected '(' in availability condition"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end availability condition"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected code block in 'if' statement"),
       ]
     )
@@ -93,7 +93,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition", notes: [
+        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
         DiagnosticSpec(message: "expected code block in 'if' statement"),
@@ -109,7 +109,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(message: "expected ')' to end availability condition"),
         DiagnosticSpec(message: "expected '{' in 'if' statement"),
       ]
     )
@@ -123,7 +123,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected version number
-        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition", notes: [
+        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
       ]
@@ -149,7 +149,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition", notes: [
+        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
       ]
@@ -247,7 +247,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: expected platform name
-        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(message: "expected ')' to end availability condition"),
         DiagnosticSpec(message: "expected '{' in 'if' statement"),
       ]
     )
@@ -260,7 +260,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition", notes: [
+        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
       ]
@@ -285,7 +285,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition", notes: [
+        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
         DiagnosticSpec(message: "expected code block in 'if' statement"),
@@ -301,7 +301,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(message: "expected ')' to end availability condition"),
         DiagnosticSpec(message: "expected '{' in 'if' statement"),
       ]
     )
@@ -315,7 +315,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected version number
-        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition", notes: [
+        DiagnosticSpec(message: "expected ')' to end availability condition", notes: [
           NoteSpec(message: "to match this opening '('")
         ]),
       ]
@@ -351,7 +351,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: '||' cannot be used in an availability condition
-        DiagnosticSpec(message: "unexpected code '|| iOS 8.0' in '#unavailable' condition"),
+        DiagnosticSpec(message: "unexpected code '|| iOS 8.0' in availability condition"),
       ]
     )
   }
@@ -365,7 +365,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: version comparison not needed, Fix-It replacements: 21 - 24 = ''
-        DiagnosticSpec(message: "unexpected code '>= 10.51' in '#unavailable' condition"),
+        DiagnosticSpec(message: "unexpected code '>= 10.51' in availability condition"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -348,8 +348,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: '||' cannot be used in an availability condition
-        DiagnosticSpec(message: "unexpected code '|| iOS 8.0' in availability condition"),
+        DiagnosticSpec(message: "expected ',' joining platforms in availability condition"),
       ]
     )
   }

--- a/gyb_syntax_support/AvailabilityNodes.py
+++ b/gyb_syntax_support/AvailabilityNodes.py
@@ -11,7 +11,7 @@ AVAILABILITY_NODES = [
     #                     | identifier ','?
     #                     | availability-version-restriction ','?
     #                     | availability-versioned-argument ','?
-    Node('AvailabilityArgument', name_for_diagnostics="'@available' argument",
+    Node('AvailabilityArgument', name_for_diagnostics="availability argument",
          kind='Syntax',
          description='''
          A single argument to an `@available` argument like `*`, `iOS 10.1`,
@@ -38,7 +38,7 @@ AVAILABILITY_NODES = [
 
     # Representation of 'deprecated: 2.3', 'message: "Hello world"' etc.
     # availability-versioned-argument -> identifier ':' version-tuple
-    Node('AvailabilityLabeledArgument', name_for_diagnostics="'@available' argument",
+    Node('AvailabilityLabeledArgument', name_for_diagnostics="availability argument",
          kind='Syntax',
          description='''
          A argument to an `@available` attribute that consists of a label and
@@ -58,7 +58,7 @@ AVAILABILITY_NODES = [
 
     # Representation for 'iOS 10', 'swift 3.4' etc.
     # availability-version-restriction -> identifier version-tuple
-    Node('AvailabilityVersionRestriction', name_for_diagnostics="'@available' argument",
+    Node('AvailabilityVersionRestriction', name_for_diagnostics="availability argument",
          kind='Syntax',
          description='''
          An argument to `@available` that restricts the availability on a

--- a/gyb_syntax_support/AvailabilityNodes.py
+++ b/gyb_syntax_support/AvailabilityNodes.py
@@ -72,13 +72,13 @@ AVAILABILITY_NODES = [
                    restricted or 'swift' if the availability should be
                    restricted based on a Swift version.
                    '''),
-             Child('Version', kind='VersionTuple', name_for_diagnostics='version', is_optional=True),
+             Child('Version', kind='VersionTuple', name_for_diagnostics='version'),
          ]),
 
     # version-tuple -> integer-literal
     #                | float-literal
     #                | float-literal '.' integer-literal
-    Node('VersionTuple', name_for_diagnostics='version tuple', kind='Syntax',
+    Node('VersionTuple', name_for_diagnostics='version number', kind='Syntax',
          description='''
          A version number of the form major.minor.patch in which the minor
          and patch part may be omitted.

--- a/gyb_syntax_support/StmtNodes.py
+++ b/gyb_syntax_support/StmtNodes.py
@@ -187,7 +187,6 @@ STMT_NODES = [
                    node_choices=[
                        Child('Expression', kind='Expr'),
                        Child('Availability', kind='AvailabilityCondition'),
-                       Child('Unavailability', kind='UnavailabilityCondition'),
                        Child('MatchingPattern',
                              kind='MatchingPatternCondition'),
                        Child('OptionalBinding',
@@ -199,10 +198,10 @@ STMT_NODES = [
          ]),
 
     # availability-condition -> '#available' '(' availability-spec ')'
-    Node('AvailabilityCondition', name_for_diagnostics="'#availabile' condition",
+    Node('AvailabilityCondition', name_for_diagnostics="availability condition",
          kind='Syntax',
          children=[
-             Child('PoundAvailableKeyword', kind='PoundAvailableToken'),
+             Child('AvailabilityKeyword', kind='Token', token_choices=['PoundAvailableToken', 'PoundUnavailableToken']),
              Child('LeftParen', kind='LeftParenToken'),
              Child('AvailabilitySpec', kind='AvailabilitySpecList',
                    collection_element_name='AvailabilityArgument'),
@@ -229,17 +228,6 @@ STMT_NODES = [
                    is_optional=True),
              Child('Initializer', kind='InitializerClause',
                    is_optional=True),
-         ]),
-
-    # unavailability-condition -> '#unavailable' '(' availability-spec ')'
-    Node('UnavailabilityCondition', name_for_diagnostics="'#unavailable' condition",
-         kind='Syntax',
-         children=[
-             Child('PoundUnavailableKeyword', kind='PoundUnavailableToken'),
-             Child('LeftParen', kind='LeftParenToken'),
-             Child('AvailabilitySpec', kind='AvailabilitySpecList',
-                   collection_element_name='AvailabilityArgument'),
-             Child('RightParen', kind='RightParenToken'),
          ]),
 
     # has-symbol-condition -> '#_hasSymbol' '(' expression ')'


### PR DESCRIPTION
Depends on https://github.com/apple/swift-syntax/pull/1125.

The relevant commit is https://github.com/apple/swift-syntax/pull/1126/commits/fd2f4fb1cf57e6f47b4f75864a85c730eb45ac9c.

---

AFAICT we always require a version after the platform in `#available`. The C++ parser was a little complicated here, making assumptions but I couldn't find a case in which the version was truly optional.