### PR TITLE
Use generic parameter for `TupleExprElement` convenience initializer

### DIFF
--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
@@ -376,7 +376,7 @@ extension TernaryExpr {
 extension TupleExprElement {
   /// A convenience initializer that allows passing in label as an optional string.
   /// The presence of the colon will be inferred based on the presence of the label.
-  public init(label: String? = nil, expression: ExprSyntax) {
+  public init<E: ExprSyntaxProtocol>(label: String? = nil, expression: E) {
     self.init(
       label: label.map { .identifier($0) },
       colon: label == nil ? nil : .colonToken(),

--- a/Tests/SwiftSyntaxBuilderTest/CustomAttributeTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/CustomAttributeTests.swift
@@ -21,8 +21,8 @@ final class CustomAttributeTests: XCTestCase {
       #line: (CustomAttribute("WithParens") {}, "@WithParens()"),
       #line: (
         CustomAttribute("WithArgs") {
-          TupleExprElement(expression: "value1")
-          TupleExprElement(label: "labelled", expression: "value2")
+          TupleExprElement(expression: Expr("value1"))
+          TupleExprElement(label: "labelled", expression: Expr("value2"))
         }, "@WithArgs(value1, labelled: value2)"
       ),
     ]

--- a/Tests/SwiftSyntaxBuilderTest/DoStmtTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/DoStmtTests.swift
@@ -43,7 +43,7 @@ final class DoStmtTests: XCTestCase {
         },
         CatchClause {
           FunctionCallExpr(callee: ExprSyntax("print")) {
-            TupleExprElement(expression: "error")
+            TupleExprElement(expression: Expr("error"))
           }
         },
       ]

--- a/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
@@ -40,7 +40,7 @@ final class FunctionTests: XCTestCase {
   func testArguments() {
     let buildable = FunctionCallExpr(callee: ExprSyntax("test")) {
       for param in (1...5) {
-        TupleExprElement(label: param.isMultiple(of: 2) ? "p\(param)" : nil, expression: "value\(raw: param)")
+        TupleExprElement(label: param.isMultiple(of: 2) ? "p\(param)" : nil, expression: Expr("value\(raw: param)"))
       }
     }
     AssertBuildResult(buildable, "test(value1, p2: value2, value3, p4: value4, value5)")
@@ -130,7 +130,7 @@ final class FunctionTests: XCTestCase {
 
   func testParensEmittedForArgumentAndTrailingClosure() {
     let buildable = FunctionCallExpr(callee: ExprSyntax("test"), trailingClosure: ClosureExpr()) {
-      TupleExprElement(expression: "42")
+      TupleExprElement(expression: Expr("42"))
     }
     AssertBuildResult(buildable, "test(42) {\n}")
   }
@@ -138,7 +138,7 @@ final class FunctionTests: XCTestCase {
   func testParensOmittedForNoArgumentsAndTrailingClosure() {
     let closure = ClosureExpr(statementsBuilder: {
       FunctionCallExpr(callee: ExprSyntax("f")) {
-        TupleExprElement(expression: "a")
+        TupleExprElement(expression: Expr("a"))
       }
     })
     let buildable = FunctionCallExpr(callee: ExprSyntax("test"), trailingClosure: closure)

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -176,8 +176,8 @@ final class VariableTests: XCTestCase {
         VariableDecl(
           attributes: AttributeList {
             CustomAttribute("WithArgs") {
-              TupleExprElement(expression: "value1")
-              TupleExprElement(label: "label", expression: "value2")
+              TupleExprElement(expression: Expr("value1"))
+              TupleExprElement(label: "label", expression: Expr("value2"))
             }
           },
           name: "z",
@@ -195,7 +195,7 @@ final class VariableTests: XCTestCase {
         VariableDecl(
           attributes: AttributeList {
             CustomAttribute("WithArgs") {
-              TupleExprElement(expression: "value")
+              TupleExprElement(expression: Expr("value"))
             }
           },
           modifiers: [DeclModifier(name: .public)],


### PR DESCRIPTION
This includes breaking changes! ⚠️

Not sure if we should deprecate the convince initialiser or just merge it?