### PR TITLE
Prepend/append trivia passed to RawSyntax.makeLayout instead of overriding it

### DIFF
--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -714,12 +714,12 @@ extension RawSyntax {
       if let leadingTrivia = leadingTrivia,
         let idx = layout.firstIndex(where: { $0 != nil })
       {
-        layout[idx] = layout[idx]!.withLeadingTrivia(leadingTrivia, arena: arena)
+        layout[idx] = layout[idx]!.withLeadingTrivia(leadingTrivia + (layout[idx]?.formLeadingTrivia() ?? []), arena: arena)
       }
       if let trailingTrivia = trailingTrivia,
         let idx = layout.lastIndex(where: { $0 != nil })
       {
-        layout[idx] = layout[idx]!.withTrailingTrivia(trailingTrivia, arena: arena)
+        layout[idx] = layout[idx]!.withTrailingTrivia((layout[idx]?.formTrailingTrivia() ?? []) + trailingTrivia, arena: arena)
       }
       return .makeLayout(kind: kind, from: layout, arena: arena)
     }

--- a/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
@@ -211,4 +211,27 @@ public class SyntaxCreationTests: XCTestCase {
       XCTAssertEqual("\(exprList)", "1 \(operatorName) 1")
     }
   }
+
+  func testTriviaInInitializxerDoesNotOverrideFirstNode() {
+    let node = ExpressionPatternSyntax(
+      leadingTrivia: .lineComment("// Outer leading") + .newline,
+      expression: IntegerLiteralExprSyntax(
+        leadingTrivia: .lineComment("// Inner leading") + .newline,
+        digits: .integerLiteral("42"),
+        trailingTrivia: .newline + .lineComment("// Inner trailing")
+      ),
+      trailingTrivia: .newline + .lineComment("// Outer trailing")
+    )
+
+    XCTAssertEqual(
+      node.description,
+      """
+      // Outer leading
+      // Inner leading
+      42
+      // Inner trailing
+      // Outer trailing
+      """
+    )
+  }
 }


### PR DESCRIPTION
Previously, the first/last node's leading/trailing trivia was overriden. That’s surprising. Instead, we want to prepend/append the new trivia.

Discovered by @kimdv here: https://github.com/apple/swift-syntax/pull/1151/files#r1050708880