### PR TITLE
[Variadic Generics] Add a new type syntax node and parsing support for explicit pack references.

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/TypeNodes.swift
@@ -216,6 +216,19 @@ public let TYPE_NODES: [Node] = [
                ])
        ]),
   
+  Node(name: "PackReferenceType",
+       nameForDiagnostics: "pack reference",
+       kind: "Type",
+       children: [
+         Child(name: "EachKeyword",
+               kind: "ContextualKeyworkToken",
+               textChoices: [
+                 "each"
+               ]),
+         Child(name: "PackType",
+               kind: "Type")
+       ]),
+  
   Node(name: "TupleTypeElement",
        nameForDiagnostics: nil,
        kind: "Syntax",

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -350,7 +350,8 @@ extension Parser.Lookahead {
       // If the first name wasn't "isolated", we're done.
       if !self.atContextualKeyword("isolated") &&
           !self.atContextualKeyword("some") &&
-          !self.atContextualKeyword("any") {
+          !self.atContextualKeyword("any") &&
+          !self.atContextualKeyword("each") {
         return true
       }
 

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -120,6 +120,13 @@ extension Parser {
   ///     protocol-composition-continuation → type-identifier | protocol-composition-type
   @_spi(RawSyntax)
   public mutating func parseSimpleOrCompositionType() -> RawTypeSyntax {
+    // 'each' is a contextual keyword for a pack reference.
+    if let each = consume(ifAny: [], contextualKeywords: ["each"]) {
+      let packType = parseSimpleType()
+      return RawTypeSyntax(RawPackReferenceTypeSyntax(
+        eachKeyword: each, packType: packType, arena: self.arena))
+    }
+
     let someOrAny = self.consume(ifAny: [], contextualKeywords: ["some", "any"])
 
     var base = self.parseSimpleType()

--- a/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
@@ -162,6 +162,7 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/ImplicitlyUnwrappedOptionalTypeSyntax>
 - <doc:SwiftSyntax/CompositionTypeSyntax>
 - <doc:SwiftSyntax/PackExpansionTypeSyntax>
+- <doc:SwiftSyntax/PackReferenceTypeSyntax>
 - <doc:SwiftSyntax/TupleTypeSyntax>
 - <doc:SwiftSyntax/FunctionTypeSyntax>
 - <doc:SwiftSyntax/AttributedTypeSyntax>

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -127,7 +127,7 @@ public struct RawTypeSyntax: RawTypeSyntaxNodeProtocol {
 
   public static func isKindOf(_ raw: RawSyntax) -> Bool {
     switch raw.kind {
-    case .missingType, .simpleTypeIdentifier, .memberTypeIdentifier, .classRestrictionType, .arrayType, .dictionaryType, .metatypeType, .optionalType, .constrainedSugarType, .implicitlyUnwrappedOptionalType, .compositionType, .packExpansionType, .tupleType, .functionType, .attributedType, .namedOpaqueReturnType: return true
+    case .missingType, .simpleTypeIdentifier, .memberTypeIdentifier, .classRestrictionType, .arrayType, .dictionaryType, .metatypeType, .optionalType, .constrainedSugarType, .implicitlyUnwrappedOptionalType, .compositionType, .packExpansionType, .packReferenceType, .tupleType, .functionType, .attributedType, .namedOpaqueReturnType: return true
     default: return false
     }
   }
@@ -16732,6 +16732,66 @@ public struct RawPackExpansionTypeSyntax: RawTypeSyntaxNodeProtocol {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))!
   }
   public var unexpectedAfterEllipsis: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+}
+
+@_spi(RawSyntax)
+public struct RawPackReferenceTypeSyntax: RawTypeSyntaxNodeProtocol {
+
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .packReferenceType
+  }
+
+  public var raw: RawSyntax
+  init(raw: RawSyntax) {
+    assert(Self.isKindOf(raw))
+    self.raw = raw
+  }
+
+  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+    guard Self.isKindOf(other.raw) else { return nil }
+    self.init(raw: other.raw)
+  }
+
+  public init(
+    _ unexpectedBeforeEachKeyword: RawUnexpectedNodesSyntax? = nil,
+    eachKeyword: RawTokenSyntax,
+    _ unexpectedBetweenEachKeywordAndPackType: RawUnexpectedNodesSyntax? = nil,
+    packType: RawTypeSyntax,
+    _ unexpectedAfterPackType: RawUnexpectedNodesSyntax? = nil,
+    arena: __shared SyntaxArena
+  ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .packReferenceType, uninitializedCount: 5, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeEachKeyword?.raw
+      layout[1] = eachKeyword.raw
+      layout[2] = unexpectedBetweenEachKeywordAndPackType?.raw
+      layout[3] = packType.raw
+      layout[4] = unexpectedAfterPackType?.raw
+    }
+    self.init(raw: raw)
+  }
+
+  public var unexpectedBeforeEachKeyword: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var eachKeyword: RawTokenSyntax {
+    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedBetweenEachKeywordAndPackType: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var packType: RawTypeSyntax {
+    layoutView.children[3].map(RawTypeSyntax.init(raw:))!
+  }
+  public var unexpectedAfterPackType: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
@@ -2438,6 +2438,14 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
     break
+  case .packReferenceType:
+    assert(layout.count == 5)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self))
+    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 3, verify(layout[3], as: RawTypeSyntax.self))
+    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
+    break
   case .tupleTypeElement:
     assert(layout.count == 17)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/Misc.swift
+++ b/Sources/SwiftSyntax/generated/Misc.swift
@@ -198,6 +198,7 @@ extension Syntax {
     .node(OptionalPatternSyntax.self), 
     .node(OptionalTypeSyntax.self), 
     .node(PackExpansionTypeSyntax.self), 
+    .node(PackReferenceTypeSyntax.self), 
     .node(ParameterClauseSyntax.self), 
     .node(PatternBindingListSyntax.self), 
     .node(PatternBindingSyntax.self), 
@@ -646,6 +647,8 @@ extension SyntaxKind {
       return OptionalTypeSyntax.self
     case .packExpansionType: 
       return PackExpansionTypeSyntax.self
+    case .packReferenceType: 
+      return PackReferenceTypeSyntax.self
     case .parameterClause: 
       return ParameterClauseSyntax.self
     case .patternBindingList: 
@@ -1175,6 +1178,8 @@ extension SyntaxKind {
       return "optional type"
     case .packExpansionType: 
       return "variadic expansion"
+    case .packReferenceType: 
+      return "pack reference"
     case .parameterClause: 
       return "parameter clause"
     case .patternBindingList: 

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
@@ -1698,6 +1698,13 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   override open func visitPost(_ node: PackExpansionTypeSyntax) {
     visitAnyPost(node._syntaxNode)
   }
+  override open func visit(_ node: PackReferenceTypeSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: PackReferenceTypeSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
   override open func visit(_ node: TupleTypeElementSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
@@ -525,7 +525,7 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public init?<S: SyntaxProtocol>(_ node: S) {
     switch node.raw.kind {
-    case .missingType, .simpleTypeIdentifier, .memberTypeIdentifier, .classRestrictionType, .arrayType, .dictionaryType, .metatypeType, .optionalType, .constrainedSugarType, .implicitlyUnwrappedOptionalType, .compositionType, .packExpansionType, .tupleType, .functionType, .attributedType, .namedOpaqueReturnType:
+    case .missingType, .simpleTypeIdentifier, .memberTypeIdentifier, .classRestrictionType, .arrayType, .dictionaryType, .metatypeType, .optionalType, .constrainedSugarType, .implicitlyUnwrappedOptionalType, .compositionType, .packExpansionType, .packReferenceType, .tupleType, .functionType, .attributedType, .namedOpaqueReturnType:
       self._syntaxNode = node._syntaxNode
     default:
       return nil
@@ -539,7 +539,7 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     // Assert that the kind of the given data matches in debug builds.
 #if DEBUG
     switch data.raw.kind {
-    case .missingType, .simpleTypeIdentifier, .memberTypeIdentifier, .classRestrictionType, .arrayType, .dictionaryType, .metatypeType, .optionalType, .constrainedSugarType, .implicitlyUnwrappedOptionalType, .compositionType, .packExpansionType, .tupleType, .functionType, .attributedType, .namedOpaqueReturnType:
+    case .missingType, .simpleTypeIdentifier, .memberTypeIdentifier, .classRestrictionType, .arrayType, .dictionaryType, .metatypeType, .optionalType, .constrainedSugarType, .implicitlyUnwrappedOptionalType, .compositionType, .packExpansionType, .packReferenceType, .tupleType, .functionType, .attributedType, .namedOpaqueReturnType:
       break
     default:
       fatalError("Unable to create TypeSyntax from \(data.raw.kind)")
@@ -589,6 +589,7 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       .node(ImplicitlyUnwrappedOptionalTypeSyntax.self),
       .node(CompositionTypeSyntax.self),
       .node(PackExpansionTypeSyntax.self),
+      .node(PackReferenceTypeSyntax.self),
       .node(TupleTypeSyntax.self),
       .node(FunctionTypeSyntax.self),
       .node(AttributedTypeSyntax.self),

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -251,6 +251,7 @@ public enum SyntaxEnum {
   case compositionTypeElementList(CompositionTypeElementListSyntax)
   case compositionType(CompositionTypeSyntax)
   case packExpansionType(PackExpansionTypeSyntax)
+  case packReferenceType(PackReferenceTypeSyntax)
   case tupleTypeElement(TupleTypeElementSyntax)
   case tupleTypeElementList(TupleTypeElementListSyntax)
   case tupleType(TupleTypeSyntax)
@@ -755,6 +756,8 @@ public extension Syntax {
       return .compositionType(CompositionTypeSyntax(self)!)
     case .packExpansionType:
       return .packExpansionType(PackExpansionTypeSyntax(self)!)
+    case .packReferenceType:
+      return .packReferenceType(PackReferenceTypeSyntax(self)!)
     case .tupleTypeElement:
       return .tupleTypeElement(TupleTypeElementSyntax(self)!)
     case .tupleTypeElementList:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -7826,6 +7826,37 @@ public enum SyntaxFactory {
       return PackExpansionTypeSyntax(data)
     }
   }
+  @available(*, deprecated, message: "Use initializer on PackReferenceTypeSyntax")
+  public static func makePackReferenceType(_ unexpectedBeforeEachKeyword: UnexpectedNodesSyntax? = nil, eachKeyword: TokenSyntax, _ unexpectedBetweenEachKeywordAndPackType: UnexpectedNodesSyntax? = nil, packType: TypeSyntax, _ unexpectedAfterPackType: UnexpectedNodesSyntax? = nil) -> PackReferenceTypeSyntax {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeEachKeyword?.raw,
+      eachKeyword.raw,
+      unexpectedBetweenEachKeywordAndPackType?.raw,
+      packType.raw,
+      unexpectedAfterPackType?.raw,
+    ]
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.packReferenceType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PackReferenceTypeSyntax(data)
+    }
+  }
+
+  @available(*, deprecated, message: "Use initializer on PackReferenceTypeSyntax")
+  public static func makeBlankPackReferenceType(presence: SourcePresence = .present) -> PackReferenceTypeSyntax {
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .packReferenceType,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena),
+        nil,
+      ], arena: arena))
+      return PackReferenceTypeSyntax(data)
+    }
+  }
   @available(*, deprecated, message: "Use initializer on TupleTypeElementSyntax")
   public static func makeTupleTypeElement(_ unexpectedBeforeInOut: UnexpectedNodesSyntax? = nil, inOut: TokenSyntax?, _ unexpectedBetweenInOutAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax?, _ unexpectedBetweenNameAndSecondName: UnexpectedNodesSyntax? = nil, secondName: TokenSyntax?, _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil, ellipsis: TokenSyntax?, _ unexpectedBetweenEllipsisAndInitializer: UnexpectedNodesSyntax? = nil, initializer: InitializerClauseSyntax?, _ unexpectedBetweenInitializerAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> TupleTypeElementSyntax {
     let layout: [RawSyntax?] = [

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
@@ -251,6 +251,7 @@ public enum SyntaxKind {
   case compositionTypeElementList
   case compositionType
   case packExpansionType
+  case packReferenceType
   case tupleTypeElement
   case tupleTypeElementList
   case tupleType

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -1668,6 +1668,13 @@ open class SyntaxRewriter {
     return TypeSyntax(visitChildren(node))
   }
 
+  /// Visit a `PackReferenceTypeSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: PackReferenceTypeSyntax) -> TypeSyntax {
+    return TypeSyntax(visitChildren(node))
+  }
+
   /// Visit a `TupleTypeElementSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -4275,6 +4282,16 @@ open class SyntaxRewriter {
   }
 
   /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplPackReferenceTypeSyntax(_ data: SyntaxData) -> Syntax {
+    let node = PackReferenceTypeSyntax(data)
+    // Accessing _syntaxNode directly is faster than calling Syntax(node)
+    visitPre(node._syntaxNode)
+    defer { visitPost(node._syntaxNode) }
+    if let newNode = visitAny(node._syntaxNode) { return newNode }
+    return Syntax(visit(node))
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplTupleTypeElementSyntax(_ data: SyntaxData) -> Syntax {
     let node = TupleTypeElementSyntax(data)
     // Accessing _syntaxNode directly is faster than calling Syntax(node)
@@ -5044,6 +5061,8 @@ open class SyntaxRewriter {
       return visitImplCompositionTypeSyntax
     case .packExpansionType:
       return visitImplPackExpansionTypeSyntax
+    case .packReferenceType:
+      return visitImplPackReferenceTypeSyntax
     case .tupleTypeElement:
       return visitImplTupleTypeElementSyntax
     case .tupleTypeElementList:
@@ -5579,6 +5598,8 @@ open class SyntaxRewriter {
       return visitImplCompositionTypeSyntax(data)
     case .packExpansionType:
       return visitImplPackExpansionTypeSyntax(data)
+    case .packReferenceType:
+      return visitImplPackReferenceTypeSyntax(data)
     case .tupleTypeElement:
       return visitImplTupleTypeElementSyntax(data)
     case .tupleTypeElementList:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
@@ -959,6 +959,10 @@ public protocol SyntaxTransformVisitor {
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: PackExpansionTypeSyntax) -> ResultType
+  /// Visiting `PackReferenceTypeSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: PackReferenceTypeSyntax) -> ResultType
   /// Visiting `TupleTypeElementSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -2480,6 +2484,12 @@ extension SyntaxTransformVisitor {
   public func visit(_ node: PackExpansionTypeSyntax) -> ResultType {
     visitAny(Syntax(node))
   }
+  /// Visiting `PackReferenceTypeSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: PackReferenceTypeSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
   /// Visiting `TupleTypeElementSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
@@ -3110,6 +3120,8 @@ extension SyntaxTransformVisitor {
     case .compositionType(let derived):
       return visit(derived)
     case .packExpansionType(let derived):
+      return visit(derived)
+    case .packReferenceType(let derived):
       return visit(derived)
     case .tupleTypeElement(let derived):
       return visit(derived)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -2391,6 +2391,16 @@ open class SyntaxVisitor {
   /// The function called after visiting `PackExpansionTypeSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: PackExpansionTypeSyntax) {}
+  /// Visiting `PackReferenceTypeSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: PackReferenceTypeSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `PackReferenceTypeSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: PackReferenceTypeSyntax) {}
   /// Visiting `TupleTypeElementSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -5249,6 +5259,17 @@ open class SyntaxVisitor {
   }
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplPackReferenceTypeSyntax(_ data: SyntaxData) {
+    let node = PackReferenceTypeSyntax(data)
+    let needsChildren = (visit(node) == .visitChildren)
+    // Avoid calling into visitChildren if possible.
+    if needsChildren && !node.raw.layoutView!.children.isEmpty {
+      visitChildren(node)
+    }
+    visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplTupleTypeElementSyntax(_ data: SyntaxData) {
     let node = TupleTypeElementSyntax(data)
     let needsChildren = (visit(node) == .visitChildren)
@@ -6016,6 +6037,8 @@ open class SyntaxVisitor {
       visitImplCompositionTypeSyntax(data)
     case .packExpansionType:
       visitImplPackExpansionTypeSyntax(data)
+    case .packReferenceType:
+      visitImplPackReferenceTypeSyntax(data)
     case .tupleTypeElement:
       visitImplTupleTypeElementSyntax(data)
     case .tupleTypeElementList:

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -2362,6 +2362,189 @@ extension PackExpansionTypeSyntax: CustomReflectable {
   }
 }
 
+// MARK: - PackReferenceTypeSyntax
+
+public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+  public let _syntaxNode: Syntax
+
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .packReferenceType else { return nil }
+    self._syntaxNode = node._syntaxNode
+  }
+
+  /// Creates a `PackReferenceTypeSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .packReferenceType)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ unexpectedBeforeEachKeyword: UnexpectedNodesSyntax? = nil,
+    eachKeyword: TokenSyntax,
+    _ unexpectedBetweenEachKeywordAndPackType: UnexpectedNodesSyntax? = nil,
+    packType: TypeSyntax,
+    _ unexpectedAfterPackType: UnexpectedNodesSyntax? = nil
+  ) {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeEachKeyword?.raw,
+      eachKeyword.raw,
+      unexpectedBetweenEachKeywordAndPackType?.raw,
+      packType.raw,
+      unexpectedAfterPackType?.raw,
+    ]
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.packReferenceType,
+        from: layout, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
+    self.init(data)
+  }
+
+  public var unexpectedBeforeEachKeyword: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 0, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBeforeEachKeyword(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBeforeEachKeyword` replaced.
+  /// - param newChild: The new `unexpectedBeforeEachKeyword` to replace the node's
+  ///                   current `unexpectedBeforeEachKeyword`, if present.
+  public func withUnexpectedBeforeEachKeyword(_ newChild: UnexpectedNodesSyntax?) -> PackReferenceTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw
+    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+    return PackReferenceTypeSyntax(newData)
+  }
+
+  public var eachKeyword: TokenSyntax {
+    get {
+      let childData = data.child(at: 1, parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withEachKeyword(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `eachKeyword` replaced.
+  /// - param newChild: The new `eachKeyword` to replace the node's
+  ///                   current `eachKeyword`, if present.
+  public func withEachKeyword(_ newChild: TokenSyntax?) -> PackReferenceTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+    return PackReferenceTypeSyntax(newData)
+  }
+
+  public var unexpectedBetweenEachKeywordAndPackType: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenEachKeywordAndPackType(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenEachKeywordAndPackType` replaced.
+  /// - param newChild: The new `unexpectedBetweenEachKeywordAndPackType` to replace the node's
+  ///                   current `unexpectedBetweenEachKeywordAndPackType`, if present.
+  public func withUnexpectedBetweenEachKeywordAndPackType(_ newChild: UnexpectedNodesSyntax?) -> PackReferenceTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw
+    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+    return PackReferenceTypeSyntax(newData)
+  }
+
+  public var packType: TypeSyntax {
+    get {
+      let childData = data.child(at: 3, parent: Syntax(self))
+      return TypeSyntax(childData!)
+    }
+    set(value) {
+      self = withPackType(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `packType` replaced.
+  /// - param newChild: The new `packType` to replace the node's
+  ///                   current `packType`, if present.
+  public func withPackType(_ newChild: TypeSyntax?) -> PackReferenceTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+    return PackReferenceTypeSyntax(newData)
+  }
+
+  public var unexpectedAfterPackType: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterPackType(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterPackType` replaced.
+  /// - param newChild: The new `unexpectedAfterPackType` to replace the node's
+  ///                   current `unexpectedAfterPackType`, if present.
+  public func withUnexpectedAfterPackType(_ newChild: UnexpectedNodesSyntax?) -> PackReferenceTypeSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw
+    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+    return PackReferenceTypeSyntax(newData)
+  }
+
+  public static var structure: SyntaxNodeStructure {
+    return .layout([
+      \Self.unexpectedBeforeEachKeyword,
+      \Self.eachKeyword,
+      \Self.unexpectedBetweenEachKeywordAndPackType,
+      \Self.packType,
+      \Self.unexpectedAfterPackType,
+    ])
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
+}
+
+extension PackReferenceTypeSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "unexpectedBeforeEachKeyword": unexpectedBeforeEachKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "eachKeyword": Syntax(eachKeyword).asProtocol(SyntaxProtocol.self),
+      "unexpectedBetweenEachKeywordAndPackType": unexpectedBetweenEachKeywordAndPackType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "packType": Syntax(packType).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterPackType": unexpectedAfterPackType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+    ])
+  }
+}
+
 // MARK: - TupleTypeSyntax
 
 public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -3378,6 +3378,21 @@ extension PackExpansionType {
   }
 }
 
+extension PackReferenceType {
+  /// Creates a `PackReferenceType` using the provided parameters.
+  /// - Parameters:
+  ///   - unexpectedBeforeEachKeyword: 
+  ///   - eachKeyword: 
+  ///   - unexpectedBetweenEachKeywordAndPackType: 
+  ///   - packType: 
+  @_disfavoredOverload public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeEachKeyword: UnexpectedNodes? = nil, eachKeyword: Token, unexpectedBetweenEachKeywordAndPackType: UnexpectedNodes? = nil, packType: TypeSyntaxProtocol) {
+    assert(eachKeyword.text == "each")
+    self = PackReferenceTypeSyntax(unexpectedBeforeEachKeyword, eachKeyword: eachKeyword, unexpectedBetweenEachKeywordAndPackType, packType: TypeSyntax(fromProtocol: packType))
+    self.leadingTrivia = leadingTrivia + (self.leadingTrivia ?? [])
+    self.trailingTrivia = trailingTrivia + (self.trailingTrivia ?? [])
+  }
+}
+
 extension ParameterClause {
   /// Creates a `ParameterClause` using the provided parameters.
   /// - Parameters:

--- a/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
@@ -300,6 +300,9 @@ extension OptionalTypeSyntax: SyntaxExpressibleByStringInterpolation {
 extension PackExpansionTypeSyntax: SyntaxExpressibleByStringInterpolation { 
 }
 
+extension PackReferenceTypeSyntax: SyntaxExpressibleByStringInterpolation { 
+}
+
 extension PatternSyntaxProtocol {
   public init (stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws {
     self = try performParse(source: stringInterpolation.sourceText, parse: { parser in 

--- a/Sources/SwiftSyntaxBuilder/generated/Typealiases.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/Typealiases.swift
@@ -367,6 +367,8 @@ public typealias OptionalType = OptionalTypeSyntax
 
 public typealias PackExpansionType = PackExpansionTypeSyntax
 
+public typealias PackReferenceType = PackReferenceTypeSyntax
+
 public typealias ParameterClause = ParameterClauseSyntax
 
 public typealias PatternBindingList = PatternBindingListSyntax

--- a/Tests/SwiftParserTest/VariadicGenericsTests.swift
+++ b/Tests/SwiftParserTest/VariadicGenericsTests.swift
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+
+import XCTest
+
+final class VariadicGenericsTests: XCTestCase {
+  func testSimple() {
+    AssertParse(
+      """
+      func tuplify<T...>(_ t: (each T)...) -> ((each T)...) {
+      }
+      """
+    )
+  }
+
+  func testRequirement() {
+    AssertParse(
+      """
+      func requirement<T...>() where each T: P {
+      }
+      """
+    )
+  }
+
+  func testElementOutsideExpansion() {
+    // This is valid to parse, and becomes invalid during type resolution.
+    AssertParse(
+      """
+      func invalid<T...>(_ t: each T) -> each T {}
+      """
+    )
+  }
+
+  func testInvalidPackElement() {
+    AssertParse(
+      """
+      func invalid<T...>() -> (each any 1️⃣T) {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected ',' in tuple type")
+      ]
+    )
+
+    AssertParse(
+      """
+      func invalid<T...>(_: each T 1️⃣& P) {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "unexpected code '& P' in parameter clause")
+      ]
+    )
+  }
+}

--- a/gyb_syntax_support/TypeNodes.py
+++ b/gyb_syntax_support/TypeNodes.py
@@ -123,6 +123,14 @@ TYPE_NODES = [
              Child('Ellipsis', kind='EllipsisToken')
          ]),
 
+    # pack-reference-type -> 'each' type
+    Node('PackReferenceType', name_for_diagnostics='pack reference', kind='Type',
+         children=[
+             Child('EachKeyword', kind='ContextualKeyworkToken',
+                   text_choices=['each'], is_optional=False),
+             Child('PackType', kind='Type')
+         ]),
+
     # tuple-type-element -> identifier? ':'? type-annotation ','?
     Node('TupleTypeElement', name_for_diagnostics=None, kind='Syntax',
          traits=['WithTrailingComma'],


### PR DESCRIPTION
* Add a new type node, `PackReferenceType`, for pack references spelled with a contextual `each` keyword.
* Add parsing support to produce `PackReferenceTypeSyntax` when the contextual `each` keyword is applied to a type.