### PR TITLE
Fix trailing space on `init` keyword

### DIFF
--- a/CodeGeneration/Sources/generate-swiftbasicformat/BasicFormatFile.swift
+++ b/CodeGeneration/Sources/generate-swiftbasicformat/BasicFormatFile.swift
@@ -141,8 +141,8 @@ let basicFormatFile = SourceFile {
         switch (token.tokenKind, token.nextToken(viewMode: .sourceAccurate)?.tokenKind) {
         case (.asKeyword, .exclamationMark),
              (.asKeyword, .postfixQuestionMark),
-             (.initKeyword, .postfixQuestionMark),
              (.initKeyword, .leftParen),
+             (.initKeyword, .postfixQuestionMark),
              (.tryKeyword, .exclamationMark),
              (.tryKeyword, .postfixQuestionMark):
           return false

--- a/CodeGeneration/Sources/generate-swiftbasicformat/BasicFormatFile.swift
+++ b/CodeGeneration/Sources/generate-swiftbasicformat/BasicFormatFile.swift
@@ -142,6 +142,7 @@ let basicFormatFile = SourceFile {
         case (.asKeyword, .exclamationMark),
              (.asKeyword, .postfixQuestionMark),
              (.initKeyword, .postfixQuestionMark),
+             (.initKeyword, .leftParen),
              (.tryKeyword, .exclamationMark),
              (.tryKeyword, .postfixQuestionMark):
           return false

--- a/Sources/SwiftBasicFormat/generated/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat.swift
@@ -141,6 +141,7 @@ open class BasicFormat: SyntaxRewriter {
     case (.asKeyword, .exclamationMark), 
      (.asKeyword, .postfixQuestionMark), 
      (.initKeyword, .postfixQuestionMark), 
+     (.initKeyword, .leftParen), 
      (.tryKeyword, .exclamationMark), 
      (.tryKeyword, .postfixQuestionMark): 
       return false

--- a/Sources/SwiftBasicFormat/generated/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat.swift
@@ -140,8 +140,8 @@ open class BasicFormat: SyntaxRewriter {
     switch (token.tokenKind, token.nextToken(viewMode: .sourceAccurate)?.tokenKind) {
     case (.asKeyword, .exclamationMark), 
      (.asKeyword, .postfixQuestionMark), 
-     (.initKeyword, .postfixQuestionMark), 
      (.initKeyword, .leftParen), 
+     (.initKeyword, .postfixQuestionMark), 
      (.tryKeyword, .exclamationMark), 
      (.tryKeyword, .postfixQuestionMark): 
       return false

--- a/Tests/SwiftSyntaxBuilderTest/InitializerDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/InitializerDeclTests.swift
@@ -17,6 +17,22 @@ import SwiftSyntaxBuilder
 final class InitializerDeclTests: XCTestCase {
   func testInitializerDecl() {
     let builder = InitializerDecl("""
+      public init(errorCode: Int) {
+        self.code = errorCode
+      }
+      """)
+    
+    print(builder.formatted().description)
+    
+    AssertBuildResult(builder, """
+      public init(errorCode: Int) {
+          self.code = errorCode
+      }
+      """)
+  }
+  
+  func testFailableInitializerDecl() {
+    let builder = InitializerDecl("""
       public init?(errorCode: Int) {
         guard errorCode > 0 else { return nil }
         self.code = errorCode

--- a/Tests/SwiftSyntaxBuilderTest/InitializerDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/InitializerDeclTests.swift
@@ -22,8 +22,6 @@ final class InitializerDeclTests: XCTestCase {
       }
       """)
     
-    print(builder.formatted().description)
-    
     AssertBuildResult(builder, """
       public init(errorCode: Int) {
           self.code = errorCode
@@ -38,8 +36,6 @@ final class InitializerDeclTests: XCTestCase {
         self.code = errorCode
       }
       """)
-    
-    print(builder.formatted().description)
     
     AssertBuildResult(builder, """
       public init?(errorCode: Int) {


### PR DESCRIPTION
Minor fix-up to #1137 which solves the problem of `BasicFormat` formatting `init()` into `init ()`.