### PR TITLE
[Variadic Generics] Parse contextual `each` in expression context as `PackElementExprSyntax`.

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
@@ -213,6 +213,22 @@ public let EXPR_NODES: [Node] = [
                ])
        ]),
 
+  Node(name: "PackElementExpr",
+       nameForDiagnostics: nil,
+       kind: "Expr",
+       children: [
+         Child(name: "EachKeyword",
+               kind: "ContextualKeywordToken",
+               tokenChoices: [
+                 "ContextualKeyword"
+               ],
+               textChoices: [
+                 "each"
+               ]),
+         Child(name: "PackRefExpr",
+               kind: "Expr")
+       ]),
+
   Node(name: "SequenceExpr",
        nameForDiagnostics: nil,
        kind: "Expr",

--- a/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
@@ -112,6 +112,7 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/NilLiteralExprSyntax>
 - <doc:SwiftSyntax/DiscardAssignmentExprSyntax>
 - <doc:SwiftSyntax/AssignmentExprSyntax>
+- <doc:SwiftSyntax/PackElementExprSyntax>
 - <doc:SwiftSyntax/SequenceExprSyntax>
 - <doc:SwiftSyntax/SymbolicReferenceExprSyntax>
 - <doc:SwiftSyntax/PrefixOperatorExprSyntax>

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -65,7 +65,7 @@ public struct RawExprSyntax: RawExprSyntaxNodeProtocol {
 
   public static func isKindOf(_ raw: RawSyntax) -> Bool {
     switch raw.kind {
-    case .missingExpr, .inOutExpr, .poundColumnExpr, .tryExpr, .awaitExpr, .moveExpr, .identifierExpr, .superRefExpr, .nilLiteralExpr, .discardAssignmentExpr, .assignmentExpr, .sequenceExpr, .symbolicReferenceExpr, .prefixOperatorExpr, .binaryOperatorExpr, .arrowExpr, .infixOperatorExpr, .floatLiteralExpr, .tupleExpr, .arrayExpr, .dictionaryExpr, .integerLiteralExpr, .booleanLiteralExpr, .unresolvedTernaryExpr, .ternaryExpr, .memberAccessExpr, .unresolvedIsExpr, .isExpr, .unresolvedAsExpr, .asExpr, .typeExpr, .closureExpr, .unresolvedPatternExpr, .functionCallExpr, .subscriptExpr, .optionalChainingExpr, .forcedValueExpr, .postfixUnaryExpr, .specializeExpr, .stringLiteralExpr, .regexLiteralExpr, .keyPathExpr, .macroExpansionExpr, .postfixIfConfigExpr, .editorPlaceholderExpr: return true
+    case .missingExpr, .inOutExpr, .poundColumnExpr, .tryExpr, .awaitExpr, .moveExpr, .identifierExpr, .superRefExpr, .nilLiteralExpr, .discardAssignmentExpr, .assignmentExpr, .packElementExpr, .sequenceExpr, .symbolicReferenceExpr, .prefixOperatorExpr, .binaryOperatorExpr, .arrowExpr, .infixOperatorExpr, .floatLiteralExpr, .tupleExpr, .arrayExpr, .dictionaryExpr, .integerLiteralExpr, .booleanLiteralExpr, .unresolvedTernaryExpr, .ternaryExpr, .memberAccessExpr, .unresolvedIsExpr, .isExpr, .unresolvedAsExpr, .asExpr, .typeExpr, .closureExpr, .unresolvedPatternExpr, .functionCallExpr, .subscriptExpr, .optionalChainingExpr, .forcedValueExpr, .postfixUnaryExpr, .specializeExpr, .stringLiteralExpr, .regexLiteralExpr, .keyPathExpr, .macroExpansionExpr, .postfixIfConfigExpr, .editorPlaceholderExpr: return true
     default: return false
     }
   }
@@ -1582,6 +1582,66 @@ public struct RawAssignmentExprSyntax: RawExprSyntaxNodeProtocol {
   }
   public var unexpectedAfterAssignToken: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+}
+
+@_spi(RawSyntax)
+public struct RawPackElementExprSyntax: RawExprSyntaxNodeProtocol {
+
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .packElementExpr
+  }
+
+  public var raw: RawSyntax
+  init(raw: RawSyntax) {
+    assert(Self.isKindOf(raw))
+    self.raw = raw
+  }
+
+  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+    guard Self.isKindOf(other.raw) else { return nil }
+    self.init(raw: other.raw)
+  }
+
+  public init(
+    _ unexpectedBeforeEachKeyword: RawUnexpectedNodesSyntax? = nil,
+    eachKeyword: RawTokenSyntax,
+    _ unexpectedBetweenEachKeywordAndPackRefExpr: RawUnexpectedNodesSyntax? = nil,
+    packRefExpr: RawExprSyntax,
+    _ unexpectedAfterPackRefExpr: RawUnexpectedNodesSyntax? = nil,
+    arena: __shared SyntaxArena
+  ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .packElementExpr, uninitializedCount: 5, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeEachKeyword?.raw
+      layout[1] = eachKeyword.raw
+      layout[2] = unexpectedBetweenEachKeywordAndPackRefExpr?.raw
+      layout[3] = packRefExpr.raw
+      layout[4] = unexpectedAfterPackRefExpr?.raw
+    }
+    self.init(raw: raw)
+  }
+
+  public var unexpectedBeforeEachKeyword: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var eachKeyword: RawTokenSyntax {
+    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedBetweenEachKeywordAndPackRefExpr: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var packRefExpr: RawExprSyntax {
+    layoutView.children[3].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterPackRefExpr: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
@@ -264,6 +264,14 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     break
+  case .packElementExpr:
+    assert(layout.count == 5)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self))
+    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 3, verify(layout[3], as: RawExprSyntax.self))
+    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
+    break
   case .sequenceExpr:
     assert(layout.count == 3)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/Misc.swift
+++ b/Sources/SwiftSyntax/generated/Misc.swift
@@ -197,6 +197,7 @@ extension Syntax {
     .node(OptionalChainingExprSyntax.self), 
     .node(OptionalPatternSyntax.self), 
     .node(OptionalTypeSyntax.self), 
+    .node(PackElementExprSyntax.self), 
     .node(PackExpansionTypeSyntax.self), 
     .node(PackReferenceTypeSyntax.self), 
     .node(ParameterClauseSyntax.self), 
@@ -645,6 +646,8 @@ extension SyntaxKind {
       return OptionalPatternSyntax.self
     case .optionalType: 
       return OptionalTypeSyntax.self
+    case .packElementExpr: 
+      return PackElementExprSyntax.self
     case .packExpansionType: 
       return PackExpansionTypeSyntax.self
     case .packReferenceType: 
@@ -1176,6 +1179,8 @@ extension SyntaxKind {
       return "optional pattern"
     case .optionalType: 
       return "optional type"
+    case .packElementExpr: 
+      return nil
     case .packExpansionType: 
       return "variadic expansion"
     case .packReferenceType: 

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
@@ -242,6 +242,13 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   override open func visitPost(_ node: AssignmentExprSyntax) {
     visitAnyPost(node._syntaxNode)
   }
+  override open func visit(_ node: PackElementExprSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: PackElementExprSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
   override open func visit(_ node: SequenceExprSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
@@ -215,7 +215,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init?<S: SyntaxProtocol>(_ node: S) {
     switch node.raw.kind {
-    case .missingExpr, .inOutExpr, .poundColumnExpr, .tryExpr, .awaitExpr, .moveExpr, .identifierExpr, .superRefExpr, .nilLiteralExpr, .discardAssignmentExpr, .assignmentExpr, .sequenceExpr, .symbolicReferenceExpr, .prefixOperatorExpr, .binaryOperatorExpr, .arrowExpr, .infixOperatorExpr, .floatLiteralExpr, .tupleExpr, .arrayExpr, .dictionaryExpr, .integerLiteralExpr, .booleanLiteralExpr, .unresolvedTernaryExpr, .ternaryExpr, .memberAccessExpr, .unresolvedIsExpr, .isExpr, .unresolvedAsExpr, .asExpr, .typeExpr, .closureExpr, .unresolvedPatternExpr, .functionCallExpr, .subscriptExpr, .optionalChainingExpr, .forcedValueExpr, .postfixUnaryExpr, .specializeExpr, .stringLiteralExpr, .regexLiteralExpr, .keyPathExpr, .macroExpansionExpr, .postfixIfConfigExpr, .editorPlaceholderExpr:
+    case .missingExpr, .inOutExpr, .poundColumnExpr, .tryExpr, .awaitExpr, .moveExpr, .identifierExpr, .superRefExpr, .nilLiteralExpr, .discardAssignmentExpr, .assignmentExpr, .packElementExpr, .sequenceExpr, .symbolicReferenceExpr, .prefixOperatorExpr, .binaryOperatorExpr, .arrowExpr, .infixOperatorExpr, .floatLiteralExpr, .tupleExpr, .arrayExpr, .dictionaryExpr, .integerLiteralExpr, .booleanLiteralExpr, .unresolvedTernaryExpr, .ternaryExpr, .memberAccessExpr, .unresolvedIsExpr, .isExpr, .unresolvedAsExpr, .asExpr, .typeExpr, .closureExpr, .unresolvedPatternExpr, .functionCallExpr, .subscriptExpr, .optionalChainingExpr, .forcedValueExpr, .postfixUnaryExpr, .specializeExpr, .stringLiteralExpr, .regexLiteralExpr, .keyPathExpr, .macroExpansionExpr, .postfixIfConfigExpr, .editorPlaceholderExpr:
       self._syntaxNode = node._syntaxNode
     default:
       return nil
@@ -229,7 +229,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     // Assert that the kind of the given data matches in debug builds.
 #if DEBUG
     switch data.raw.kind {
-    case .missingExpr, .inOutExpr, .poundColumnExpr, .tryExpr, .awaitExpr, .moveExpr, .identifierExpr, .superRefExpr, .nilLiteralExpr, .discardAssignmentExpr, .assignmentExpr, .sequenceExpr, .symbolicReferenceExpr, .prefixOperatorExpr, .binaryOperatorExpr, .arrowExpr, .infixOperatorExpr, .floatLiteralExpr, .tupleExpr, .arrayExpr, .dictionaryExpr, .integerLiteralExpr, .booleanLiteralExpr, .unresolvedTernaryExpr, .ternaryExpr, .memberAccessExpr, .unresolvedIsExpr, .isExpr, .unresolvedAsExpr, .asExpr, .typeExpr, .closureExpr, .unresolvedPatternExpr, .functionCallExpr, .subscriptExpr, .optionalChainingExpr, .forcedValueExpr, .postfixUnaryExpr, .specializeExpr, .stringLiteralExpr, .regexLiteralExpr, .keyPathExpr, .macroExpansionExpr, .postfixIfConfigExpr, .editorPlaceholderExpr:
+    case .missingExpr, .inOutExpr, .poundColumnExpr, .tryExpr, .awaitExpr, .moveExpr, .identifierExpr, .superRefExpr, .nilLiteralExpr, .discardAssignmentExpr, .assignmentExpr, .packElementExpr, .sequenceExpr, .symbolicReferenceExpr, .prefixOperatorExpr, .binaryOperatorExpr, .arrowExpr, .infixOperatorExpr, .floatLiteralExpr, .tupleExpr, .arrayExpr, .dictionaryExpr, .integerLiteralExpr, .booleanLiteralExpr, .unresolvedTernaryExpr, .ternaryExpr, .memberAccessExpr, .unresolvedIsExpr, .isExpr, .unresolvedAsExpr, .asExpr, .typeExpr, .closureExpr, .unresolvedPatternExpr, .functionCallExpr, .subscriptExpr, .optionalChainingExpr, .forcedValueExpr, .postfixUnaryExpr, .specializeExpr, .stringLiteralExpr, .regexLiteralExpr, .keyPathExpr, .macroExpansionExpr, .postfixIfConfigExpr, .editorPlaceholderExpr:
       break
     default:
       fatalError("Unable to create ExprSyntax from \(data.raw.kind)")
@@ -278,6 +278,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       .node(NilLiteralExprSyntax.self),
       .node(DiscardAssignmentExprSyntax.self),
       .node(AssignmentExprSyntax.self),
+      .node(PackElementExprSyntax.self),
       .node(SequenceExprSyntax.self),
       .node(SymbolicReferenceExprSyntax.self),
       .node(PrefixOperatorExprSyntax.self),

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -43,6 +43,7 @@ public enum SyntaxEnum {
   case nilLiteralExpr(NilLiteralExprSyntax)
   case discardAssignmentExpr(DiscardAssignmentExprSyntax)
   case assignmentExpr(AssignmentExprSyntax)
+  case packElementExpr(PackElementExprSyntax)
   case sequenceExpr(SequenceExprSyntax)
   case exprList(ExprListSyntax)
   case symbolicReferenceExpr(SymbolicReferenceExprSyntax)
@@ -340,6 +341,8 @@ public extension Syntax {
       return .discardAssignmentExpr(DiscardAssignmentExprSyntax(self)!)
     case .assignmentExpr:
       return .assignmentExpr(AssignmentExprSyntax(self)!)
+    case .packElementExpr:
+      return .packElementExpr(PackElementExprSyntax(self)!)
     case .sequenceExpr:
       return .sequenceExpr(SequenceExprSyntax(self)!)
     case .exprList:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -692,6 +692,37 @@ public enum SyntaxFactory {
       return AssignmentExprSyntax(data)
     }
   }
+  @available(*, deprecated, message: "Use initializer on PackElementExprSyntax")
+  public static func makePackElementExpr(_ unexpectedBeforeEachKeyword: UnexpectedNodesSyntax? = nil, eachKeyword: TokenSyntax, _ unexpectedBetweenEachKeywordAndPackRefExpr: UnexpectedNodesSyntax? = nil, packRefExpr: ExprSyntax, _ unexpectedAfterPackRefExpr: UnexpectedNodesSyntax? = nil) -> PackElementExprSyntax {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeEachKeyword?.raw,
+      eachKeyword.raw,
+      unexpectedBetweenEachKeywordAndPackRefExpr?.raw,
+      packRefExpr.raw,
+      unexpectedAfterPackRefExpr?.raw,
+    ]
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.packElementExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return PackElementExprSyntax(data)
+    }
+  }
+
+  @available(*, deprecated, message: "Use initializer on PackElementExprSyntax")
+  public static func makeBlankPackElementExpr(presence: SourcePresence = .present) -> PackElementExprSyntax {
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .packElementExpr,
+        from: [
+        nil,
+        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena),
+        nil,
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
+        nil,
+      ], arena: arena))
+      return PackElementExprSyntax(data)
+    }
+  }
   @available(*, deprecated, message: "Use initializer on SequenceExprSyntax")
   public static func makeSequenceExpr(_ unexpectedBeforeElements: UnexpectedNodesSyntax? = nil, elements: ExprListSyntax, _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil) -> SequenceExprSyntax {
     let layout: [RawSyntax?] = [

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
@@ -43,6 +43,7 @@ public enum SyntaxKind {
   case nilLiteralExpr
   case discardAssignmentExpr
   case assignmentExpr
+  case packElementExpr
   case sequenceExpr
   case exprList
   case symbolicReferenceExpr

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -212,6 +212,13 @@ open class SyntaxRewriter {
     return ExprSyntax(visitChildren(node))
   }
 
+  /// Visit a `PackElementExprSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: PackElementExprSyntax) -> ExprSyntax {
+    return ExprSyntax(visitChildren(node))
+  }
+
   /// Visit a `SequenceExprSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -2194,6 +2201,16 @@ open class SyntaxRewriter {
   /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplAssignmentExprSyntax(_ data: SyntaxData) -> Syntax {
     let node = AssignmentExprSyntax(data)
+    // Accessing _syntaxNode directly is faster than calling Syntax(node)
+    visitPre(node._syntaxNode)
+    defer { visitPost(node._syntaxNode) }
+    if let newNode = visitAny(node._syntaxNode) { return newNode }
+    return Syntax(visit(node))
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplPackElementExprSyntax(_ data: SyntaxData) -> Syntax {
+    let node = PackElementExprSyntax(data)
     // Accessing _syntaxNode directly is faster than calling Syntax(node)
     visitPre(node._syntaxNode)
     defer { visitPost(node._syntaxNode) }
@@ -4645,6 +4662,8 @@ open class SyntaxRewriter {
       return visitImplDiscardAssignmentExprSyntax
     case .assignmentExpr:
       return visitImplAssignmentExprSyntax
+    case .packElementExpr:
+      return visitImplPackElementExprSyntax
     case .sequenceExpr:
       return visitImplSequenceExprSyntax
     case .exprList:
@@ -5182,6 +5201,8 @@ open class SyntaxRewriter {
       return visitImplDiscardAssignmentExprSyntax(data)
     case .assignmentExpr:
       return visitImplAssignmentExprSyntax(data)
+    case .packElementExpr:
+      return visitImplPackElementExprSyntax(data)
     case .sequenceExpr:
       return visitImplSequenceExprSyntax(data)
     case .exprList:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
@@ -127,6 +127,10 @@ public protocol SyntaxTransformVisitor {
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: AssignmentExprSyntax) -> ResultType
+  /// Visiting `PackElementExprSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: PackElementExprSyntax) -> ResultType
   /// Visiting `SequenceExprSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -1234,6 +1238,12 @@ extension SyntaxTransformVisitor {
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
   public func visit(_ node: AssignmentExprSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
+  /// Visiting `PackElementExprSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: PackElementExprSyntax) -> ResultType {
     visitAny(Syntax(node))
   }
   /// Visiting `SequenceExprSyntax` specifically.
@@ -2704,6 +2714,8 @@ extension SyntaxTransformVisitor {
     case .discardAssignmentExpr(let derived):
       return visit(derived)
     case .assignmentExpr(let derived):
+      return visit(derived)
+    case .packElementExpr(let derived):
       return visit(derived)
     case .sequenceExpr(let derived):
       return visit(derived)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -311,6 +311,16 @@ open class SyntaxVisitor {
   /// The function called after visiting `AssignmentExprSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: AssignmentExprSyntax) {}
+  /// Visiting `PackElementExprSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: PackElementExprSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `PackElementExprSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: PackElementExprSyntax) {}
   /// Visiting `SequenceExprSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -2971,6 +2981,17 @@ open class SyntaxVisitor {
   }
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplPackElementExprSyntax(_ data: SyntaxData) {
+    let node = PackElementExprSyntax(data)
+    let needsChildren = (visit(node) == .visitChildren)
+    // Avoid calling into visitChildren if possible.
+    if needsChildren && !node.raw.layoutView!.children.isEmpty {
+      visitChildren(node)
+    }
+    visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplSequenceExprSyntax(_ data: SyntaxData) {
     let node = SequenceExprSyntax(data)
     let needsChildren = (visit(node) == .visitChildren)
@@ -5621,6 +5642,8 @@ open class SyntaxVisitor {
       visitImplDiscardAssignmentExprSyntax(data)
     case .assignmentExpr:
       visitImplAssignmentExprSyntax(data)
+    case .packElementExpr:
+      visitImplPackElementExprSyntax(data)
     case .sequenceExpr:
       visitImplSequenceExprSyntax(data)
     case .exprList:

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -1709,6 +1709,192 @@ extension AssignmentExprSyntax: CustomReflectable {
   }
 }
 
+// MARK: - PackElementExprSyntax
+
+public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+  public let _syntaxNode: Syntax
+
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .packElementExpr else { return nil }
+    self._syntaxNode = node._syntaxNode
+  }
+
+  /// Creates a `PackElementExprSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .packElementExpr)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public init<P: ExprSyntaxProtocol>(
+    leadingTrivia: Trivia? = nil,
+    _ unexpectedBeforeEachKeyword: UnexpectedNodesSyntax? = nil,
+    eachKeyword: TokenSyntax = .contextualKeyword("each"),
+    _ unexpectedBetweenEachKeywordAndPackRefExpr: UnexpectedNodesSyntax? = nil,
+    packRefExpr: P,
+    _ unexpectedAfterPackRefExpr: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeEachKeyword?.raw,
+      eachKeyword.raw,
+      unexpectedBetweenEachKeywordAndPackRefExpr?.raw,
+      packRefExpr.raw,
+      unexpectedAfterPackRefExpr?.raw,
+    ]
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.packElementExpr, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
+      return SyntaxData.forRoot(raw)
+    }
+    self.init(data)
+  }
+
+  public var unexpectedBeforeEachKeyword: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 0, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBeforeEachKeyword(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBeforeEachKeyword` replaced.
+  /// - param newChild: The new `unexpectedBeforeEachKeyword` to replace the node's
+  ///                   current `unexpectedBeforeEachKeyword`, if present.
+  public func withUnexpectedBeforeEachKeyword(_ newChild: UnexpectedNodesSyntax?) -> PackElementExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw
+    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+    return PackElementExprSyntax(newData)
+  }
+
+  public var eachKeyword: TokenSyntax {
+    get {
+      let childData = data.child(at: 1, parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withEachKeyword(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `eachKeyword` replaced.
+  /// - param newChild: The new `eachKeyword` to replace the node's
+  ///                   current `eachKeyword`, if present.
+  public func withEachKeyword(_ newChild: TokenSyntax?) -> PackElementExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena)
+    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+    return PackElementExprSyntax(newData)
+  }
+
+  public var unexpectedBetweenEachKeywordAndPackRefExpr: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenEachKeywordAndPackRefExpr(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenEachKeywordAndPackRefExpr` replaced.
+  /// - param newChild: The new `unexpectedBetweenEachKeywordAndPackRefExpr` to replace the node's
+  ///                   current `unexpectedBetweenEachKeywordAndPackRefExpr`, if present.
+  public func withUnexpectedBetweenEachKeywordAndPackRefExpr(_ newChild: UnexpectedNodesSyntax?) -> PackElementExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw
+    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+    return PackElementExprSyntax(newData)
+  }
+
+  public var packRefExpr: ExprSyntax {
+    get {
+      let childData = data.child(at: 3, parent: Syntax(self))
+      return ExprSyntax(childData!)
+    }
+    set(value) {
+      self = withPackRefExpr(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `packRefExpr` replaced.
+  /// - param newChild: The new `packRefExpr` to replace the node's
+  ///                   current `packRefExpr`, if present.
+  public func withPackRefExpr(_ newChild: ExprSyntax?) -> PackElementExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+    return PackElementExprSyntax(newData)
+  }
+
+  public var unexpectedAfterPackRefExpr: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterPackRefExpr(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterPackRefExpr` replaced.
+  /// - param newChild: The new `unexpectedAfterPackRefExpr` to replace the node's
+  ///                   current `unexpectedAfterPackRefExpr`, if present.
+  public func withUnexpectedAfterPackRefExpr(_ newChild: UnexpectedNodesSyntax?) -> PackElementExprSyntax {
+    let arena = SyntaxArena()
+    let raw = newChild?.raw
+    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+    return PackElementExprSyntax(newData)
+  }
+
+  public static var structure: SyntaxNodeStructure {
+    return .layout([
+      \Self.unexpectedBeforeEachKeyword,
+      \Self.eachKeyword,
+      \Self.unexpectedBetweenEachKeywordAndPackRefExpr,
+      \Self.packRefExpr,
+      \Self.unexpectedAfterPackRefExpr,
+    ])
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
+}
+
+extension PackElementExprSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "unexpectedBeforeEachKeyword": unexpectedBeforeEachKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "eachKeyword": Syntax(eachKeyword).asProtocol(SyntaxProtocol.self),
+      "unexpectedBetweenEachKeywordAndPackRefExpr": unexpectedBetweenEachKeywordAndPackRefExpr.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "packRefExpr": Syntax(packRefExpr).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterPackRefExpr": unexpectedAfterPackRefExpr.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+    ])
+  }
+}
+
 // MARK: - SequenceExprSyntax
 
 public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -891,6 +891,15 @@ extension OperatorPrecedenceAndTypes {
   }
 }
 
+extension PackElementExpr {
+  /// A convenience initializer that allows:
+  ///  - Initializing syntax collections using result builders
+  ///  - Initializing tokens without default text using strings
+  public init (leadingTrivia: Trivia? = nil, unexpectedBeforeEachKeyword: UnexpectedNodes? = nil, eachKeyword: String, unexpectedBetweenEachKeywordAndPackRefExpr: UnexpectedNodes? = nil, packRefExpr: ExprSyntaxProtocol, trailingTrivia: Trivia? = nil) {
+    self.init (leadingTrivia: leadingTrivia, unexpectedBeforeEachKeyword, eachKeyword: Token.`contextualKeyword`(eachKeyword), unexpectedBetweenEachKeywordAndPackRefExpr, packRefExpr: ExprSyntax(fromProtocol: packRefExpr), trailingTrivia: trailingTrivia)
+  }
+}
+
 extension ParameterClause {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders

--- a/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/SyntaxExpressibleByStringInterpolationConformances.swift
@@ -297,6 +297,9 @@ extension OptionalPatternSyntax: SyntaxExpressibleByStringInterpolation {
 extension OptionalTypeSyntax: SyntaxExpressibleByStringInterpolation { 
 }
 
+extension PackElementExprSyntax: SyntaxExpressibleByStringInterpolation { 
+}
+
 extension PackExpansionTypeSyntax: SyntaxExpressibleByStringInterpolation { 
 }
 

--- a/Sources/SwiftSyntaxBuilder/generated/Typealiases.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/Typealiases.swift
@@ -365,6 +365,8 @@ public typealias OptionalPattern = OptionalPatternSyntax
 
 public typealias OptionalType = OptionalTypeSyntax
 
+public typealias PackElementExpr = PackElementExprSyntax
+
 public typealias PackExpansionType = PackExpansionTypeSyntax
 
 public typealias PackReferenceType = PackReferenceTypeSyntax

--- a/Tests/SwiftParserTest/VariadicGenericsTests.swift
+++ b/Tests/SwiftParserTest/VariadicGenericsTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-
+import SwiftSyntax
 import XCTest
 
 final class VariadicGenericsTests: XCTestCase {
@@ -58,6 +58,86 @@ final class VariadicGenericsTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(message: "unexpected code '& P' in parameter clause")
       ]
+    )
+  }
+
+  func testPackElementExprSimple() {
+    AssertParse(
+      """
+      func tuplify<T...>(_ t: (each T)...) -> ((each T)...) {
+        return ((each t)...)
+      }
+      """
+    )
+
+    AssertParse(
+      """
+      func zip<T..., U...>(_ first: T..., with second: U...) -> ((T, U)...) {
+        return ((each first, each second)...)
+      }
+      """
+    )
+
+    AssertParse(
+      """
+      func variadicMap<T..., Result...>(_ t: T..., transform: ((T) -> Result)...) -> (Result...) {
+        return ((each transform)(each t)...)
+      }
+      """
+    )
+  }
+
+  func testEachExprContextualKeyword() {
+    let callExpr = FunctionCallExprSyntax(
+      calledExpression: IdentifierExprSyntax(
+        identifier: .identifier("each")
+      ),
+      leftParen: .leftParen,
+      argumentList: TupleExprElementListSyntax([
+        .init(expression:
+                IdentifierExprSyntax(
+                  identifier: .identifier("x")
+                )
+             )
+      ]),
+      rightParen: .rightParen
+    )
+
+    AssertParse(
+      """
+      func test() {
+      1️⃣each(x)
+      }
+      """,
+      substructure: Syntax(callExpr),
+      substructureAfterMarker: "1️⃣"
+    )
+
+    AssertParse(
+      """
+      func test() {
+      1️⃣each (x)
+      }
+      """,
+      substructure: Syntax(callExpr),
+      substructureAfterMarker: "1️⃣"
+    )
+
+    AssertParse(
+      """
+      func test() {
+      1️⃣each x
+      }
+      """,
+      substructure: Syntax(
+        PackElementExprSyntax(
+          eachKeyword: .contextualKeyword("each"),
+          packRefExpr: IdentifierExprSyntax(
+            identifier: .identifier("x")
+          )
+        )
+      ),
+      substructureAfterMarker: "1️⃣"
     )
   }
 }

--- a/gyb_syntax_support/ExprNodes.py
+++ b/gyb_syntax_support/ExprNodes.py
@@ -120,6 +120,14 @@ EXPR_NODES = [
              Child('AssignToken', kind='EqualToken'),
          ]),
 
+    # A pack element expr spelled with 'each'.
+    Node('PackElementExpr', name_for_diagnostics=None, kind='Expr',
+         children=[
+             Child('EachKeyword', kind='ContextualKeywordToken',
+                   text_choices=['each']),
+             Child('PackRefExpr', kind='Expr'),
+         ]),
+
     # A flat list of expressions before sequence folding, e.g. 1 + 2 + 3.
     Node('SequenceExpr', name_for_diagnostics=None, kind='Expr',
          children=[


### PR DESCRIPTION
This change adds a new `PackElementExprSyntax` and parses a contextual `each` keyword in expression context as this new syntax node. This is the expression follow-up to https://github.com/apple/swift-syntax/pull/1134