### PR TITLE
Bump swift-syntax from `0.50700.0` to `0.50700.1` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Replace `<#Specify Release tag#>` by the version of SwiftSyntax that you want to
 
 | Xcode Release | Swift Release Tag | SwiftSyntax Release Tag  |
 |:-------------------:|:-------------------:|:-------------------------:|
-| Xcode 14.0   | swift-5.7-RELEASE   | 0.50700.0 |
+| Xcode 14.0   | swift-5.7-RELEASE   | 0.50700.1 |
 | Xcode 13.3   | swift-5.6-RELEASE   | 0.50600.1 |
 | Xcode 13.0   | swift-5.5-RELEASE   | 0.50500.0 |
 | Xcode 12.5   | swift-5.4-RELEASE   | 0.50400.0 |


### PR DESCRIPTION
Bump swift-syntax from `0.50700.0` to `0.50700.1` in README.
Is it for Linux compatibility that the README is not updated?

## Reference

- https://github.com/apple/swift-syntax/releases/tag/0.50700.1