### PR TITLE
Disable two code blocks to make the package compiler on iOS-like platforms

### DIFF
--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -302,6 +302,13 @@ class Reduce: ParsableCommand {
   /// Invoke `swift-parser-cli verify-round-trip` with the same arguments as this `reduce` subcommand.
   /// Returns the exit code of the invocation.
   private func runVerifyRoundTripInSeparateProcess(source: [UInt8]) throws -> ProcessExit {
+#if os(iOS) || os(tvOS) || os(watchOS)
+    // We cannot launch a new process on iOS-like platforms.
+    // Default to running verification in-process.
+    // Honestly, this isn't very important because you can't launch swift-parser-cli
+    // on iOS anyway but this fixes a compilation error of the pacakge on iOS.
+    return try runVerifyRoundTripInCurrentProcess(source: source) ? ProcessExit.success : ProcessExit.potentialCrash
+#else
     return try withTemporaryFile(contents: source) { tempFileURL in
       let process = Process()
       process.executableURL = URL(fileURLWithPath: ProcessInfo.processInfo.arguments[0])
@@ -337,6 +344,7 @@ class Reduce: ParsableCommand {
         return .potentialCrash
       }
     }
+#endif
   }
 
   /// Runs the `verify-round-trip` subcommand in process.

--- a/Tests/SwiftParserTest/LinkageTests.swift
+++ b/Tests/SwiftParserTest/LinkageTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
+#if canImport(Darwin) && !os(iOS) && !os(tvOS) && !os(watchOS)
 import Darwin
 import XCTest
 


### PR DESCRIPTION
The targets that failed to build weren’t important for iOS but it’s good hygine to make the entire package compile on iOS-like platforms as well.

rdar://103294088