### PR TITLE
Stop parsing #keyPath and #selector as special grammar productions

### DIFF
--- a/Sources/SwiftParser/Lexer.swift
+++ b/Sources/SwiftParser/Lexer.swift
@@ -1565,8 +1565,6 @@ extension Lexer.Cursor {
 
     let kind: RawTokenKind
     switch literal {
-    case "keyPath": kind = .poundKeyPathKeyword
-    case "selector": kind = .poundSelectorKeyword
     case "assert": kind = .poundAssertKeyword
     case "sourceLocation": kind = .poundSourceLocationKeyword
     case "warning": kind = .poundWarningKeyword

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -700,8 +700,6 @@ enum PrimaryExpressionStart: RawTokenKindSubset {
   case nilKeyword
   case period
   case pound
-  case poundKeyPathKeyword
-  case poundSelectorKeyword
   case prefixPeriod
   case regexLiteral
   case selfKeyword
@@ -731,8 +729,6 @@ enum PrimaryExpressionStart: RawTokenKindSubset {
     case .nilKeyword: self = .nilKeyword
     case .period: self = .period
     case .pound: self = .pound
-    case .poundKeyPathKeyword: self = .poundKeyPathKeyword
-    case .poundSelectorKeyword: self = .poundSelectorKeyword
     case .prefixPeriod: self = .prefixPeriod
     case .regexLiteral: self = .regexLiteral
     case .selfKeyword: self = .selfKeyword
@@ -765,8 +761,6 @@ enum PrimaryExpressionStart: RawTokenKindSubset {
     case .nilKeyword: return .nilKeyword
     case .period: return .period
     case .pound: return .pound
-    case .poundKeyPathKeyword: return .poundKeyPathKeyword
-    case .poundSelectorKeyword: return .poundSelectorKeyword
     case .prefixPeriod: return .prefixPeriod
     case .regexLiteral: return .regexLiteral
     case .selfKeyword: return .selfKeyword

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -637,11 +637,10 @@ final class ExpressionTests: XCTestCase {
       ]
     )
 
-    AssertParse("#keyPath(1️⃣(b:2️⃣)",
+    AssertParse("#keyPath((b:1️⃣)2️⃣",
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in '#keyPath' expression"),
-                  DiagnosticSpec(locationMarker: "1️⃣", message: "expected ')' to end '#keyPath' expression"),
-                  DiagnosticSpec(locationMarker: "2️⃣", message: "expected value in function call"),
+                  DiagnosticSpec(locationMarker: "1️⃣", message: "expected value in tuple"),
+                  DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end pound literal expression"),
                 ])
   }
 


### PR DESCRIPTION
Instead, they'll be parsed as a macro expansion expression.