### PR TITLE
Explicitly model all supported contextual keywords in the `contextualKeyword` `RawTokenKind`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ If you are seeing issues regarding a mismatched parser library, try the followin
 Tip: Running SwiftSyntax’s self-parse tests takes the majority of testing time. If you want to iterate quickly, you can skip these tests using the following steps:
 1. Product -> Scheme -> Edit Scheme…
 2. Select the Arguments tab in the Run section
-3. Add a `SKIP_SELF_PARSE` environment variable with value `1`
+3. Add a `SKIP_LONG_TESTS` environment variable with value `1`
 
 ### `lit`-based tests
 

--- a/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift.gyb
+++ b/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift.gyb
@@ -29,6 +29,7 @@ public class TokenSpec {
   public let isKeyword: Bool
   public let requiresLeadingSpace: Bool
   public let requiresTrailingSpace: Bool
+  public let associatedValueClass: String?
 
   public var swiftKind: String {
     let name = lowercaseFirstWord(name: self.name)
@@ -49,7 +50,8 @@ public class TokenSpec {
     classification: String = "None",
     isKeyword: Bool = false,
     requiresLeadingSpace: Bool = false,
-    requiresTrailingSpace: Bool = false
+    requiresTrailingSpace: Bool = false,
+    associatedValueClass: String? = nil
   ) {
     self.name = name
     self.kind = kind
@@ -64,6 +66,7 @@ public class TokenSpec {
     self.isKeyword = isKeyword
     self.requiresLeadingSpace = requiresLeadingSpace
     self.requiresTrailingSpace = requiresTrailingSpace
+    self.associatedValueClass = associatedValueClass
   }
 }
 
@@ -243,6 +246,9 @@ public let SYNTAX_TOKENS: [TokenSpec] = [
 %     if token.requires_trailing_space:
 %       parameters += ['requiresTrailingSpace: true']
 %     end
+%   end
+%   if token.associated_value_class:
+%     parameters += [f'associatedValueClass: "{token.associated_value_class}"']
 %   end
   ${class_name}Spec(${", ".join(parameters)}),
 % end

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/TokenSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/TokenSpec.swift
@@ -23,6 +23,7 @@ public class TokenSpec {
   public let isKeyword: Bool
   public let requiresLeadingSpace: Bool
   public let requiresTrailingSpace: Bool
+  public let associatedValueClass: String?
 
   public var swiftKind: String {
     let name = lowercaseFirstWord(name: self.name)
@@ -43,7 +44,8 @@ public class TokenSpec {
     classification: String = "None",
     isKeyword: Bool = false,
     requiresLeadingSpace: Bool = false,
-    requiresTrailingSpace: Bool = false
+    requiresTrailingSpace: Bool = false,
+    associatedValueClass: String? = nil
   ) {
     self.name = name
     self.kind = kind
@@ -58,6 +60,7 @@ public class TokenSpec {
     self.isKeyword = isKeyword
     self.requiresLeadingSpace = requiresLeadingSpace
     self.requiresTrailingSpace = requiresTrailingSpace
+    self.associatedValueClass = associatedValueClass
   }
 }
 
@@ -315,7 +318,7 @@ public let SYNTAX_TOKENS: [TokenSpec] = [
   MiscSpec(name: "PostfixOperator", kind: "oper_postfix", nameForDiagnostics: "postfix operator", classification: "OperatorIdentifier"),
   MiscSpec(name: "PrefixOperator", kind: "oper_prefix", nameForDiagnostics: "prefix operator", classification: "OperatorIdentifier"),
   MiscSpec(name: "DollarIdentifier", kind: "dollarident", nameForDiagnostics: "dollar identifier", classification: "DollarIdentifier"),
-  MiscSpec(name: "ContextualKeyword", kind: "contextual_keyword", nameForDiagnostics: "keyword", classification: "Keyword"),
+  MiscSpec(name: "ContextualKeyword", kind: "contextual_keyword", nameForDiagnostics: "keyword", classification: "Keyword", associatedValueClass: "Keyword"),
   MiscSpec(name: "RawStringDelimiter", kind: "raw_string_delimiter", nameForDiagnostics: "raw string delimiter"),
   MiscSpec(name: "StringSegment", kind: "string_segment", nameForDiagnostics: "string segment", classification: "StringLiteral"),
   MiscSpec(name: "Yield", kind: "kw_yield", nameForDiagnostics: "yield", text: "yield"),

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/basicformat/BasicFormatFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/basicformat/BasicFormatFile.swift
@@ -182,7 +182,7 @@ let basicFormatFile = SourceFile {
             }
           }
         }
-        SwitchCase(#"case .contextualKeyword("async"):"#) {
+        SwitchCase("case .contextualKeyword(.async):") {
           ReturnStmt("return true")
         }
         SwitchCase("default:") {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/DeclarationAttributeFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/DeclarationAttributeFile.swift
@@ -25,11 +25,49 @@ let declarationAttributeFile = SourceFile {
   )
   
   ExtensionDecl("extension Parser") {
-    EnumDecl("enum DeclarationAttribute: SyntaxText, ContextualKeywords") {
+    EnumDecl("enum DeclarationAttribute: RawTokenKindSubset") {
       for attribute in DECL_ATTR_KINDS {
-        EnumCaseDecl("case \(raw: attribute.swiftName) = \"\(raw: attribute.name)\"")
+        EnumCaseDecl("case \(raw: attribute.swiftName)")
       }
-      EnumCaseDecl(#"case _spi_available = "_spi_available""#)
+      EnumCaseDecl("case _spi_available")
+
+      InitializerDecl("init?(lexeme: Lexer.Lexeme)") {
+        SwitchStmt(switchKeyword: .switch, expression: Expr("lexeme")) {
+          for attribute in DECL_ATTR_KINDS {
+            SwitchCase("case RawTokenKindMatch(.\(raw: attribute.name)):") {
+              SequenceExpr("self = .\(raw: attribute.swiftName)")
+            }
+          }
+          SwitchCase("case RawTokenKindMatch(.rethrowsKeyword):") {
+            SequenceExpr("self = .atRethrows")
+          }
+          SwitchCase("case RawTokenKindMatch(._spi_available):") {
+            SequenceExpr("self = ._spi_available")
+          }
+          SwitchCase("default:") {
+            ReturnStmt("return nil")
+          }
+        }
+      }
+
+      VariableDecl(
+        name: IdentifierPattern("rawTokenKind"),
+        type: TypeAnnotation(
+          colon: .colon,
+          type: SimpleTypeIdentifier("RawTokenKind")
+        )
+      ) {
+        SwitchStmt(switchKeyword: .switch, expression: Expr("self")) {
+          for attribute in DECL_ATTR_KINDS {
+            SwitchCase("case .\(raw: attribute.swiftName):") {
+              ReturnStmt("return .contextualKeyword(.\(raw: attribute.name))")
+            }
+          }
+          SwitchCase("case ._spi_available:") {
+            ReturnStmt("return .contextualKeyword(._spi_available)")
+          }
+        }
+      }
     }
   }
 }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/TypeAttributeFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/TypeAttributeFile.swift
@@ -25,9 +25,38 @@ let typeAttributeFile = SourceFile {
   )
   
   ExtensionDecl("extension Parser") {
-    EnumDecl("enum TypeAttribute: SyntaxText, ContextualKeywords") {
+    EnumDecl("enum TypeAttribute: RawTokenKindSubset") {
       for attribute in TYPE_ATTR_KINDS {
-        EnumCaseDecl("case \(raw: attribute.name) = \"\(raw: attribute.name)\"")
+        EnumCaseDecl("case \(raw: attribute.name)")
+      }
+
+      InitializerDecl("init?(lexeme: Lexer.Lexeme)") {
+        SwitchStmt(switchKeyword: .switch, expression: Expr("lexeme")) {
+          for attribute in TYPE_ATTR_KINDS {
+            SwitchCase("case RawTokenKindMatch(.\(raw: attribute.name)):") {
+              SequenceExpr("self = .\(raw: attribute.swiftName)")
+            }
+          }
+          SwitchCase("default:") {
+            ReturnStmt("return nil")
+          }
+        }
+      }
+
+      VariableDecl(
+        name: IdentifierPattern("rawTokenKind"),
+        type: TypeAnnotation(
+          colon: .colon,
+          type: SimpleTypeIdentifier("RawTokenKind")
+        )
+      ) {
+        SwitchStmt(switchKeyword: .switch, expression: Expr("self")) {
+          for attribute in TYPE_ATTR_KINDS {
+            SwitchCase("case .\(raw: attribute.swiftName):") {
+              ReturnStmt("return .contextualKeyword(.\(raw: attribute.name))")
+            }
+          }
+        }
       }
     }
   }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTraitsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTraitsFile.swift
@@ -25,7 +25,7 @@ let syntaxTraitsFile = SourceFileSyntax {
       
       for child in trait.children {
         VariableDeclSyntax("var \(raw: child.swiftName): \(raw: child.typeName)\(raw: child.isOptional ? "?" : "") { get }")
-        FunctionDeclSyntax("func with\(raw: child.name)(_ newChild: \(raw: child.typeName)?) -> Self")
+        FunctionDeclSyntax("func with\(raw: child.name)(_ newChild: \(raw: child.typeName)\(raw: child.isOptional ? "?" : "")) -> Self")
       }
     }
     

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokensFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokensFile.swift
@@ -49,6 +49,22 @@ let tokensFile = SourceFile(
             )
           }
           """)
+        } else if let associatedValueClass = token.associatedValueClass {
+          FunctionDecl("""
+          public static func \(raw: token.swiftKind)(
+            _ value: \(raw: associatedValueClass),
+            leadingTrivia: Trivia = [],
+            trailingTrivia: Trivia = [],
+            presence: SourcePresence = .present
+          ) -> TokenSyntax {
+            return TokenSyntax(
+              .\(raw: token.swiftKind)(value),
+              leadingTrivia: leadingTrivia,
+              trailingTrivia: trailingTrivia,
+              presence: presence
+            )
+          }
+          """)
         } else {
           FunctionDecl("""
           public static func \(raw: token.swiftKind)(

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntaxbuilder/BuildableNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntaxbuilder/BuildableNodesFile.swift
@@ -112,7 +112,7 @@ private func createConvenienceInitializer(node: Node) -> InitializerDecl? {
     } else if let token = child.type.token, token.text == nil {
       // Allow initializing identifiers and other tokens without default text with a String
       shouldCreateInitializer = true
-      let paramType = child.type.optionalWrapped(type: Type("String"))
+      let paramType = child.type.optionalWrapped(type: "\(raw: token.associatedValueClass ?? "String")" as TypeSyntax)
       let tokenExpr = MemberAccessExpr("Token.\(raw: token.swiftKind.withFirstCharacterLowercased.backticked)")
       if child.type.isOptional {
         produceExpr = Expr(FunctionCallExpr("\(raw: child.swiftName).map { \(tokenExpr)($0) }"))

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntaxbuilder/TokenFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntaxbuilder/TokenFile.swift
@@ -52,7 +52,7 @@ let tokenFile = SourceFile {
     VariableDecl("""
       /// The `open` contextual token
       static var open: TokenSyntax {
-        return .contextualKeyword("open").withTrailingTrivia(.space)
+        return .contextualKeyword(.open).withTrailingTrivia(.space)
       }
       """
     )

--- a/Sources/SwiftBasicFormat/generated/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat.swift
@@ -336,7 +336,7 @@ open class BasicFormat: SyntaxRewriter {
       return true
     case .spacedBinaryOperator: 
       return true
-    case .contextualKeyword("async"): 
+    case .contextualKeyword(.async): 
       return true
     default: 
       return false

--- a/Sources/SwiftOperators/PrecedenceGroup.swift
+++ b/Sources/SwiftOperators/PrecedenceGroup.swift
@@ -43,6 +43,13 @@ public struct PrecedenceRelation {
   public enum Kind {
     case higherThan
     case lowerThan
+
+    var keyword: Keyword {
+      switch self {
+      case .higherThan: return .higherThan
+      case .lowerThan: return .lowerThan
+      }
+    }
   }
 
   /// The relationship to the other group.

--- a/Sources/SwiftOperators/SyntaxSynthesis.swift
+++ b/Sources/SwiftOperators/SyntaxSynthesis.swift
@@ -49,7 +49,7 @@ extension PrecedenceRelation {
   ) -> PrecedenceGroupRelationSyntax {
     PrecedenceGroupRelationSyntax(
       higherThanOrLowerThan: .contextualKeyword(
-        "\(kind)",
+        kind.keyword,
         leadingTrivia: [.newlines(1), .spaces(indentation)]
       ),
       colon: .colonToken(),

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -149,9 +149,9 @@ extension Parser {
 
     let argument: RawAttributeSyntax.Argument
     do {
-      if self.peek().tokenKind == .integerLiteral {
+      if self.peek().rawTokenKind == .integerLiteral {
         argument = .availability(self.parseAvailabilitySpecList(from: .available))
-      } else if self.peek().tokenKind == .floatingLiteral {
+      } else if self.peek().rawTokenKind == .floatingLiteral {
         argument = .availability(self.parseAvailabilitySpecList(from: .available))
       } else {
         argument = .availability(self.parseExtendedAvailabilitySpecList())
@@ -181,9 +181,9 @@ extension Parser {
 
     let argument: RawAttributeSyntax.Argument
     do {
-      if self.peek().tokenKind == .integerLiteral {
+      if self.peek().rawTokenKind == .integerLiteral {
         argument = .availability(self.parseAvailabilitySpecList(from: .available))
-      } else if self.peek().tokenKind == .floatingLiteral {
+      } else if self.peek().rawTokenKind == .floatingLiteral {
         argument = .availability(self.parseAvailabilitySpecList(from: .available))
       } else {
         argument = .availability(self.parseExtendedAvailabilitySpecList())
@@ -331,7 +331,7 @@ extension Parser {
       case selfKeyword
 
       init?(lexeme: Lexer.Lexeme) {
-        switch lexeme.tokenKind {
+        switch lexeme.rawTokenKind {
         case .identifier: self = .identifier
         case .integerLiteral: self = .integerLiteral
         case .selfKeyword: self = .selfKeyword
@@ -962,7 +962,7 @@ extension Parser.Lookahead {
     // Alternatively, we might have a token that illustrates we're not going to
     // get anything following the attribute, which means the parentheses describe
     // what follows the attribute.
-    switch lookahead.currentToken.tokenKind {
+    switch lookahead.currentToken.rawTokenKind {
     case .arrow,
       .throwKeyword,
       .throwsKeyword,

--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -21,6 +21,7 @@ add_swift_host_library(SwiftParser
   Nominals.swift
   Parser.swift
   Patterns.swift
+  RawTokenKindMatch.swift
   RawTokenKindSubset.swift
   Recovery.swift
   Statements.swift

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -47,7 +47,7 @@ extension TokenConsumer {
       _ = subparser.consumeAttributeList()
     }
 
-    if subparser.currentToken.isKeyword || subparser.currentToken.tokenKind == .identifier {
+    if subparser.currentToken.isKeyword || subparser.currentToken.rawTokenKind == .identifier {
       var modifierProgress = LoopProgressCondition()
       while let (modifierKind, handle) = subparser.at(anyIn: DeclarationModifier.self),
         modifierKind != .classKeyword,
@@ -85,7 +85,7 @@ extension TokenConsumer {
     switch declStartKeyword {
     case .actorContextualKeyword:
       // actor Foo {}
-      if subparser.peek().tokenKind == .identifier {
+      if subparser.peek().rawTokenKind == .identifier {
         return true
       }
       // actor may be somewhere in the modifier list. Eat the tokens until we get
@@ -104,7 +104,7 @@ extension TokenConsumer {
       return allowInitDecl
     case .macroContextualKeyword:
       // macro Foo ...
-      return subparser.peek().tokenKind == .identifier
+      return subparser.peek().rawTokenKind == .identifier
     case .some(_):
       // All other decl start keywords unconditonally start a decl.
       return true
@@ -250,8 +250,8 @@ extension Parser {
       return RawDeclSyntax(self.parseMacroDeclaration(attrs: attrs, introducerHandle: handle))
     case nil:
       if inMemberDeclList {
-        let isProbablyVarDecl = self.at(any: [.identifier, .wildcardKeyword]) && self.peek().tokenKind.is(any: [.colon, .equal, .comma])
-        let isProbablyTupleDecl = self.at(.leftParen) && self.peek().tokenKind.is(any: [.identifier, .wildcardKeyword])
+        let isProbablyVarDecl = self.at(any: [.identifier, .wildcardKeyword]) && self.peek().rawTokenKind.is(any: [.colon, .equal, .comma])
+        let isProbablyTupleDecl = self.at(.leftParen) && self.peek().rawTokenKind.is(any: [.identifier, .wildcardKeyword])
 
         if isProbablyVarDecl || isProbablyTupleDecl {
           return RawDeclSyntax(self.parseLetOrVarDeclaration(attrs, .missing(.varKeyword)))
@@ -553,7 +553,7 @@ extension Parser {
           case prefixOperator
 
           init?(lexeme: Lexer.Lexeme) {
-            switch (lexeme.tokenKind, lexeme.tokenText) {
+            switch (lexeme.rawTokenKind, lexeme.tokenText) {
             case (.colon, _): self = .colon
             case (.spacedBinaryOperator, "=="): self = .spacedBinaryOperator
             case (.unspacedBinaryOperator, "=="): self = .unspacedBinaryOperator
@@ -1242,7 +1242,7 @@ extension Parser {
     let identifier: RawTokenSyntax
     if self.at(anyIn: Operator.self) != nil || self.at(any: [.exclamationMark, .prefixAmpersand]) || self.atRegexLiteralThatCouldBeAnOperator() {
       var name = self.currentToken.tokenText
-      if name.count > 1 && name.hasSuffix("<") && self.peek().tokenKind == .identifier {
+      if name.count > 1 && name.hasSuffix("<") && self.peek().rawTokenKind == .identifier {
         name = SyntaxText(rebasing: name.dropLast())
       }
       unexpectedBeforeIdentifier = nil
@@ -1338,7 +1338,7 @@ extension Parser {
     let (unexpectedBeforeSubscriptKeyword, subscriptKeyword) = self.eat(handle)
 
     let unexpectedName: RawTokenSyntax?
-    if self.at(.identifier) && self.peek().starts(with: "<") || self.peek().tokenKind == .leftParen {
+    if self.at(.identifier) && self.peek().starts(with: "<") || self.peek().rawTokenKind == .leftParen {
       unexpectedName = self.consumeAnyToken()
     } else {
       unexpectedName = nil
@@ -2057,7 +2057,7 @@ extension Parser {
       case poundWarningKeyword
 
       init?(lexeme: Lexer.Lexeme) {
-        switch lexeme.tokenKind {
+        switch lexeme.rawTokenKind {
         case .poundErrorKeyword: self = .poundErrorKeyword
         case .poundWarningKeyword: self = .poundWarningKeyword
         default: return nil

--- a/Sources/SwiftParser/Lexer.swift
+++ b/Sources/SwiftParser/Lexer.swift
@@ -46,7 +46,7 @@ public struct Lexer {
     }
 
     @_spi(RawSyntax)
-    public var tokenKind: RawTokenKind
+    public var rawTokenKind: RawTokenKind
     public var flags: Lexeme.Flags
     public var error: LexerError?
     var start: UnsafePointer<UInt8>
@@ -59,12 +59,12 @@ public struct Lexer {
     }
 
     var isMultilineStringLiteral: Bool {
-      assert(self.tokenKind == .stringLiteral)
+      assert(self.rawTokenKind == .stringLiteral)
       return self.flags.contains(.isMultilineStringLiteral)
     }
 
     var isEditorPlaceholder: Bool {
-      return self.tokenKind == .identifier && self.tokenText.isEditorPlaceholder
+      return self.rawTokenKind == .identifier && self.tokenText.isEditorPlaceholder
     }
 
     @_spi(RawSyntax)
@@ -77,7 +77,7 @@ public struct Lexer {
       textLength: Int,
       trailingTriviaLength: Int
     ) {
-      self.tokenKind = tokenKind
+      self.rawTokenKind = tokenKind
       self.flags = flags
       self.error = error
       self.start = start

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -266,7 +266,7 @@ extension Parser.Lookahead {
     }
 
     // If we don't have attributes, then it cannot be an accessor block.
-    if nextToken.tokenKind != .atSign {
+    if nextToken.rawTokenKind != .atSign {
       return false
     }
 
@@ -316,7 +316,7 @@ extension Parser.Lookahead {
     case poundElseifKeyword
 
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme.tokenKind {
+      switch lexeme.rawTokenKind {
       case .leftParen: self = .leftParen
       case .leftBrace: self = .leftBrace
       case .leftSquareBracket: self = .leftSquareBracket

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -286,7 +286,7 @@ extension Parser.Lookahead {
     }
 
     // Check if we have 'didSet'/'willSet' after attributes.
-    return lookahead.at(any: [], contextualKeywords: ["didSet", "willSet"])
+    return lookahead.at(any: [.contextualKeyword(.didSet), .contextualKeyword(.willSet)])
   }
 }
 

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -44,7 +44,7 @@ extension Parser {
         // treat 'class' as a modifier in the case of a following CC
         // token, we cannot be sure there is no intention to override
         // or witness something static.
-        if lookahead.atStartOfDeclaration() || lookahead.atContextualKeyword("override") {
+        if lookahead.atStartOfDeclaration() || lookahead.at(.contextualKeyword(.override)) {
           let classKeyword = self.eat(handle)
           elements.append(
             RawDeclModifierSyntax(
@@ -59,30 +59,31 @@ extension Parser {
         }
       case (.unowned, _)?:
         elements.append(self.parseUnownedModifier())
-      case (.final, _)?,
-        (.required, _)?,
-        (.optional, _)?,
-        (.lazy, _)?,
-        (.dynamic, _)?,
-        (.infix, _)?,
-        (.prefix, _)?,
-        (.postfix, _)?,
-        (.__consuming, _)?,
-        (.mutating, _)?,
-        (.nonmutating, _)?,
-        (.convenience, _)?,
-        (.override, _)?,
-        (.weak, _)?,
-        (.indirect, _)?,
-        (.isolated, _)?,
-        (.async, _)?,
-        (.nonisolated, _)?,
-        (.distributed, _)?,
-        (._const, _)?,
-        (._local, _)?,
-        (.__setter_access, _)?,
-        (.reasync, _)?:
-        elements.append(self.parseSimpleModifier())
+      case (.final, let handle)?,
+        (.required, let handle)?,
+        (.optional, let handle)?,
+        (.lazy, let handle)?,
+        (.dynamic, let handle)?,
+        (.infix, let handle)?,
+        (.prefix, let handle)?,
+        (.postfix, let handle)?,
+        (.__consuming, let handle)?,
+        (.mutating, let handle)?,
+        (.nonmutating, let handle)?,
+        (.convenience, let handle)?,
+        (.override, let handle)?,
+        (.weak, let handle)?,
+        (.indirect, let handle)?,
+        (.isolated, let handle)?,
+        (.async, let handle)?,
+        (.nonisolated, let handle)?,
+        (.distributed, let handle)?,
+        (._const, let handle)?,
+        (._local, let handle)?,
+        (.__setter_access, let handle)?,
+        (.reasync, let handle)?:
+        let keyword = self.eat(handle)
+        elements.append(RawDeclModifierSyntax(name: keyword, detail: nil, arena: self.arena))
       case (.rethrows, _)?:
         fallthrough
       case nil:
@@ -94,11 +95,6 @@ extension Parser {
 }
 
 extension Parser {
-  mutating func parseSimpleModifier() -> RawDeclModifierSyntax {
-    let keyword = self.consumeAnyToken(remapping: .contextualKeyword)
-    return RawDeclModifierSyntax(name: keyword, detail: nil, arena: self.arena)
-  }
-
   mutating func parseModifierDetail() -> RawDeclModifierDetailSyntax {
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
     let detailToken = self.consumeAnyToken()
@@ -114,7 +110,7 @@ extension Parser {
   }
 
   mutating func parseUnownedModifier() -> RawDeclModifierSyntax {
-    let (unexpectedBeforeKeyword, keyword) = self.expectContextualKeyword("unowned")
+    let (unexpectedBeforeKeyword, keyword) = self.expect(.contextualKeyword(.unowned))
 
     let detail: RawDeclModifierDetailSyntax?
     if self.at(.leftParen) {
@@ -132,7 +128,7 @@ extension Parser {
   }
 
   mutating func parsePackageAccessLevelModifier() -> RawDeclModifierSyntax {
-    let (unexpectedBeforeName, name) = self.expectContextualKeyword("package")
+    let (unexpectedBeforeName, name) = self.expect(.contextualKeyword(.package))
     let details = self.parseAccessModifierDetails()
     return RawDeclModifierSyntax(
       unexpectedBeforeName,
@@ -143,7 +139,7 @@ extension Parser {
   }
 
   mutating func parseOpenAccessLevelModifier() -> RawDeclModifierSyntax {
-    let (unexpectedBeforeName, name) = self.expectContextualKeyword("open")
+    let (unexpectedBeforeName, name) = self.expect(.contextualKeyword(.open))
     let details = self.parseAccessModifierDetails()
     return RawDeclModifierSyntax(
       unexpectedBeforeName,
@@ -174,12 +170,12 @@ extension Parser {
 
     let unexpectedBeforeDetail: RawUnexpectedNodesSyntax?
     let detail: RawTokenSyntax
-    if let setHandle = canRecoverToContextualKeyword("set", precedence: .weakBracketClose) {
+    if let setHandle = canRecoverTo(.contextualKeyword(.set), recoveryPrecedence: .weakBracketClose) {
       (unexpectedBeforeDetail, detail) = eat(setHandle)
     } else {
       unexpectedBeforeDetail = nil
       detail = RawTokenSyntax(
-        missing: .contextualKeyword,
+        missing: .contextualKeyword(.set),
         text: "set",
         arena: arena
       )

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -68,7 +68,7 @@ extension Parser {
       ident = self.expectIdentifierWithoutRecovery()
     } else if flags.contains(.operators), let (_, _) = self.at(anyIn: Operator.self) {
       ident = self.consumeAnyToken(remapping: .unspacedBinaryOperator)
-    } else if flags.contains(.keywords) && self.currentToken.tokenKind.isKeyword {
+    } else if flags.contains(.keywords) && self.currentToken.rawTokenKind.isKeyword {
       ident = self.consumeAnyToken(remapping: .identifier)
     } else {
       ident = self.expectIdentifierWithoutRecovery()
@@ -94,9 +94,9 @@ extension Parser {
     let next = self.peek()
 
     // A close parenthesis, if empty lists are allowed.
-    let nextIsRParen = flags.contains(.zeroArgCompoundNames) && next.tokenKind == .rightParen
+    let nextIsRParen = flags.contains(.zeroArgCompoundNames) && next.rawTokenKind == .rightParen
     // An argument label.
-    let nextIsArgLabel = next.canBeArgumentLabel() || next.tokenKind == .colon
+    let nextIsArgLabel = next.canBeArgumentLabel() || next.rawTokenKind == .colon
 
     guard nextIsRParen || nextIsArgLabel else {
       return nil
@@ -115,7 +115,7 @@ extension Parser {
       var loopProgress = LoopProgressCondition()
       while !self.at(any: [.eof, .rightParen]) && loopProgress.evaluate(currentToken) {
         // Check to see if there is an argument label.
-        assert(self.currentToken.canBeArgumentLabel() && self.peek().tokenKind == .colon)
+        assert(self.currentToken.canBeArgumentLabel() && self.peek().rawTokenKind == .colon)
         let name = self.consumeAnyToken()
         let (unexpectedBeforeColon, colon) = self.expect(.colon)
         elements.append(
@@ -239,7 +239,7 @@ extension Parser.Lookahead {
     var loopProgress = LoopProgressCondition()
     while !lookahead.at(any: [.eof, .rightParen]) && loopProgress.evaluate(lookahead.currentToken) {
       // Check to see if there is an argument label.
-      guard lookahead.currentToken.canBeArgumentLabel() && lookahead.peek().tokenKind == .colon else {
+      guard lookahead.currentToken.canBeArgumentLabel() && lookahead.peek().rawTokenKind == .colon else {
         return false
       }
 
@@ -262,7 +262,7 @@ extension Lexer.Lexeme {
     if TypeSpecifier(lexeme: self) != nil {
       return false
     }
-    switch self.tokenKind {
+    switch self.rawTokenKind {
     case .identifier, .wildcardKeyword:
       // Identifiers, escaped identifiers, and '_' can be argument labels.
       return true
@@ -275,7 +275,7 @@ extension Lexer.Lexeme {
   }
 
   func isContextualKeyword(_ name: SyntaxText) -> Bool {
-    switch self.tokenKind {
+    switch self.rawTokenKind {
     case .identifier, .contextualKeyword:
       return self.tokenText == name
     default:
@@ -284,7 +284,7 @@ extension Lexer.Lexeme {
   }
 
   func isContextualKeyword(_ names: [SyntaxText]) -> Bool {
-    switch self.tokenKind {
+    switch self.rawTokenKind {
     case .identifier, .contextualKeyword:
       return names.contains(self.tokenText)
     default:
@@ -297,11 +297,11 @@ extension Lexer.Lexeme {
   }
 
   var isKeyword: Bool {
-    self.tokenKind.isKeyword
+    self.rawTokenKind.isKeyword
   }
 
   func starts(with symbol: SyntaxText) -> Bool {
-    guard Operator(lexeme: self) != nil || self.tokenKind.isPunctuation else {
+    guard Operator(lexeme: self) != nil || self.rawTokenKind.isPunctuation else {
       return false
     }
 

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -174,7 +174,7 @@ public struct Parser {
   /// - Returns: The token that was consumed.
   @_spi(RawSyntax)
   public mutating func consumeAnyToken() -> RawTokenSyntax {
-    adjustNestingLevel(for: self.currentToken.tokenKind)
+    adjustNestingLevel(for: self.currentToken.rawTokenKind)
     return self.consumeAnyTokenWithoutAdjustingNestingLevel()
   }
 
@@ -183,7 +183,7 @@ public struct Parser {
     let tok = self.currentToken
     self.currentToken = self.lexemes.advance()
     return RawTokenSyntax(
-      kind: tok.tokenKind,
+      kind: tok.rawTokenKind,
       wholeText: tok.wholeText,
       textRange: tok.textRange,
       presence: .present,
@@ -228,7 +228,7 @@ extension Parser {
   ///            given `TokenKind`.
   @_spi(RawSyntax)
   public mutating func consumeAnyToken(remapping kind: RawTokenKind) -> RawTokenSyntax {
-    self.currentToken.tokenKind = kind
+    self.currentToken.rawTokenKind = kind
     return self.consumeAnyToken()
   }
 
@@ -263,7 +263,7 @@ extension Parser {
       return RecoveryConsumptionHandle(
         unexpectedTokens: 0,
         tokenConsumptionHandle: TokenConsumptionHandle(
-          tokenKind: self.currentToken.tokenKind,
+          tokenKind: self.currentToken.rawTokenKind,
           remappedKind: .contextualKeyword
         )
       )
@@ -285,7 +285,7 @@ extension Parser {
     if self.at(any: kinds) {
       return RecoveryConsumptionHandle(
         unexpectedTokens: 0,
-        tokenConsumptionHandle: TokenConsumptionHandle(tokenKind: self.currentToken.tokenKind)
+        tokenConsumptionHandle: TokenConsumptionHandle(tokenKind: self.currentToken.rawTokenKind)
       )
     }
     var lookahead = self.lookahead()
@@ -434,7 +434,7 @@ extension Parser {
         RawUnexpectedNodesSyntax(elements: [RawSyntax(number)], arena: self.arena),
         self.missingToken(.identifier, text: nil)
       )
-    } else if keywordRecovery, self.currentToken.tokenKind.isKeyword, !self.currentToken.isAtStartOfLine {
+    } else if keywordRecovery, self.currentToken.rawTokenKind.isKeyword, !self.currentToken.isAtStartOfLine {
       let keyword = self.consumeAnyToken()
       return (
         RawUnexpectedNodesSyntax(elements: [RawSyntax(keyword)], arena: self.arena),

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -55,7 +55,7 @@ extension Parser {
       case varKeyword
 
       init?(lexeme: Lexer.Lexeme) {
-        switch lexeme.tokenKind {
+        switch lexeme.rawTokenKind {
         case .leftParen: self = .leftParen
         case .wildcardKeyword: self = .wildcardKeyword
         case .identifier: self = .identifier
@@ -131,7 +131,7 @@ extension Parser {
         )
       )
     case nil:
-      if self.currentToken.tokenKind.isKeyword, !self.currentToken.isAtStartOfLine {
+      if self.currentToken.rawTokenKind.isKeyword, !self.currentToken.isAtStartOfLine {
         // Recover if a keyword was used instead of an identifier
         let keyword = self.consumeAnyToken()
         return RawPatternSyntax(
@@ -296,7 +296,7 @@ extension Parser.Lookahead {
       case leftParen
 
       init?(lexeme: Lexer.Lexeme) {
-        switch lexeme.tokenKind {
+        switch lexeme.rawTokenKind {
         case .identifier: self = .identifier
         case .wildcardKeyword: self = .wildcardKeyword
         case .letKeyword: self = .letKeyword
@@ -366,7 +366,7 @@ extension Parser.Lookahead {
 
     // If the next token is ':', this is a name.
     let nextTok = self.peek()
-    if nextTok.tokenKind == .colon {
+    if nextTok.rawTokenKind == .colon {
       return true
     }
 
@@ -385,11 +385,11 @@ extension Parser.Lookahead {
           return true  // isolated :
         }
         self.consumeAnyToken()
-        return self.currentToken.canBeArgumentLabel(allowDollarIdentifier: true) && self.peek().tokenKind == .colon
+        return self.currentToken.canBeArgumentLabel(allowDollarIdentifier: true) && self.peek().rawTokenKind == .colon
       }
     }
 
-    if nextTok.tokenKind == .postfixQuestionMark || nextTok.tokenKind == .exclamationMark {
+    if nextTok.rawTokenKind == .postfixQuestionMark || nextTok.rawTokenKind == .exclamationMark {
       return false
     }
 

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -373,7 +373,7 @@ extension Parser.Lookahead {
     // If the next token can be an argument label, we might have a name.
     if nextTok.canBeArgumentLabel(allowDollarIdentifier: true) {
       // If the first name wasn't "isolated", we're done.
-      if !self.atContextualKeyword("isolated") && !self.atContextualKeyword("some") && !self.atContextualKeyword("any") && !self.atContextualKeyword("each") && !self.at(.repeatKeyword) {
+      if !self.at(.contextualKeyword(.isolated)) && !self.at(.contextualKeyword(.some)) && !self.at(.contextualKeyword(.any)) && !self.at(.contextualKeyword(.each)) && !self.at(.repeatKeyword) {
         return true
       }
 

--- a/Sources/SwiftParser/RawTokenKindMatch.swift
+++ b/Sources/SwiftParser/RawTokenKindMatch.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RawSyntax) import SwiftSyntax
+
+/// Allows pattern matching of lexemes and tokens against `RawTokenKind` in a way
+/// that considers keywords and identifiers the same if their contents match.
+struct RawTokenKindMatch {
+  var rawTokenKind: RawTokenKind
+
+  init(_ rawTokenKind: RawTokenKind) {
+    self.rawTokenKind = rawTokenKind
+  }
+
+  init(_ keyword: Keyword) {
+    self.rawTokenKind = .contextualKeyword(keyword)
+  }
+
+  func matches(rawTokenKind: RawTokenKind, text: SyntaxText) -> Bool {
+    if rawTokenKind == self.rawTokenKind {
+      return true
+    } else if rawTokenKind == .identifier, case .contextualKeyword = self.rawTokenKind {
+      // We are looking for a contextual keyword but have an identifier.
+      // If the contents match, we want to interpret the identifier as a keyword.
+      let defaultText = self.rawTokenKind.defaultText
+      assert(defaultText != nil)
+      return text == defaultText
+    } else {
+      return false
+    }
+  }
+
+  static func ~= (kind: RawTokenKindMatch, lexeme: Lexer.Lexeme) -> Bool {
+    return kind.matches(rawTokenKind: lexeme.rawTokenKind, text: lexeme.tokenText)
+  }
+
+  static func ~= (kind: RawTokenKindMatch, token: TokenSyntax) -> Bool {
+    return kind.matches(rawTokenKind: token.rawTokenKind, text: token.tokenView.rawText)
+  }
+}

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -57,7 +57,7 @@ protocol ContextualKeywords: RawRepresentable, RawTokenKindSubset {}
 
 extension ContextualKeywords where RawValue == SyntaxText {
   init?(lexeme: Lexer.Lexeme) {
-    guard lexeme.tokenKind == .identifier else { return nil }
+    guard lexeme.rawTokenKind == .identifier else { return nil }
     self.init(rawValue: lexeme.tokenText)
   }
 
@@ -92,7 +92,7 @@ enum BinaryOperator: RawTokenKindSubset {
   case unspacedBinaryOperator
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme.tokenKind {
+    switch lexeme.rawTokenKind {
     case .spacedBinaryOperator: self = .spacedBinaryOperator
     case .unspacedBinaryOperator: self = .unspacedBinaryOperator
     default: return nil
@@ -126,7 +126,7 @@ enum CanBeStatementStart: RawTokenKindSubset {
   case yieldAsIdentifier
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme.tokenKind {
+    switch lexeme.rawTokenKind {
     case .breakKeyword: self = .breakKeyword
     case .continueKeyword: self = .continueKeyword
     case .deferKeyword: self = .deferKeyword
@@ -234,7 +234,7 @@ enum DeclarationStart: RawTokenKindSubset {
   case varKeyword
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme.tokenKind {
+    switch lexeme.rawTokenKind {
     case .identifier where lexeme.tokenText == "actor": self = .actorContextualKeyword
     case .identifier where lexeme.tokenText == "macro": self = .macroContextualKeyword
     case .associatedtypeKeyword: self = .associatedtypeKeyword
@@ -312,7 +312,7 @@ enum EffectsSpecifier: RawTokenKindSubset {
   init?(lexeme: Lexer.Lexeme) {
     // We'll take 'await', 'throw' and 'try' too for recovery but they have to
     // be on the same line as the declaration they're modifying.
-    switch lexeme.tokenKind {
+    switch lexeme.rawTokenKind {
     case .identifier where lexeme.tokenText == "async": self = .asyncContextualKeyword
     case .identifier where lexeme.tokenText == "await" && !lexeme.isAtStartOfLine: self = .awaitContextualKeyword
     case .identifier where lexeme.tokenText == "reasync": self = .reasyncContextualKeyword
@@ -354,7 +354,7 @@ enum IdentifierTokens: RawTokenKindSubset {
   case selfKeyword
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme.tokenKind {
+    switch lexeme.rawTokenKind {
     case .anyKeyword: self = .anyKeyword
     case .capitalSelfKeyword: self = .capitalSelfKeyword
     case .identifier: self = .identifier
@@ -383,7 +383,7 @@ enum IdentifierOrRethrowsTokens: RawTokenKindSubset {
   case rethrowsKeyword
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme.tokenKind {
+    switch lexeme.rawTokenKind {
     case .anyKeyword: self = .anyKeyword
     case .capitalSelfKeyword: self = .capitalSelfKeyword
     case .identifier: self = .identifier
@@ -419,7 +419,7 @@ enum Operator: RawTokenKindSubset {
   case prefixOperator
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme.tokenKind {
+    switch lexeme.rawTokenKind {
     case .spacedBinaryOperator: self = .spacedBinaryOperator
     case .unspacedBinaryOperator: self = .unspacedBinaryOperator
     case .postfixOperator: self = .postfixOperator
@@ -453,7 +453,7 @@ enum OperatorLike: RawTokenKindSubset {
       self = .operator(op)
       return
     }
-    switch lexeme.tokenKind {
+    switch lexeme.rawTokenKind {
     case .exclamationMark: self = .exclamationMark
     case .infixQuestionMark: self = .infixQuestionMark
     case .postfixQuestionMark: self = .postfixQuestionMark
@@ -501,7 +501,7 @@ enum PoundDeclarationStart: RawTokenKindSubset {
   case poundErrorKeyword
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme.tokenKind {
+    switch lexeme.rawTokenKind {
     case .poundIfKeyword: self = .poundIfKeyword
     case .poundWarningKeyword: self = .poundWarningKeyword
     case .poundErrorKeyword: self = .poundErrorKeyword
@@ -523,7 +523,7 @@ enum SwitchCaseStart: RawTokenKindSubset {
   case defaultKeyword
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme.tokenKind {
+    switch lexeme.rawTokenKind {
     case .caseKeyword: self = .caseKeyword
     case .defaultKeyword: self = .defaultKeyword
     default: return nil
@@ -544,7 +544,7 @@ public enum TypeSpecifier: RawTokenKindSubset {
   case shared
 
   init?(lexeme: Lexer.Lexeme) {
-    switch (lexeme.tokenKind, lexeme.tokenText) {
+    switch (lexeme.rawTokenKind, lexeme.tokenText) {
     case (.inoutKeyword, _): self = .inoutKeyword
     case (.identifier, "__owned"): self = .owned
     case (.identifier, "__shared"): self = .shared
@@ -587,7 +587,7 @@ enum AwaitTryMove: RawTokenKindSubset {
   case tryKeyword
 
   init?(lexeme: Lexer.Lexeme) {
-    switch (lexeme.tokenKind, lexeme.tokenText) {
+    switch (lexeme.rawTokenKind, lexeme.tokenText) {
     case (.tryKeyword, _): self = .tryKeyword
     case (.identifier, "await"): self = .awaitContextualKeyword
     case (.identifier, "_move"): self = ._moveContextualKeyword
@@ -621,7 +621,7 @@ enum ExpressionPrefixOperator: RawTokenKindSubset {
   case prefixOperator
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme.tokenKind {
+    switch lexeme.rawTokenKind {
     case .backslash: self = .backslash
     case .prefixAmpersand: self = .prefixAmpersand
     case .prefixOperator: self = .prefixOperator
@@ -644,7 +644,7 @@ enum MatchingPatternStart: RawTokenKindSubset {
   case varKeyword
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme.tokenKind {
+    switch lexeme.rawTokenKind {
     case .isKeyword: self = .isKeyword
     case .letKeyword: self = .letKeyword
     case .varKeyword: self = .varKeyword
@@ -666,7 +666,7 @@ enum ParameterModifier: RawTokenKindSubset {
   case isolated
 
   init?(lexeme: Lexer.Lexeme) {
-    switch (lexeme.tokenKind, lexeme.tokenText) {
+    switch (lexeme.rawTokenKind, lexeme.tokenText) {
     case (.identifier, "_const"): self = ._const
     case (.identifier, "isolated"): self = .isolated
     default: return nil
@@ -708,7 +708,7 @@ enum PrimaryExpressionStart: RawTokenKindSubset {
   case wildcardKeyword
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme.tokenKind {
+    switch lexeme.rawTokenKind {
     case .anyKeyword: self = .anyKeyword
     case .capitalSelfKeyword: self = .capitalSelfKeyword
     case .dollarIdentifier: self = .dollarIdentifier

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -52,16 +52,11 @@ extension Parser.Lookahead {
   /// `lookahead.tokensConsumed` as unexpected.
   mutating func canRecoverTo(
     _ kinds: [RawTokenKind],
-    contextualKeywords: [SyntaxText] = [],
     recoveryPrecedence: TokenPrecedence? = nil
   ) -> RecoveryConsumptionHandle? {
     let initialTokensConsumed = self.tokensConsumed
 
-    var precedences = kinds.map(TokenPrecedence.init)
-    if !contextualKeywords.isEmpty {
-      precedences += [TokenPrecedence(.identifier), TokenPrecedence(.contextualKeyword)]
-    }
-    let recoveryPrecedence = recoveryPrecedence ?? precedences.min()!
+    let recoveryPrecedence = recoveryPrecedence ?? kinds.map(TokenPrecedence.init).min()!
 
     while !self.at(.eof) {
       if !recoveryPrecedence.shouldSkipOverNewlines,
@@ -69,12 +64,12 @@ extension Parser.Lookahead {
       {
         break
       }
-      if self.at(any: kinds, contextualKeywords: contextualKeywords) {
+      if self.at(any: kinds) {
         return RecoveryConsumptionHandle(
           unexpectedTokens: self.tokensConsumed - initialTokensConsumed,
           tokenConsumptionHandle: TokenConsumptionHandle(
             tokenKind: self.currentToken.rawTokenKind,
-            remappedKind: self.at(any: [], contextualKeywords: contextualKeywords) ? .contextualKeyword : nil
+            remappedKind: nil
           )
         )
       }
@@ -114,7 +109,8 @@ extension Parser.Lookahead {
           return TokenPrecedence($0.rawTokenKind)
         }
       }).min()!
-    while !self.at(.eof) {
+    var loopProgress = LoopProgressCondition()
+    while !self.at(.eof) && loopProgress.evaluate(self.currentToken) {
       if !recoveryPrecedence.shouldSkipOverNewlines,
         self.currentToken.isAtStartOfLine
       {

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -73,12 +73,12 @@ extension Parser.Lookahead {
         return RecoveryConsumptionHandle(
           unexpectedTokens: self.tokensConsumed - initialTokensConsumed,
           tokenConsumptionHandle: TokenConsumptionHandle(
-            tokenKind: self.currentToken.tokenKind,
+            tokenKind: self.currentToken.rawTokenKind,
             remappedKind: self.at(any: [], contextualKeywords: contextualKeywords) ? .contextualKeyword : nil
           )
         )
       }
-      let currentTokenPrecedence = TokenPrecedence(self.currentToken.tokenKind)
+      let currentTokenPrecedence = TokenPrecedence(self.currentToken.rawTokenKind)
       if currentTokenPrecedence >= recoveryPrecedence {
         break
       }
@@ -129,7 +129,7 @@ extension Parser.Lookahead {
           )
         )
       }
-      let currentTokenPrecedence = TokenPrecedence(self.currentToken.tokenKind)
+      let currentTokenPrecedence = TokenPrecedence(self.currentToken.rawTokenKind)
       if currentTokenPrecedence >= recoveryPrecedence {
         break
       }

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -632,7 +632,7 @@ extension Parser {
     let (unexpectedBeforeForKeyword, forKeyword) = self.eat(forHandle)
     let tryKeyword = self.consume(if: .tryKeyword)
 
-    let awaitKeyword = self.consumeIfContextualKeyword("await")
+    let awaitKeyword = self.consume(if: .contextualKeyword(.await))
 
     // Parse the pattern.  This is either 'case <refutable pattern>' or just a
     // normal pattern.

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -1265,9 +1265,9 @@ extension Parser.Lookahead {
       // is a pack expansion expression.
       // FIXME: 'repeat' followed by '{' could be a pack expansion
       // with a closure pattern.
-      return self.peek().tokenKind == .leftBrace
+      return self.peek().rawTokenKind == .leftBrace
     case .yieldAsIdentifier?:
-      switch self.peek().tokenKind {
+      switch self.peek().rawTokenKind {
       case .prefixAmpersand:
         // "yield &" always denotes a yield statement.
         return true
@@ -1298,7 +1298,7 @@ extension Parser.Lookahead {
     var loopProgress = LoopProgressCondition()
     var hasAttribute = false
     while lookahead.at(.atSign) && loopProgress.evaluate(lookahead.currentToken) {
-      guard lookahead.peek().tokenKind == .identifier else {
+      guard lookahead.peek().rawTokenKind == .identifier else {
         return false
       }
 

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -61,7 +61,7 @@ extension TokenConsumer {
     _ kind: RawTokenKind,
     where condition: (Lexer.Lexeme) -> Bool = { _ in true }
   ) -> Bool {
-    return self.currentToken.tokenKind == kind && condition(self.currentToken)
+    return self.currentToken.rawTokenKind == kind && condition(self.currentToken)
   }
 
   /// Returns whether the current token is a contextual keyword with the given `name`.
@@ -91,10 +91,10 @@ extension TokenConsumer {
     contextualKeywords: [SyntaxText] = [],
     where condition: (Lexer.Lexeme) -> Bool = { _ in true }
   ) -> Bool {
-    if kinds.contains(self.currentToken.tokenKind) && condition(self.currentToken) {
+    if kinds.contains(self.currentToken.rawTokenKind) && condition(self.currentToken) {
       return true
     }
-    switch self.currentToken.tokenKind {
+    switch self.currentToken.rawTokenKind {
     case .identifier, .contextualKeyword:
       return contextualKeywords.contains(self.currentToken.tokenText) && condition(self.currentToken)
     default:
@@ -207,7 +207,7 @@ extension TokenConsumer {
   /// tokens and return them. Otherwise, return `nil`.
   @_spi(RawSyntax)
   public mutating func consume(if kind1: RawTokenKind, followedBy kind2: RawTokenKind) -> (Token, Token)? {
-    if self.at(kind1) && self.peek().tokenKind == kind2 {
+    if self.at(kind1) && self.peek().rawTokenKind == kind2 {
       return (consumeAnyToken(), consumeAnyToken())
     } else {
       return nil

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -61,13 +61,7 @@ extension TokenConsumer {
     _ kind: RawTokenKind,
     where condition: (Lexer.Lexeme) -> Bool = { _ in true }
   ) -> Bool {
-    return self.currentToken.rawTokenKind == kind && condition(self.currentToken)
-  }
-
-  /// Returns whether the current token is a contextual keyword with the given `name`.
-  @_spi(RawSyntax)
-  public func atContextualKeyword(_ name: SyntaxText) -> Bool {
-    return self.currentToken.isContextualKeyword(name)
+    return RawTokenKindMatch(kind) ~= self.currentToken && condition(self.currentToken)
   }
 
   /// Returns whether the current token is an operator with the given `name`.
@@ -81,25 +75,15 @@ extension TokenConsumer {
   /// additionally satisfies `condition`.
   ///
   /// - Parameter kinds: The kinds to test for.
-  /// - Parameter contextualKeywords: Contextual keywords that are also accepted.
   /// - Parameter condition: An additional condition that must be satisfied for
   ///                        this function to return `true`.
   /// - Returns: `true` if the current token's kind is in `kinds`.
   @_spi(RawSyntax)
   public func at(
     any kinds: [RawTokenKind],
-    contextualKeywords: [SyntaxText] = [],
     where condition: (Lexer.Lexeme) -> Bool = { _ in true }
   ) -> Bool {
-    if kinds.contains(self.currentToken.rawTokenKind) && condition(self.currentToken) {
-      return true
-    }
-    switch self.currentToken.rawTokenKind {
-    case .identifier, .contextualKeyword:
-      return contextualKeywords.contains(self.currentToken.tokenText) && condition(self.currentToken)
-    default:
-      return false
-    }
+    return kinds.contains(where: { RawTokenKindMatch($0) ~= self.currentToken }) && condition(self.currentToken)
   }
 
   /// Checks whether the parser is currently positioned at any token in `Subset`.
@@ -125,6 +109,10 @@ extension TokenConsumer {
     } else if let remappedKind = handle.remappedKind {
       assert(self.at(handle.tokenKind))
       return consumeAnyToken(remapping: remappedKind)
+    } else if case .contextualKeyword = handle.tokenKind {
+      // We support remapping identifiers to contextual keywords
+      assert(self.currentToken.rawTokenKind == .identifier || self.currentToken.rawTokenKind == handle.tokenKind)
+      return consumeAnyToken(remapping: handle.tokenKind)
     } else {
       assert(self.at(handle.tokenKind))
       return consumeAnyToken()
@@ -157,18 +145,12 @@ extension TokenConsumer {
     if self.at(kind, where: condition) {
       if let remapping = remapping {
         return self.consumeAnyToken(remapping: remapping)
+      } else if case .contextualKeyword = kind {
+        // We support remapping identifiers to contextual keywords
+        return self.consumeAnyToken(remapping: kind)
       } else {
         return self.consumeAnyToken()
       }
-    }
-    return nil
-  }
-
-  /// Consumes and returns the current token is a contextual keyword with the given `name`.
-  @_spi(RawSyntax)
-  public mutating func consumeIfContextualKeyword(_ name: SyntaxText) -> Token? {
-    if self.atContextualKeyword(name) {
-      return self.consumeAnyToken(remapping: .contextualKeyword)
     }
     return nil
   }
@@ -187,17 +169,15 @@ extension TokenConsumer {
   /// additionally satisfies `condition`.
   ///
   /// - Parameter kind: The kinds of token to consume.
-  /// - Parameter contextualKeywords: Contextual keywords that are also accepted.
   /// - Parameter condition: An additional condition that must be satisfied for
   ///                        the token to be consumed.
   /// - Returns: A token of the given kind if one was consumed, else `nil`.
   @_spi(RawSyntax)
   public mutating func consume(
     ifAny kinds: [RawTokenKind],
-    contextualKeywords: [SyntaxText] = [],
     where condition: (Lexer.Lexeme) -> Bool = { _ in true }
   ) -> Token? {
-    if self.at(any: kinds, contextualKeywords: contextualKeywords, where: condition) {
+    if self.at(any: kinds, where: condition) {
       return self.consumeAnyToken()
     }
     return nil
@@ -260,21 +240,6 @@ extension TokenConsumer {
       return token
     } else {
       return missingToken(kind, text: nil)
-    }
-  }
-
-  /// If the current token is a contextual keyword with the given `name`,
-  /// consume it. Othwerise, synthesize a missing contextual keyword with that
-  /// `name`.
-  ///
-  /// This method does not try to eat unexpected until it finds the token of the specified `kind`.
-  /// In the parser, `expect` should be preferred.
-  @_spi(RawSyntax)
-  public mutating func expectContextualKeywordWithoutRecovery(_ name: SyntaxText) -> Token {
-    if let token = self.consumeIfContextualKeyword(name) {
-      return token
-    } else {
-      return missingToken(.contextualKeyword, text: name)
     }
   }
 }

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -26,7 +26,7 @@ extension Parser {
   /// as unexpected nodes that have the `isMaximumNestingLevelOverflow` bit set.
   /// Check this in places that are likely to cause deep recursion and if this returns non-nil, abort parsing.
   mutating func remainingTokensIfMaximumNestingLevelReached() -> RawUnexpectedNodesSyntax? {
-    if nestingLevel > self.maximumNestingLevel && self.currentToken.tokenKind != .eof {
+    if nestingLevel > self.maximumNestingLevel && self.currentToken.rawTokenKind != .eof {
       let remainingTokens = self.consumeRemainingTokens()
       return RawUnexpectedNodesSyntax(elements: remainingTokens, isMaximumNestingLevelOverflow: true, arena: self.arena)
     } else {

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -232,7 +232,7 @@ extension Parser {
     stopAtFirstPeriod: Bool = false
   ) -> RawTypeSyntax {
     var base: RawTypeSyntax
-    switch self.currentToken.tokenKind {
+    switch self.currentToken.rawTokenKind {
     case .capitalSelfKeyword,
       .anyKeyword,
       .identifier:
@@ -509,7 +509,7 @@ extension Parser {
             second = nil
             unexpectedBeforeColon = nil
             colon = parsedColon
-          } else if self.currentToken.canBeArgumentLabel(allowDollarIdentifier: true) && self.peek().tokenKind == .colon {
+          } else if self.currentToken.canBeArgumentLabel(allowDollarIdentifier: true) && self.peek().rawTokenKind == .colon {
             (unexpectedBeforeSecond, second) = self.parseArgumentLabel()
             (unexpectedBeforeColon, colon) = self.expect(.colon)
           } else {
@@ -724,7 +724,7 @@ extension Parser.Lookahead {
   }
 
   mutating func canParseSimpleType() -> Bool {
-    switch self.currentToken.tokenKind {
+    switch self.currentToken.rawTokenKind {
     case .anyKeyword:
       self.consumeAnyToken()
     case .capitalSelfKeyword, .identifier:
@@ -847,7 +847,7 @@ extension Parser.Lookahead {
     }
 
     if self.at(anyIn: EffectsSpecifier.self) != nil {
-      if self.peek().tokenKind == .arrow {
+      if self.peek().rawTokenKind == .arrow {
         return true
       }
 
@@ -1051,14 +1051,14 @@ extension Parser {
 
 extension Lexer.Lexeme {
   var isBinaryOperator: Bool {
-    return self.tokenKind == .spacedBinaryOperator
-      || self.tokenKind == .unspacedBinaryOperator
+    return self.rawTokenKind == .spacedBinaryOperator
+      || self.rawTokenKind == .unspacedBinaryOperator
   }
 
   var isAnyOperator: Bool {
     return self.isBinaryOperator
-      || self.tokenKind == .postfixOperator
-      || self.tokenKind == .prefixOperator
+      || self.rawTokenKind == .postfixOperator
+      || self.rawTokenKind == .prefixOperator
   }
 
   var isEllipsis: Bool {
@@ -1066,7 +1066,7 @@ extension Lexer.Lexeme {
   }
 
   var isGenericTypeDisambiguatingToken: Bool {
-    switch self.tokenKind {
+    switch self.rawTokenKind {
     case .rightParen,
       .rightSquareBracket,
       .leftBrace,

--- a/Sources/SwiftParser/generated/DeclarationAttribute.swift
+++ b/Sources/SwiftParser/generated/DeclarationAttribute.swift
@@ -17,217 +17,655 @@
 @_spi(RawSyntax) import SwiftSyntax
 
 extension Parser {
-  enum DeclarationAttribute: SyntaxText, ContextualKeywords {
-    case _silgen_name = "_silgen_name"
+  enum DeclarationAttribute: RawTokenKindSubset {
+    case _silgen_name
     
-    case available = "available"
+    case available
     
-    case objc = "objc"
+    case objc
     
-    case dynamicCallable = "dynamicCallable"
+    case dynamicCallable
     
-    case main = "main"
+    case main
     
-    case _exported = "_exported"
+    case _exported
     
-    case dynamicMemberLookup = "dynamicMemberLookup"
+    case dynamicMemberLookup
     
-    case NSCopying = "NSCopying"
+    case NSCopying
     
-    case IBAction = "IBAction"
+    case IBAction
     
-    case IBDesignable = "IBDesignable"
+    case IBDesignable
     
-    case IBInspectable = "IBInspectable"
+    case IBInspectable
     
-    case IBOutlet = "IBOutlet"
+    case IBOutlet
     
-    case NSManaged = "NSManaged"
+    case NSManaged
     
-    case LLDBDebuggerFunction = "LLDBDebuggerFunction"
+    case LLDBDebuggerFunction
     
-    case UIApplicationMain = "UIApplicationMain"
+    case UIApplicationMain
     
-    case unsafe_no_objc_tagged_pointer = "unsafe_no_objc_tagged_pointer"
+    case unsafe_no_objc_tagged_pointer
     
-    case inline = "inline"
+    case inline
     
-    case _semantics = "_semantics"
+    case _semantics
     
-    case _transparent = "_transparent"
+    case _transparent
     
-    case requires_stored_property_inits = "requires_stored_property_inits"
+    case requires_stored_property_inits
     
-    case nonobjc = "nonobjc"
+    case nonobjc
     
-    case _fixed_layout = "_fixed_layout"
+    case _fixed_layout
     
-    case inlinable = "inlinable"
+    case inlinable
     
-    case _specialize = "_specialize"
+    case _specialize
     
-    case objcMembers = "objcMembers"
+    case objcMembers
     
-    case _compilerInitialized = "_compilerInitialized"
+    case _compilerInitialized
     
-    case _hasStorage = "_hasStorage"
+    case _hasStorage
     
-    case __raw_doc_comment = "__raw_doc_comment"
+    case __raw_doc_comment
     
-    case _effects = "_effects"
+    case _effects
     
-    case __objc_bridged = "__objc_bridged"
+    case __objc_bridged
     
-    case NSApplicationMain = "NSApplicationMain"
+    case NSApplicationMain
     
-    case _objc_non_lazy_realization = "_objc_non_lazy_realization"
+    case _objc_non_lazy_realization
     
-    case __synthesized_protocol = "__synthesized_protocol"
+    case __synthesized_protocol
     
-    case testable = "testable"
+    case testable
     
-    case _alignment = "_alignment"
+    case _alignment
     
-    case atRethrows = "rethrows"
+    case atRethrows
     
-    case _swift_native_objc_runtime_base = "_swift_native_objc_runtime_base"
+    case _swift_native_objc_runtime_base
     
-    case warn_unqualified_access = "warn_unqualified_access"
+    case warn_unqualified_access
     
-    case _show_in_interface = "_show_in_interface"
+    case _show_in_interface
     
-    case _cdecl = "_cdecl"
+    case _cdecl
     
-    case usableFromInline = "usableFromInline"
+    case usableFromInline
     
-    case discardableResult = "discardableResult"
+    case discardableResult
     
-    case GKInspectable = "GKInspectable"
+    case GKInspectable
     
-    case _implements = "_implements"
+    case _implements
     
-    case _objcRuntimeName = "_objcRuntimeName"
+    case _objcRuntimeName
     
-    case _staticInitializeObjCMetadata = "_staticInitializeObjCMetadata"
+    case _staticInitializeObjCMetadata
     
-    case _restatedObjCConformance = "_restatedObjCConformance"
+    case _restatedObjCConformance
     
-    case _objcImplementation = "_objcImplementation"
+    case _objcImplementation
     
-    case _optimize = "_optimize"
+    case _optimize
     
-    case _clangImporterSynthesizedType = "_clangImporterSynthesizedType"
+    case _clangImporterSynthesizedType
     
-    case _weakLinked = "_weakLinked"
+    case _weakLinked
     
-    case frozen = "frozen"
+    case frozen
     
-    case _frozen = "_frozen"
+    case _frozen
     
-    case _forbidSerializingReference = "_forbidSerializingReference"
+    case _forbidSerializingReference
     
-    case _hasInitialValue = "_hasInitialValue"
+    case _hasInitialValue
     
-    case _nonoverride = "_nonoverride"
+    case _nonoverride
     
-    case _dynamicReplacement = "_dynamicReplacement"
+    case _dynamicReplacement
     
-    case _borrowed = "_borrowed"
+    case _borrowed
     
-    case _private = "_private"
+    case _private
     
-    case _alwaysEmitIntoClient = "_alwaysEmitIntoClient"
+    case _alwaysEmitIntoClient
     
-    case _implementationOnly = "_implementationOnly"
+    case _implementationOnly
     
-    case _custom = "_custom"
+    case _custom
     
-    case propertyWrapper = "propertyWrapper"
+    case propertyWrapper
     
-    case _disfavoredOverload = "_disfavoredOverload"
+    case _disfavoredOverload
     
-    case resultBuilder = "resultBuilder"
+    case resultBuilder
     
-    case _projectedValueProperty = "_projectedValueProperty"
+    case _projectedValueProperty
     
-    case _nonEphemeral = "_nonEphemeral"
+    case _nonEphemeral
     
-    case differentiable = "differentiable"
+    case differentiable
     
-    case _hasMissingDesignatedInitializers = "_hasMissingDesignatedInitializers"
+    case _hasMissingDesignatedInitializers
     
-    case _inheritsConvenienceInitializers = "_inheritsConvenienceInitializers"
+    case _inheritsConvenienceInitializers
     
-    case _typeEraser = "_typeEraser"
+    case _typeEraser
     
-    case IBSegueAction = "IBSegueAction"
+    case IBSegueAction
     
-    case _originallyDefinedIn = "_originallyDefinedIn"
+    case _originallyDefinedIn
     
-    case derivative = "derivative"
+    case derivative
     
-    case _spi = "_spi"
+    case _spi
     
-    case transpose = "transpose"
+    case transpose
     
-    case noDerivative = "noDerivative"
+    case noDerivative
     
-    case globalActor = "globalActor"
+    case globalActor
     
-    case _specializeExtension = "_specializeExtension"
+    case _specializeExtension
     
-    case Sendable = "Sendable"
+    case Sendable
     
-    case _marker = "_marker"
+    case _marker
     
-    case atReasync = "reasync"
+    case atReasync
     
-    case _unsafeInheritExecutor = "_unsafeInheritExecutor"
+    case _unsafeInheritExecutor
     
-    case _implicitSelfCapture = "_implicitSelfCapture"
+    case _implicitSelfCapture
     
-    case _inheritActorContext = "_inheritActorContext"
+    case _inheritActorContext
     
-    case _eagerMove = "_eagerMove"
+    case _eagerMove
     
-    case _noEagerMove = "_noEagerMove"
+    case _noEagerMove
     
-    case _assemblyVision = "_assemblyVision"
+    case _assemblyVision
     
-    case _nonSendable = "_nonSendable"
+    case _nonSendable
     
-    case _noImplicitCopy = "_noImplicitCopy"
+    case _noImplicitCopy
     
-    case _noLocks = "_noLocks"
+    case _noLocks
     
-    case _noAllocation = "_noAllocation"
+    case _noAllocation
     
-    case preconcurrency = "preconcurrency"
+    case preconcurrency
     
-    case _unavailableFromAsync = "_unavailableFromAsync"
+    case _unavailableFromAsync
     
-    case exclusivity = "exclusivity"
+    case exclusivity
     
-    case _backDeploy = "_backDeploy"
+    case _backDeploy
     
-    case _moveOnly = "_moveOnly"
+    case _moveOnly
     
-    case _alwaysEmitConformanceMetadata = "_alwaysEmitConformanceMetadata"
+    case _alwaysEmitConformanceMetadata
     
-    case _expose = "_expose"
+    case _expose
     
-    case typeWrapper = "typeWrapper"
+    case typeWrapper
     
-    case _spiOnly = "_spiOnly"
+    case _spiOnly
     
-    case _documentation = "_documentation"
+    case _documentation
     
-    case typeWrapperIgnored = "typeWrapperIgnored"
+    case typeWrapperIgnored
     
-    case _noMetadata = "_noMetadata"
+    case _noMetadata
     
-    case runtimeMetadata = "runtimeMetadata"
+    case runtimeMetadata
     
-    case _spi_available = "_spi_available"
+    case _spi_available
+    
+    init?(lexeme: Lexer.Lexeme) {
+      switch lexeme {
+      case RawTokenKindMatch(._silgen_name): 
+        self = ._silgen_name
+      case RawTokenKindMatch(.available): 
+        self = .available
+      case RawTokenKindMatch(.objc): 
+        self = .objc
+      case RawTokenKindMatch(.dynamicCallable): 
+        self = .dynamicCallable
+      case RawTokenKindMatch(.main): 
+        self = .main
+      case RawTokenKindMatch(._exported): 
+        self = ._exported
+      case RawTokenKindMatch(.dynamicMemberLookup): 
+        self = .dynamicMemberLookup
+      case RawTokenKindMatch(.NSCopying): 
+        self = .NSCopying
+      case RawTokenKindMatch(.IBAction): 
+        self = .IBAction
+      case RawTokenKindMatch(.IBDesignable): 
+        self = .IBDesignable
+      case RawTokenKindMatch(.IBInspectable): 
+        self = .IBInspectable
+      case RawTokenKindMatch(.IBOutlet): 
+        self = .IBOutlet
+      case RawTokenKindMatch(.NSManaged): 
+        self = .NSManaged
+      case RawTokenKindMatch(.LLDBDebuggerFunction): 
+        self = .LLDBDebuggerFunction
+      case RawTokenKindMatch(.UIApplicationMain): 
+        self = .UIApplicationMain
+      case RawTokenKindMatch(.unsafe_no_objc_tagged_pointer): 
+        self = .unsafe_no_objc_tagged_pointer
+      case RawTokenKindMatch(.inline): 
+        self = .inline
+      case RawTokenKindMatch(._semantics): 
+        self = ._semantics
+      case RawTokenKindMatch(._transparent): 
+        self = ._transparent
+      case RawTokenKindMatch(.requires_stored_property_inits): 
+        self = .requires_stored_property_inits
+      case RawTokenKindMatch(.nonobjc): 
+        self = .nonobjc
+      case RawTokenKindMatch(._fixed_layout): 
+        self = ._fixed_layout
+      case RawTokenKindMatch(.inlinable): 
+        self = .inlinable
+      case RawTokenKindMatch(._specialize): 
+        self = ._specialize
+      case RawTokenKindMatch(.objcMembers): 
+        self = .objcMembers
+      case RawTokenKindMatch(._compilerInitialized): 
+        self = ._compilerInitialized
+      case RawTokenKindMatch(._hasStorage): 
+        self = ._hasStorage
+      case RawTokenKindMatch(.__raw_doc_comment): 
+        self = .__raw_doc_comment
+      case RawTokenKindMatch(._effects): 
+        self = ._effects
+      case RawTokenKindMatch(.__objc_bridged): 
+        self = .__objc_bridged
+      case RawTokenKindMatch(.NSApplicationMain): 
+        self = .NSApplicationMain
+      case RawTokenKindMatch(._objc_non_lazy_realization): 
+        self = ._objc_non_lazy_realization
+      case RawTokenKindMatch(.__synthesized_protocol): 
+        self = .__synthesized_protocol
+      case RawTokenKindMatch(.testable): 
+        self = .testable
+      case RawTokenKindMatch(._alignment): 
+        self = ._alignment
+      case RawTokenKindMatch(.rethrows): 
+        self = .atRethrows
+      case RawTokenKindMatch(._swift_native_objc_runtime_base): 
+        self = ._swift_native_objc_runtime_base
+      case RawTokenKindMatch(.warn_unqualified_access): 
+        self = .warn_unqualified_access
+      case RawTokenKindMatch(._show_in_interface): 
+        self = ._show_in_interface
+      case RawTokenKindMatch(._cdecl): 
+        self = ._cdecl
+      case RawTokenKindMatch(.usableFromInline): 
+        self = .usableFromInline
+      case RawTokenKindMatch(.discardableResult): 
+        self = .discardableResult
+      case RawTokenKindMatch(.GKInspectable): 
+        self = .GKInspectable
+      case RawTokenKindMatch(._implements): 
+        self = ._implements
+      case RawTokenKindMatch(._objcRuntimeName): 
+        self = ._objcRuntimeName
+      case RawTokenKindMatch(._staticInitializeObjCMetadata): 
+        self = ._staticInitializeObjCMetadata
+      case RawTokenKindMatch(._restatedObjCConformance): 
+        self = ._restatedObjCConformance
+      case RawTokenKindMatch(._objcImplementation): 
+        self = ._objcImplementation
+      case RawTokenKindMatch(._optimize): 
+        self = ._optimize
+      case RawTokenKindMatch(._clangImporterSynthesizedType): 
+        self = ._clangImporterSynthesizedType
+      case RawTokenKindMatch(._weakLinked): 
+        self = ._weakLinked
+      case RawTokenKindMatch(.frozen): 
+        self = .frozen
+      case RawTokenKindMatch(._frozen): 
+        self = ._frozen
+      case RawTokenKindMatch(._forbidSerializingReference): 
+        self = ._forbidSerializingReference
+      case RawTokenKindMatch(._hasInitialValue): 
+        self = ._hasInitialValue
+      case RawTokenKindMatch(._nonoverride): 
+        self = ._nonoverride
+      case RawTokenKindMatch(._dynamicReplacement): 
+        self = ._dynamicReplacement
+      case RawTokenKindMatch(._borrowed): 
+        self = ._borrowed
+      case RawTokenKindMatch(._private): 
+        self = ._private
+      case RawTokenKindMatch(._alwaysEmitIntoClient): 
+        self = ._alwaysEmitIntoClient
+      case RawTokenKindMatch(._implementationOnly): 
+        self = ._implementationOnly
+      case RawTokenKindMatch(._custom): 
+        self = ._custom
+      case RawTokenKindMatch(.propertyWrapper): 
+        self = .propertyWrapper
+      case RawTokenKindMatch(._disfavoredOverload): 
+        self = ._disfavoredOverload
+      case RawTokenKindMatch(.resultBuilder): 
+        self = .resultBuilder
+      case RawTokenKindMatch(._projectedValueProperty): 
+        self = ._projectedValueProperty
+      case RawTokenKindMatch(._nonEphemeral): 
+        self = ._nonEphemeral
+      case RawTokenKindMatch(.differentiable): 
+        self = .differentiable
+      case RawTokenKindMatch(._hasMissingDesignatedInitializers): 
+        self = ._hasMissingDesignatedInitializers
+      case RawTokenKindMatch(._inheritsConvenienceInitializers): 
+        self = ._inheritsConvenienceInitializers
+      case RawTokenKindMatch(._typeEraser): 
+        self = ._typeEraser
+      case RawTokenKindMatch(.IBSegueAction): 
+        self = .IBSegueAction
+      case RawTokenKindMatch(._originallyDefinedIn): 
+        self = ._originallyDefinedIn
+      case RawTokenKindMatch(.derivative): 
+        self = .derivative
+      case RawTokenKindMatch(._spi): 
+        self = ._spi
+      case RawTokenKindMatch(.transpose): 
+        self = .transpose
+      case RawTokenKindMatch(.noDerivative): 
+        self = .noDerivative
+      case RawTokenKindMatch(.globalActor): 
+        self = .globalActor
+      case RawTokenKindMatch(._specializeExtension): 
+        self = ._specializeExtension
+      case RawTokenKindMatch(.Sendable): 
+        self = .Sendable
+      case RawTokenKindMatch(._marker): 
+        self = ._marker
+      case RawTokenKindMatch(.reasync): 
+        self = .atReasync
+      case RawTokenKindMatch(._unsafeInheritExecutor): 
+        self = ._unsafeInheritExecutor
+      case RawTokenKindMatch(._implicitSelfCapture): 
+        self = ._implicitSelfCapture
+      case RawTokenKindMatch(._inheritActorContext): 
+        self = ._inheritActorContext
+      case RawTokenKindMatch(._eagerMove): 
+        self = ._eagerMove
+      case RawTokenKindMatch(._noEagerMove): 
+        self = ._noEagerMove
+      case RawTokenKindMatch(._assemblyVision): 
+        self = ._assemblyVision
+      case RawTokenKindMatch(._nonSendable): 
+        self = ._nonSendable
+      case RawTokenKindMatch(._noImplicitCopy): 
+        self = ._noImplicitCopy
+      case RawTokenKindMatch(._noLocks): 
+        self = ._noLocks
+      case RawTokenKindMatch(._noAllocation): 
+        self = ._noAllocation
+      case RawTokenKindMatch(.preconcurrency): 
+        self = .preconcurrency
+      case RawTokenKindMatch(._unavailableFromAsync): 
+        self = ._unavailableFromAsync
+      case RawTokenKindMatch(.exclusivity): 
+        self = .exclusivity
+      case RawTokenKindMatch(._backDeploy): 
+        self = ._backDeploy
+      case RawTokenKindMatch(._moveOnly): 
+        self = ._moveOnly
+      case RawTokenKindMatch(._alwaysEmitConformanceMetadata): 
+        self = ._alwaysEmitConformanceMetadata
+      case RawTokenKindMatch(._expose): 
+        self = ._expose
+      case RawTokenKindMatch(.typeWrapper): 
+        self = .typeWrapper
+      case RawTokenKindMatch(._spiOnly): 
+        self = ._spiOnly
+      case RawTokenKindMatch(._documentation): 
+        self = ._documentation
+      case RawTokenKindMatch(.typeWrapperIgnored): 
+        self = .typeWrapperIgnored
+      case RawTokenKindMatch(._noMetadata): 
+        self = ._noMetadata
+      case RawTokenKindMatch(.runtimeMetadata): 
+        self = .runtimeMetadata
+      case RawTokenKindMatch(.rethrowsKeyword): 
+        self = .atRethrows
+      case RawTokenKindMatch(._spi_available): 
+        self = ._spi_available
+      default: 
+        return nil
+      }
+    }
+    
+    var rawTokenKind: RawTokenKind {
+      switch self {
+      case ._silgen_name: 
+        return .contextualKeyword(._silgen_name)
+      case .available: 
+        return .contextualKeyword(.available)
+      case .objc: 
+        return .contextualKeyword(.objc)
+      case .dynamicCallable: 
+        return .contextualKeyword(.dynamicCallable)
+      case .main: 
+        return .contextualKeyword(.main)
+      case ._exported: 
+        return .contextualKeyword(._exported)
+      case .dynamicMemberLookup: 
+        return .contextualKeyword(.dynamicMemberLookup)
+      case .NSCopying: 
+        return .contextualKeyword(.NSCopying)
+      case .IBAction: 
+        return .contextualKeyword(.IBAction)
+      case .IBDesignable: 
+        return .contextualKeyword(.IBDesignable)
+      case .IBInspectable: 
+        return .contextualKeyword(.IBInspectable)
+      case .IBOutlet: 
+        return .contextualKeyword(.IBOutlet)
+      case .NSManaged: 
+        return .contextualKeyword(.NSManaged)
+      case .LLDBDebuggerFunction: 
+        return .contextualKeyword(.LLDBDebuggerFunction)
+      case .UIApplicationMain: 
+        return .contextualKeyword(.UIApplicationMain)
+      case .unsafe_no_objc_tagged_pointer: 
+        return .contextualKeyword(.unsafe_no_objc_tagged_pointer)
+      case .inline: 
+        return .contextualKeyword(.inline)
+      case ._semantics: 
+        return .contextualKeyword(._semantics)
+      case ._transparent: 
+        return .contextualKeyword(._transparent)
+      case .requires_stored_property_inits: 
+        return .contextualKeyword(.requires_stored_property_inits)
+      case .nonobjc: 
+        return .contextualKeyword(.nonobjc)
+      case ._fixed_layout: 
+        return .contextualKeyword(._fixed_layout)
+      case .inlinable: 
+        return .contextualKeyword(.inlinable)
+      case ._specialize: 
+        return .contextualKeyword(._specialize)
+      case .objcMembers: 
+        return .contextualKeyword(.objcMembers)
+      case ._compilerInitialized: 
+        return .contextualKeyword(._compilerInitialized)
+      case ._hasStorage: 
+        return .contextualKeyword(._hasStorage)
+      case .__raw_doc_comment: 
+        return .contextualKeyword(.__raw_doc_comment)
+      case ._effects: 
+        return .contextualKeyword(._effects)
+      case .__objc_bridged: 
+        return .contextualKeyword(.__objc_bridged)
+      case .NSApplicationMain: 
+        return .contextualKeyword(.NSApplicationMain)
+      case ._objc_non_lazy_realization: 
+        return .contextualKeyword(._objc_non_lazy_realization)
+      case .__synthesized_protocol: 
+        return .contextualKeyword(.__synthesized_protocol)
+      case .testable: 
+        return .contextualKeyword(.testable)
+      case ._alignment: 
+        return .contextualKeyword(._alignment)
+      case .atRethrows: 
+        return .contextualKeyword(.rethrows)
+      case ._swift_native_objc_runtime_base: 
+        return .contextualKeyword(._swift_native_objc_runtime_base)
+      case .warn_unqualified_access: 
+        return .contextualKeyword(.warn_unqualified_access)
+      case ._show_in_interface: 
+        return .contextualKeyword(._show_in_interface)
+      case ._cdecl: 
+        return .contextualKeyword(._cdecl)
+      case .usableFromInline: 
+        return .contextualKeyword(.usableFromInline)
+      case .discardableResult: 
+        return .contextualKeyword(.discardableResult)
+      case .GKInspectable: 
+        return .contextualKeyword(.GKInspectable)
+      case ._implements: 
+        return .contextualKeyword(._implements)
+      case ._objcRuntimeName: 
+        return .contextualKeyword(._objcRuntimeName)
+      case ._staticInitializeObjCMetadata: 
+        return .contextualKeyword(._staticInitializeObjCMetadata)
+      case ._restatedObjCConformance: 
+        return .contextualKeyword(._restatedObjCConformance)
+      case ._objcImplementation: 
+        return .contextualKeyword(._objcImplementation)
+      case ._optimize: 
+        return .contextualKeyword(._optimize)
+      case ._clangImporterSynthesizedType: 
+        return .contextualKeyword(._clangImporterSynthesizedType)
+      case ._weakLinked: 
+        return .contextualKeyword(._weakLinked)
+      case .frozen: 
+        return .contextualKeyword(.frozen)
+      case ._frozen: 
+        return .contextualKeyword(._frozen)
+      case ._forbidSerializingReference: 
+        return .contextualKeyword(._forbidSerializingReference)
+      case ._hasInitialValue: 
+        return .contextualKeyword(._hasInitialValue)
+      case ._nonoverride: 
+        return .contextualKeyword(._nonoverride)
+      case ._dynamicReplacement: 
+        return .contextualKeyword(._dynamicReplacement)
+      case ._borrowed: 
+        return .contextualKeyword(._borrowed)
+      case ._private: 
+        return .contextualKeyword(._private)
+      case ._alwaysEmitIntoClient: 
+        return .contextualKeyword(._alwaysEmitIntoClient)
+      case ._implementationOnly: 
+        return .contextualKeyword(._implementationOnly)
+      case ._custom: 
+        return .contextualKeyword(._custom)
+      case .propertyWrapper: 
+        return .contextualKeyword(.propertyWrapper)
+      case ._disfavoredOverload: 
+        return .contextualKeyword(._disfavoredOverload)
+      case .resultBuilder: 
+        return .contextualKeyword(.resultBuilder)
+      case ._projectedValueProperty: 
+        return .contextualKeyword(._projectedValueProperty)
+      case ._nonEphemeral: 
+        return .contextualKeyword(._nonEphemeral)
+      case .differentiable: 
+        return .contextualKeyword(.differentiable)
+      case ._hasMissingDesignatedInitializers: 
+        return .contextualKeyword(._hasMissingDesignatedInitializers)
+      case ._inheritsConvenienceInitializers: 
+        return .contextualKeyword(._inheritsConvenienceInitializers)
+      case ._typeEraser: 
+        return .contextualKeyword(._typeEraser)
+      case .IBSegueAction: 
+        return .contextualKeyword(.IBSegueAction)
+      case ._originallyDefinedIn: 
+        return .contextualKeyword(._originallyDefinedIn)
+      case .derivative: 
+        return .contextualKeyword(.derivative)
+      case ._spi: 
+        return .contextualKeyword(._spi)
+      case .transpose: 
+        return .contextualKeyword(.transpose)
+      case .noDerivative: 
+        return .contextualKeyword(.noDerivative)
+      case .globalActor: 
+        return .contextualKeyword(.globalActor)
+      case ._specializeExtension: 
+        return .contextualKeyword(._specializeExtension)
+      case .Sendable: 
+        return .contextualKeyword(.Sendable)
+      case ._marker: 
+        return .contextualKeyword(._marker)
+      case .atReasync: 
+        return .contextualKeyword(.reasync)
+      case ._unsafeInheritExecutor: 
+        return .contextualKeyword(._unsafeInheritExecutor)
+      case ._implicitSelfCapture: 
+        return .contextualKeyword(._implicitSelfCapture)
+      case ._inheritActorContext: 
+        return .contextualKeyword(._inheritActorContext)
+      case ._eagerMove: 
+        return .contextualKeyword(._eagerMove)
+      case ._noEagerMove: 
+        return .contextualKeyword(._noEagerMove)
+      case ._assemblyVision: 
+        return .contextualKeyword(._assemblyVision)
+      case ._nonSendable: 
+        return .contextualKeyword(._nonSendable)
+      case ._noImplicitCopy: 
+        return .contextualKeyword(._noImplicitCopy)
+      case ._noLocks: 
+        return .contextualKeyword(._noLocks)
+      case ._noAllocation: 
+        return .contextualKeyword(._noAllocation)
+      case .preconcurrency: 
+        return .contextualKeyword(.preconcurrency)
+      case ._unavailableFromAsync: 
+        return .contextualKeyword(._unavailableFromAsync)
+      case .exclusivity: 
+        return .contextualKeyword(.exclusivity)
+      case ._backDeploy: 
+        return .contextualKeyword(._backDeploy)
+      case ._moveOnly: 
+        return .contextualKeyword(._moveOnly)
+      case ._alwaysEmitConformanceMetadata: 
+        return .contextualKeyword(._alwaysEmitConformanceMetadata)
+      case ._expose: 
+        return .contextualKeyword(._expose)
+      case .typeWrapper: 
+        return .contextualKeyword(.typeWrapper)
+      case ._spiOnly: 
+        return .contextualKeyword(._spiOnly)
+      case ._documentation: 
+        return .contextualKeyword(._documentation)
+      case .typeWrapperIgnored: 
+        return .contextualKeyword(.typeWrapperIgnored)
+      case ._noMetadata: 
+        return .contextualKeyword(._noMetadata)
+      case .runtimeMetadata: 
+        return .contextualKeyword(.runtimeMetadata)
+      case ._spi_available: 
+        return .contextualKeyword(._spi_available)
+      }
+    }
   }
 }

--- a/Sources/SwiftParser/generated/DeclarationModifier.swift
+++ b/Sources/SwiftParser/generated/DeclarationModifier.swift
@@ -16,89 +16,141 @@
 
 @_spi(RawSyntax) import SwiftSyntax
 
-enum DeclarationModifier: SyntaxText, ContextualKeywords, RawTokenKindSubset {
-  case staticKeyword = "static"
+enum DeclarationModifier: RawTokenKindSubset {
+  case staticKeyword
   
-  case classKeyword = "class"
+  case classKeyword
   
-  case final = "final"
+  case final
   
-  case required = "required"
+  case required
   
-  case optional = "optional"
+  case optional
   
-  case lazy = "lazy"
+  case lazy
   
-  case dynamic = "dynamic"
+  case dynamic
   
-  case infix = "infix"
+  case infix
   
-  case prefix = "prefix"
+  case prefix
   
-  case postfix = "postfix"
+  case postfix
   
-  case __consuming = "__consuming"
+  case __consuming
   
-  case mutating = "mutating"
+  case mutating
   
-  case nonmutating = "nonmutating"
+  case nonmutating
   
-  case convenience = "convenience"
+  case convenience
   
-  case override = "override"
+  case override
   
-  case privateKeyword = "private"
+  case privateKeyword
   
-  case fileprivateKeyword = "fileprivate"
+  case fileprivateKeyword
   
-  case internalKeyword = "internal"
+  case internalKeyword
   
-  case publicKeyword = "public"
+  case publicKeyword
   
-  case package = "package"
+  case package
   
-  case open = "open"
+  case open
   
-  case __setter_access = "__setter_access"
+  case __setter_access
   
-  case weak = "weak"
+  case weak
   
-  case unowned = "unowned"
+  case unowned
   
-  case `rethrows` = "rethrows"
+  case `rethrows`
   
-  case indirect = "indirect"
+  case indirect
   
-  case isolated = "isolated"
+  case isolated
   
-  case async = "async"
+  case async
   
-  case reasync = "reasync"
+  case reasync
   
-  case nonisolated = "nonisolated"
+  case nonisolated
   
-  case distributed = "distributed"
+  case distributed
   
-  case _const = "_const"
+  case _const
   
-  case _local = "_local"
+  case _local
   
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme.rawTokenKind {
-    case .staticKeyword: 
+    switch lexeme {
+    case RawTokenKindMatch(.staticKeyword): 
       self = .staticKeyword
-    case .classKeyword: 
+    case RawTokenKindMatch(.classKeyword): 
       self = .classKeyword
-    case .privateKeyword: 
+    case RawTokenKindMatch(.final): 
+      self = .final
+    case RawTokenKindMatch(.required): 
+      self = .required
+    case RawTokenKindMatch(.optional): 
+      self = .optional
+    case RawTokenKindMatch(.lazy): 
+      self = .lazy
+    case RawTokenKindMatch(.dynamic): 
+      self = .dynamic
+    case RawTokenKindMatch(.infix): 
+      self = .infix
+    case RawTokenKindMatch(.prefix): 
+      self = .prefix
+    case RawTokenKindMatch(.postfix): 
+      self = .postfix
+    case RawTokenKindMatch(.__consuming): 
+      self = .__consuming
+    case RawTokenKindMatch(.mutating): 
+      self = .mutating
+    case RawTokenKindMatch(.nonmutating): 
+      self = .nonmutating
+    case RawTokenKindMatch(.convenience): 
+      self = .convenience
+    case RawTokenKindMatch(.override): 
+      self = .override
+    case RawTokenKindMatch(.privateKeyword): 
       self = .privateKeyword
-    case .fileprivateKeyword: 
+    case RawTokenKindMatch(.fileprivateKeyword): 
       self = .fileprivateKeyword
-    case .internalKeyword: 
+    case RawTokenKindMatch(.internalKeyword): 
       self = .internalKeyword
-    case .publicKeyword: 
+    case RawTokenKindMatch(.publicKeyword): 
       self = .publicKeyword
-    case .identifier: 
-      self.init(rawValue: lexeme.tokenText)
+    case RawTokenKindMatch(.package): 
+      self = .package
+    case RawTokenKindMatch(.open): 
+      self = .open
+    case RawTokenKindMatch(.__setter_access): 
+      self = .__setter_access
+    case RawTokenKindMatch(.weak): 
+      self = .weak
+    case RawTokenKindMatch(.unowned): 
+      self = .unowned
+    case RawTokenKindMatch(.`rethrows`): 
+      self = .`rethrows`
+    case RawTokenKindMatch(.indirect): 
+      self = .indirect
+    case RawTokenKindMatch(.isolated): 
+      self = .isolated
+    case RawTokenKindMatch(.async): 
+      self = .async
+    case RawTokenKindMatch(.reasync): 
+      self = .reasync
+    case RawTokenKindMatch(.nonisolated): 
+      self = .nonisolated
+    case RawTokenKindMatch(.distributed): 
+      self = .distributed
+    case RawTokenKindMatch(._const): 
+      self = ._const
+    case RawTokenKindMatch(._local): 
+      self = ._local
     default: 
       return nil
     }
@@ -111,31 +163,31 @@ enum DeclarationModifier: SyntaxText, ContextualKeywords, RawTokenKindSubset {
     case .classKeyword: 
       return .classKeyword
     case .final: 
-      return .identifier
+      return .contextualKeyword(.final)
     case .required: 
-      return .identifier
+      return .contextualKeyword(.required)
     case .optional: 
-      return .identifier
+      return .contextualKeyword(.optional)
     case .lazy: 
-      return .identifier
+      return .contextualKeyword(.lazy)
     case .dynamic: 
-      return .identifier
+      return .contextualKeyword(.dynamic)
     case .infix: 
-      return .identifier
+      return .contextualKeyword(.infix)
     case .prefix: 
-      return .identifier
+      return .contextualKeyword(.prefix)
     case .postfix: 
-      return .identifier
+      return .contextualKeyword(.postfix)
     case .__consuming: 
-      return .identifier
+      return .contextualKeyword(.__consuming)
     case .mutating: 
-      return .identifier
+      return .contextualKeyword(.mutating)
     case .nonmutating: 
-      return .identifier
+      return .contextualKeyword(.nonmutating)
     case .convenience: 
-      return .identifier
+      return .contextualKeyword(.convenience)
     case .override: 
-      return .identifier
+      return .contextualKeyword(.override)
     case .privateKeyword: 
       return .privateKeyword
     case .fileprivateKeyword: 
@@ -145,94 +197,33 @@ enum DeclarationModifier: SyntaxText, ContextualKeywords, RawTokenKindSubset {
     case .publicKeyword: 
       return .publicKeyword
     case .package: 
-      return .identifier
+      return .contextualKeyword(.package)
     case .open: 
-      return .identifier
+      return .contextualKeyword(.open)
     case .__setter_access: 
-      return .identifier
+      return .contextualKeyword(.__setter_access)
     case .weak: 
-      return .identifier
+      return .contextualKeyword(.weak)
     case .unowned: 
-      return .identifier
+      return .contextualKeyword(.unowned)
     case .`rethrows`: 
-      return .identifier
+      return .contextualKeyword(.`rethrows`)
     case .indirect: 
-      return .identifier
+      return .contextualKeyword(.indirect)
     case .isolated: 
-      return .identifier
+      return .contextualKeyword(.isolated)
     case .async: 
-      return .identifier
+      return .contextualKeyword(.async)
     case .reasync: 
-      return .identifier
+      return .contextualKeyword(.reasync)
     case .nonisolated: 
-      return .identifier
+      return .contextualKeyword(.nonisolated)
     case .distributed: 
-      return .identifier
+      return .contextualKeyword(.distributed)
     case ._const: 
-      return .identifier
+      return .contextualKeyword(._const)
     case ._local: 
-      return .identifier
-    }
-  }
-  
-  var contextualKeyword: SyntaxText? {
-    switch self {
-    case .final: 
-      return "final"
-    case .required: 
-      return "required"
-    case .optional: 
-      return "optional"
-    case .lazy: 
-      return "lazy"
-    case .dynamic: 
-      return "dynamic"
-    case .infix: 
-      return "infix"
-    case .prefix: 
-      return "prefix"
-    case .postfix: 
-      return "postfix"
-    case .__consuming: 
-      return "__consuming"
-    case .mutating: 
-      return "mutating"
-    case .nonmutating: 
-      return "nonmutating"
-    case .convenience: 
-      return "convenience"
-    case .override: 
-      return "override"
-    case .package: 
-      return "package"
-    case .open: 
-      return "open"
-    case .__setter_access: 
-      return "__setter_access"
-    case .weak: 
-      return "weak"
-    case .unowned: 
-      return "unowned"
-    case .`rethrows`: 
-      return "rethrows"
-    case .indirect: 
-      return "indirect"
-    case .isolated: 
-      return "isolated"
-    case .async: 
-      return "async"
-    case .reasync: 
-      return "reasync"
-    case .nonisolated: 
-      return "nonisolated"
-    case .distributed: 
-      return "distributed"
-    case ._const: 
-      return "_const"
-    case ._local: 
-      return "_local"
-    default: 
-      return nil
+      return .contextualKeyword(._local)
     }
   }
 }

--- a/Sources/SwiftParser/generated/DeclarationModifier.swift
+++ b/Sources/SwiftParser/generated/DeclarationModifier.swift
@@ -84,7 +84,7 @@ enum DeclarationModifier: SyntaxText, ContextualKeywords, RawTokenKindSubset {
   case _local = "_local"
   
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme.tokenKind {
+    switch lexeme.rawTokenKind {
     case .staticKeyword: 
       self = .staticKeyword
     case .classKeyword: 

--- a/Sources/SwiftParser/generated/TypeAttribute.swift
+++ b/Sources/SwiftParser/generated/TypeAttribute.swift
@@ -17,29 +17,89 @@
 @_spi(RawSyntax) import SwiftSyntax
 
 extension Parser {
-  enum TypeAttribute: SyntaxText, ContextualKeywords {
-    case autoclosure = "autoclosure"
+  enum TypeAttribute: RawTokenKindSubset {
+    case autoclosure
     
-    case convention = "convention"
+    case convention
     
-    case noescape = "noescape"
+    case noescape
     
-    case escaping = "escaping"
+    case escaping
     
-    case differentiable = "differentiable"
+    case differentiable
     
-    case noDerivative = "noDerivative"
+    case noDerivative
     
-    case async = "async"
+    case async
     
-    case Sendable = "Sendable"
+    case Sendable
     
-    case unchecked = "unchecked"
+    case unchecked
     
-    case _local = "_local"
+    case _local
     
-    case _noMetadata = "_noMetadata"
+    case _noMetadata
     
-    case _opaqueReturnTypeOf = "_opaqueReturnTypeOf"
+    case _opaqueReturnTypeOf
+    
+    init?(lexeme: Lexer.Lexeme) {
+      switch lexeme {
+      case RawTokenKindMatch(.autoclosure): 
+        self = .autoclosure
+      case RawTokenKindMatch(.convention): 
+        self = .convention
+      case RawTokenKindMatch(.noescape): 
+        self = .noescape
+      case RawTokenKindMatch(.escaping): 
+        self = .escaping
+      case RawTokenKindMatch(.differentiable): 
+        self = .differentiable
+      case RawTokenKindMatch(.noDerivative): 
+        self = .noDerivative
+      case RawTokenKindMatch(.async): 
+        self = .async
+      case RawTokenKindMatch(.Sendable): 
+        self = .Sendable
+      case RawTokenKindMatch(.unchecked): 
+        self = .unchecked
+      case RawTokenKindMatch(._local): 
+        self = ._local
+      case RawTokenKindMatch(._noMetadata): 
+        self = ._noMetadata
+      case RawTokenKindMatch(._opaqueReturnTypeOf): 
+        self = ._opaqueReturnTypeOf
+      default: 
+        return nil
+      }
+    }
+    
+    var rawTokenKind: RawTokenKind {
+      switch self {
+      case .autoclosure: 
+        return .contextualKeyword(.autoclosure)
+      case .convention: 
+        return .contextualKeyword(.convention)
+      case .noescape: 
+        return .contextualKeyword(.noescape)
+      case .escaping: 
+        return .contextualKeyword(.escaping)
+      case .differentiable: 
+        return .contextualKeyword(.differentiable)
+      case .noDerivative: 
+        return .contextualKeyword(.noDerivative)
+      case .async: 
+        return .contextualKeyword(.async)
+      case .Sendable: 
+        return .contextualKeyword(.Sendable)
+      case .unchecked: 
+        return .contextualKeyword(.unchecked)
+      case ._local: 
+        return .contextualKeyword(._local)
+      case ._noMetadata: 
+        return .contextualKeyword(._noMetadata)
+      case ._opaqueReturnTypeOf: 
+        return .contextualKeyword(._opaqueReturnTypeOf)
+      }
+    }
   }
 }

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -256,7 +256,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     }
     exchangeTokens(
       unexpected: node.unexpectedAfterArrowToken,
-      unexpectedTokenCondition: { $0.tokenKind == .contextualKeyword("async") || $0.tokenKind == .throwsKeyword },
+      unexpectedTokenCondition: { $0.tokenKind == .contextualKeyword(.async) || $0.tokenKind == .throwsKeyword },
       correctTokens: [node.asyncKeyword, node.throwsToken],
       message: { EffectsSpecifierAfterArrow(effectsSpecifiersAfterArrow: $0) },
       moveFixIt: { MoveTokensInFrontOfFixIt(movedTokens: $0, inFrontOf: .arrow) }

--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -12,6 +12,7 @@ add_swift_host_library(SwiftSyntax
   CommonAncestor.swift
   IncrementalParseTransition.swift
   LexerError.swift
+  Keyword.swift
   SourceLength.swift
   SourceLocation.swift
   SourcePresence.swift

--- a/Sources/SwiftSyntax/Keyword.swift
+++ b/Sources/SwiftSyntax/Keyword.swift
@@ -1,0 +1,414 @@
+//===--------------------------- Keyword.swift ----------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@frozen  // FIXME: Not actually stable, works around a miscompile
+public enum Keyword: Hashable {
+  case `__consuming`
+  case `__objc_bridged`
+  case `__owned`
+  case `__raw_doc_comment`
+  case `__setter_access`
+  case `__shared`
+  case `__synthesized_protocol`
+  case `_alignment`
+  case `_alwaysEmitConformanceMetadata`
+  case `_alwaysEmitIntoClient`
+  case `_assemblyVision`
+  case `_backDeploy`
+  case `_borrow`
+  case `_borrowed`
+  case `_PackageDescription`
+  case `_cdecl`
+  case `_clangImporterSynthesizedType`
+  case `_Class`
+  case `_compilerInitialized`
+  case `_const`
+  case `_custom`
+  case `_disfavoredOverload`
+  case `_documentation`
+  case `_dynamicReplacement`
+  case `_eagerMove`
+  case `_effects`
+  case `_exported`
+  case `_expose`
+  case `_fixed_layout`
+  case `_forbidSerializingReference`
+  case `_forward`
+  case `_frozen`
+  case `_hasInitialValue`
+  case `_hasMissingDesignatedInitializers`
+  case `_hasStorage`
+  case `_implementationOnly`
+  case `_implements`
+  case `_implicitSelfCapture`
+  case `_inheritActorContext`
+  case `_inheritsConvenienceInitializers`
+  case `_linear`
+  case `_local`
+  case `_marker`
+  case `_modify`
+  case `_move`
+  case `_moveOnly`
+  case `_NativeClass`
+  case `_NativeRefCountedObject`
+  case `_noAllocation`
+  case `_noEagerMove`
+  case `_noImplicitCopy`
+  case `_noLocks`
+  case `_noMetadata`
+  case `_nonEphemeral`
+  case `_nonoverride`
+  case `_nonSendable`
+  case `_objc_non_lazy_realization`
+  case `_objcImplementation`
+  case `_objcRuntimeName`
+  case `_opaqueReturnTypeOf`
+  case `_optimize`
+  case `_originallyDefinedIn`
+  case `_private`
+  case `_projectedValueProperty`
+  case `_read`
+  case `_RefCountedObject`
+  case `_restatedObjCConformance`
+  case `_semantics`
+  case `_show_in_interface`
+  case `_silgen_name`
+  case `_specialize`
+  case `_specializeExtension`
+  case `_spi`
+  case `_spi_available`
+  case `_spiOnly`
+  case `_staticInitializeObjCMetadata`
+  case `_swift_native_objc_runtime_base`
+  case `_transparent`
+  case `_Trivial`
+  case `_TrivialAtMost`
+  case `_typeEraser`
+  case `_unavailableFromAsync`
+  case `_UnknownLayout`
+  case `_unsafeInheritExecutor`
+  case `_weakLinked`
+  case `actor`
+  case `addressWithNativeOwner`
+  case `addressWithOwner`
+  case `any`
+  case `assignment`
+  case `associativity`
+  case `async`
+  case `autoclosure`
+  case `availability`
+  case `available`
+  case `await`
+  case `Protocol`
+  case `Type`
+  case `convenience`
+  case `convention`
+  case `deprecated`
+  case `derivative`
+  case `didSet`
+  case `differentiable`
+  case `discardableResult`
+  case `distributed`
+  case `dynamic`
+  case `dynamicCallable`
+  case `dynamicMemberLookup`
+  case `each`
+  case `escaping`
+  case `exclusivity`
+  case `exported`
+  case `final`
+  case `frozen`
+  case `get`
+  case `GKInspectable`
+  case `globalActor`
+  case `higherThan`
+  case `IBAction`
+  case `IBDesignable`
+  case `IBInspectable`
+  case `IBOutlet`
+  case `IBSegueAction`
+  case `indirect`
+  case `infix`
+  case `inlinable`
+  case `inline`
+  case `introduced`
+  case `isolated`
+  case `kind`
+  case `lazy`
+  case `LLDBDebuggerFunction`
+  case `lowerThan`
+  case `macro`
+  case `main`
+  case `message`
+  case `mutableAddressWithNativeOwner`
+  case `mutableAddressWithOwner`
+  case `mutating`
+  case `noasync`
+  case `noDerivative`
+  case `noescape`
+  case `nonisolated`
+  case `nonmutating`
+  case `nonobjc`
+  case `NSApplicationMain`
+  case `NSCopying`
+  case `NSManaged`
+  case `objc`
+  case `objcMembers`
+  case `obsoleted`
+  case `of`
+  case `open`
+  case `optional`
+  case `override`
+  case `package`
+  case `postfix`
+  case `preconcurrency`
+  case `prefix`
+  case `propertyWrapper`
+  case `reasync`
+  case `renamed`
+  case `required`
+  case `requires_stored_property_inits`
+  case `resultBuilder`
+  case `rethrows`
+  case `reverse`
+  case `runtimeMetadata`
+  case `safe`
+  case `Sendable`
+  case `set`
+  case `some`
+  case `spi`
+  case `spiModule`
+  case `static`
+  case `swift`
+  case `target`
+  case `testable`
+  case `transpose`
+  case `typeWrapper`
+  case `typeWrapperIgnored`
+  case `UIApplicationMain`
+  case `unavailable`
+  case `unchecked`
+  case `unowned`
+  case `unsafe`
+  case `unsafe_no_objc_tagged_pointer`
+  case `unsafeAddress`
+  case `unsafeMutableAddress`
+  case `usableFromInline`
+  case `warn_unqualified_access`
+  case `weak`
+  case `willSet`
+  case `witness_method`
+  case `wrt`
+  case `yield`
+
+  var defaultText: SyntaxText {
+    switch self {
+    case .__consuming: return "__consuming"
+    case .__objc_bridged: return "__objc_bridged"
+    case .__owned: return "__owned"
+    case .__raw_doc_comment: return "__raw_doc_comment"
+    case .__setter_access: return "__setter_access"
+    case .__shared: return "__shared"
+    case .__synthesized_protocol: return "__synthesized_protocol"
+    case ._alignment: return "_alignment"
+    case ._alwaysEmitConformanceMetadata: return "_alwaysEmitConformanceMetadata"
+    case ._alwaysEmitIntoClient: return "_alwaysEmitIntoClient"
+    case ._assemblyVision: return "_assemblyVision"
+    case ._backDeploy: return "_backDeploy"
+    case ._borrow: return "_borrow"
+    case ._borrowed: return "_borrowed"
+    case ._PackageDescription: return "_PackageDescription"
+    case ._cdecl: return "_cdecl"
+    case ._clangImporterSynthesizedType: return "_clangImporterSynthesizedType"
+    case ._Class: return "_Class"
+    case ._compilerInitialized: return "_compilerInitialized"
+    case ._const: return "_const"
+    case ._custom: return "_custom"
+    case ._disfavoredOverload: return "_disfavoredOverload"
+    case ._documentation: return "_documentation"
+    case ._dynamicReplacement: return "_dynamicReplacement"
+    case ._eagerMove: return "_eagerMove"
+    case ._effects: return "_effects"
+    case ._exported: return "_exported"
+    case ._expose: return "_expose"
+    case ._fixed_layout: return "_fixed_layout"
+    case ._forbidSerializingReference: return "_forbidSerializingReference"
+    case ._forward: return "_forward"
+    case ._frozen: return "_frozen"
+    case ._hasInitialValue: return "_hasInitialValue"
+    case ._hasMissingDesignatedInitializers: return "_hasMissingDesignatedInitializers"
+    case ._hasStorage: return "_hasStorage"
+    case ._implementationOnly: return "_implementationOnly"
+    case ._implements: return "_implements"
+    case ._implicitSelfCapture: return "_implicitSelfCapture"
+    case ._inheritActorContext: return "_inheritActorContext"
+    case ._inheritsConvenienceInitializers: return "_inheritsConvenienceInitializers"
+    case ._linear: return "_linear"
+    case ._local: return "_local"
+    case ._marker: return "_marker"
+    case ._modify: return "_modify"
+    case ._move: return "_move"
+    case ._moveOnly: return "_moveOnly"
+    case ._NativeClass: return "_NativeClass"
+    case ._NativeRefCountedObject: return "_NativeRefCountedObject"
+    case ._noAllocation: return "_noAllocation"
+    case ._noEagerMove: return "_noEagerMove"
+    case ._noImplicitCopy: return "_noImplicitCopy"
+    case ._noLocks: return "_noLocks"
+    case ._noMetadata: return "_noMetadata"
+    case ._nonEphemeral: return "_nonEphemeral"
+    case ._nonoverride: return "_nonoverride"
+    case ._nonSendable: return "_nonSendable"
+    case ._objc_non_lazy_realization: return "_objc_non_lazy_realization"
+    case ._objcImplementation: return "_objcImplementation"
+    case ._objcRuntimeName: return "_objcRuntimeName"
+    case ._opaqueReturnTypeOf: return "_opaqueReturnTypeOf"
+    case ._optimize: return "_optimize"
+    case ._originallyDefinedIn: return "_originallyDefinedIn"
+    case ._private: return "_private"
+    case ._projectedValueProperty: return "_projectedValueProperty"
+    case ._read: return "_read"
+    case ._RefCountedObject: return "_RefCountedObject"
+    case ._restatedObjCConformance: return "_restatedObjCConformance"
+    case ._semantics: return "_semantics"
+    case ._show_in_interface: return "_show_in_interface"
+    case ._silgen_name: return "_silgen_name"
+    case ._specialize: return "_specialize"
+    case ._specializeExtension: return "_specializeExtension"
+    case ._spi: return "_spi"
+    case ._spi_available: return "_spi_available"
+    case ._spiOnly: return "_spiOnly"
+    case ._staticInitializeObjCMetadata: return "_staticInitializeObjCMetadata"
+    case ._swift_native_objc_runtime_base: return "_swift_native_objc_runtime_base"
+    case ._transparent: return "_transparent"
+    case ._Trivial: return "_Trivial"
+    case ._TrivialAtMost: return "_TrivialAtMost"
+    case ._typeEraser: return "_typeEraser"
+    case ._unavailableFromAsync: return "_unavailableFromAsync"
+    case ._UnknownLayout: return "_UnknownLayout"
+    case ._unsafeInheritExecutor: return "_unsafeInheritExecutor"
+    case ._weakLinked: return "_weakLinked"
+    case .actor: return "actor"
+    case .addressWithNativeOwner: return "addressWithNativeOwner"
+    case .addressWithOwner: return "addressWithOwner"
+    case .any: return "any"
+    case .assignment: return "assignment"
+    case .associativity: return "associativity"
+    case .async: return "async"
+    case .autoclosure: return "autoclosure"
+    case .availability: return "availability"
+    case .available: return "available"
+    case .await: return "await"
+    case .Protocol: return "Protocol"
+    case .Type: return "Type"
+    case .convenience: return "convenience"
+    case .convention: return "convention"
+    case .deprecated: return "deprecated"
+    case .derivative: return "derivative"
+    case .didSet: return "didSet"
+    case .differentiable: return "differentiable"
+    case .discardableResult: return "discardableResult"
+    case .distributed: return "distributed"
+    case .dynamic: return "dynamic"
+    case .dynamicCallable: return "dynamicCallable"
+    case .dynamicMemberLookup: return "dynamicMemberLookup"
+    case .each: return "each"
+    case .escaping: return "escaping"
+    case .exclusivity: return "exclusivity"
+    case .exported: return "exported"
+    case .final: return "final"
+    case .frozen: return "frozen"
+    case .get: return "get"
+    case .GKInspectable: return "GKInspectable"
+    case .globalActor: return "globalActor"
+    case .higherThan: return "higherThan"
+    case .IBAction: return "IBAction"
+    case .IBDesignable: return "IBDesignable"
+    case .IBInspectable: return "IBInspectable"
+    case .IBOutlet: return "IBOutlet"
+    case .IBSegueAction: return "IBSegueAction"
+    case .indirect: return "indirect"
+    case .infix: return "infix"
+    case .inlinable: return "inlinable"
+    case .inline: return "inline"
+    case .introduced: return "introduced"
+    case .isolated: return "isolated"
+    case .kind: return "kind"
+    case .lazy: return "lazy"
+    case .LLDBDebuggerFunction: return "LLDBDebuggerFunction"
+    case .lowerThan: return "lowerThan"
+    case .macro: return "macro"
+    case .main: return "main"
+    case .message: return "message"
+    case .mutableAddressWithNativeOwner: return "mutableAddressWithNativeOwner"
+    case .mutableAddressWithOwner: return "mutableAddressWithOwner"
+    case .mutating: return "mutating"
+    case .noasync: return "noasync"
+    case .noDerivative: return "noDerivative"
+    case .noescape: return "noescape"
+    case .nonisolated: return "nonisolated"
+    case .nonmutating: return "nonmutating"
+    case .nonobjc: return "nonobjc"
+    case .NSApplicationMain: return "NSApplicationMain"
+    case .NSCopying: return "NSCopying"
+    case .NSManaged: return "NSManaged"
+    case .objc: return "objc"
+    case .objcMembers: return "objcMembers"
+    case .obsoleted: return "obsoleted"
+    case .of: return "of"
+    case .open: return "open"
+    case .optional: return "optional"
+    case .override: return "override"
+    case .package: return "package"
+    case .postfix: return "postfix"
+    case .preconcurrency: return "preconcurrency"
+    case .prefix: return "prefix"
+    case .propertyWrapper: return "propertyWrapper"
+    case .reasync: return "reasync"
+    case .renamed: return "renamed"
+    case .required: return "required"
+    case .requires_stored_property_inits: return "requires_stored_property_inits"
+    case .resultBuilder: return "resultBuilder"
+    case .rethrows: return "rethrows"
+    case .reverse: return "reverse"
+    case .runtimeMetadata: return "runtimeMetadata"
+    case .safe: return "safe"
+    case .Sendable: return "Sendable"
+    case .set: return "set"
+    case .some: return "some"
+    case .spi: return "spi"
+    case .spiModule: return "spiModule"
+    case .static: return "static"
+    case .swift: return "swift"
+    case .target: return "target"
+    case .testable: return "testable"
+    case .transpose: return "transpose"
+    case .typeWrapper: return "typeWrapper"
+    case .typeWrapperIgnored: return "typeWrapperIgnored"
+    case .UIApplicationMain: return "UIApplicationMain"
+    case .unavailable: return "unavailable"
+    case .unchecked: return "unchecked"
+    case .unowned: return "unowned"
+    case .unsafe: return "unsafe"
+    case .unsafe_no_objc_tagged_pointer: return "unsafe_no_objc_tagged_pointer"
+    case .unsafeAddress: return "unsafeAddress"
+    case .unsafeMutableAddress: return "unsafeMutableAddress"
+    case .usableFromInline: return "usableFromInline"
+    case .warn_unqualified_access: return "warn_unqualified_access"
+    case .weak: return "weak"
+    case .willSet: return "willSet"
+    case .witness_method: return "witness_method"
+    case .wrt: return "wrt"
+    case .yield: return "yield"
+    }
+  }
+}

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -527,6 +527,7 @@ extension RawSyntax {
     initializingLeadingTriviaWith: (UnsafeMutableBufferPointer<RawTriviaPiece>) -> Void,
     initializingTrailingTriviaWith: (UnsafeMutableBufferPointer<RawTriviaPiece>) -> Void
   ) -> RawSyntax {
+    assert(kind.defaultText == nil || text.isEmpty || kind.defaultText == text)
     let totalTriviaCount = leadingTriviaPieceCount + trailingTriviaPieceCount
     let triviaBuffer = arena.allocateRawTriviaPieceBuffer(count: totalTriviaCount)
     initializingLeadingTriviaWith(

--- a/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -142,6 +142,17 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+%   elif token.associated_value_class:
+  @available(*, deprecated, message: "Use TokenSyntax.${token.swift_kind()} instead")
+  public static func make${token.name}(
+    _ value: ${token.associated_value_class},
+    leadingTrivia: Trivia = ${leading_trivia},
+    trailingTrivia: Trivia = ${trailing_trivia}
+  ) -> TokenSyntax {
+    return makeToken(.${token.swift_kind()}(value), presence: .present,
+                     leadingTrivia: leadingTrivia,
+                     trailingTrivia: trailingTrivia)
+  }
 %   else:
   @available(*, deprecated, message: "Use TokenSyntax.${token.swift_kind()} instead")
   public static func make${token.name}(

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
@@ -236,12 +236,12 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `${child.swift_name}` replaced.
   /// - param newChild: The new `${child.swift_name}` to replace the node's
   ///                   current `${child.swift_name}`, if present.
-  public func with${child.name}(_ newChild: ${child_type}?) -> ${node.name} {
+  public func with${child.name}(_ newChild: ${child_type}${'?' if child.is_optional else ''}) -> ${node.name} {
     let arena = SyntaxArena()
 %       if child.is_optional:
     let raw = newChild?.raw
 %       else:
-    let raw = newChild?.raw ?? ${make_missing_swift_child(child)}
+    let raw = newChild.raw
 %       end
     let newData = data.replacingChild(at: ${idx}, with: raw, arena: arena)
     return ${node.name}(newData)

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -37,7 +37,7 @@ public protocol DeclGroupSyntax: SyntaxProtocol {
   
   var members: MemberDeclBlockSyntax { get }
   
-  func withMembers(_ newChild: MemberDeclBlockSyntax?) -> Self
+  func withMembers(_ newChild: MemberDeclBlockSyntax) -> Self
 }
 
 public extension SyntaxProtocol {
@@ -61,11 +61,11 @@ public extension SyntaxProtocol {
 public protocol BracedSyntax: SyntaxProtocol {
   var leftBrace: TokenSyntax { get }
   
-  func withLeftBrace(_ newChild: TokenSyntax?) -> Self
+  func withLeftBrace(_ newChild: TokenSyntax) -> Self
   
   var rightBrace: TokenSyntax { get }
   
-  func withRightBrace(_ newChild: TokenSyntax?) -> Self
+  func withRightBrace(_ newChild: TokenSyntax) -> Self
 }
 
 public extension SyntaxProtocol {
@@ -89,7 +89,7 @@ public extension SyntaxProtocol {
 public protocol IdentifiedDeclSyntax: SyntaxProtocol {
   var identifier: TokenSyntax { get }
   
-  func withIdentifier(_ newChild: TokenSyntax?) -> Self
+  func withIdentifier(_ newChild: TokenSyntax) -> Self
 }
 
 public extension SyntaxProtocol {
@@ -113,7 +113,7 @@ public extension SyntaxProtocol {
 public protocol WithCodeBlockSyntax: SyntaxProtocol {
   var body: CodeBlockSyntax { get }
   
-  func withBody(_ newChild: CodeBlockSyntax?) -> Self
+  func withBody(_ newChild: CodeBlockSyntax) -> Self
 }
 
 public extension SyntaxProtocol {
@@ -137,11 +137,11 @@ public extension SyntaxProtocol {
 public protocol ParenthesizedSyntax: SyntaxProtocol {
   var leftParen: TokenSyntax { get }
   
-  func withLeftParen(_ newChild: TokenSyntax?) -> Self
+  func withLeftParen(_ newChild: TokenSyntax) -> Self
   
   var rightParen: TokenSyntax { get }
   
-  func withRightParen(_ newChild: TokenSyntax?) -> Self
+  func withRightParen(_ newChild: TokenSyntax) -> Self
 }
 
 public extension SyntaxProtocol {
@@ -189,7 +189,7 @@ public extension SyntaxProtocol {
 public protocol WithStatementsSyntax: SyntaxProtocol {
   var statements: CodeBlockItemListSyntax { get }
   
-  func withStatements(_ newChild: CodeBlockItemListSyntax?) -> Self
+  func withStatements(_ newChild: CodeBlockItemListSyntax) -> Self
 }
 
 public extension SyntaxProtocol {

--- a/Sources/SwiftSyntax/generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/generated/TokenKind.swift
@@ -233,7 +233,7 @@ public enum TokenKind: Hashable {
   
   case dollarIdentifier(String)
   
-  case contextualKeyword(String)
+  case contextualKeyword(Keyword)
   
   case rawStringDelimiter(String)
   
@@ -636,8 +636,8 @@ public enum TokenKind: Hashable {
       return text
     case .dollarIdentifier(let text): 
       return text
-    case .contextualKeyword(let text): 
-      return text
+    case .contextualKeyword(let assoc): 
+      return String(syntaxText: assoc.defaultText)
     case .rawStringDelimiter(let text): 
       return text
     case .stringSegment(let text): 
@@ -645,6 +645,227 @@ public enum TokenKind: Hashable {
     case .yield: 
       return #"yield"#
     case .eof: 
+      return ""
+    }
+  }
+  
+  /// If this token kind always has the same syntax text, that syntax text, otherwise `nil`.
+  @_spi(RawSyntax) 
+  public var defaultText: SyntaxText? {
+    switch self {
+    case .associatedtypeKeyword: 
+      return #"associatedtype"#
+    case .classKeyword: 
+      return #"class"#
+    case .deinitKeyword: 
+      return #"deinit"#
+    case .enumKeyword: 
+      return #"enum"#
+    case .extensionKeyword: 
+      return #"extension"#
+    case .funcKeyword: 
+      return #"func"#
+    case .importKeyword: 
+      return #"import"#
+    case .initKeyword: 
+      return #"init"#
+    case .inoutKeyword: 
+      return #"inout"#
+    case .letKeyword: 
+      return #"let"#
+    case .operatorKeyword: 
+      return #"operator"#
+    case .precedencegroupKeyword: 
+      return #"precedencegroup"#
+    case .protocolKeyword: 
+      return #"protocol"#
+    case .structKeyword: 
+      return #"struct"#
+    case .subscriptKeyword: 
+      return #"subscript"#
+    case .typealiasKeyword: 
+      return #"typealias"#
+    case .varKeyword: 
+      return #"var"#
+    case .fileprivateKeyword: 
+      return #"fileprivate"#
+    case .internalKeyword: 
+      return #"internal"#
+    case .privateKeyword: 
+      return #"private"#
+    case .publicKeyword: 
+      return #"public"#
+    case .staticKeyword: 
+      return #"static"#
+    case .deferKeyword: 
+      return #"defer"#
+    case .ifKeyword: 
+      return #"if"#
+    case .guardKeyword: 
+      return #"guard"#
+    case .doKeyword: 
+      return #"do"#
+    case .repeatKeyword: 
+      return #"repeat"#
+    case .elseKeyword: 
+      return #"else"#
+    case .forKeyword: 
+      return #"for"#
+    case .inKeyword: 
+      return #"in"#
+    case .whileKeyword: 
+      return #"while"#
+    case .returnKeyword: 
+      return #"return"#
+    case .breakKeyword: 
+      return #"break"#
+    case .continueKeyword: 
+      return #"continue"#
+    case .fallthroughKeyword: 
+      return #"fallthrough"#
+    case .switchKeyword: 
+      return #"switch"#
+    case .caseKeyword: 
+      return #"case"#
+    case .defaultKeyword: 
+      return #"default"#
+    case .whereKeyword: 
+      return #"where"#
+    case .catchKeyword: 
+      return #"catch"#
+    case .throwKeyword: 
+      return #"throw"#
+    case .asKeyword: 
+      return #"as"#
+    case .anyKeyword: 
+      return #"Any"#
+    case .falseKeyword: 
+      return #"false"#
+    case .isKeyword: 
+      return #"is"#
+    case .nilKeyword: 
+      return #"nil"#
+    case .rethrowsKeyword: 
+      return #"rethrows"#
+    case .superKeyword: 
+      return #"super"#
+    case .selfKeyword: 
+      return #"self"#
+    case .capitalSelfKeyword: 
+      return #"Self"#
+    case .trueKeyword: 
+      return #"true"#
+    case .tryKeyword: 
+      return #"try"#
+    case .throwsKeyword: 
+      return #"throws"#
+    case .wildcardKeyword: 
+      return #"_"#
+    case .leftParen: 
+      return #"("#
+    case .rightParen: 
+      return #")"#
+    case .leftBrace: 
+      return #"{"#
+    case .rightBrace: 
+      return #"}"#
+    case .leftSquareBracket: 
+      return #"["#
+    case .rightSquareBracket: 
+      return #"]"#
+    case .leftAngle: 
+      return #"<"#
+    case .rightAngle: 
+      return #">"#
+    case .period: 
+      return #"."#
+    case .comma: 
+      return #","#
+    case .ellipsis: 
+      return #"..."#
+    case .colon: 
+      return #":"#
+    case .semicolon: 
+      return #";"#
+    case .equal: 
+      return #"="#
+    case .atSign: 
+      return #"@"#
+    case .pound: 
+      return #"#"#
+    case .prefixAmpersand: 
+      return #"&"#
+    case .arrow: 
+      return #"->"#
+    case .backtick: 
+      return #"`"#
+    case .backslash: 
+      return #"\"#
+    case .exclamationMark: 
+      return #"!"#
+    case .postfixQuestionMark: 
+      return #"?"#
+    case .infixQuestionMark: 
+      return #"?"#
+    case .stringQuote: 
+      return #"""#
+    case .singleQuote: 
+      return #"'"#
+    case .multilineStringQuote: 
+      return #"""""#
+    case .poundKeyPathKeyword: 
+      return #"#keyPath"#
+    case .poundLineKeyword: 
+      return #"#line"#
+    case .poundSelectorKeyword: 
+      return #"#selector"#
+    case .poundFileKeyword: 
+      return #"#file"#
+    case .poundFileIDKeyword: 
+      return #"#fileID"#
+    case .poundFilePathKeyword: 
+      return #"#filePath"#
+    case .poundColumnKeyword: 
+      return #"#column"#
+    case .poundFunctionKeyword: 
+      return #"#function"#
+    case .poundDsohandleKeyword: 
+      return #"#dsohandle"#
+    case .poundAssertKeyword: 
+      return #"#assert"#
+    case .poundSourceLocationKeyword: 
+      return #"#sourceLocation"#
+    case .poundWarningKeyword: 
+      return #"#warning"#
+    case .poundErrorKeyword: 
+      return #"#error"#
+    case .poundIfKeyword: 
+      return #"#if"#
+    case .poundElseKeyword: 
+      return #"#else"#
+    case .poundElseifKeyword: 
+      return #"#elseif"#
+    case .poundEndifKeyword: 
+      return #"#endif"#
+    case .poundAvailableKeyword: 
+      return #"#available"#
+    case .poundUnavailableKeyword: 
+      return #"#unavailable"#
+    case .poundFileLiteralKeyword: 
+      return #"#fileLiteral"#
+    case .poundImageLiteralKeyword: 
+      return #"#imageLiteral"#
+    case .poundColorLiteralKeyword: 
+      return #"#colorLiteral"#
+    case .poundHasSymbolKeyword: 
+      return #"#_hasSymbol"#
+    case .contextualKeyword(let assoc): 
+      return assoc.defaultText
+    case .yield: 
+      return #"yield"#
+    case .eof: 
+      return ""
+    default: 
       return ""
     }
   }
@@ -1144,249 +1365,6 @@ public enum TokenKind: Hashable {
       return false
     }
   }
-  
-  public var sourceLength: SourceLength {
-    switch self {
-    case .eof: 
-      return .zero
-    case .associatedtypeKeyword: 
-      return SourceLength(utf8Length: 14)
-    case .classKeyword: 
-      return SourceLength(utf8Length: 5)
-    case .deinitKeyword: 
-      return SourceLength(utf8Length: 6)
-    case .enumKeyword: 
-      return SourceLength(utf8Length: 4)
-    case .extensionKeyword: 
-      return SourceLength(utf8Length: 9)
-    case .funcKeyword: 
-      return SourceLength(utf8Length: 4)
-    case .importKeyword: 
-      return SourceLength(utf8Length: 6)
-    case .initKeyword: 
-      return SourceLength(utf8Length: 4)
-    case .inoutKeyword: 
-      return SourceLength(utf8Length: 5)
-    case .letKeyword: 
-      return SourceLength(utf8Length: 3)
-    case .operatorKeyword: 
-      return SourceLength(utf8Length: 8)
-    case .precedencegroupKeyword: 
-      return SourceLength(utf8Length: 15)
-    case .protocolKeyword: 
-      return SourceLength(utf8Length: 8)
-    case .structKeyword: 
-      return SourceLength(utf8Length: 6)
-    case .subscriptKeyword: 
-      return SourceLength(utf8Length: 9)
-    case .typealiasKeyword: 
-      return SourceLength(utf8Length: 9)
-    case .varKeyword: 
-      return SourceLength(utf8Length: 3)
-    case .fileprivateKeyword: 
-      return SourceLength(utf8Length: 11)
-    case .internalKeyword: 
-      return SourceLength(utf8Length: 8)
-    case .privateKeyword: 
-      return SourceLength(utf8Length: 7)
-    case .publicKeyword: 
-      return SourceLength(utf8Length: 6)
-    case .staticKeyword: 
-      return SourceLength(utf8Length: 6)
-    case .deferKeyword: 
-      return SourceLength(utf8Length: 5)
-    case .ifKeyword: 
-      return SourceLength(utf8Length: 2)
-    case .guardKeyword: 
-      return SourceLength(utf8Length: 5)
-    case .doKeyword: 
-      return SourceLength(utf8Length: 2)
-    case .repeatKeyword: 
-      return SourceLength(utf8Length: 6)
-    case .elseKeyword: 
-      return SourceLength(utf8Length: 4)
-    case .forKeyword: 
-      return SourceLength(utf8Length: 3)
-    case .inKeyword: 
-      return SourceLength(utf8Length: 2)
-    case .whileKeyword: 
-      return SourceLength(utf8Length: 5)
-    case .returnKeyword: 
-      return SourceLength(utf8Length: 6)
-    case .breakKeyword: 
-      return SourceLength(utf8Length: 5)
-    case .continueKeyword: 
-      return SourceLength(utf8Length: 8)
-    case .fallthroughKeyword: 
-      return SourceLength(utf8Length: 11)
-    case .switchKeyword: 
-      return SourceLength(utf8Length: 6)
-    case .caseKeyword: 
-      return SourceLength(utf8Length: 4)
-    case .defaultKeyword: 
-      return SourceLength(utf8Length: 7)
-    case .whereKeyword: 
-      return SourceLength(utf8Length: 5)
-    case .catchKeyword: 
-      return SourceLength(utf8Length: 5)
-    case .throwKeyword: 
-      return SourceLength(utf8Length: 5)
-    case .asKeyword: 
-      return SourceLength(utf8Length: 2)
-    case .anyKeyword: 
-      return SourceLength(utf8Length: 3)
-    case .falseKeyword: 
-      return SourceLength(utf8Length: 5)
-    case .isKeyword: 
-      return SourceLength(utf8Length: 2)
-    case .nilKeyword: 
-      return SourceLength(utf8Length: 3)
-    case .rethrowsKeyword: 
-      return SourceLength(utf8Length: 8)
-    case .superKeyword: 
-      return SourceLength(utf8Length: 5)
-    case .selfKeyword: 
-      return SourceLength(utf8Length: 4)
-    case .capitalSelfKeyword: 
-      return SourceLength(utf8Length: 4)
-    case .trueKeyword: 
-      return SourceLength(utf8Length: 4)
-    case .tryKeyword: 
-      return SourceLength(utf8Length: 3)
-    case .throwsKeyword: 
-      return SourceLength(utf8Length: 6)
-    case .wildcardKeyword: 
-      return SourceLength(utf8Length: 1)
-    case .leftParen: 
-      return SourceLength(utf8Length: 1)
-    case .rightParen: 
-      return SourceLength(utf8Length: 1)
-    case .leftBrace: 
-      return SourceLength(utf8Length: 1)
-    case .rightBrace: 
-      return SourceLength(utf8Length: 1)
-    case .leftSquareBracket: 
-      return SourceLength(utf8Length: 1)
-    case .rightSquareBracket: 
-      return SourceLength(utf8Length: 1)
-    case .leftAngle: 
-      return SourceLength(utf8Length: 1)
-    case .rightAngle: 
-      return SourceLength(utf8Length: 1)
-    case .period: 
-      return SourceLength(utf8Length: 1)
-    case .comma: 
-      return SourceLength(utf8Length: 1)
-    case .ellipsis: 
-      return SourceLength(utf8Length: 3)
-    case .colon: 
-      return SourceLength(utf8Length: 1)
-    case .semicolon: 
-      return SourceLength(utf8Length: 1)
-    case .equal: 
-      return SourceLength(utf8Length: 1)
-    case .atSign: 
-      return SourceLength(utf8Length: 1)
-    case .pound: 
-      return SourceLength(utf8Length: 1)
-    case .prefixAmpersand: 
-      return SourceLength(utf8Length: 1)
-    case .arrow: 
-      return SourceLength(utf8Length: 2)
-    case .backtick: 
-      return SourceLength(utf8Length: 1)
-    case .backslash: 
-      return SourceLength(utf8Length: 1)
-    case .exclamationMark: 
-      return SourceLength(utf8Length: 1)
-    case .postfixQuestionMark: 
-      return SourceLength(utf8Length: 1)
-    case .infixQuestionMark: 
-      return SourceLength(utf8Length: 1)
-    case .stringQuote: 
-      return SourceLength(utf8Length: 1)
-    case .singleQuote: 
-      return SourceLength(utf8Length: 1)
-    case .multilineStringQuote: 
-      return SourceLength(utf8Length: 3)
-    case .poundKeyPathKeyword: 
-      return SourceLength(utf8Length: 8)
-    case .poundLineKeyword: 
-      return SourceLength(utf8Length: 5)
-    case .poundSelectorKeyword: 
-      return SourceLength(utf8Length: 9)
-    case .poundFileKeyword: 
-      return SourceLength(utf8Length: 5)
-    case .poundFileIDKeyword: 
-      return SourceLength(utf8Length: 7)
-    case .poundFilePathKeyword: 
-      return SourceLength(utf8Length: 9)
-    case .poundColumnKeyword: 
-      return SourceLength(utf8Length: 7)
-    case .poundFunctionKeyword: 
-      return SourceLength(utf8Length: 9)
-    case .poundDsohandleKeyword: 
-      return SourceLength(utf8Length: 10)
-    case .poundAssertKeyword: 
-      return SourceLength(utf8Length: 7)
-    case .poundSourceLocationKeyword: 
-      return SourceLength(utf8Length: 15)
-    case .poundWarningKeyword: 
-      return SourceLength(utf8Length: 8)
-    case .poundErrorKeyword: 
-      return SourceLength(utf8Length: 6)
-    case .poundIfKeyword: 
-      return SourceLength(utf8Length: 3)
-    case .poundElseKeyword: 
-      return SourceLength(utf8Length: 5)
-    case .poundElseifKeyword: 
-      return SourceLength(utf8Length: 7)
-    case .poundEndifKeyword: 
-      return SourceLength(utf8Length: 6)
-    case .poundAvailableKeyword: 
-      return SourceLength(utf8Length: 10)
-    case .poundUnavailableKeyword: 
-      return SourceLength(utf8Length: 12)
-    case .poundFileLiteralKeyword: 
-      return SourceLength(utf8Length: 12)
-    case .poundImageLiteralKeyword: 
-      return SourceLength(utf8Length: 13)
-    case .poundColorLiteralKeyword: 
-      return SourceLength(utf8Length: 13)
-    case .poundHasSymbolKeyword: 
-      return SourceLength(utf8Length: 11)
-    case .integerLiteral(let text): 
-      return SourceLength(of: text)
-    case .floatingLiteral(let text): 
-      return SourceLength(of: text)
-    case .stringLiteral(let text): 
-      return SourceLength(of: text)
-    case .regexLiteral(let text): 
-      return SourceLength(of: text)
-    case .unknown(let text): 
-      return SourceLength(of: text)
-    case .identifier(let text): 
-      return SourceLength(of: text)
-    case .unspacedBinaryOperator(let text): 
-      return SourceLength(of: text)
-    case .spacedBinaryOperator(let text): 
-      return SourceLength(of: text)
-    case .postfixOperator(let text): 
-      return SourceLength(of: text)
-    case .prefixOperator(let text): 
-      return SourceLength(of: text)
-    case .dollarIdentifier(let text): 
-      return SourceLength(of: text)
-    case .contextualKeyword(let text): 
-      return SourceLength(of: text)
-    case .rawStringDelimiter(let text): 
-      return SourceLength(of: text)
-    case .stringSegment(let text): 
-      return SourceLength(of: text)
-    case .yield: 
-      return SourceLength(utf8Length: 5)
-    }
-  }
 }
 
 extension TokenKind: Equatable {
@@ -1869,7 +1847,7 @@ public enum RawTokenKind: Equatable, Hashable {
   
   case dollarIdentifier
   
-  case contextualKeyword
+  case contextualKeyword(Keyword)
   
   case rawStringDelimiter
   
@@ -2088,6 +2066,8 @@ public enum RawTokenKind: Equatable, Hashable {
       return #"#colorLiteral"#
     case .poundHasSymbolKeyword: 
       return #"#_hasSymbol"#
+    case .contextualKeyword(let assoc): 
+      return assoc.defaultText
     case .yield: 
       return #"yield"#
     default: 
@@ -3410,8 +3390,9 @@ extension TokenKind {
       return .prefixOperator(text)
     case .dollarIdentifier: 
       return .dollarIdentifier(text)
-    case .contextualKeyword: 
-      return .contextualKeyword(text)
+    case .contextualKeyword(let assoc): 
+      assert(text.isEmpty || String(syntaxText: assoc.defaultText) == text)
+      return .contextualKeyword(assoc)
     case .rawStringDelimiter: 
       return .rawStringDelimiter(text)
     case .stringSegment: 
@@ -3657,8 +3638,8 @@ extension TokenKind {
       return (.prefixOperator, str)
     case .dollarIdentifier(let str): 
       return (.dollarIdentifier, str)
-    case .contextualKeyword(let str): 
-      return (.contextualKeyword, str)
+    case .contextualKeyword(let assoc): 
+      return (.contextualKeyword(assoc), String(syntaxText: assoc.defaultText))
     case .rawStringDelimiter(let str): 
       return (.rawStringDelimiter, str)
     case .stringSegment(let str): 

--- a/Sources/SwiftSyntax/generated/Tokens.swift
+++ b/Sources/SwiftSyntax/generated/Tokens.swift
@@ -1509,13 +1509,13 @@ extension TokenSyntax {
   }
   
   public static func contextualKeyword(
-    _ text: String, 
+    _ value: Keyword, 
     leadingTrivia: Trivia = [], 
     trailingTrivia: Trivia = [], 
     presence: SourcePresence = .present
   ) -> TokenSyntax {
     return TokenSyntax(
-      .contextualKeyword(text), 
+      .contextualKeyword(value), 
       leadingTrivia: leadingTrivia, 
       trailingTrivia: trailingTrivia, 
       presence: presence

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -401,7 +401,7 @@ public enum SyntaxFactory {
       let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .awaitExpr,
         from: [
         nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena),
+        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(.await), arena: arena),
         nil,
         RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
         nil,
@@ -432,7 +432,7 @@ public enum SyntaxFactory {
       let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .moveExpr,
         from: [
         nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena),
+        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(._move), arena: arena),
         nil,
         RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
         nil,
@@ -463,7 +463,7 @@ public enum SyntaxFactory {
       let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .borrowExpr,
         from: [
         nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena),
+        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(._borrow), arena: arena),
         nil,
         RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
         nil,
@@ -750,7 +750,7 @@ public enum SyntaxFactory {
       let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .packElementExpr,
         from: [
         nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena),
+        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(.each), arena: arena),
         nil,
         RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena),
         nil,
@@ -3284,7 +3284,7 @@ public enum SyntaxFactory {
         nil,
         nil,
         nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena),
+        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(.actor), arena: arena),
         nil,
         RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
         nil,
@@ -4777,7 +4777,7 @@ public enum SyntaxFactory {
         nil,
         nil,
         nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena),
+        RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(.macro), arena: arena),
         nil,
         RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
         nil,
@@ -9536,11 +9536,11 @@ public enum SyntaxFactory {
   }
   @available(*, deprecated, message: "Use TokenSyntax.contextualKeyword instead")
   public static func makeContextualKeyword(
-    _ text: String,
+    _ value: Keyword,
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
   ) -> TokenSyntax {
-    return makeToken(.contextualKeyword(text), presence: .present,
+    return makeToken(.contextualKeyword(value), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -462,9 +462,9 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typealiasKeyword` replaced.
   /// - param newChild: The new `typealiasKeyword` to replace the node's
   ///                   current `typealiasKeyword`, if present.
-  public func withTypealiasKeyword(_ newChild: TokenSyntax?) -> TypealiasDeclSyntax {
+  public func withTypealiasKeyword(_ newChild: TokenSyntax) -> TypealiasDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.typealiasKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
@@ -503,9 +503,9 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> TypealiasDeclSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> TypealiasDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
@@ -586,9 +586,9 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `initializer` replaced.
   /// - param newChild: The new `initializer` to replace the node's
   ///                   current `initializer`, if present.
-  public func withInitializer(_ newChild: TypeInitializerClauseSyntax?) -> TypealiasDeclSyntax {
+  public func withInitializer(_ newChild: TypeInitializerClauseSyntax) -> TypealiasDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.typeInitializerClause, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 11, with: raw, arena: arena)
     return TypealiasDeclSyntax(newData)
   }
@@ -957,9 +957,9 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `associatedtypeKeyword` replaced.
   /// - param newChild: The new `associatedtypeKeyword` to replace the node's
   ///                   current `associatedtypeKeyword`, if present.
-  public func withAssociatedtypeKeyword(_ newChild: TokenSyntax?) -> AssociatedtypeDeclSyntax {
+  public func withAssociatedtypeKeyword(_ newChild: TokenSyntax) -> AssociatedtypeDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.associatedtypeKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
@@ -998,9 +998,9 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> AssociatedtypeDeclSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> AssociatedtypeDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return AssociatedtypeDeclSyntax(newData)
   }
@@ -1330,9 +1330,9 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `clauses` replaced.
   /// - param newChild: The new `clauses` to replace the node's
   ///                   current `clauses`, if present.
-  public func withClauses(_ newChild: IfConfigClauseListSyntax?) -> IfConfigDeclSyntax {
+  public func withClauses(_ newChild: IfConfigClauseListSyntax) -> IfConfigDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifConfigClauseList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return IfConfigDeclSyntax(newData)
   }
@@ -1371,9 +1371,9 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundEndif` replaced.
   /// - param newChild: The new `poundEndif` to replace the node's
   ///                   current `poundEndif`, if present.
-  public func withPoundEndif(_ newChild: TokenSyntax?) -> IfConfigDeclSyntax {
+  public func withPoundEndif(_ newChild: TokenSyntax) -> IfConfigDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundEndifKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return IfConfigDeclSyntax(newData)
   }
@@ -1526,9 +1526,9 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundError` replaced.
   /// - param newChild: The new `poundError` to replace the node's
   ///                   current `poundError`, if present.
-  public func withPoundError(_ newChild: TokenSyntax?) -> PoundErrorDeclSyntax {
+  public func withPoundError(_ newChild: TokenSyntax) -> PoundErrorDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundErrorKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PoundErrorDeclSyntax(newData)
   }
@@ -1567,9 +1567,9 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> PoundErrorDeclSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> PoundErrorDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PoundErrorDeclSyntax(newData)
   }
@@ -1608,9 +1608,9 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `message` replaced.
   /// - param newChild: The new `message` to replace the node's
   ///                   current `message`, if present.
-  public func withMessage(_ newChild: StringLiteralExprSyntax?) -> PoundErrorDeclSyntax {
+  public func withMessage(_ newChild: StringLiteralExprSyntax) -> PoundErrorDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return PoundErrorDeclSyntax(newData)
   }
@@ -1649,9 +1649,9 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> PoundErrorDeclSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> PoundErrorDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return PoundErrorDeclSyntax(newData)
   }
@@ -1820,9 +1820,9 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundWarning` replaced.
   /// - param newChild: The new `poundWarning` to replace the node's
   ///                   current `poundWarning`, if present.
-  public func withPoundWarning(_ newChild: TokenSyntax?) -> PoundWarningDeclSyntax {
+  public func withPoundWarning(_ newChild: TokenSyntax) -> PoundWarningDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundWarningKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PoundWarningDeclSyntax(newData)
   }
@@ -1861,9 +1861,9 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> PoundWarningDeclSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> PoundWarningDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PoundWarningDeclSyntax(newData)
   }
@@ -1902,9 +1902,9 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `message` replaced.
   /// - param newChild: The new `message` to replace the node's
   ///                   current `message`, if present.
-  public func withMessage(_ newChild: StringLiteralExprSyntax?) -> PoundWarningDeclSyntax {
+  public func withMessage(_ newChild: StringLiteralExprSyntax) -> PoundWarningDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return PoundWarningDeclSyntax(newData)
   }
@@ -1943,9 +1943,9 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> PoundWarningDeclSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> PoundWarningDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return PoundWarningDeclSyntax(newData)
   }
@@ -2114,9 +2114,9 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundSourceLocation` replaced.
   /// - param newChild: The new `poundSourceLocation` to replace the node's
   ///                   current `poundSourceLocation`, if present.
-  public func withPoundSourceLocation(_ newChild: TokenSyntax?) -> PoundSourceLocationSyntax {
+  public func withPoundSourceLocation(_ newChild: TokenSyntax) -> PoundSourceLocationSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundSourceLocationKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PoundSourceLocationSyntax(newData)
   }
@@ -2155,9 +2155,9 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> PoundSourceLocationSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> PoundSourceLocationSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PoundSourceLocationSyntax(newData)
   }
@@ -2238,9 +2238,9 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> PoundSourceLocationSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> PoundSourceLocationSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return PoundSourceLocationSyntax(newData)
   }
@@ -2547,9 +2547,9 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `classKeyword` replaced.
   /// - param newChild: The new `classKeyword` to replace the node's
   ///                   current `classKeyword`, if present.
-  public func withClassKeyword(_ newChild: TokenSyntax?) -> ClassDeclSyntax {
+  public func withClassKeyword(_ newChild: TokenSyntax) -> ClassDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.classKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return ClassDeclSyntax(newData)
   }
@@ -2588,9 +2588,9 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> ClassDeclSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> ClassDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return ClassDeclSyntax(newData)
   }
@@ -2755,9 +2755,9 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `members` replaced.
   /// - param newChild: The new `members` to replace the node's
   ///                   current `members`, if present.
-  public func withMembers(_ newChild: MemberDeclBlockSyntax?) -> ClassDeclSyntax {
+  public func withMembers(_ newChild: MemberDeclBlockSyntax) -> ClassDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 15, with: raw, arena: arena)
     return ClassDeclSyntax(newData)
   }
@@ -2896,7 +2896,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
     modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndActorKeyword: UnexpectedNodesSyntax? = nil,
-    actorKeyword: TokenSyntax = .contextualKeyword("actor"),
+    actorKeyword: TokenSyntax = .contextualKeyword(.actor),
     _ unexpectedBetweenActorKeywordAndIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil,
@@ -3096,9 +3096,9 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `actorKeyword` replaced.
   /// - param newChild: The new `actorKeyword` to replace the node's
   ///                   current `actorKeyword`, if present.
-  public func withActorKeyword(_ newChild: TokenSyntax?) -> ActorDeclSyntax {
+  public func withActorKeyword(_ newChild: TokenSyntax) -> ActorDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return ActorDeclSyntax(newData)
   }
@@ -3137,9 +3137,9 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> ActorDeclSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> ActorDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return ActorDeclSyntax(newData)
   }
@@ -3304,9 +3304,9 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `members` replaced.
   /// - param newChild: The new `members` to replace the node's
   ///                   current `members`, if present.
-  public func withMembers(_ newChild: MemberDeclBlockSyntax?) -> ActorDeclSyntax {
+  public func withMembers(_ newChild: MemberDeclBlockSyntax) -> ActorDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 15, with: raw, arena: arena)
     return ActorDeclSyntax(newData)
   }
@@ -3645,9 +3645,9 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `structKeyword` replaced.
   /// - param newChild: The new `structKeyword` to replace the node's
   ///                   current `structKeyword`, if present.
-  public func withStructKeyword(_ newChild: TokenSyntax?) -> StructDeclSyntax {
+  public func withStructKeyword(_ newChild: TokenSyntax) -> StructDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.structKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return StructDeclSyntax(newData)
   }
@@ -3686,9 +3686,9 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> StructDeclSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> StructDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return StructDeclSyntax(newData)
   }
@@ -3853,9 +3853,9 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `members` replaced.
   /// - param newChild: The new `members` to replace the node's
   ///                   current `members`, if present.
-  public func withMembers(_ newChild: MemberDeclBlockSyntax?) -> StructDeclSyntax {
+  public func withMembers(_ newChild: MemberDeclBlockSyntax) -> StructDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 15, with: raw, arena: arena)
     return StructDeclSyntax(newData)
   }
@@ -4194,9 +4194,9 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `protocolKeyword` replaced.
   /// - param newChild: The new `protocolKeyword` to replace the node's
   ///                   current `protocolKeyword`, if present.
-  public func withProtocolKeyword(_ newChild: TokenSyntax?) -> ProtocolDeclSyntax {
+  public func withProtocolKeyword(_ newChild: TokenSyntax) -> ProtocolDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.protocolKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
@@ -4235,9 +4235,9 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> ProtocolDeclSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> ProtocolDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
@@ -4402,9 +4402,9 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `members` replaced.
   /// - param newChild: The new `members` to replace the node's
   ///                   current `members`, if present.
-  public func withMembers(_ newChild: MemberDeclBlockSyntax?) -> ProtocolDeclSyntax {
+  public func withMembers(_ newChild: MemberDeclBlockSyntax) -> ProtocolDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 15, with: raw, arena: arena)
     return ProtocolDeclSyntax(newData)
   }
@@ -4739,9 +4739,9 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `extensionKeyword` replaced.
   /// - param newChild: The new `extensionKeyword` to replace the node's
   ///                   current `extensionKeyword`, if present.
-  public func withExtensionKeyword(_ newChild: TokenSyntax?) -> ExtensionDeclSyntax {
+  public func withExtensionKeyword(_ newChild: TokenSyntax) -> ExtensionDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.extensionKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
@@ -4780,9 +4780,9 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `extendedType` replaced.
   /// - param newChild: The new `extendedType` to replace the node's
   ///                   current `extendedType`, if present.
-  public func withExtendedType(_ newChild: TypeSyntax?) -> ExtensionDeclSyntax {
+  public func withExtendedType(_ newChild: TypeSyntax) -> ExtensionDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
@@ -4905,9 +4905,9 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `members` replaced.
   /// - param newChild: The new `members` to replace the node's
   ///                   current `members`, if present.
-  public func withMembers(_ newChild: MemberDeclBlockSyntax?) -> ExtensionDeclSyntax {
+  public func withMembers(_ newChild: MemberDeclBlockSyntax) -> ExtensionDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 13, with: raw, arena: arena)
     return ExtensionDeclSyntax(newData)
   }
@@ -5238,9 +5238,9 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `funcKeyword` replaced.
   /// - param newChild: The new `funcKeyword` to replace the node's
   ///                   current `funcKeyword`, if present.
-  public func withFuncKeyword(_ newChild: TokenSyntax?) -> FunctionDeclSyntax {
+  public func withFuncKeyword(_ newChild: TokenSyntax) -> FunctionDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.funcKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return FunctionDeclSyntax(newData)
   }
@@ -5279,9 +5279,9 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> FunctionDeclSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> FunctionDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return FunctionDeclSyntax(newData)
   }
@@ -5362,9 +5362,9 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `signature` replaced.
   /// - param newChild: The new `signature` to replace the node's
   ///                   current `signature`, if present.
-  public func withSignature(_ newChild: FunctionSignatureSyntax?) -> FunctionDeclSyntax {
+  public func withSignature(_ newChild: FunctionSignatureSyntax) -> FunctionDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionSignature, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 11, with: raw, arena: arena)
     return FunctionDeclSyntax(newData)
   }
@@ -5787,9 +5787,9 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `initKeyword` replaced.
   /// - param newChild: The new `initKeyword` to replace the node's
   ///                   current `initKeyword`, if present.
-  public func withInitKeyword(_ newChild: TokenSyntax?) -> InitializerDeclSyntax {
+  public func withInitKeyword(_ newChild: TokenSyntax) -> InitializerDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.initKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return InitializerDeclSyntax(newData)
   }
@@ -5912,9 +5912,9 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `signature` replaced.
   /// - param newChild: The new `signature` to replace the node's
   ///                   current `signature`, if present.
-  public func withSignature(_ newChild: FunctionSignatureSyntax?) -> InitializerDeclSyntax {
+  public func withSignature(_ newChild: FunctionSignatureSyntax) -> InitializerDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionSignature, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 11, with: raw, arena: arena)
     return InitializerDeclSyntax(newData)
   }
@@ -6321,9 +6321,9 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `deinitKeyword` replaced.
   /// - param newChild: The new `deinitKeyword` to replace the node's
   ///                   current `deinitKeyword`, if present.
-  public func withDeinitKeyword(_ newChild: TokenSyntax?) -> DeinitializerDeclSyntax {
+  public func withDeinitKeyword(_ newChild: TokenSyntax) -> DeinitializerDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.deinitKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return DeinitializerDeclSyntax(newData)
   }
@@ -6708,9 +6708,9 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `subscriptKeyword` replaced.
   /// - param newChild: The new `subscriptKeyword` to replace the node's
   ///                   current `subscriptKeyword`, if present.
-  public func withSubscriptKeyword(_ newChild: TokenSyntax?) -> SubscriptDeclSyntax {
+  public func withSubscriptKeyword(_ newChild: TokenSyntax) -> SubscriptDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.subscriptKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
@@ -6791,9 +6791,9 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `indices` replaced.
   /// - param newChild: The new `indices` to replace the node's
   ///                   current `indices`, if present.
-  public func withIndices(_ newChild: ParameterClauseSyntax?) -> SubscriptDeclSyntax {
+  public func withIndices(_ newChild: ParameterClauseSyntax) -> SubscriptDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.parameterClause, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 9, with: raw, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
@@ -6832,9 +6832,9 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `result` replaced.
   /// - param newChild: The new `result` to replace the node's
   ///                   current `result`, if present.
-  public func withResult(_ newChild: ReturnClauseSyntax?) -> SubscriptDeclSyntax {
+  public func withResult(_ newChild: ReturnClauseSyntax) -> SubscriptDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.returnClause, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 11, with: raw, arena: arena)
     return SubscriptDeclSyntax(newData)
   }
@@ -7245,9 +7245,9 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `importTok` replaced.
   /// - param newChild: The new `importTok` to replace the node's
   ///                   current `importTok`, if present.
-  public func withImportTok(_ newChild: TokenSyntax?) -> ImportDeclSyntax {
+  public func withImportTok(_ newChild: TokenSyntax) -> ImportDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.importKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return ImportDeclSyntax(newData)
   }
@@ -7347,9 +7347,9 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `path` replaced.
   /// - param newChild: The new `path` to replace the node's
   ///                   current `path`, if present.
-  public func withPath(_ newChild: AccessPathSyntax?) -> ImportDeclSyntax {
+  public func withPath(_ newChild: AccessPathSyntax) -> ImportDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.accessPath, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 9, with: raw, arena: arena)
     return ImportDeclSyntax(newData)
   }
@@ -7641,9 +7641,9 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `accessorKind` replaced.
   /// - param newChild: The new `accessorKind` to replace the node's
   ///                   current `accessorKind`, if present.
-  public func withAccessorKind(_ newChild: TokenSyntax?) -> AccessorDeclSyntax {
+  public func withAccessorKind(_ newChild: TokenSyntax) -> AccessorDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return AccessorDeclSyntax(newData)
   }
@@ -8126,9 +8126,9 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `letOrVarKeyword` replaced.
   /// - param newChild: The new `letOrVarKeyword` to replace the node's
   ///                   current `letOrVarKeyword`, if present.
-  public func withLetOrVarKeyword(_ newChild: TokenSyntax?) -> VariableDeclSyntax {
+  public func withLetOrVarKeyword(_ newChild: TokenSyntax) -> VariableDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return VariableDeclSyntax(newData)
   }
@@ -8186,9 +8186,9 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `bindings` replaced.
   /// - param newChild: The new `bindings` to replace the node's
   ///                   current `bindings`, if present.
-  public func withBindings(_ newChild: PatternBindingListSyntax?) -> VariableDeclSyntax {
+  public func withBindings(_ newChild: PatternBindingListSyntax) -> VariableDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.patternBindingList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return VariableDeclSyntax(newData)
   }
@@ -8491,9 +8491,9 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `caseKeyword` replaced.
   /// - param newChild: The new `caseKeyword` to replace the node's
   ///                   current `caseKeyword`, if present.
-  public func withCaseKeyword(_ newChild: TokenSyntax?) -> EnumCaseDeclSyntax {
+  public func withCaseKeyword(_ newChild: TokenSyntax) -> EnumCaseDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return EnumCaseDeclSyntax(newData)
   }
@@ -8552,9 +8552,9 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `elements` replaced.
   /// - param newChild: The new `elements` to replace the node's
   ///                   current `elements`, if present.
-  public func withElements(_ newChild: EnumCaseElementListSyntax?) -> EnumCaseDeclSyntax {
+  public func withElements(_ newChild: EnumCaseElementListSyntax) -> EnumCaseDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.enumCaseElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return EnumCaseDeclSyntax(newData)
   }
@@ -8871,9 +8871,9 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `enumKeyword` replaced.
   /// - param newChild: The new `enumKeyword` to replace the node's
   ///                   current `enumKeyword`, if present.
-  public func withEnumKeyword(_ newChild: TokenSyntax?) -> EnumDeclSyntax {
+  public func withEnumKeyword(_ newChild: TokenSyntax) -> EnumDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.enumKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return EnumDeclSyntax(newData)
   }
@@ -8915,9 +8915,9 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> EnumDeclSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> EnumDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return EnumDeclSyntax(newData)
   }
@@ -9096,9 +9096,9 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `members` replaced.
   /// - param newChild: The new `members` to replace the node's
   ///                   current `members`, if present.
-  public func withMembers(_ newChild: MemberDeclBlockSyntax?) -> EnumDeclSyntax {
+  public func withMembers(_ newChild: MemberDeclBlockSyntax) -> EnumDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 15, with: raw, arena: arena)
     return EnumDeclSyntax(newData)
   }
@@ -9433,9 +9433,9 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `operatorKeyword` replaced.
   /// - param newChild: The new `operatorKeyword` to replace the node's
   ///                   current `operatorKeyword`, if present.
-  public func withOperatorKeyword(_ newChild: TokenSyntax?) -> OperatorDeclSyntax {
+  public func withOperatorKeyword(_ newChild: TokenSyntax) -> OperatorDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.operatorKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return OperatorDeclSyntax(newData)
   }
@@ -9474,9 +9474,9 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> OperatorDeclSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> OperatorDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unspacedBinaryOperator(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return OperatorDeclSyntax(newData)
   }
@@ -9840,9 +9840,9 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `precedencegroupKeyword` replaced.
   /// - param newChild: The new `precedencegroupKeyword` to replace the node's
   ///                   current `precedencegroupKeyword`, if present.
-  public func withPrecedencegroupKeyword(_ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
+  public func withPrecedencegroupKeyword(_ newChild: TokenSyntax) -> PrecedenceGroupDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.precedencegroupKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
@@ -9884,9 +9884,9 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> PrecedenceGroupDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
@@ -9925,9 +9925,9 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBrace` replaced.
   /// - param newChild: The new `leftBrace` to replace the node's
   ///                   current `leftBrace`, if present.
-  public func withLeftBrace(_ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
+  public func withLeftBrace(_ newChild: TokenSyntax) -> PrecedenceGroupDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 9, with: raw, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
@@ -9988,9 +9988,9 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `groupAttributes` replaced.
   /// - param newChild: The new `groupAttributes` to replace the node's
   ///                   current `groupAttributes`, if present.
-  public func withGroupAttributes(_ newChild: PrecedenceGroupAttributeListSyntax?) -> PrecedenceGroupDeclSyntax {
+  public func withGroupAttributes(_ newChild: PrecedenceGroupAttributeListSyntax) -> PrecedenceGroupDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.precedenceGroupAttributeList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 11, with: raw, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
@@ -10029,9 +10029,9 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBrace` replaced.
   /// - param newChild: The new `rightBrace` to replace the node's
   ///                   current `rightBrace`, if present.
-  public func withRightBrace(_ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
+  public func withRightBrace(_ newChild: TokenSyntax) -> PrecedenceGroupDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 13, with: raw, arena: arena)
     return PrecedenceGroupDeclSyntax(newData)
   }
@@ -10198,7 +10198,7 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
     modifiers: ModifierListSyntax? = nil,
     _ unexpectedBetweenModifiersAndMacroKeyword: UnexpectedNodesSyntax? = nil,
-    macroKeyword: TokenSyntax = .contextualKeyword("macro"),
+    macroKeyword: TokenSyntax = .contextualKeyword(.macro),
     _ unexpectedBetweenMacroKeywordAndIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil,
@@ -10398,9 +10398,9 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `macroKeyword` replaced.
   /// - param newChild: The new `macroKeyword` to replace the node's
   ///                   current `macroKeyword`, if present.
-  public func withMacroKeyword(_ newChild: TokenSyntax?) -> MacroDeclSyntax {
+  public func withMacroKeyword(_ newChild: TokenSyntax) -> MacroDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return MacroDeclSyntax(newData)
   }
@@ -10439,9 +10439,9 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> MacroDeclSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> MacroDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return MacroDeclSyntax(newData)
   }
@@ -10522,9 +10522,9 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `signature` replaced.
   /// - param newChild: The new `signature` to replace the node's
   ///                   current `signature`, if present.
-  public func withSignature(_ newChild: Signature?) -> MacroDeclSyntax {
+  public func withSignature(_ newChild: Signature) -> MacroDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missing, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 11, with: raw, arena: arena)
     return MacroDeclSyntax(newData)
   }
@@ -10826,9 +10826,9 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundToken` replaced.
   /// - param newChild: The new `poundToken` to replace the node's
   ///                   current `poundToken`, if present.
-  public func withPoundToken(_ newChild: TokenSyntax?) -> MacroExpansionDeclSyntax {
+  public func withPoundToken(_ newChild: TokenSyntax) -> MacroExpansionDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.pound, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
@@ -10867,9 +10867,9 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `macro` replaced.
   /// - param newChild: The new `macro` to replace the node's
   ///                   current `macro`, if present.
-  public func withMacro(_ newChild: TokenSyntax?) -> MacroExpansionDeclSyntax {
+  public func withMacro(_ newChild: TokenSyntax) -> MacroExpansionDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }
@@ -11011,9 +11011,9 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `argumentList` replaced.
   /// - param newChild: The new `argumentList` to replace the node's
   ///                   current `argumentList`, if present.
-  public func withArgumentList(_ newChild: TupleExprElementListSyntax?) -> MacroExpansionDeclSyntax {
+  public func withArgumentList(_ newChild: TupleExprElementListSyntax) -> MacroExpansionDeclSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 9, with: raw, arena: arena)
     return MacroExpansionDeclSyntax(newData)
   }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -140,9 +140,9 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `ampersand` replaced.
   /// - param newChild: The new `ampersand` to replace the node's
   ///                   current `ampersand`, if present.
-  public func withAmpersand(_ newChild: TokenSyntax?) -> InOutExprSyntax {
+  public func withAmpersand(_ newChild: TokenSyntax) -> InOutExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.prefixAmpersand, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return InOutExprSyntax(newData)
   }
@@ -181,9 +181,9 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> InOutExprSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> InOutExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return InOutExprSyntax(newData)
   }
@@ -332,9 +332,9 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `tryKeyword` replaced.
   /// - param newChild: The new `tryKeyword` to replace the node's
   ///                   current `tryKeyword`, if present.
-  public func withTryKeyword(_ newChild: TokenSyntax?) -> TryExprSyntax {
+  public func withTryKeyword(_ newChild: TokenSyntax) -> TryExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.tryKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return TryExprSyntax(newData)
   }
@@ -415,9 +415,9 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> TryExprSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> TryExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return TryExprSyntax(newData)
   }
@@ -512,7 +512,7 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public init<E: ExprSyntaxProtocol>(
     leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeAwaitKeyword: UnexpectedNodesSyntax? = nil,
-    awaitKeyword: TokenSyntax = .contextualKeyword("await"),
+    awaitKeyword: TokenSyntax = .contextualKeyword(.await),
     _ unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodesSyntax? = nil,
     expression: E,
     _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
@@ -570,9 +570,9 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `awaitKeyword` replaced.
   /// - param newChild: The new `awaitKeyword` to replace the node's
   ///                   current `awaitKeyword`, if present.
-  public func withAwaitKeyword(_ newChild: TokenSyntax?) -> AwaitExprSyntax {
+  public func withAwaitKeyword(_ newChild: TokenSyntax) -> AwaitExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return AwaitExprSyntax(newData)
   }
@@ -611,9 +611,9 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> AwaitExprSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> AwaitExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return AwaitExprSyntax(newData)
   }
@@ -700,7 +700,7 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public init<E: ExprSyntaxProtocol>(
     leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeMoveKeyword: UnexpectedNodesSyntax? = nil,
-    moveKeyword: TokenSyntax = .contextualKeyword("_move"),
+    moveKeyword: TokenSyntax = .contextualKeyword(._move),
     _ unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodesSyntax? = nil,
     expression: E,
     _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
@@ -758,9 +758,9 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `moveKeyword` replaced.
   /// - param newChild: The new `moveKeyword` to replace the node's
   ///                   current `moveKeyword`, if present.
-  public func withMoveKeyword(_ newChild: TokenSyntax?) -> MoveExprSyntax {
+  public func withMoveKeyword(_ newChild: TokenSyntax) -> MoveExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return MoveExprSyntax(newData)
   }
@@ -799,9 +799,9 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> MoveExprSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> MoveExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return MoveExprSyntax(newData)
   }
@@ -888,7 +888,7 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public init<E: ExprSyntaxProtocol>(
     leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeBorrowKeyword: UnexpectedNodesSyntax? = nil,
-    borrowKeyword: TokenSyntax = .contextualKeyword("_borrow"),
+    borrowKeyword: TokenSyntax = .contextualKeyword(._borrow),
     _ unexpectedBetweenBorrowKeywordAndExpression: UnexpectedNodesSyntax? = nil,
     expression: E,
     _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
@@ -946,9 +946,9 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `borrowKeyword` replaced.
   /// - param newChild: The new `borrowKeyword` to replace the node's
   ///                   current `borrowKeyword`, if present.
-  public func withBorrowKeyword(_ newChild: TokenSyntax?) -> BorrowExprSyntax {
+  public func withBorrowKeyword(_ newChild: TokenSyntax) -> BorrowExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return BorrowExprSyntax(newData)
   }
@@ -987,9 +987,9 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> BorrowExprSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> BorrowExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return BorrowExprSyntax(newData)
   }
@@ -1134,9 +1134,9 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> IdentifierExprSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> IdentifierExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return IdentifierExprSyntax(newData)
   }
@@ -1319,9 +1319,9 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `superKeyword` replaced.
   /// - param newChild: The new `superKeyword` to replace the node's
   ///                   current `superKeyword`, if present.
-  public func withSuperKeyword(_ newChild: TokenSyntax?) -> SuperRefExprSyntax {
+  public func withSuperKeyword(_ newChild: TokenSyntax) -> SuperRefExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.superKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return SuperRefExprSyntax(newData)
   }
@@ -1454,9 +1454,9 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `nilKeyword` replaced.
   /// - param newChild: The new `nilKeyword` to replace the node's
   ///                   current `nilKeyword`, if present.
-  public func withNilKeyword(_ newChild: TokenSyntax?) -> NilLiteralExprSyntax {
+  public func withNilKeyword(_ newChild: TokenSyntax) -> NilLiteralExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.nilKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return NilLiteralExprSyntax(newData)
   }
@@ -1589,9 +1589,9 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `wildcard` replaced.
   /// - param newChild: The new `wildcard` to replace the node's
   ///                   current `wildcard`, if present.
-  public func withWildcard(_ newChild: TokenSyntax?) -> DiscardAssignmentExprSyntax {
+  public func withWildcard(_ newChild: TokenSyntax) -> DiscardAssignmentExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.wildcardKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DiscardAssignmentExprSyntax(newData)
   }
@@ -1724,9 +1724,9 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `assignToken` replaced.
   /// - param newChild: The new `assignToken` to replace the node's
   ///                   current `assignToken`, if present.
-  public func withAssignToken(_ newChild: TokenSyntax?) -> AssignmentExprSyntax {
+  public func withAssignToken(_ newChild: TokenSyntax) -> AssignmentExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return AssignmentExprSyntax(newData)
   }
@@ -1863,9 +1863,9 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `repeatKeyword` replaced.
   /// - param newChild: The new `repeatKeyword` to replace the node's
   ///                   current `repeatKeyword`, if present.
-  public func withRepeatKeyword(_ newChild: TokenSyntax?) -> PackExpansionExprSyntax {
+  public func withRepeatKeyword(_ newChild: TokenSyntax) -> PackExpansionExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.repeatKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PackExpansionExprSyntax(newData)
   }
@@ -1904,9 +1904,9 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `patternExpr` replaced.
   /// - param newChild: The new `patternExpr` to replace the node's
   ///                   current `patternExpr`, if present.
-  public func withPatternExpr(_ newChild: ExprSyntax?) -> PackExpansionExprSyntax {
+  public func withPatternExpr(_ newChild: ExprSyntax) -> PackExpansionExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PackExpansionExprSyntax(newData)
   }
@@ -1993,7 +1993,7 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public init<P: ExprSyntaxProtocol>(
     leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeEachKeyword: UnexpectedNodesSyntax? = nil,
-    eachKeyword: TokenSyntax = .contextualKeyword("each"),
+    eachKeyword: TokenSyntax = .contextualKeyword(.each),
     _ unexpectedBetweenEachKeywordAndPackRefExpr: UnexpectedNodesSyntax? = nil,
     packRefExpr: P,
     _ unexpectedAfterPackRefExpr: UnexpectedNodesSyntax? = nil,
@@ -2051,9 +2051,9 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `eachKeyword` replaced.
   /// - param newChild: The new `eachKeyword` to replace the node's
   ///                   current `eachKeyword`, if present.
-  public func withEachKeyword(_ newChild: TokenSyntax?) -> PackElementExprSyntax {
+  public func withEachKeyword(_ newChild: TokenSyntax) -> PackElementExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PackElementExprSyntax(newData)
   }
@@ -2092,9 +2092,9 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `packRefExpr` replaced.
   /// - param newChild: The new `packRefExpr` to replace the node's
   ///                   current `packRefExpr`, if present.
-  public func withPackRefExpr(_ newChild: ExprSyntax?) -> PackElementExprSyntax {
+  public func withPackRefExpr(_ newChild: ExprSyntax) -> PackElementExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PackElementExprSyntax(newData)
   }
@@ -2254,9 +2254,9 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `elements` replaced.
   /// - param newChild: The new `elements` to replace the node's
   ///                   current `elements`, if present.
-  public func withElements(_ newChild: ExprListSyntax?) -> SequenceExprSyntax {
+  public func withElements(_ newChild: ExprListSyntax) -> SequenceExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.exprList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return SequenceExprSyntax(newData)
   }
@@ -2435,9 +2435,9 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `postfixExpression` replaced.
   /// - param newChild: The new `postfixExpression` to replace the node's
   ///                   current `postfixExpression`, if present.
-  public func withPostfixExpression(_ newChild: ExprSyntax?) -> PrefixOperatorExprSyntax {
+  public func withPostfixExpression(_ newChild: ExprSyntax) -> PrefixOperatorExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PrefixOperatorExprSyntax(newData)
   }
@@ -2578,9 +2578,9 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `operatorToken` replaced.
   /// - param newChild: The new `operatorToken` to replace the node's
   ///                   current `operatorToken`, if present.
-  public func withOperatorToken(_ newChild: TokenSyntax?) -> BinaryOperatorExprSyntax {
+  public func withOperatorToken(_ newChild: TokenSyntax) -> BinaryOperatorExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return BinaryOperatorExprSyntax(newData)
   }
@@ -2805,9 +2805,9 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `arrowToken` replaced.
   /// - param newChild: The new `arrowToken` to replace the node's
   ///                   current `arrowToken`, if present.
-  public func withArrowToken(_ newChild: TokenSyntax?) -> ArrowExprSyntax {
+  public func withArrowToken(_ newChild: TokenSyntax) -> ArrowExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return ArrowExprSyntax(newData)
   }
@@ -2964,9 +2964,9 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftOperand` replaced.
   /// - param newChild: The new `leftOperand` to replace the node's
   ///                   current `leftOperand`, if present.
-  public func withLeftOperand(_ newChild: ExprSyntax?) -> InfixOperatorExprSyntax {
+  public func withLeftOperand(_ newChild: ExprSyntax) -> InfixOperatorExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return InfixOperatorExprSyntax(newData)
   }
@@ -3005,9 +3005,9 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `operatorOperand` replaced.
   /// - param newChild: The new `operatorOperand` to replace the node's
   ///                   current `operatorOperand`, if present.
-  public func withOperatorOperand(_ newChild: ExprSyntax?) -> InfixOperatorExprSyntax {
+  public func withOperatorOperand(_ newChild: ExprSyntax) -> InfixOperatorExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return InfixOperatorExprSyntax(newData)
   }
@@ -3046,9 +3046,9 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightOperand` replaced.
   /// - param newChild: The new `rightOperand` to replace the node's
   ///                   current `rightOperand`, if present.
-  public func withRightOperand(_ newChild: ExprSyntax?) -> InfixOperatorExprSyntax {
+  public func withRightOperand(_ newChild: ExprSyntax) -> InfixOperatorExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return InfixOperatorExprSyntax(newData)
   }
@@ -3197,9 +3197,9 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `floatingDigits` replaced.
   /// - param newChild: The new `floatingDigits` to replace the node's
   ///                   current `floatingDigits`, if present.
-  public func withFloatingDigits(_ newChild: TokenSyntax?) -> FloatLiteralExprSyntax {
+  public func withFloatingDigits(_ newChild: TokenSyntax) -> FloatLiteralExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.floatingLiteral(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return FloatLiteralExprSyntax(newData)
   }
@@ -3340,9 +3340,9 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> TupleExprSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> TupleExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return TupleExprSyntax(newData)
   }
@@ -3400,9 +3400,9 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `elementList` replaced.
   /// - param newChild: The new `elementList` to replace the node's
   ///                   current `elementList`, if present.
-  public func withElementList(_ newChild: TupleExprElementListSyntax?) -> TupleExprSyntax {
+  public func withElementList(_ newChild: TupleExprElementListSyntax) -> TupleExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return TupleExprSyntax(newData)
   }
@@ -3441,9 +3441,9 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> TupleExprSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> TupleExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return TupleExprSyntax(newData)
   }
@@ -3600,9 +3600,9 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftSquare` replaced.
   /// - param newChild: The new `leftSquare` to replace the node's
   ///                   current `leftSquare`, if present.
-  public func withLeftSquare(_ newChild: TokenSyntax?) -> ArrayExprSyntax {
+  public func withLeftSquare(_ newChild: TokenSyntax) -> ArrayExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ArrayExprSyntax(newData)
   }
@@ -3660,9 +3660,9 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `elements` replaced.
   /// - param newChild: The new `elements` to replace the node's
   ///                   current `elements`, if present.
-  public func withElements(_ newChild: ArrayElementListSyntax?) -> ArrayExprSyntax {
+  public func withElements(_ newChild: ArrayElementListSyntax) -> ArrayExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.arrayElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return ArrayExprSyntax(newData)
   }
@@ -3701,9 +3701,9 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightSquare` replaced.
   /// - param newChild: The new `rightSquare` to replace the node's
   ///                   current `rightSquare`, if present.
-  public func withRightSquare(_ newChild: TokenSyntax?) -> ArrayExprSyntax {
+  public func withRightSquare(_ newChild: TokenSyntax) -> ArrayExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return ArrayExprSyntax(newData)
   }
@@ -3896,9 +3896,9 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftSquare` replaced.
   /// - param newChild: The new `leftSquare` to replace the node's
   ///                   current `leftSquare`, if present.
-  public func withLeftSquare(_ newChild: TokenSyntax?) -> DictionaryExprSyntax {
+  public func withLeftSquare(_ newChild: TokenSyntax) -> DictionaryExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DictionaryExprSyntax(newData)
   }
@@ -3937,9 +3937,9 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `content` replaced.
   /// - param newChild: The new `content` to replace the node's
   ///                   current `content`, if present.
-  public func withContent(_ newChild: Content?) -> DictionaryExprSyntax {
+  public func withContent(_ newChild: Content) -> DictionaryExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missing, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return DictionaryExprSyntax(newData)
   }
@@ -3978,9 +3978,9 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightSquare` replaced.
   /// - param newChild: The new `rightSquare` to replace the node's
   ///                   current `rightSquare`, if present.
-  public func withRightSquare(_ newChild: TokenSyntax?) -> DictionaryExprSyntax {
+  public func withRightSquare(_ newChild: TokenSyntax) -> DictionaryExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return DictionaryExprSyntax(newData)
   }
@@ -4129,9 +4129,9 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `digits` replaced.
   /// - param newChild: The new `digits` to replace the node's
   ///                   current `digits`, if present.
-  public func withDigits(_ newChild: TokenSyntax?) -> IntegerLiteralExprSyntax {
+  public func withDigits(_ newChild: TokenSyntax) -> IntegerLiteralExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return IntegerLiteralExprSyntax(newData)
   }
@@ -4264,9 +4264,9 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `booleanLiteral` replaced.
   /// - param newChild: The new `booleanLiteral` to replace the node's
   ///                   current `booleanLiteral`, if present.
-  public func withBooleanLiteral(_ newChild: TokenSyntax?) -> BooleanLiteralExprSyntax {
+  public func withBooleanLiteral(_ newChild: TokenSyntax) -> BooleanLiteralExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.trueKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return BooleanLiteralExprSyntax(newData)
   }
@@ -4407,9 +4407,9 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `questionMark` replaced.
   /// - param newChild: The new `questionMark` to replace the node's
   ///                   current `questionMark`, if present.
-  public func withQuestionMark(_ newChild: TokenSyntax?) -> UnresolvedTernaryExprSyntax {
+  public func withQuestionMark(_ newChild: TokenSyntax) -> UnresolvedTernaryExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.infixQuestionMark, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return UnresolvedTernaryExprSyntax(newData)
   }
@@ -4448,9 +4448,9 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `firstChoice` replaced.
   /// - param newChild: The new `firstChoice` to replace the node's
   ///                   current `firstChoice`, if present.
-  public func withFirstChoice(_ newChild: ExprSyntax?) -> UnresolvedTernaryExprSyntax {
+  public func withFirstChoice(_ newChild: ExprSyntax) -> UnresolvedTernaryExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return UnresolvedTernaryExprSyntax(newData)
   }
@@ -4489,9 +4489,9 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colonMark` replaced.
   /// - param newChild: The new `colonMark` to replace the node's
   ///                   current `colonMark`, if present.
-  public func withColonMark(_ newChild: TokenSyntax?) -> UnresolvedTernaryExprSyntax {
+  public func withColonMark(_ newChild: TokenSyntax) -> UnresolvedTernaryExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return UnresolvedTernaryExprSyntax(newData)
   }
@@ -4656,9 +4656,9 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `conditionExpression` replaced.
   /// - param newChild: The new `conditionExpression` to replace the node's
   ///                   current `conditionExpression`, if present.
-  public func withConditionExpression(_ newChild: ExprSyntax?) -> TernaryExprSyntax {
+  public func withConditionExpression(_ newChild: ExprSyntax) -> TernaryExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return TernaryExprSyntax(newData)
   }
@@ -4697,9 +4697,9 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `questionMark` replaced.
   /// - param newChild: The new `questionMark` to replace the node's
   ///                   current `questionMark`, if present.
-  public func withQuestionMark(_ newChild: TokenSyntax?) -> TernaryExprSyntax {
+  public func withQuestionMark(_ newChild: TokenSyntax) -> TernaryExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.infixQuestionMark, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return TernaryExprSyntax(newData)
   }
@@ -4738,9 +4738,9 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `firstChoice` replaced.
   /// - param newChild: The new `firstChoice` to replace the node's
   ///                   current `firstChoice`, if present.
-  public func withFirstChoice(_ newChild: ExprSyntax?) -> TernaryExprSyntax {
+  public func withFirstChoice(_ newChild: ExprSyntax) -> TernaryExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return TernaryExprSyntax(newData)
   }
@@ -4779,9 +4779,9 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colonMark` replaced.
   /// - param newChild: The new `colonMark` to replace the node's
   ///                   current `colonMark`, if present.
-  public func withColonMark(_ newChild: TokenSyntax?) -> TernaryExprSyntax {
+  public func withColonMark(_ newChild: TokenSyntax) -> TernaryExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return TernaryExprSyntax(newData)
   }
@@ -4820,9 +4820,9 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `secondChoice` replaced.
   /// - param newChild: The new `secondChoice` to replace the node's
   ///                   current `secondChoice`, if present.
-  public func withSecondChoice(_ newChild: ExprSyntax?) -> TernaryExprSyntax {
+  public func withSecondChoice(_ newChild: ExprSyntax) -> TernaryExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 9, with: raw, arena: arena)
     return TernaryExprSyntax(newData)
   }
@@ -5079,9 +5079,9 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `dot` replaced.
   /// - param newChild: The new `dot` to replace the node's
   ///                   current `dot`, if present.
-  public func withDot(_ newChild: TokenSyntax?) -> MemberAccessExprSyntax {
+  public func withDot(_ newChild: TokenSyntax) -> MemberAccessExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return MemberAccessExprSyntax(newData)
   }
@@ -5120,9 +5120,9 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> MemberAccessExprSyntax {
+  public func withName(_ newChild: TokenSyntax) -> MemberAccessExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return MemberAccessExprSyntax(newData)
   }
@@ -5321,9 +5321,9 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `isTok` replaced.
   /// - param newChild: The new `isTok` to replace the node's
   ///                   current `isTok`, if present.
-  public func withIsTok(_ newChild: TokenSyntax?) -> UnresolvedIsExprSyntax {
+  public func withIsTok(_ newChild: TokenSyntax) -> UnresolvedIsExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return UnresolvedIsExprSyntax(newData)
   }
@@ -5464,9 +5464,9 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> IsExprSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> IsExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return IsExprSyntax(newData)
   }
@@ -5505,9 +5505,9 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `isTok` replaced.
   /// - param newChild: The new `isTok` to replace the node's
   ///                   current `isTok`, if present.
-  public func withIsTok(_ newChild: TokenSyntax?) -> IsExprSyntax {
+  public func withIsTok(_ newChild: TokenSyntax) -> IsExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return IsExprSyntax(newData)
   }
@@ -5546,9 +5546,9 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typeName` replaced.
   /// - param newChild: The new `typeName` to replace the node's
   ///                   current `typeName`, if present.
-  public func withTypeName(_ newChild: TypeSyntax?) -> IsExprSyntax {
+  public func withTypeName(_ newChild: TypeSyntax) -> IsExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return IsExprSyntax(newData)
   }
@@ -5701,9 +5701,9 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `asTok` replaced.
   /// - param newChild: The new `asTok` to replace the node's
   ///                   current `asTok`, if present.
-  public func withAsTok(_ newChild: TokenSyntax?) -> UnresolvedAsExprSyntax {
+  public func withAsTok(_ newChild: TokenSyntax) -> UnresolvedAsExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return UnresolvedAsExprSyntax(newData)
   }
@@ -5898,9 +5898,9 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> AsExprSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> AsExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return AsExprSyntax(newData)
   }
@@ -5939,9 +5939,9 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `asTok` replaced.
   /// - param newChild: The new `asTok` to replace the node's
   ///                   current `asTok`, if present.
-  public func withAsTok(_ newChild: TokenSyntax?) -> AsExprSyntax {
+  public func withAsTok(_ newChild: TokenSyntax) -> AsExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return AsExprSyntax(newData)
   }
@@ -6022,9 +6022,9 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typeName` replaced.
   /// - param newChild: The new `typeName` to replace the node's
   ///                   current `typeName`, if present.
-  public func withTypeName(_ newChild: TypeSyntax?) -> AsExprSyntax {
+  public func withTypeName(_ newChild: TypeSyntax) -> AsExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return AsExprSyntax(newData)
   }
@@ -6181,9 +6181,9 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `type` replaced.
   /// - param newChild: The new `type` to replace the node's
   ///                   current `type`, if present.
-  public func withType(_ newChild: TypeSyntax?) -> TypeExprSyntax {
+  public func withType(_ newChild: TypeSyntax) -> TypeExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return TypeExprSyntax(newData)
   }
@@ -6328,9 +6328,9 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBrace` replaced.
   /// - param newChild: The new `leftBrace` to replace the node's
   ///                   current `leftBrace`, if present.
-  public func withLeftBrace(_ newChild: TokenSyntax?) -> ClosureExprSyntax {
+  public func withLeftBrace(_ newChild: TokenSyntax) -> ClosureExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ClosureExprSyntax(newData)
   }
@@ -6430,9 +6430,9 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `statements` replaced.
   /// - param newChild: The new `statements` to replace the node's
   ///                   current `statements`, if present.
-  public func withStatements(_ newChild: CodeBlockItemListSyntax?) -> ClosureExprSyntax {
+  public func withStatements(_ newChild: CodeBlockItemListSyntax) -> ClosureExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return ClosureExprSyntax(newData)
   }
@@ -6471,9 +6471,9 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBrace` replaced.
   /// - param newChild: The new `rightBrace` to replace the node's
   ///                   current `rightBrace`, if present.
-  public func withRightBrace(_ newChild: TokenSyntax?) -> ClosureExprSyntax {
+  public func withRightBrace(_ newChild: TokenSyntax) -> ClosureExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return ClosureExprSyntax(newData)
   }
@@ -6630,9 +6630,9 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(_ newChild: PatternSyntax?) -> UnresolvedPatternExprSyntax {
+  public func withPattern(_ newChild: PatternSyntax) -> UnresolvedPatternExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return UnresolvedPatternExprSyntax(newData)
   }
@@ -6785,9 +6785,9 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `calledExpression` replaced.
   /// - param newChild: The new `calledExpression` to replace the node's
   ///                   current `calledExpression`, if present.
-  public func withCalledExpression(_ newChild: ExprSyntax?) -> FunctionCallExprSyntax {
+  public func withCalledExpression(_ newChild: ExprSyntax) -> FunctionCallExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
@@ -6887,9 +6887,9 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `argumentList` replaced.
   /// - param newChild: The new `argumentList` to replace the node's
   ///                   current `argumentList`, if present.
-  public func withArgumentList(_ newChild: TupleExprElementListSyntax?) -> FunctionCallExprSyntax {
+  public func withArgumentList(_ newChild: TupleExprElementListSyntax) -> FunctionCallExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return FunctionCallExprSyntax(newData)
   }
@@ -7227,9 +7227,9 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `calledExpression` replaced.
   /// - param newChild: The new `calledExpression` to replace the node's
   ///                   current `calledExpression`, if present.
-  public func withCalledExpression(_ newChild: ExprSyntax?) -> SubscriptExprSyntax {
+  public func withCalledExpression(_ newChild: ExprSyntax) -> SubscriptExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return SubscriptExprSyntax(newData)
   }
@@ -7268,9 +7268,9 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBracket` replaced.
   /// - param newChild: The new `leftBracket` to replace the node's
   ///                   current `leftBracket`, if present.
-  public func withLeftBracket(_ newChild: TokenSyntax?) -> SubscriptExprSyntax {
+  public func withLeftBracket(_ newChild: TokenSyntax) -> SubscriptExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return SubscriptExprSyntax(newData)
   }
@@ -7328,9 +7328,9 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `argumentList` replaced.
   /// - param newChild: The new `argumentList` to replace the node's
   ///                   current `argumentList`, if present.
-  public func withArgumentList(_ newChild: TupleExprElementListSyntax?) -> SubscriptExprSyntax {
+  public func withArgumentList(_ newChild: TupleExprElementListSyntax) -> SubscriptExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return SubscriptExprSyntax(newData)
   }
@@ -7369,9 +7369,9 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBracket` replaced.
   /// - param newChild: The new `rightBracket` to replace the node's
   ///                   current `rightBracket`, if present.
-  public func withRightBracket(_ newChild: TokenSyntax?) -> SubscriptExprSyntax {
+  public func withRightBracket(_ newChild: TokenSyntax) -> SubscriptExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return SubscriptExprSyntax(newData)
   }
@@ -7651,9 +7651,9 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> OptionalChainingExprSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> OptionalChainingExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return OptionalChainingExprSyntax(newData)
   }
@@ -7692,9 +7692,9 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `questionMark` replaced.
   /// - param newChild: The new `questionMark` to replace the node's
   ///                   current `questionMark`, if present.
-  public func withQuestionMark(_ newChild: TokenSyntax?) -> OptionalChainingExprSyntax {
+  public func withQuestionMark(_ newChild: TokenSyntax) -> OptionalChainingExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return OptionalChainingExprSyntax(newData)
   }
@@ -7839,9 +7839,9 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> ForcedValueExprSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> ForcedValueExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ForcedValueExprSyntax(newData)
   }
@@ -7880,9 +7880,9 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `exclamationMark` replaced.
   /// - param newChild: The new `exclamationMark` to replace the node's
   ///                   current `exclamationMark`, if present.
-  public func withExclamationMark(_ newChild: TokenSyntax?) -> ForcedValueExprSyntax {
+  public func withExclamationMark(_ newChild: TokenSyntax) -> ForcedValueExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.exclamationMark, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return ForcedValueExprSyntax(newData)
   }
@@ -8027,9 +8027,9 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> PostfixUnaryExprSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> PostfixUnaryExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PostfixUnaryExprSyntax(newData)
   }
@@ -8068,9 +8068,9 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `operatorToken` replaced.
   /// - param newChild: The new `operatorToken` to replace the node's
   ///                   current `operatorToken`, if present.
-  public func withOperatorToken(_ newChild: TokenSyntax?) -> PostfixUnaryExprSyntax {
+  public func withOperatorToken(_ newChild: TokenSyntax) -> PostfixUnaryExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixOperator(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PostfixUnaryExprSyntax(newData)
   }
@@ -8215,9 +8215,9 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> SpecializeExprSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> SpecializeExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return SpecializeExprSyntax(newData)
   }
@@ -8256,9 +8256,9 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericArgumentClause` replaced.
   /// - param newChild: The new `genericArgumentClause` to replace the node's
   ///                   current `genericArgumentClause`, if present.
-  public func withGenericArgumentClause(_ newChild: GenericArgumentClauseSyntax?) -> SpecializeExprSyntax {
+  public func withGenericArgumentClause(_ newChild: GenericArgumentClauseSyntax) -> SpecializeExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericArgumentClause, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return SpecializeExprSyntax(newData)
   }
@@ -8457,9 +8457,9 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `openQuote` replaced.
   /// - param newChild: The new `openQuote` to replace the node's
   ///                   current `openQuote`, if present.
-  public func withOpenQuote(_ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
+  public func withOpenQuote(_ newChild: TokenSyntax) -> StringLiteralExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringQuote, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return StringLiteralExprSyntax(newData)
   }
@@ -8517,9 +8517,9 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `segments` replaced.
   /// - param newChild: The new `segments` to replace the node's
   ///                   current `segments`, if present.
-  public func withSegments(_ newChild: StringLiteralSegmentsSyntax?) -> StringLiteralExprSyntax {
+  public func withSegments(_ newChild: StringLiteralSegmentsSyntax) -> StringLiteralExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralSegments, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return StringLiteralExprSyntax(newData)
   }
@@ -8558,9 +8558,9 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `closeQuote` replaced.
   /// - param newChild: The new `closeQuote` to replace the node's
   ///                   current `closeQuote`, if present.
-  public func withCloseQuote(_ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
+  public func withCloseQuote(_ newChild: TokenSyntax) -> StringLiteralExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringQuote, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return StringLiteralExprSyntax(newData)
   }
@@ -8767,9 +8767,9 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `regex` replaced.
   /// - param newChild: The new `regex` to replace the node's
   ///                   current `regex`, if present.
-  public func withRegex(_ newChild: TokenSyntax?) -> RegexLiteralExprSyntax {
+  public func withRegex(_ newChild: TokenSyntax) -> RegexLiteralExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.regexLiteral(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return RegexLiteralExprSyntax(newData)
   }
@@ -8944,9 +8944,9 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `backslash` replaced.
   /// - param newChild: The new `backslash` to replace the node's
   ///                   current `backslash`, if present.
-  public func withBackslash(_ newChild: TokenSyntax?) -> KeyPathExprSyntax {
+  public func withBackslash(_ newChild: TokenSyntax) -> KeyPathExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return KeyPathExprSyntax(newData)
   }
@@ -9046,9 +9046,9 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `components` replaced.
   /// - param newChild: The new `components` to replace the node's
   ///                   current `components`, if present.
-  public func withComponents(_ newChild: KeyPathComponentListSyntax?) -> KeyPathExprSyntax {
+  public func withComponents(_ newChild: KeyPathComponentListSyntax) -> KeyPathExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.keyPathComponentList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return KeyPathExprSyntax(newData)
   }
@@ -9226,9 +9226,9 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundToken` replaced.
   /// - param newChild: The new `poundToken` to replace the node's
   ///                   current `poundToken`, if present.
-  public func withPoundToken(_ newChild: TokenSyntax?) -> MacroExpansionExprSyntax {
+  public func withPoundToken(_ newChild: TokenSyntax) -> MacroExpansionExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.pound, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
@@ -9267,9 +9267,9 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `macro` replaced.
   /// - param newChild: The new `macro` to replace the node's
   ///                   current `macro`, if present.
-  public func withMacro(_ newChild: TokenSyntax?) -> MacroExpansionExprSyntax {
+  public func withMacro(_ newChild: TokenSyntax) -> MacroExpansionExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
@@ -9411,9 +9411,9 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `argumentList` replaced.
   /// - param newChild: The new `argumentList` to replace the node's
   ///                   current `argumentList`, if present.
-  public func withArgumentList(_ newChild: TupleExprElementListSyntax?) -> MacroExpansionExprSyntax {
+  public func withArgumentList(_ newChild: TupleExprElementListSyntax) -> MacroExpansionExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 9, with: raw, arena: arena)
     return MacroExpansionExprSyntax(newData)
   }
@@ -9823,9 +9823,9 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `config` replaced.
   /// - param newChild: The new `config` to replace the node's
   ///                   current `config`, if present.
-  public func withConfig(_ newChild: IfConfigDeclSyntax?) -> PostfixIfConfigExprSyntax {
+  public func withConfig(_ newChild: IfConfigDeclSyntax) -> PostfixIfConfigExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifConfigDecl, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PostfixIfConfigExprSyntax(newData)
   }
@@ -9966,9 +9966,9 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> EditorPlaceholderExprSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> EditorPlaceholderExprSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return EditorPlaceholderExprSyntax(newData)
   }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -239,9 +239,9 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `item` replaced.
   /// - param newChild: The new `item` to replace the node's
   ///                   current `item`, if present.
-  public func withItem(_ newChild: Item?) -> CodeBlockItemSyntax {
+  public func withItem(_ newChild: Item) -> CodeBlockItemSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missing, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return CodeBlockItemSyntax(newData)
   }
@@ -485,9 +485,9 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBrace` replaced.
   /// - param newChild: The new `leftBrace` to replace the node's
   ///                   current `leftBrace`, if present.
-  public func withLeftBrace(_ newChild: TokenSyntax?) -> CodeBlockSyntax {
+  public func withLeftBrace(_ newChild: TokenSyntax) -> CodeBlockSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return CodeBlockSyntax(newData)
   }
@@ -545,9 +545,9 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `statements` replaced.
   /// - param newChild: The new `statements` to replace the node's
   ///                   current `statements`, if present.
-  public func withStatements(_ newChild: CodeBlockItemListSyntax?) -> CodeBlockSyntax {
+  public func withStatements(_ newChild: CodeBlockItemListSyntax) -> CodeBlockSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return CodeBlockSyntax(newData)
   }
@@ -586,9 +586,9 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBrace` replaced.
   /// - param newChild: The new `rightBrace` to replace the node's
   ///                   current `rightBrace`, if present.
-  public func withRightBrace(_ newChild: TokenSyntax?) -> CodeBlockSyntax {
+  public func withRightBrace(_ newChild: TokenSyntax) -> CodeBlockSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return CodeBlockSyntax(newData)
   }
@@ -741,9 +741,9 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> DeclNameArgumentSyntax {
+  public func withName(_ newChild: TokenSyntax) -> DeclNameArgumentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DeclNameArgumentSyntax(newData)
   }
@@ -782,9 +782,9 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> DeclNameArgumentSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> DeclNameArgumentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return DeclNameArgumentSyntax(newData)
   }
@@ -933,9 +933,9 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> DeclNameArgumentsSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> DeclNameArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DeclNameArgumentsSyntax(newData)
   }
@@ -993,9 +993,9 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `arguments` replaced.
   /// - param newChild: The new `arguments` to replace the node's
   ///                   current `arguments`, if present.
-  public func withArguments(_ newChild: DeclNameArgumentListSyntax?) -> DeclNameArgumentsSyntax {
+  public func withArguments(_ newChild: DeclNameArgumentListSyntax) -> DeclNameArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.declNameArgumentList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return DeclNameArgumentsSyntax(newData)
   }
@@ -1034,9 +1034,9 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> DeclNameArgumentsSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> DeclNameArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return DeclNameArgumentsSyntax(newData)
   }
@@ -1281,9 +1281,9 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> TupleExprElementSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> TupleExprElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return TupleExprElementSyntax(newData)
   }
@@ -1486,9 +1486,9 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> ArrayElementSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> ArrayElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ArrayElementSyntax(newData)
   }
@@ -1683,9 +1683,9 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `keyExpression` replaced.
   /// - param newChild: The new `keyExpression` to replace the node's
   ///                   current `keyExpression`, if present.
-  public func withKeyExpression(_ newChild: ExprSyntax?) -> DictionaryElementSyntax {
+  public func withKeyExpression(_ newChild: ExprSyntax) -> DictionaryElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DictionaryElementSyntax(newData)
   }
@@ -1724,9 +1724,9 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> DictionaryElementSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> DictionaryElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return DictionaryElementSyntax(newData)
   }
@@ -1765,9 +1765,9 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `valueExpression` replaced.
   /// - param newChild: The new `valueExpression` to replace the node's
   ///                   current `valueExpression`, if present.
-  public func withValueExpression(_ newChild: ExprSyntax?) -> DictionaryElementSyntax {
+  public func withValueExpression(_ newChild: ExprSyntax) -> DictionaryElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return DictionaryElementSyntax(newData)
   }
@@ -2127,9 +2127,9 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> ClosureCaptureItemSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> ClosureCaptureItemSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return ClosureCaptureItemSyntax(newData)
   }
@@ -2344,9 +2344,9 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftSquare` replaced.
   /// - param newChild: The new `leftSquare` to replace the node's
   ///                   current `leftSquare`, if present.
-  public func withLeftSquare(_ newChild: TokenSyntax?) -> ClosureCaptureSignatureSyntax {
+  public func withLeftSquare(_ newChild: TokenSyntax) -> ClosureCaptureSignatureSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ClosureCaptureSignatureSyntax(newData)
   }
@@ -2446,9 +2446,9 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightSquare` replaced.
   /// - param newChild: The new `rightSquare` to replace the node's
   ///                   current `rightSquare`, if present.
-  public func withRightSquare(_ newChild: TokenSyntax?) -> ClosureCaptureSignatureSyntax {
+  public func withRightSquare(_ newChild: TokenSyntax) -> ClosureCaptureSignatureSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return ClosureCaptureSignatureSyntax(newData)
   }
@@ -2601,9 +2601,9 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> ClosureParamSyntax {
+  public func withName(_ newChild: TokenSyntax) -> ClosureParamSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ClosureParamSyntax(newData)
   }
@@ -3117,9 +3117,9 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `inTok` replaced.
   /// - param newChild: The new `inTok` to replace the node's
   ///                   current `inTok`, if present.
-  public func withInTok(_ newChild: TokenSyntax?) -> ClosureSignatureSyntax {
+  public func withInTok(_ newChild: TokenSyntax) -> ClosureSignatureSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.inKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 13, with: raw, arena: arena)
     return ClosureSignatureSyntax(newData)
   }
@@ -3308,9 +3308,9 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `label` replaced.
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
-  public func withLabel(_ newChild: TokenSyntax?) -> MultipleTrailingClosureElementSyntax {
+  public func withLabel(_ newChild: TokenSyntax) -> MultipleTrailingClosureElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return MultipleTrailingClosureElementSyntax(newData)
   }
@@ -3349,9 +3349,9 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> MultipleTrailingClosureElementSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> MultipleTrailingClosureElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return MultipleTrailingClosureElementSyntax(newData)
   }
@@ -3390,9 +3390,9 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `closure` replaced.
   /// - param newChild: The new `closure` to replace the node's
   ///                   current `closure`, if present.
-  public func withClosure(_ newChild: ClosureExprSyntax?) -> MultipleTrailingClosureElementSyntax {
+  public func withClosure(_ newChild: ClosureExprSyntax) -> MultipleTrailingClosureElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.closureExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return MultipleTrailingClosureElementSyntax(newData)
   }
@@ -3541,9 +3541,9 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `content` replaced.
   /// - param newChild: The new `content` to replace the node's
   ///                   current `content`, if present.
-  public func withContent(_ newChild: TokenSyntax?) -> StringSegmentSyntax {
+  public func withContent(_ newChild: TokenSyntax) -> StringSegmentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringSegment(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return StringSegmentSyntax(newData)
   }
@@ -3692,9 +3692,9 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `backslash` replaced.
   /// - param newChild: The new `backslash` to replace the node's
   ///                   current `backslash`, if present.
-  public func withBackslash(_ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
+  public func withBackslash(_ newChild: TokenSyntax) -> ExpressionSegmentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
@@ -3775,9 +3775,9 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> ExpressionSegmentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
@@ -3835,9 +3835,9 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expressions` replaced.
   /// - param newChild: The new `expressions` to replace the node's
   ///                   current `expressions`, if present.
-  public func withExpressions(_ newChild: TupleExprElementListSyntax?) -> ExpressionSegmentSyntax {
+  public func withExpressions(_ newChild: TupleExprElementListSyntax) -> ExpressionSegmentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
@@ -3876,9 +3876,9 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> ExpressionSegmentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 9, with: raw, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }
@@ -4135,9 +4135,9 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `component` replaced.
   /// - param newChild: The new `component` to replace the node's
   ///                   current `component`, if present.
-  public func withComponent(_ newChild: Component?) -> KeyPathComponentSyntax {
+  public func withComponent(_ newChild: Component) -> KeyPathComponentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missing, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return KeyPathComponentSyntax(newData)
   }
@@ -4286,9 +4286,9 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> KeyPathPropertyComponentSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> KeyPathPropertyComponentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return KeyPathPropertyComponentSyntax(newData)
   }
@@ -4529,9 +4529,9 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBracket` replaced.
   /// - param newChild: The new `leftBracket` to replace the node's
   ///                   current `leftBracket`, if present.
-  public func withLeftBracket(_ newChild: TokenSyntax?) -> KeyPathSubscriptComponentSyntax {
+  public func withLeftBracket(_ newChild: TokenSyntax) -> KeyPathSubscriptComponentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return KeyPathSubscriptComponentSyntax(newData)
   }
@@ -4589,9 +4589,9 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `argumentList` replaced.
   /// - param newChild: The new `argumentList` to replace the node's
   ///                   current `argumentList`, if present.
-  public func withArgumentList(_ newChild: TupleExprElementListSyntax?) -> KeyPathSubscriptComponentSyntax {
+  public func withArgumentList(_ newChild: TupleExprElementListSyntax) -> KeyPathSubscriptComponentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return KeyPathSubscriptComponentSyntax(newData)
   }
@@ -4630,9 +4630,9 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBracket` replaced.
   /// - param newChild: The new `rightBracket` to replace the node's
   ///                   current `rightBracket`, if present.
-  public func withRightBracket(_ newChild: TokenSyntax?) -> KeyPathSubscriptComponentSyntax {
+  public func withRightBracket(_ newChild: TokenSyntax) -> KeyPathSubscriptComponentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return KeyPathSubscriptComponentSyntax(newData)
   }
@@ -4781,9 +4781,9 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `questionOrExclamationMark` replaced.
   /// - param newChild: The new `questionOrExclamationMark` to replace the node's
   ///                   current `questionOrExclamationMark`, if present.
-  public func withQuestionOrExclamationMark(_ newChild: TokenSyntax?) -> KeyPathOptionalComponentSyntax {
+  public func withQuestionOrExclamationMark(_ newChild: TokenSyntax) -> KeyPathOptionalComponentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return KeyPathOptionalComponentSyntax(newData)
   }
@@ -4920,9 +4920,9 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> YieldExprListElementSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> YieldExprListElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return YieldExprListElementSyntax(newData)
   }
@@ -5109,9 +5109,9 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `equal` replaced.
   /// - param newChild: The new `equal` to replace the node's
   ///                   current `equal`, if present.
-  public func withEqual(_ newChild: TokenSyntax?) -> TypeInitializerClauseSyntax {
+  public func withEqual(_ newChild: TokenSyntax) -> TypeInitializerClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return TypeInitializerClauseSyntax(newData)
   }
@@ -5150,9 +5150,9 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `value` replaced.
   /// - param newChild: The new `value` to replace the node's
   ///                   current `value`, if present.
-  public func withValue(_ newChild: TypeSyntax?) -> TypeInitializerClauseSyntax {
+  public func withValue(_ newChild: TypeSyntax) -> TypeInitializerClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return TypeInitializerClauseSyntax(newData)
   }
@@ -5301,9 +5301,9 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> ParameterClauseSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> ParameterClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ParameterClauseSyntax(newData)
   }
@@ -5361,9 +5361,9 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `parameterList` replaced.
   /// - param newChild: The new `parameterList` to replace the node's
   ///                   current `parameterList`, if present.
-  public func withParameterList(_ newChild: FunctionParameterListSyntax?) -> ParameterClauseSyntax {
+  public func withParameterList(_ newChild: FunctionParameterListSyntax) -> ParameterClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionParameterList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return ParameterClauseSyntax(newData)
   }
@@ -5402,9 +5402,9 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> ParameterClauseSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> ParameterClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return ParameterClauseSyntax(newData)
   }
@@ -5557,9 +5557,9 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `arrow` replaced.
   /// - param newChild: The new `arrow` to replace the node's
   ///                   current `arrow`, if present.
-  public func withArrow(_ newChild: TokenSyntax?) -> ReturnClauseSyntax {
+  public func withArrow(_ newChild: TokenSyntax) -> ReturnClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ReturnClauseSyntax(newData)
   }
@@ -5598,9 +5598,9 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `returnType` replaced.
   /// - param newChild: The new `returnType` to replace the node's
   ///                   current `returnType`, if present.
-  public func withReturnType(_ newChild: TypeSyntax?) -> ReturnClauseSyntax {
+  public func withReturnType(_ newChild: TypeSyntax) -> ReturnClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return ReturnClauseSyntax(newData)
   }
@@ -5753,9 +5753,9 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `input` replaced.
   /// - param newChild: The new `input` to replace the node's
   ///                   current `input`, if present.
-  public func withInput(_ newChild: ParameterClauseSyntax?) -> FunctionSignatureSyntax {
+  public func withInput(_ newChild: ParameterClauseSyntax) -> FunctionSignatureSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.parameterClause, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return FunctionSignatureSyntax(newData)
   }
@@ -6146,9 +6146,9 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundKeyword` replaced.
   /// - param newChild: The new `poundKeyword` to replace the node's
   ///                   current `poundKeyword`, if present.
-  public func withPoundKeyword(_ newChild: TokenSyntax?) -> IfConfigClauseSyntax {
+  public func withPoundKeyword(_ newChild: TokenSyntax) -> IfConfigClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundIfKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return IfConfigClauseSyntax(newData)
   }
@@ -6405,9 +6405,9 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `fileArgLabel` replaced.
   /// - param newChild: The new `fileArgLabel` to replace the node's
   ///                   current `fileArgLabel`, if present.
-  public func withFileArgLabel(_ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
+  public func withFileArgLabel(_ newChild: TokenSyntax) -> PoundSourceLocationArgsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
@@ -6446,9 +6446,9 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `fileArgColon` replaced.
   /// - param newChild: The new `fileArgColon` to replace the node's
   ///                   current `fileArgColon`, if present.
-  public func withFileArgColon(_ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
+  public func withFileArgColon(_ newChild: TokenSyntax) -> PoundSourceLocationArgsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
@@ -6487,9 +6487,9 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `fileName` replaced.
   /// - param newChild: The new `fileName` to replace the node's
   ///                   current `fileName`, if present.
-  public func withFileName(_ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
+  public func withFileName(_ newChild: TokenSyntax) -> PoundSourceLocationArgsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
@@ -6528,9 +6528,9 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `comma` replaced.
   /// - param newChild: The new `comma` to replace the node's
   ///                   current `comma`, if present.
-  public func withComma(_ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
+  public func withComma(_ newChild: TokenSyntax) -> PoundSourceLocationArgsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
@@ -6569,9 +6569,9 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `lineArgLabel` replaced.
   /// - param newChild: The new `lineArgLabel` to replace the node's
   ///                   current `lineArgLabel`, if present.
-  public func withLineArgLabel(_ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
+  public func withLineArgLabel(_ newChild: TokenSyntax) -> PoundSourceLocationArgsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 9, with: raw, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
@@ -6610,9 +6610,9 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `lineArgColon` replaced.
   /// - param newChild: The new `lineArgColon` to replace the node's
   ///                   current `lineArgColon`, if present.
-  public func withLineArgColon(_ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
+  public func withLineArgColon(_ newChild: TokenSyntax) -> PoundSourceLocationArgsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 11, with: raw, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
@@ -6651,9 +6651,9 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `lineNumber` replaced.
   /// - param newChild: The new `lineNumber` to replace the node's
   ///                   current `lineNumber`, if present.
-  public func withLineNumber(_ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
+  public func withLineNumber(_ newChild: TokenSyntax) -> PoundSourceLocationArgsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 13, with: raw, arena: arena)
     return PoundSourceLocationArgsSyntax(newData)
   }
@@ -6842,9 +6842,9 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> DeclModifierDetailSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> DeclModifierDetailSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DeclModifierDetailSyntax(newData)
   }
@@ -6883,9 +6883,9 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `detail` replaced.
   /// - param newChild: The new `detail` to replace the node's
   ///                   current `detail`, if present.
-  public func withDetail(_ newChild: TokenSyntax?) -> DeclModifierDetailSyntax {
+  public func withDetail(_ newChild: TokenSyntax) -> DeclModifierDetailSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return DeclModifierDetailSyntax(newData)
   }
@@ -6924,9 +6924,9 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> DeclModifierDetailSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> DeclModifierDetailSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return DeclModifierDetailSyntax(newData)
   }
@@ -7079,9 +7079,9 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> DeclModifierSyntax {
+  public func withName(_ newChild: TokenSyntax) -> DeclModifierSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DeclModifierSyntax(newData)
   }
@@ -7268,9 +7268,9 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typeName` replaced.
   /// - param newChild: The new `typeName` to replace the node's
   ///                   current `typeName`, if present.
-  public func withTypeName(_ newChild: TypeSyntax?) -> InheritedTypeSyntax {
+  public func withTypeName(_ newChild: TypeSyntax) -> InheritedTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return InheritedTypeSyntax(newData)
   }
@@ -7457,9 +7457,9 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> TypeInheritanceClauseSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> TypeInheritanceClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return TypeInheritanceClauseSyntax(newData)
   }
@@ -7517,9 +7517,9 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `inheritedTypeCollection` replaced.
   /// - param newChild: The new `inheritedTypeCollection` to replace the node's
   ///                   current `inheritedTypeCollection`, if present.
-  public func withInheritedTypeCollection(_ newChild: InheritedTypeListSyntax?) -> TypeInheritanceClauseSyntax {
+  public func withInheritedTypeCollection(_ newChild: InheritedTypeListSyntax) -> TypeInheritanceClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.inheritedTypeList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return TypeInheritanceClauseSyntax(newData)
   }
@@ -7668,9 +7668,9 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBrace` replaced.
   /// - param newChild: The new `leftBrace` to replace the node's
   ///                   current `leftBrace`, if present.
-  public func withLeftBrace(_ newChild: TokenSyntax?) -> MemberDeclBlockSyntax {
+  public func withLeftBrace(_ newChild: TokenSyntax) -> MemberDeclBlockSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return MemberDeclBlockSyntax(newData)
   }
@@ -7728,9 +7728,9 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `members` replaced.
   /// - param newChild: The new `members` to replace the node's
   ///                   current `members`, if present.
-  public func withMembers(_ newChild: MemberDeclListSyntax?) -> MemberDeclBlockSyntax {
+  public func withMembers(_ newChild: MemberDeclListSyntax) -> MemberDeclBlockSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return MemberDeclBlockSyntax(newData)
   }
@@ -7769,9 +7769,9 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBrace` replaced.
   /// - param newChild: The new `rightBrace` to replace the node's
   ///                   current `rightBrace`, if present.
-  public func withRightBrace(_ newChild: TokenSyntax?) -> MemberDeclBlockSyntax {
+  public func withRightBrace(_ newChild: TokenSyntax) -> MemberDeclBlockSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return MemberDeclBlockSyntax(newData)
   }
@@ -7929,9 +7929,9 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `decl` replaced.
   /// - param newChild: The new `decl` to replace the node's
   ///                   current `decl`, if present.
-  public func withDecl(_ newChild: DeclSyntax?) -> MemberDeclListItemSyntax {
+  public func withDecl(_ newChild: DeclSyntax) -> MemberDeclListItemSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingDecl, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return MemberDeclListItemSyntax(newData)
   }
@@ -8138,9 +8138,9 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `statements` replaced.
   /// - param newChild: The new `statements` to replace the node's
   ///                   current `statements`, if present.
-  public func withStatements(_ newChild: CodeBlockItemListSyntax?) -> SourceFileSyntax {
+  public func withStatements(_ newChild: CodeBlockItemListSyntax) -> SourceFileSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return SourceFileSyntax(newData)
   }
@@ -8179,9 +8179,9 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `eofToken` replaced.
   /// - param newChild: The new `eofToken` to replace the node's
   ///                   current `eofToken`, if present.
-  public func withEOFToken(_ newChild: TokenSyntax?) -> SourceFileSyntax {
+  public func withEOFToken(_ newChild: TokenSyntax) -> SourceFileSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return SourceFileSyntax(newData)
   }
@@ -8326,9 +8326,9 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `equal` replaced.
   /// - param newChild: The new `equal` to replace the node's
   ///                   current `equal`, if present.
-  public func withEqual(_ newChild: TokenSyntax?) -> InitializerClauseSyntax {
+  public func withEqual(_ newChild: TokenSyntax) -> InitializerClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return InitializerClauseSyntax(newData)
   }
@@ -8367,9 +8367,9 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `value` replaced.
   /// - param newChild: The new `value` to replace the node's
   ///                   current `value`, if present.
-  public func withValue(_ newChild: ExprSyntax?) -> InitializerClauseSyntax {
+  public func withValue(_ newChild: ExprSyntax) -> InitializerClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return InitializerClauseSyntax(newData)
   }
@@ -9178,9 +9178,9 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> AccessPathComponentSyntax {
+  public func withName(_ newChild: TokenSyntax) -> AccessPathComponentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return AccessPathComponentSyntax(newData)
   }
@@ -9371,9 +9371,9 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> AccessorParameterSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> AccessorParameterSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return AccessorParameterSyntax(newData)
   }
@@ -9412,9 +9412,9 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> AccessorParameterSyntax {
+  public func withName(_ newChild: TokenSyntax) -> AccessorParameterSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return AccessorParameterSyntax(newData)
   }
@@ -9453,9 +9453,9 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> AccessorParameterSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> AccessorParameterSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return AccessorParameterSyntax(newData)
   }
@@ -9612,9 +9612,9 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBrace` replaced.
   /// - param newChild: The new `leftBrace` to replace the node's
   ///                   current `leftBrace`, if present.
-  public func withLeftBrace(_ newChild: TokenSyntax?) -> AccessorBlockSyntax {
+  public func withLeftBrace(_ newChild: TokenSyntax) -> AccessorBlockSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return AccessorBlockSyntax(newData)
   }
@@ -9672,9 +9672,9 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `accessors` replaced.
   /// - param newChild: The new `accessors` to replace the node's
   ///                   current `accessors`, if present.
-  public func withAccessors(_ newChild: AccessorListSyntax?) -> AccessorBlockSyntax {
+  public func withAccessors(_ newChild: AccessorListSyntax) -> AccessorBlockSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.accessorList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return AccessorBlockSyntax(newData)
   }
@@ -9713,9 +9713,9 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBrace` replaced.
   /// - param newChild: The new `rightBrace` to replace the node's
   ///                   current `rightBrace`, if present.
-  public func withRightBrace(_ newChild: TokenSyntax?) -> AccessorBlockSyntax {
+  public func withRightBrace(_ newChild: TokenSyntax) -> AccessorBlockSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return AccessorBlockSyntax(newData)
   }
@@ -9916,9 +9916,9 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(_ newChild: PatternSyntax?) -> PatternBindingSyntax {
+  public func withPattern(_ newChild: PatternSyntax) -> PatternBindingSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PatternBindingSyntax(newData)
   }
@@ -10268,9 +10268,9 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> EnumCaseElementSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> EnumCaseElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return EnumCaseElementSyntax(newData)
   }
@@ -10565,9 +10565,9 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leadingComma` replaced.
   /// - param newChild: The new `leadingComma` to replace the node's
   ///                   current `leadingComma`, if present.
-  public func withLeadingComma(_ newChild: TokenSyntax?) -> DesignatedTypeElementSyntax {
+  public func withLeadingComma(_ newChild: TokenSyntax) -> DesignatedTypeElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DesignatedTypeElementSyntax(newData)
   }
@@ -10606,9 +10606,9 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> DesignatedTypeElementSyntax {
+  public func withName(_ newChild: TokenSyntax) -> DesignatedTypeElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return DesignatedTypeElementSyntax(newData)
   }
@@ -10760,9 +10760,9 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> OperatorPrecedenceAndTypesSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
@@ -10804,9 +10804,9 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `precedenceGroup` replaced.
   /// - param newChild: The new `precedenceGroup` to replace the node's
   ///                   current `precedenceGroup`, if present.
-  public func withPrecedenceGroup(_ newChild: TokenSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+  public func withPrecedenceGroup(_ newChild: TokenSyntax) -> OperatorPrecedenceAndTypesSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
@@ -10867,9 +10867,9 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `designatedTypes` replaced.
   /// - param newChild: The new `designatedTypes` to replace the node's
   ///                   current `designatedTypes`, if present.
-  public func withDesignatedTypes(_ newChild: DesignatedTypeListSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+  public func withDesignatedTypes(_ newChild: DesignatedTypeListSyntax) -> OperatorPrecedenceAndTypesSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.designatedTypeList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
@@ -11033,9 +11033,9 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `higherThanOrLowerThan` replaced.
   /// - param newChild: The new `higherThanOrLowerThan` to replace the node's
   ///                   current `higherThanOrLowerThan`, if present.
-  public func withHigherThanOrLowerThan(_ newChild: TokenSyntax?) -> PrecedenceGroupRelationSyntax {
+  public func withHigherThanOrLowerThan(_ newChild: TokenSyntax) -> PrecedenceGroupRelationSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PrecedenceGroupRelationSyntax(newData)
   }
@@ -11074,9 +11074,9 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> PrecedenceGroupRelationSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> PrecedenceGroupRelationSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PrecedenceGroupRelationSyntax(newData)
   }
@@ -11138,9 +11138,9 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `otherNames` replaced.
   /// - param newChild: The new `otherNames` to replace the node's
   ///                   current `otherNames`, if present.
-  public func withOtherNames(_ newChild: PrecedenceGroupNameListSyntax?) -> PrecedenceGroupRelationSyntax {
+  public func withOtherNames(_ newChild: PrecedenceGroupNameListSyntax) -> PrecedenceGroupRelationSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.precedenceGroupNameList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return PrecedenceGroupRelationSyntax(newData)
   }
@@ -11293,9 +11293,9 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> PrecedenceGroupNameElementSyntax {
+  public func withName(_ newChild: TokenSyntax) -> PrecedenceGroupNameElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PrecedenceGroupNameElementSyntax(newData)
   }
@@ -11490,9 +11490,9 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `assignmentKeyword` replaced.
   /// - param newChild: The new `assignmentKeyword` to replace the node's
   ///                   current `assignmentKeyword`, if present.
-  public func withAssignmentKeyword(_ newChild: TokenSyntax?) -> PrecedenceGroupAssignmentSyntax {
+  public func withAssignmentKeyword(_ newChild: TokenSyntax) -> PrecedenceGroupAssignmentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
@@ -11531,9 +11531,9 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> PrecedenceGroupAssignmentSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> PrecedenceGroupAssignmentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
@@ -11579,9 +11579,9 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `flag` replaced.
   /// - param newChild: The new `flag` to replace the node's
   ///                   current `flag`, if present.
-  public func withFlag(_ newChild: TokenSyntax?) -> PrecedenceGroupAssignmentSyntax {
+  public func withFlag(_ newChild: TokenSyntax) -> PrecedenceGroupAssignmentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.trueKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
@@ -11742,9 +11742,9 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `associativityKeyword` replaced.
   /// - param newChild: The new `associativityKeyword` to replace the node's
   ///                   current `associativityKeyword`, if present.
-  public func withAssociativityKeyword(_ newChild: TokenSyntax?) -> PrecedenceGroupAssociativitySyntax {
+  public func withAssociativityKeyword(_ newChild: TokenSyntax) -> PrecedenceGroupAssociativitySyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
@@ -11783,9 +11783,9 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> PrecedenceGroupAssociativitySyntax {
+  public func withColon(_ newChild: TokenSyntax) -> PrecedenceGroupAssociativitySyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
@@ -11830,9 +11830,9 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `value` replaced.
   /// - param newChild: The new `value` to replace the node's
   ///                   current `value`, if present.
-  public func withValue(_ newChild: TokenSyntax?) -> PrecedenceGroupAssociativitySyntax {
+  public func withValue(_ newChild: TokenSyntax) -> PrecedenceGroupAssociativitySyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
@@ -12001,9 +12001,9 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `atSignToken` replaced.
   /// - param newChild: The new `atSignToken` to replace the node's
   ///                   current `atSignToken`, if present.
-  public func withAtSignToken(_ newChild: TokenSyntax?) -> CustomAttributeSyntax {
+  public func withAtSignToken(_ newChild: TokenSyntax) -> CustomAttributeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.atSign, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return CustomAttributeSyntax(newData)
   }
@@ -12043,9 +12043,9 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `attributeName` replaced.
   /// - param newChild: The new `attributeName` to replace the node's
   ///                   current `attributeName`, if present.
-  public func withAttributeName(_ newChild: TypeSyntax?) -> CustomAttributeSyntax {
+  public func withAttributeName(_ newChild: TypeSyntax) -> CustomAttributeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return CustomAttributeSyntax(newData)
   }
@@ -12535,9 +12535,9 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `atSignToken` replaced.
   /// - param newChild: The new `atSignToken` to replace the node's
   ///                   current `atSignToken`, if present.
-  public func withAtSignToken(_ newChild: TokenSyntax?) -> AttributeSyntax {
+  public func withAtSignToken(_ newChild: TokenSyntax) -> AttributeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.atSign, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return AttributeSyntax(newData)
   }
@@ -12577,9 +12577,9 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `attributeName` replaced.
   /// - param newChild: The new `attributeName` to replace the node's
   ///                   current `attributeName`, if present.
-  public func withAttributeName(_ newChild: TokenSyntax?) -> AttributeSyntax {
+  public func withAttributeName(_ newChild: TokenSyntax) -> AttributeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return AttributeSyntax(newData)
   }
@@ -12966,9 +12966,9 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `label` replaced.
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
-  public func withLabel(_ newChild: TokenSyntax?) -> AvailabilityEntrySyntax {
+  public func withLabel(_ newChild: TokenSyntax) -> AvailabilityEntrySyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return AvailabilityEntrySyntax(newData)
   }
@@ -13008,9 +13008,9 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> AvailabilityEntrySyntax {
+  public func withColon(_ newChild: TokenSyntax) -> AvailabilityEntrySyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return AvailabilityEntrySyntax(newData)
   }
@@ -13068,9 +13068,9 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `availabilityList` replaced.
   /// - param newChild: The new `availabilityList` to replace the node's
   ///                   current `availabilityList`, if present.
-  public func withAvailabilityList(_ newChild: AvailabilitySpecListSyntax?) -> AvailabilityEntrySyntax {
+  public func withAvailabilityList(_ newChild: AvailabilitySpecListSyntax) -> AvailabilityEntrySyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return AvailabilityEntrySyntax(newData)
   }
@@ -13109,9 +13109,9 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `semicolon` replaced.
   /// - param newChild: The new `semicolon` to replace the node's
   ///                   current `semicolon`, if present.
-  public func withSemicolon(_ newChild: TokenSyntax?) -> AvailabilityEntrySyntax {
+  public func withSemicolon(_ newChild: TokenSyntax) -> AvailabilityEntrySyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.semicolon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return AvailabilityEntrySyntax(newData)
   }
@@ -13285,9 +13285,9 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `label` replaced.
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
-  public func withLabel(_ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
+  public func withLabel(_ newChild: TokenSyntax) -> LabeledSpecializeEntrySyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return LabeledSpecializeEntrySyntax(newData)
   }
@@ -13327,9 +13327,9 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
+  public func withColon(_ newChild: TokenSyntax) -> LabeledSpecializeEntrySyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return LabeledSpecializeEntrySyntax(newData)
   }
@@ -13369,9 +13369,9 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `value` replaced.
   /// - param newChild: The new `value` to replace the node's
   ///                   current `value`, if present.
-  public func withValue(_ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
+  public func withValue(_ newChild: TokenSyntax) -> LabeledSpecializeEntrySyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return LabeledSpecializeEntrySyntax(newData)
   }
@@ -13591,9 +13591,9 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `label` replaced.
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
-  public func withLabel(_ newChild: TokenSyntax?) -> TargetFunctionEntrySyntax {
+  public func withLabel(_ newChild: TokenSyntax) -> TargetFunctionEntrySyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return TargetFunctionEntrySyntax(newData)
   }
@@ -13633,9 +13633,9 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> TargetFunctionEntrySyntax {
+  public func withColon(_ newChild: TokenSyntax) -> TargetFunctionEntrySyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return TargetFunctionEntrySyntax(newData)
   }
@@ -13675,9 +13675,9 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `declname` replaced.
   /// - param newChild: The new `declname` to replace the node's
   ///                   current `declname`, if present.
-  public func withDeclname(_ newChild: DeclNameSyntax?) -> TargetFunctionEntrySyntax {
+  public func withDeclname(_ newChild: DeclNameSyntax) -> TargetFunctionEntrySyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.declName, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return TargetFunctionEntrySyntax(newData)
   }
@@ -13929,9 +13929,9 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `nameTok` replaced.
   /// - param newChild: The new `nameTok` to replace the node's
   ///                   current `nameTok`, if present.
-  public func withNameTok(_ newChild: TokenSyntax?) -> NamedAttributeStringArgumentSyntax {
+  public func withNameTok(_ newChild: TokenSyntax) -> NamedAttributeStringArgumentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return NamedAttributeStringArgumentSyntax(newData)
   }
@@ -13971,9 +13971,9 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> NamedAttributeStringArgumentSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> NamedAttributeStringArgumentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return NamedAttributeStringArgumentSyntax(newData)
   }
@@ -14012,9 +14012,9 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `stringOrDeclname` replaced.
   /// - param newChild: The new `stringOrDeclname` to replace the node's
   ///                   current `stringOrDeclname`, if present.
-  public func withStringOrDeclname(_ newChild: StringOrDeclname?) -> NamedAttributeStringArgumentSyntax {
+  public func withStringOrDeclname(_ newChild: StringOrDeclname) -> NamedAttributeStringArgumentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missing, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return NamedAttributeStringArgumentSyntax(newData)
   }
@@ -14170,9 +14170,9 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `declBaseName` replaced.
   /// - param newChild: The new `declBaseName` to replace the node's
   ///                   current `declBaseName`, if present.
-  public func withDeclBaseName(_ newChild: TokenSyntax?) -> DeclNameSyntax {
+  public func withDeclBaseName(_ newChild: TokenSyntax) -> DeclNameSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DeclNameSyntax(newData)
   }
@@ -14379,9 +14379,9 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `type` replaced.
   /// - param newChild: The new `type` to replace the node's
   ///                   current `type`, if present.
-  public func withType(_ newChild: TypeSyntax?) -> ImplementsAttributeArgumentsSyntax {
+  public func withType(_ newChild: TypeSyntax) -> ImplementsAttributeArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
@@ -14423,9 +14423,9 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `comma` replaced.
   /// - param newChild: The new `comma` to replace the node's
   ///                   current `comma`, if present.
-  public func withComma(_ newChild: TokenSyntax?) -> ImplementsAttributeArgumentsSyntax {
+  public func withComma(_ newChild: TokenSyntax) -> ImplementsAttributeArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
@@ -14467,9 +14467,9 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `declBaseName` replaced.
   /// - param newChild: The new `declBaseName` to replace the node's
   ///                   current `declBaseName`, if present.
-  public func withDeclBaseName(_ newChild: TokenSyntax?) -> ImplementsAttributeArgumentsSyntax {
+  public func withDeclBaseName(_ newChild: TokenSyntax) -> ImplementsAttributeArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
@@ -15277,9 +15277,9 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   /// Returns a copy of the receiver with its `wrtLabel` replaced.
   /// - param newChild: The new `wrtLabel` to replace the node's
   ///                   current `wrtLabel`, if present.
-  public func withWrtLabel(_ newChild: TokenSyntax?) -> DifferentiabilityParamsClauseSyntax {
+  public func withWrtLabel(_ newChild: TokenSyntax) -> DifferentiabilityParamsClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
@@ -15321,9 +15321,9 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> DifferentiabilityParamsClauseSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> DifferentiabilityParamsClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
@@ -15362,9 +15362,9 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   /// Returns a copy of the receiver with its `parameters` replaced.
   /// - param newChild: The new `parameters` to replace the node's
   ///                   current `parameters`, if present.
-  public func withParameters(_ newChild: Parameters?) -> DifferentiabilityParamsClauseSyntax {
+  public func withParameters(_ newChild: Parameters) -> DifferentiabilityParamsClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missing, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
@@ -15522,9 +15522,9 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> DifferentiabilityParamsSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> DifferentiabilityParamsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DifferentiabilityParamsSyntax(newData)
   }
@@ -15583,9 +15583,9 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `diffParams` replaced.
   /// - param newChild: The new `diffParams` to replace the node's
   ///                   current `diffParams`, if present.
-  public func withDiffParams(_ newChild: DifferentiabilityParamListSyntax?) -> DifferentiabilityParamsSyntax {
+  public func withDiffParams(_ newChild: DifferentiabilityParamListSyntax) -> DifferentiabilityParamsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.differentiabilityParamList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return DifferentiabilityParamsSyntax(newData)
   }
@@ -15624,9 +15624,9 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> DifferentiabilityParamsSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> DifferentiabilityParamsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return DifferentiabilityParamsSyntax(newData)
   }
@@ -15783,9 +15783,9 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `parameter` replaced.
   /// - param newChild: The new `parameter` to replace the node's
   ///                   current `parameter`, if present.
-  public func withParameter(_ newChild: TokenSyntax?) -> DifferentiabilityParamSyntax {
+  public func withParameter(_ newChild: TokenSyntax) -> DifferentiabilityParamSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.selfKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DifferentiabilityParamSyntax(newData)
   }
@@ -15998,9 +15998,9 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `ofLabel` replaced.
   /// - param newChild: The new `ofLabel` to replace the node's
   ///                   current `ofLabel`, if present.
-  public func withOfLabel(_ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public func withOfLabel(_ newChild: TokenSyntax) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
@@ -16043,9 +16043,9 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
@@ -16085,9 +16085,9 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// Returns a copy of the receiver with its `originalDeclName` replaced.
   /// - param newChild: The new `originalDeclName` to replace the node's
   ///                   current `originalDeclName`, if present.
-  public func withOriginalDeclName(_ newChild: QualifiedDeclNameSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public func withOriginalDeclName(_ newChild: QualifiedDeclNameSyntax) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.qualifiedDeclName, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
@@ -16585,9 +16585,9 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> QualifiedDeclNameSyntax {
+  public func withName(_ newChild: TokenSyntax) -> QualifiedDeclNameSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return QualifiedDeclNameSyntax(newData)
   }
@@ -16802,9 +16802,9 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `beforeLabel` replaced.
   /// - param newChild: The new `beforeLabel` to replace the node's
   ///                   current `beforeLabel`, if present.
-  public func withBeforeLabel(_ newChild: TokenSyntax?) -> BackDeployAttributeSpecListSyntax {
+  public func withBeforeLabel(_ newChild: TokenSyntax) -> BackDeployAttributeSpecListSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return BackDeployAttributeSpecListSyntax(newData)
   }
@@ -16846,9 +16846,9 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> BackDeployAttributeSpecListSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> BackDeployAttributeSpecListSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return BackDeployAttributeSpecListSyntax(newData)
   }
@@ -16910,9 +16910,9 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `versionList` replaced.
   /// - param newChild: The new `versionList` to replace the node's
   ///                   current `versionList`, if present.
-  public func withVersionList(_ newChild: BackDeployVersionListSyntax?) -> BackDeployAttributeSpecListSyntax {
+  public func withVersionList(_ newChild: BackDeployVersionListSyntax) -> BackDeployAttributeSpecListSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.backDeployVersionList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return BackDeployAttributeSpecListSyntax(newData)
   }
@@ -17069,9 +17069,9 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `availabilityVersionRestriction` replaced.
   /// - param newChild: The new `availabilityVersionRestriction` to replace the node's
   ///                   current `availabilityVersionRestriction`, if present.
-  public func withAvailabilityVersionRestriction(_ newChild: AvailabilityVersionRestrictionSyntax?) -> BackDeployVersionArgumentSyntax {
+  public func withAvailabilityVersionRestriction(_ newChild: AvailabilityVersionRestrictionSyntax) -> BackDeployVersionArgumentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilityVersionRestriction, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return BackDeployVersionArgumentSyntax(newData)
   }
@@ -17270,9 +17270,9 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
   /// Returns a copy of the receiver with its `mangledName` replaced.
   /// - param newChild: The new `mangledName` to replace the node's
   ///                   current `mangledName`, if present.
-  public func withMangledName(_ newChild: TokenSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+  public func withMangledName(_ newChild: TokenSyntax) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
@@ -17311,9 +17311,9 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
   /// Returns a copy of the receiver with its `comma` replaced.
   /// - param newChild: The new `comma` to replace the node's
   ///                   current `comma`, if present.
-  public func withComma(_ newChild: TokenSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+  public func withComma(_ newChild: TokenSyntax) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
@@ -17353,9 +17353,9 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
   /// Returns a copy of the receiver with its `ordinal` replaced.
   /// - param newChild: The new `ordinal` to replace the node's
   ///                   current `ordinal`, if present.
-  public func withOrdinal(_ newChild: TokenSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+  public func withOrdinal(_ newChild: TokenSyntax) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
@@ -17524,9 +17524,9 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `conventionLabel` replaced.
   /// - param newChild: The new `conventionLabel` to replace the node's
   ///                   current `conventionLabel`, if present.
-  public func withConventionLabel(_ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+  public func withConventionLabel(_ newChild: TokenSyntax) -> ConventionAttributeArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ConventionAttributeArgumentsSyntax(newData)
   }
@@ -17870,9 +17870,9 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
   /// Returns a copy of the receiver with its `witnessMethodLabel` replaced.
   /// - param newChild: The new `witnessMethodLabel` to replace the node's
   ///                   current `witnessMethodLabel`, if present.
-  public func withWitnessMethodLabel(_ newChild: TokenSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+  public func withWitnessMethodLabel(_ newChild: TokenSyntax) -> ConventionWitnessMethodAttributeArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
@@ -17911,9 +17911,9 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> ConventionWitnessMethodAttributeArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
@@ -17952,9 +17952,9 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
   /// Returns a copy of the receiver with its `protocolName` replaced.
   /// - param newChild: The new `protocolName` to replace the node's
   ///                   current `protocolName`, if present.
-  public func withProtocolName(_ newChild: TokenSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+  public func withProtocolName(_ newChild: TokenSyntax) -> ConventionWitnessMethodAttributeArgumentsSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
@@ -18107,9 +18107,9 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `whereKeyword` replaced.
   /// - param newChild: The new `whereKeyword` to replace the node's
   ///                   current `whereKeyword`, if present.
-  public func withWhereKeyword(_ newChild: TokenSyntax?) -> WhereClauseSyntax {
+  public func withWhereKeyword(_ newChild: TokenSyntax) -> WhereClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whereKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return WhereClauseSyntax(newData)
   }
@@ -18148,9 +18148,9 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `guardResult` replaced.
   /// - param newChild: The new `guardResult` to replace the node's
   ///                   current `guardResult`, if present.
-  public func withGuardResult(_ newChild: ExprSyntax?) -> WhereClauseSyntax {
+  public func withGuardResult(_ newChild: ExprSyntax) -> WhereClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return WhereClauseSyntax(newData)
   }
@@ -18299,9 +18299,9 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> YieldListSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> YieldListSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return YieldListSyntax(newData)
   }
@@ -18359,9 +18359,9 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `elementList` replaced.
   /// - param newChild: The new `elementList` to replace the node's
   ///                   current `elementList`, if present.
-  public func withElementList(_ newChild: YieldExprListSyntax?) -> YieldListSyntax {
+  public func withElementList(_ newChild: YieldExprListSyntax) -> YieldListSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.yieldExprList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return YieldListSyntax(newData)
   }
@@ -18400,9 +18400,9 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> YieldListSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> YieldListSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return YieldListSyntax(newData)
   }
@@ -18631,9 +18631,9 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `condition` replaced.
   /// - param newChild: The new `condition` to replace the node's
   ///                   current `condition`, if present.
-  public func withCondition(_ newChild: Condition?) -> ConditionElementSyntax {
+  public func withCondition(_ newChild: Condition) -> ConditionElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missing, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ConditionElementSyntax(newData)
   }
@@ -18828,9 +18828,9 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundAvailableKeyword` replaced.
   /// - param newChild: The new `poundAvailableKeyword` to replace the node's
   ///                   current `poundAvailableKeyword`, if present.
-  public func withPoundAvailableKeyword(_ newChild: TokenSyntax?) -> AvailabilityConditionSyntax {
+  public func withPoundAvailableKeyword(_ newChild: TokenSyntax) -> AvailabilityConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundAvailableKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
@@ -18869,9 +18869,9 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> AvailabilityConditionSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> AvailabilityConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
@@ -18929,9 +18929,9 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `availabilitySpec` replaced.
   /// - param newChild: The new `availabilitySpec` to replace the node's
   ///                   current `availabilitySpec`, if present.
-  public func withAvailabilitySpec(_ newChild: AvailabilitySpecListSyntax?) -> AvailabilityConditionSyntax {
+  public func withAvailabilitySpec(_ newChild: AvailabilitySpecListSyntax) -> AvailabilityConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
@@ -18970,9 +18970,9 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> AvailabilityConditionSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> AvailabilityConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return AvailabilityConditionSyntax(newData)
   }
@@ -19141,9 +19141,9 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `caseKeyword` replaced.
   /// - param newChild: The new `caseKeyword` to replace the node's
   ///                   current `caseKeyword`, if present.
-  public func withCaseKeyword(_ newChild: TokenSyntax?) -> MatchingPatternConditionSyntax {
+  public func withCaseKeyword(_ newChild: TokenSyntax) -> MatchingPatternConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return MatchingPatternConditionSyntax(newData)
   }
@@ -19182,9 +19182,9 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(_ newChild: PatternSyntax?) -> MatchingPatternConditionSyntax {
+  public func withPattern(_ newChild: PatternSyntax) -> MatchingPatternConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return MatchingPatternConditionSyntax(newData)
   }
@@ -19265,9 +19265,9 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `initializer` replaced.
   /// - param newChild: The new `initializer` to replace the node's
   ///                   current `initializer`, if present.
-  public func withInitializer(_ newChild: InitializerClauseSyntax?) -> MatchingPatternConditionSyntax {
+  public func withInitializer(_ newChild: InitializerClauseSyntax) -> MatchingPatternConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.initializerClause, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return MatchingPatternConditionSyntax(newData)
   }
@@ -19436,9 +19436,9 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `letOrVarKeyword` replaced.
   /// - param newChild: The new `letOrVarKeyword` to replace the node's
   ///                   current `letOrVarKeyword`, if present.
-  public func withLetOrVarKeyword(_ newChild: TokenSyntax?) -> OptionalBindingConditionSyntax {
+  public func withLetOrVarKeyword(_ newChild: TokenSyntax) -> OptionalBindingConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return OptionalBindingConditionSyntax(newData)
   }
@@ -19477,9 +19477,9 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(_ newChild: PatternSyntax?) -> OptionalBindingConditionSyntax {
+  public func withPattern(_ newChild: PatternSyntax) -> OptionalBindingConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return OptionalBindingConditionSyntax(newData)
   }
@@ -19732,9 +19732,9 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundUnavailableKeyword` replaced.
   /// - param newChild: The new `poundUnavailableKeyword` to replace the node's
   ///                   current `poundUnavailableKeyword`, if present.
-  public func withPoundUnavailableKeyword(_ newChild: TokenSyntax?) -> UnavailabilityConditionSyntax {
+  public func withPoundUnavailableKeyword(_ newChild: TokenSyntax) -> UnavailabilityConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundUnavailableKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return UnavailabilityConditionSyntax(newData)
   }
@@ -19773,9 +19773,9 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> UnavailabilityConditionSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> UnavailabilityConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return UnavailabilityConditionSyntax(newData)
   }
@@ -19833,9 +19833,9 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `availabilitySpec` replaced.
   /// - param newChild: The new `availabilitySpec` to replace the node's
   ///                   current `availabilitySpec`, if present.
-  public func withAvailabilitySpec(_ newChild: AvailabilitySpecListSyntax?) -> UnavailabilityConditionSyntax {
+  public func withAvailabilitySpec(_ newChild: AvailabilitySpecListSyntax) -> UnavailabilityConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return UnavailabilityConditionSyntax(newData)
   }
@@ -19874,9 +19874,9 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> UnavailabilityConditionSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> UnavailabilityConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return UnavailabilityConditionSyntax(newData)
   }
@@ -20045,9 +20045,9 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `hasSymbolKeyword` replaced.
   /// - param newChild: The new `hasSymbolKeyword` to replace the node's
   ///                   current `hasSymbolKeyword`, if present.
-  public func withHasSymbolKeyword(_ newChild: TokenSyntax?) -> HasSymbolConditionSyntax {
+  public func withHasSymbolKeyword(_ newChild: TokenSyntax) -> HasSymbolConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return HasSymbolConditionSyntax(newData)
   }
@@ -20086,9 +20086,9 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> HasSymbolConditionSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> HasSymbolConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return HasSymbolConditionSyntax(newData)
   }
@@ -20127,9 +20127,9 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> HasSymbolConditionSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> HasSymbolConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return HasSymbolConditionSyntax(newData)
   }
@@ -20168,9 +20168,9 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> HasSymbolConditionSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> HasSymbolConditionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return HasSymbolConditionSyntax(newData)
   }
@@ -20413,9 +20413,9 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `label` replaced.
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
-  public func withLabel(_ newChild: Label?) -> SwitchCaseSyntax {
+  public func withLabel(_ newChild: Label) -> SwitchCaseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missing, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return SwitchCaseSyntax(newData)
   }
@@ -20473,9 +20473,9 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `statements` replaced.
   /// - param newChild: The new `statements` to replace the node's
   ///                   current `statements`, if present.
-  public func withStatements(_ newChild: CodeBlockItemListSyntax?) -> SwitchCaseSyntax {
+  public func withStatements(_ newChild: CodeBlockItemListSyntax) -> SwitchCaseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return SwitchCaseSyntax(newData)
   }
@@ -20628,9 +20628,9 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `defaultKeyword` replaced.
   /// - param newChild: The new `defaultKeyword` to replace the node's
   ///                   current `defaultKeyword`, if present.
-  public func withDefaultKeyword(_ newChild: TokenSyntax?) -> SwitchDefaultLabelSyntax {
+  public func withDefaultKeyword(_ newChild: TokenSyntax) -> SwitchDefaultLabelSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.defaultKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return SwitchDefaultLabelSyntax(newData)
   }
@@ -20669,9 +20669,9 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> SwitchDefaultLabelSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> SwitchDefaultLabelSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return SwitchDefaultLabelSyntax(newData)
   }
@@ -20820,9 +20820,9 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(_ newChild: PatternSyntax?) -> CaseItemSyntax {
+  public func withPattern(_ newChild: PatternSyntax) -> CaseItemSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return CaseItemSyntax(newData)
   }
@@ -21341,9 +21341,9 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `caseKeyword` replaced.
   /// - param newChild: The new `caseKeyword` to replace the node's
   ///                   current `caseKeyword`, if present.
-  public func withCaseKeyword(_ newChild: TokenSyntax?) -> SwitchCaseLabelSyntax {
+  public func withCaseKeyword(_ newChild: TokenSyntax) -> SwitchCaseLabelSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return SwitchCaseLabelSyntax(newData)
   }
@@ -21401,9 +21401,9 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `caseItems` replaced.
   /// - param newChild: The new `caseItems` to replace the node's
   ///                   current `caseItems`, if present.
-  public func withCaseItems(_ newChild: CaseItemListSyntax?) -> SwitchCaseLabelSyntax {
+  public func withCaseItems(_ newChild: CaseItemListSyntax) -> SwitchCaseLabelSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.caseItemList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return SwitchCaseLabelSyntax(newData)
   }
@@ -21442,9 +21442,9 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> SwitchCaseLabelSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> SwitchCaseLabelSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return SwitchCaseLabelSyntax(newData)
   }
@@ -21601,9 +21601,9 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `catchKeyword` replaced.
   /// - param newChild: The new `catchKeyword` to replace the node's
   ///                   current `catchKeyword`, if present.
-  public func withCatchKeyword(_ newChild: TokenSyntax?) -> CatchClauseSyntax {
+  public func withCatchKeyword(_ newChild: TokenSyntax) -> CatchClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.catchKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return CatchClauseSyntax(newData)
   }
@@ -21703,9 +21703,9 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax?) -> CatchClauseSyntax {
+  public func withBody(_ newChild: CodeBlockSyntax) -> CatchClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return CatchClauseSyntax(newData)
   }
@@ -21858,9 +21858,9 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `whereKeyword` replaced.
   /// - param newChild: The new `whereKeyword` to replace the node's
   ///                   current `whereKeyword`, if present.
-  public func withWhereKeyword(_ newChild: TokenSyntax?) -> GenericWhereClauseSyntax {
+  public func withWhereKeyword(_ newChild: TokenSyntax) -> GenericWhereClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whereKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return GenericWhereClauseSyntax(newData)
   }
@@ -21918,9 +21918,9 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `requirementList` replaced.
   /// - param newChild: The new `requirementList` to replace the node's
   ///                   current `requirementList`, if present.
-  public func withRequirementList(_ newChild: GenericRequirementListSyntax?) -> GenericWhereClauseSyntax {
+  public func withRequirementList(_ newChild: GenericRequirementListSyntax) -> GenericWhereClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericRequirementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return GenericWhereClauseSyntax(newData)
   }
@@ -22111,9 +22111,9 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(_ newChild: Body?) -> GenericRequirementSyntax {
+  public func withBody(_ newChild: Body) -> GenericRequirementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missing, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return GenericRequirementSyntax(newData)
   }
@@ -22304,9 +22304,9 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftTypeIdentifier` replaced.
   /// - param newChild: The new `leftTypeIdentifier` to replace the node's
   ///                   current `leftTypeIdentifier`, if present.
-  public func withLeftTypeIdentifier(_ newChild: TypeSyntax?) -> SameTypeRequirementSyntax {
+  public func withLeftTypeIdentifier(_ newChild: TypeSyntax) -> SameTypeRequirementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return SameTypeRequirementSyntax(newData)
   }
@@ -22345,9 +22345,9 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `equalityToken` replaced.
   /// - param newChild: The new `equalityToken` to replace the node's
   ///                   current `equalityToken`, if present.
-  public func withEqualityToken(_ newChild: TokenSyntax?) -> SameTypeRequirementSyntax {
+  public func withEqualityToken(_ newChild: TokenSyntax) -> SameTypeRequirementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.spacedBinaryOperator(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return SameTypeRequirementSyntax(newData)
   }
@@ -22386,9 +22386,9 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightTypeIdentifier` replaced.
   /// - param newChild: The new `rightTypeIdentifier` to replace the node's
   ///                   current `rightTypeIdentifier`, if present.
-  public func withRightTypeIdentifier(_ newChild: TypeSyntax?) -> SameTypeRequirementSyntax {
+  public func withRightTypeIdentifier(_ newChild: TypeSyntax) -> SameTypeRequirementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return SameTypeRequirementSyntax(newData)
   }
@@ -22565,9 +22565,9 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typeIdentifier` replaced.
   /// - param newChild: The new `typeIdentifier` to replace the node's
   ///                   current `typeIdentifier`, if present.
-  public func withTypeIdentifier(_ newChild: TypeSyntax?) -> LayoutRequirementSyntax {
+  public func withTypeIdentifier(_ newChild: TypeSyntax) -> LayoutRequirementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
@@ -22606,9 +22606,9 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> LayoutRequirementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
@@ -22647,9 +22647,9 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `layoutConstraint` replaced.
   /// - param newChild: The new `layoutConstraint` to replace the node's
   ///                   current `layoutConstraint`, if present.
-  public func withLayoutConstraint(_ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
+  public func withLayoutConstraint(_ newChild: TokenSyntax) -> LayoutRequirementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return LayoutRequirementSyntax(newData)
   }
@@ -23175,9 +23175,9 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> GenericParameterSyntax {
+  public func withName(_ newChild: TokenSyntax) -> GenericParameterSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return GenericParameterSyntax(newData)
   }
@@ -23522,9 +23522,9 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> PrimaryAssociatedTypeSyntax {
+  public func withName(_ newChild: TokenSyntax) -> PrimaryAssociatedTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PrimaryAssociatedTypeSyntax(newData)
   }
@@ -23719,9 +23719,9 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftAngleBracket` replaced.
   /// - param newChild: The new `leftAngleBracket` to replace the node's
   ///                   current `leftAngleBracket`, if present.
-  public func withLeftAngleBracket(_ newChild: TokenSyntax?) -> GenericParameterClauseSyntax {
+  public func withLeftAngleBracket(_ newChild: TokenSyntax) -> GenericParameterClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return GenericParameterClauseSyntax(newData)
   }
@@ -23779,9 +23779,9 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericParameterList` replaced.
   /// - param newChild: The new `genericParameterList` to replace the node's
   ///                   current `genericParameterList`, if present.
-  public func withGenericParameterList(_ newChild: GenericParameterListSyntax?) -> GenericParameterClauseSyntax {
+  public func withGenericParameterList(_ newChild: GenericParameterListSyntax) -> GenericParameterClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericParameterList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return GenericParameterClauseSyntax(newData)
   }
@@ -23862,9 +23862,9 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightAngleBracket` replaced.
   /// - param newChild: The new `rightAngleBracket` to replace the node's
   ///                   current `rightAngleBracket`, if present.
-  public func withRightAngleBracket(_ newChild: TokenSyntax?) -> GenericParameterClauseSyntax {
+  public func withRightAngleBracket(_ newChild: TokenSyntax) -> GenericParameterClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return GenericParameterClauseSyntax(newData)
   }
@@ -24029,9 +24029,9 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftTypeIdentifier` replaced.
   /// - param newChild: The new `leftTypeIdentifier` to replace the node's
   ///                   current `leftTypeIdentifier`, if present.
-  public func withLeftTypeIdentifier(_ newChild: TypeSyntax?) -> ConformanceRequirementSyntax {
+  public func withLeftTypeIdentifier(_ newChild: TypeSyntax) -> ConformanceRequirementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ConformanceRequirementSyntax(newData)
   }
@@ -24070,9 +24070,9 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> ConformanceRequirementSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> ConformanceRequirementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return ConformanceRequirementSyntax(newData)
   }
@@ -24111,9 +24111,9 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightTypeIdentifier` replaced.
   /// - param newChild: The new `rightTypeIdentifier` to replace the node's
   ///                   current `rightTypeIdentifier`, if present.
-  public func withRightTypeIdentifier(_ newChild: TypeSyntax?) -> ConformanceRequirementSyntax {
+  public func withRightTypeIdentifier(_ newChild: TypeSyntax) -> ConformanceRequirementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return ConformanceRequirementSyntax(newData)
   }
@@ -24270,9 +24270,9 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `leftAngleBracket` replaced.
   /// - param newChild: The new `leftAngleBracket` to replace the node's
   ///                   current `leftAngleBracket`, if present.
-  public func withLeftAngleBracket(_ newChild: TokenSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+  public func withLeftAngleBracket(_ newChild: TokenSyntax) -> PrimaryAssociatedTypeClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
@@ -24330,9 +24330,9 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `primaryAssociatedTypeList` replaced.
   /// - param newChild: The new `primaryAssociatedTypeList` to replace the node's
   ///                   current `primaryAssociatedTypeList`, if present.
-  public func withPrimaryAssociatedTypeList(_ newChild: PrimaryAssociatedTypeListSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+  public func withPrimaryAssociatedTypeList(_ newChild: PrimaryAssociatedTypeListSyntax) -> PrimaryAssociatedTypeClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.primaryAssociatedTypeList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
@@ -24371,9 +24371,9 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `rightAngleBracket` replaced.
   /// - param newChild: The new `rightAngleBracket` to replace the node's
   ///                   current `rightAngleBracket`, if present.
-  public func withRightAngleBracket(_ newChild: TokenSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+  public func withRightAngleBracket(_ newChild: TokenSyntax) -> PrimaryAssociatedTypeClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
@@ -24526,9 +24526,9 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `type` replaced.
   /// - param newChild: The new `type` to replace the node's
   ///                   current `type`, if present.
-  public func withType(_ newChild: TypeSyntax?) -> CompositionTypeElementSyntax {
+  public func withType(_ newChild: TypeSyntax) -> CompositionTypeElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return CompositionTypeElementSyntax(newData)
   }
@@ -24907,9 +24907,9 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `type` replaced.
   /// - param newChild: The new `type` to replace the node's
   ///                   current `type`, if present.
-  public func withType(_ newChild: TypeSyntax?) -> TupleTypeElementSyntax {
+  public func withType(_ newChild: TypeSyntax) -> TupleTypeElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 9, with: raw, arena: arena)
     return TupleTypeElementSyntax(newData)
   }
@@ -25228,9 +25228,9 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `argumentType` replaced.
   /// - param newChild: The new `argumentType` to replace the node's
   ///                   current `argumentType`, if present.
-  public func withArgumentType(_ newChild: TypeSyntax?) -> GenericArgumentSyntax {
+  public func withArgumentType(_ newChild: TypeSyntax) -> GenericArgumentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return GenericArgumentSyntax(newData)
   }
@@ -25421,9 +25421,9 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftAngleBracket` replaced.
   /// - param newChild: The new `leftAngleBracket` to replace the node's
   ///                   current `leftAngleBracket`, if present.
-  public func withLeftAngleBracket(_ newChild: TokenSyntax?) -> GenericArgumentClauseSyntax {
+  public func withLeftAngleBracket(_ newChild: TokenSyntax) -> GenericArgumentClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return GenericArgumentClauseSyntax(newData)
   }
@@ -25481,9 +25481,9 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `arguments` replaced.
   /// - param newChild: The new `arguments` to replace the node's
   ///                   current `arguments`, if present.
-  public func withArguments(_ newChild: GenericArgumentListSyntax?) -> GenericArgumentClauseSyntax {
+  public func withArguments(_ newChild: GenericArgumentListSyntax) -> GenericArgumentClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericArgumentList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return GenericArgumentClauseSyntax(newData)
   }
@@ -25522,9 +25522,9 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightAngleBracket` replaced.
   /// - param newChild: The new `rightAngleBracket` to replace the node's
   ///                   current `rightAngleBracket`, if present.
-  public func withRightAngleBracket(_ newChild: TokenSyntax?) -> GenericArgumentClauseSyntax {
+  public func withRightAngleBracket(_ newChild: TokenSyntax) -> GenericArgumentClauseSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return GenericArgumentClauseSyntax(newData)
   }
@@ -25677,9 +25677,9 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> TypeAnnotationSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> TypeAnnotationSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return TypeAnnotationSyntax(newData)
   }
@@ -25718,9 +25718,9 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `type` replaced.
   /// - param newChild: The new `type` to replace the node's
   ///                   current `type`, if present.
-  public func withType(_ newChild: TypeSyntax?) -> TypeAnnotationSyntax {
+  public func withType(_ newChild: TypeSyntax) -> TypeAnnotationSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return TypeAnnotationSyntax(newData)
   }
@@ -25957,9 +25957,9 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(_ newChild: PatternSyntax?) -> TuplePatternElementSyntax {
+  public func withPattern(_ newChild: PatternSyntax) -> TuplePatternElementSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return TuplePatternElementSyntax(newData)
   }
@@ -26223,9 +26223,9 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `entry` replaced.
   /// - param newChild: The new `entry` to replace the node's
   ///                   current `entry`, if present.
-  public func withEntry(_ newChild: Entry?) -> AvailabilityArgumentSyntax {
+  public func withEntry(_ newChild: Entry) -> AvailabilityArgumentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missing, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return AvailabilityArgumentSyntax(newData)
   }
@@ -26461,9 +26461,9 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `label` replaced.
   /// - param newChild: The new `label` to replace the node's
   ///                   current `label`, if present.
-  public func withLabel(_ newChild: TokenSyntax?) -> AvailabilityLabeledArgumentSyntax {
+  public func withLabel(_ newChild: TokenSyntax) -> AvailabilityLabeledArgumentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
@@ -26503,9 +26503,9 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> AvailabilityLabeledArgumentSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> AvailabilityLabeledArgumentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
@@ -26545,9 +26545,9 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   /// Returns a copy of the receiver with its `value` replaced.
   /// - param newChild: The new `value` to replace the node's
   ///                   current `value`, if present.
-  public func withValue(_ newChild: Value?) -> AvailabilityLabeledArgumentSyntax {
+  public func withValue(_ newChild: Value) -> AvailabilityLabeledArgumentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missing, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
@@ -26709,9 +26709,9 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `platform` replaced.
   /// - param newChild: The new `platform` to replace the node's
   ///                   current `platform`, if present.
-  public func withPlatform(_ newChild: TokenSyntax?) -> AvailabilityVersionRestrictionSyntax {
+  public func withPlatform(_ newChild: TokenSyntax) -> AvailabilityVersionRestrictionSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return AvailabilityVersionRestrictionSyntax(newData)
   }
@@ -26913,9 +26913,9 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `majorMinor` replaced.
   /// - param newChild: The new `majorMinor` to replace the node's
   ///                   current `majorMinor`, if present.
-  public func withMajorMinor(_ newChild: TokenSyntax?) -> VersionTupleSyntax {
+  public func withMajorMinor(_ newChild: TokenSyntax) -> VersionTupleSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return VersionTupleSyntax(newData)
   }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
@@ -140,9 +140,9 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `isKeyword` replaced.
   /// - param newChild: The new `isKeyword` to replace the node's
   ///                   current `isKeyword`, if present.
-  public func withIsKeyword(_ newChild: TokenSyntax?) -> IsTypePatternSyntax {
+  public func withIsKeyword(_ newChild: TokenSyntax) -> IsTypePatternSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return IsTypePatternSyntax(newData)
   }
@@ -181,9 +181,9 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `type` replaced.
   /// - param newChild: The new `type` to replace the node's
   ///                   current `type`, if present.
-  public func withType(_ newChild: TypeSyntax?) -> IsTypePatternSyntax {
+  public func withType(_ newChild: TypeSyntax) -> IsTypePatternSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return IsTypePatternSyntax(newData)
   }
@@ -324,9 +324,9 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `identifier` replaced.
   /// - param newChild: The new `identifier` to replace the node's
   ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax?) -> IdentifierPatternSyntax {
+  public func withIdentifier(_ newChild: TokenSyntax) -> IdentifierPatternSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.selfKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return IdentifierPatternSyntax(newData)
   }
@@ -467,9 +467,9 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> TuplePatternSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> TuplePatternSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return TuplePatternSyntax(newData)
   }
@@ -527,9 +527,9 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `elements` replaced.
   /// - param newChild: The new `elements` to replace the node's
   ///                   current `elements`, if present.
-  public func withElements(_ newChild: TuplePatternElementListSyntax?) -> TuplePatternSyntax {
+  public func withElements(_ newChild: TuplePatternElementListSyntax) -> TuplePatternSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tuplePatternElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return TuplePatternSyntax(newData)
   }
@@ -568,9 +568,9 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> TuplePatternSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> TuplePatternSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return TuplePatternSyntax(newData)
   }
@@ -723,9 +723,9 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `wildcard` replaced.
   /// - param newChild: The new `wildcard` to replace the node's
   ///                   current `wildcard`, if present.
-  public func withWildcard(_ newChild: TokenSyntax?) -> WildcardPatternSyntax {
+  public func withWildcard(_ newChild: TokenSyntax) -> WildcardPatternSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.wildcardKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return WildcardPatternSyntax(newData)
   }
@@ -908,9 +908,9 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> ExpressionPatternSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> ExpressionPatternSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ExpressionPatternSyntax(newData)
   }
@@ -1047,9 +1047,9 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `letOrVarKeyword` replaced.
   /// - param newChild: The new `letOrVarKeyword` to replace the node's
   ///                   current `letOrVarKeyword`, if present.
-  public func withLetOrVarKeyword(_ newChild: TokenSyntax?) -> ValueBindingPatternSyntax {
+  public func withLetOrVarKeyword(_ newChild: TokenSyntax) -> ValueBindingPatternSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ValueBindingPatternSyntax(newData)
   }
@@ -1088,9 +1088,9 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `valuePattern` replaced.
   /// - param newChild: The new `valuePattern` to replace the node's
   ///                   current `valuePattern`, if present.
-  public func withValuePattern(_ newChild: PatternSyntax?) -> ValueBindingPatternSyntax {
+  public func withValuePattern(_ newChild: PatternSyntax) -> ValueBindingPatternSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return ValueBindingPatternSyntax(newData)
   }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -144,9 +144,9 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `labelName` replaced.
   /// - param newChild: The new `labelName` to replace the node's
   ///                   current `labelName`, if present.
-  public func withLabelName(_ newChild: TokenSyntax?) -> LabeledStmtSyntax {
+  public func withLabelName(_ newChild: TokenSyntax) -> LabeledStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return LabeledStmtSyntax(newData)
   }
@@ -185,9 +185,9 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `labelColon` replaced.
   /// - param newChild: The new `labelColon` to replace the node's
   ///                   current `labelColon`, if present.
-  public func withLabelColon(_ newChild: TokenSyntax?) -> LabeledStmtSyntax {
+  public func withLabelColon(_ newChild: TokenSyntax) -> LabeledStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return LabeledStmtSyntax(newData)
   }
@@ -226,9 +226,9 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `statement` replaced.
   /// - param newChild: The new `statement` to replace the node's
   ///                   current `statement`, if present.
-  public func withStatement(_ newChild: StmtSyntax?) -> LabeledStmtSyntax {
+  public func withStatement(_ newChild: StmtSyntax) -> LabeledStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingStmt, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return LabeledStmtSyntax(newData)
   }
@@ -381,9 +381,9 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `continueKeyword` replaced.
   /// - param newChild: The new `continueKeyword` to replace the node's
   ///                   current `continueKeyword`, if present.
-  public func withContinueKeyword(_ newChild: TokenSyntax?) -> ContinueStmtSyntax {
+  public func withContinueKeyword(_ newChild: TokenSyntax) -> ContinueStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.continueKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ContinueStmtSyntax(newData)
   }
@@ -574,9 +574,9 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `whileKeyword` replaced.
   /// - param newChild: The new `whileKeyword` to replace the node's
   ///                   current `whileKeyword`, if present.
-  public func withWhileKeyword(_ newChild: TokenSyntax?) -> WhileStmtSyntax {
+  public func withWhileKeyword(_ newChild: TokenSyntax) -> WhileStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whileKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return WhileStmtSyntax(newData)
   }
@@ -634,9 +634,9 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `conditions` replaced.
   /// - param newChild: The new `conditions` to replace the node's
   ///                   current `conditions`, if present.
-  public func withConditions(_ newChild: ConditionElementListSyntax?) -> WhileStmtSyntax {
+  public func withConditions(_ newChild: ConditionElementListSyntax) -> WhileStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return WhileStmtSyntax(newData)
   }
@@ -675,9 +675,9 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax?) -> WhileStmtSyntax {
+  public func withBody(_ newChild: CodeBlockSyntax) -> WhileStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return WhileStmtSyntax(newData)
   }
@@ -830,9 +830,9 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `deferKeyword` replaced.
   /// - param newChild: The new `deferKeyword` to replace the node's
   ///                   current `deferKeyword`, if present.
-  public func withDeferKeyword(_ newChild: TokenSyntax?) -> DeferStmtSyntax {
+  public func withDeferKeyword(_ newChild: TokenSyntax) -> DeferStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.deferKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DeferStmtSyntax(newData)
   }
@@ -871,9 +871,9 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax?) -> DeferStmtSyntax {
+  public func withBody(_ newChild: CodeBlockSyntax) -> DeferStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return DeferStmtSyntax(newData)
   }
@@ -1026,9 +1026,9 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `repeatKeyword` replaced.
   /// - param newChild: The new `repeatKeyword` to replace the node's
   ///                   current `repeatKeyword`, if present.
-  public func withRepeatKeyword(_ newChild: TokenSyntax?) -> RepeatWhileStmtSyntax {
+  public func withRepeatKeyword(_ newChild: TokenSyntax) -> RepeatWhileStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.repeatKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return RepeatWhileStmtSyntax(newData)
   }
@@ -1067,9 +1067,9 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax?) -> RepeatWhileStmtSyntax {
+  public func withBody(_ newChild: CodeBlockSyntax) -> RepeatWhileStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return RepeatWhileStmtSyntax(newData)
   }
@@ -1108,9 +1108,9 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `whileKeyword` replaced.
   /// - param newChild: The new `whileKeyword` to replace the node's
   ///                   current `whileKeyword`, if present.
-  public func withWhileKeyword(_ newChild: TokenSyntax?) -> RepeatWhileStmtSyntax {
+  public func withWhileKeyword(_ newChild: TokenSyntax) -> RepeatWhileStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whileKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return RepeatWhileStmtSyntax(newData)
   }
@@ -1149,9 +1149,9 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `condition` replaced.
   /// - param newChild: The new `condition` to replace the node's
   ///                   current `condition`, if present.
-  public func withCondition(_ newChild: ExprSyntax?) -> RepeatWhileStmtSyntax {
+  public func withCondition(_ newChild: ExprSyntax) -> RepeatWhileStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return RepeatWhileStmtSyntax(newData)
   }
@@ -1320,9 +1320,9 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `guardKeyword` replaced.
   /// - param newChild: The new `guardKeyword` to replace the node's
   ///                   current `guardKeyword`, if present.
-  public func withGuardKeyword(_ newChild: TokenSyntax?) -> GuardStmtSyntax {
+  public func withGuardKeyword(_ newChild: TokenSyntax) -> GuardStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.guardKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return GuardStmtSyntax(newData)
   }
@@ -1380,9 +1380,9 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `conditions` replaced.
   /// - param newChild: The new `conditions` to replace the node's
   ///                   current `conditions`, if present.
-  public func withConditions(_ newChild: ConditionElementListSyntax?) -> GuardStmtSyntax {
+  public func withConditions(_ newChild: ConditionElementListSyntax) -> GuardStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return GuardStmtSyntax(newData)
   }
@@ -1421,9 +1421,9 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `elseKeyword` replaced.
   /// - param newChild: The new `elseKeyword` to replace the node's
   ///                   current `elseKeyword`, if present.
-  public func withElseKeyword(_ newChild: TokenSyntax?) -> GuardStmtSyntax {
+  public func withElseKeyword(_ newChild: TokenSyntax) -> GuardStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.elseKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return GuardStmtSyntax(newData)
   }
@@ -1462,9 +1462,9 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax?) -> GuardStmtSyntax {
+  public func withBody(_ newChild: CodeBlockSyntax) -> GuardStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return GuardStmtSyntax(newData)
   }
@@ -1657,9 +1657,9 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `forKeyword` replaced.
   /// - param newChild: The new `forKeyword` to replace the node's
   ///                   current `forKeyword`, if present.
-  public func withForKeyword(_ newChild: TokenSyntax?) -> ForInStmtSyntax {
+  public func withForKeyword(_ newChild: TokenSyntax) -> ForInStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.forKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ForInStmtSyntax(newData)
   }
@@ -1824,9 +1824,9 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `pattern` replaced.
   /// - param newChild: The new `pattern` to replace the node's
   ///                   current `pattern`, if present.
-  public func withPattern(_ newChild: PatternSyntax?) -> ForInStmtSyntax {
+  public func withPattern(_ newChild: PatternSyntax) -> ForInStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 9, with: raw, arena: arena)
     return ForInStmtSyntax(newData)
   }
@@ -1907,9 +1907,9 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `inKeyword` replaced.
   /// - param newChild: The new `inKeyword` to replace the node's
   ///                   current `inKeyword`, if present.
-  public func withInKeyword(_ newChild: TokenSyntax?) -> ForInStmtSyntax {
+  public func withInKeyword(_ newChild: TokenSyntax) -> ForInStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.inKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 13, with: raw, arena: arena)
     return ForInStmtSyntax(newData)
   }
@@ -1948,9 +1948,9 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `sequenceExpr` replaced.
   /// - param newChild: The new `sequenceExpr` to replace the node's
   ///                   current `sequenceExpr`, if present.
-  public func withSequenceExpr(_ newChild: ExprSyntax?) -> ForInStmtSyntax {
+  public func withSequenceExpr(_ newChild: ExprSyntax) -> ForInStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 15, with: raw, arena: arena)
     return ForInStmtSyntax(newData)
   }
@@ -2031,9 +2031,9 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax?) -> ForInStmtSyntax {
+  public func withBody(_ newChild: CodeBlockSyntax) -> ForInStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 19, with: raw, arena: arena)
     return ForInStmtSyntax(newData)
   }
@@ -2254,9 +2254,9 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `switchKeyword` replaced.
   /// - param newChild: The new `switchKeyword` to replace the node's
   ///                   current `switchKeyword`, if present.
-  public func withSwitchKeyword(_ newChild: TokenSyntax?) -> SwitchStmtSyntax {
+  public func withSwitchKeyword(_ newChild: TokenSyntax) -> SwitchStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.switchKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return SwitchStmtSyntax(newData)
   }
@@ -2295,9 +2295,9 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> SwitchStmtSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> SwitchStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return SwitchStmtSyntax(newData)
   }
@@ -2336,9 +2336,9 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftBrace` replaced.
   /// - param newChild: The new `leftBrace` to replace the node's
   ///                   current `leftBrace`, if present.
-  public func withLeftBrace(_ newChild: TokenSyntax?) -> SwitchStmtSyntax {
+  public func withLeftBrace(_ newChild: TokenSyntax) -> SwitchStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return SwitchStmtSyntax(newData)
   }
@@ -2396,9 +2396,9 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `cases` replaced.
   /// - param newChild: The new `cases` to replace the node's
   ///                   current `cases`, if present.
-  public func withCases(_ newChild: SwitchCaseListSyntax?) -> SwitchStmtSyntax {
+  public func withCases(_ newChild: SwitchCaseListSyntax) -> SwitchStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.switchCaseList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return SwitchStmtSyntax(newData)
   }
@@ -2437,9 +2437,9 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightBrace` replaced.
   /// - param newChild: The new `rightBrace` to replace the node's
   ///                   current `rightBrace`, if present.
-  public func withRightBrace(_ newChild: TokenSyntax?) -> SwitchStmtSyntax {
+  public func withRightBrace(_ newChild: TokenSyntax) -> SwitchStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 9, with: raw, arena: arena)
     return SwitchStmtSyntax(newData)
   }
@@ -2612,9 +2612,9 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `doKeyword` replaced.
   /// - param newChild: The new `doKeyword` to replace the node's
   ///                   current `doKeyword`, if present.
-  public func withDoKeyword(_ newChild: TokenSyntax?) -> DoStmtSyntax {
+  public func withDoKeyword(_ newChild: TokenSyntax) -> DoStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.doKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DoStmtSyntax(newData)
   }
@@ -2653,9 +2653,9 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax?) -> DoStmtSyntax {
+  public func withBody(_ newChild: CodeBlockSyntax) -> DoStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return DoStmtSyntax(newData)
   }
@@ -2899,9 +2899,9 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `returnKeyword` replaced.
   /// - param newChild: The new `returnKeyword` to replace the node's
   ///                   current `returnKeyword`, if present.
-  public func withReturnKeyword(_ newChild: TokenSyntax?) -> ReturnStmtSyntax {
+  public func withReturnKeyword(_ newChild: TokenSyntax) -> ReturnStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.returnKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ReturnStmtSyntax(newData)
   }
@@ -3124,9 +3124,9 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `yieldKeyword` replaced.
   /// - param newChild: The new `yieldKeyword` to replace the node's
   ///                   current `yieldKeyword`, if present.
-  public func withYieldKeyword(_ newChild: TokenSyntax?) -> YieldStmtSyntax {
+  public func withYieldKeyword(_ newChild: TokenSyntax) -> YieldStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.yield, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return YieldStmtSyntax(newData)
   }
@@ -3165,9 +3165,9 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `yields` replaced.
   /// - param newChild: The new `yields` to replace the node's
   ///                   current `yields`, if present.
-  public func withYields(_ newChild: Yields?) -> YieldStmtSyntax {
+  public func withYields(_ newChild: Yields) -> YieldStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missing, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return YieldStmtSyntax(newData)
   }
@@ -3308,9 +3308,9 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `fallthroughKeyword` replaced.
   /// - param newChild: The new `fallthroughKeyword` to replace the node's
   ///                   current `fallthroughKeyword`, if present.
-  public func withFallthroughKeyword(_ newChild: TokenSyntax?) -> FallthroughStmtSyntax {
+  public func withFallthroughKeyword(_ newChild: TokenSyntax) -> FallthroughStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.fallthroughKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return FallthroughStmtSyntax(newData)
   }
@@ -3447,9 +3447,9 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `breakKeyword` replaced.
   /// - param newChild: The new `breakKeyword` to replace the node's
   ///                   current `breakKeyword`, if present.
-  public func withBreakKeyword(_ newChild: TokenSyntax?) -> BreakStmtSyntax {
+  public func withBreakKeyword(_ newChild: TokenSyntax) -> BreakStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.breakKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return BreakStmtSyntax(newData)
   }
@@ -3636,9 +3636,9 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `throwKeyword` replaced.
   /// - param newChild: The new `throwKeyword` to replace the node's
   ///                   current `throwKeyword`, if present.
-  public func withThrowKeyword(_ newChild: TokenSyntax?) -> ThrowStmtSyntax {
+  public func withThrowKeyword(_ newChild: TokenSyntax) -> ThrowStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.throwKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ThrowStmtSyntax(newData)
   }
@@ -3677,9 +3677,9 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `expression` replaced.
   /// - param newChild: The new `expression` to replace the node's
   ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> ThrowStmtSyntax {
+  public func withExpression(_ newChild: ExprSyntax) -> ThrowStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return ThrowStmtSyntax(newData)
   }
@@ -3872,9 +3872,9 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `ifKeyword` replaced.
   /// - param newChild: The new `ifKeyword` to replace the node's
   ///                   current `ifKeyword`, if present.
-  public func withIfKeyword(_ newChild: TokenSyntax?) -> IfStmtSyntax {
+  public func withIfKeyword(_ newChild: TokenSyntax) -> IfStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.ifKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return IfStmtSyntax(newData)
   }
@@ -3932,9 +3932,9 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `conditions` replaced.
   /// - param newChild: The new `conditions` to replace the node's
   ///                   current `conditions`, if present.
-  public func withConditions(_ newChild: ConditionElementListSyntax?) -> IfStmtSyntax {
+  public func withConditions(_ newChild: ConditionElementListSyntax) -> IfStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return IfStmtSyntax(newData)
   }
@@ -3973,9 +3973,9 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `body` replaced.
   /// - param newChild: The new `body` to replace the node's
   ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax?) -> IfStmtSyntax {
+  public func withBody(_ newChild: CodeBlockSyntax) -> IfStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return IfStmtSyntax(newData)
   }
@@ -4244,9 +4244,9 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `poundAssert` replaced.
   /// - param newChild: The new `poundAssert` to replace the node's
   ///                   current `poundAssert`, if present.
-  public func withPoundAssert(_ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
+  public func withPoundAssert(_ newChild: TokenSyntax) -> PoundAssertStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundAssertKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
@@ -4285,9 +4285,9 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> PoundAssertStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
@@ -4327,9 +4327,9 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `condition` replaced.
   /// - param newChild: The new `condition` to replace the node's
   ///                   current `condition`, if present.
-  public func withCondition(_ newChild: ExprSyntax?) -> PoundAssertStmtSyntax {
+  public func withCondition(_ newChild: ExprSyntax) -> PoundAssertStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }
@@ -4454,9 +4454,9 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> PoundAssertStmtSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 11, with: raw, arena: arena)
     return PoundAssertStmtSyntax(newData)
   }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -140,9 +140,9 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> SimpleTypeIdentifierSyntax {
+  public func withName(_ newChild: TokenSyntax) -> SimpleTypeIdentifierSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return SimpleTypeIdentifierSyntax(newData)
   }
@@ -337,9 +337,9 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `baseType` replaced.
   /// - param newChild: The new `baseType` to replace the node's
   ///                   current `baseType`, if present.
-  public func withBaseType(_ newChild: TypeSyntax?) -> MemberTypeIdentifierSyntax {
+  public func withBaseType(_ newChild: TypeSyntax) -> MemberTypeIdentifierSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return MemberTypeIdentifierSyntax(newData)
   }
@@ -378,9 +378,9 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `period` replaced.
   /// - param newChild: The new `period` to replace the node's
   ///                   current `period`, if present.
-  public func withPeriod(_ newChild: TokenSyntax?) -> MemberTypeIdentifierSyntax {
+  public func withPeriod(_ newChild: TokenSyntax) -> MemberTypeIdentifierSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return MemberTypeIdentifierSyntax(newData)
   }
@@ -419,9 +419,9 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `name` replaced.
   /// - param newChild: The new `name` to replace the node's
   ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> MemberTypeIdentifierSyntax {
+  public func withName(_ newChild: TokenSyntax) -> MemberTypeIdentifierSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return MemberTypeIdentifierSyntax(newData)
   }
@@ -620,9 +620,9 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `classKeyword` replaced.
   /// - param newChild: The new `classKeyword` to replace the node's
   ///                   current `classKeyword`, if present.
-  public func withClassKeyword(_ newChild: TokenSyntax?) -> ClassRestrictionTypeSyntax {
+  public func withClassKeyword(_ newChild: TokenSyntax) -> ClassRestrictionTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.classKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ClassRestrictionTypeSyntax(newData)
   }
@@ -763,9 +763,9 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftSquareBracket` replaced.
   /// - param newChild: The new `leftSquareBracket` to replace the node's
   ///                   current `leftSquareBracket`, if present.
-  public func withLeftSquareBracket(_ newChild: TokenSyntax?) -> ArrayTypeSyntax {
+  public func withLeftSquareBracket(_ newChild: TokenSyntax) -> ArrayTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ArrayTypeSyntax(newData)
   }
@@ -804,9 +804,9 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `elementType` replaced.
   /// - param newChild: The new `elementType` to replace the node's
   ///                   current `elementType`, if present.
-  public func withElementType(_ newChild: TypeSyntax?) -> ArrayTypeSyntax {
+  public func withElementType(_ newChild: TypeSyntax) -> ArrayTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return ArrayTypeSyntax(newData)
   }
@@ -845,9 +845,9 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightSquareBracket` replaced.
   /// - param newChild: The new `rightSquareBracket` to replace the node's
   ///                   current `rightSquareBracket`, if present.
-  public func withRightSquareBracket(_ newChild: TokenSyntax?) -> ArrayTypeSyntax {
+  public func withRightSquareBracket(_ newChild: TokenSyntax) -> ArrayTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return ArrayTypeSyntax(newData)
   }
@@ -1012,9 +1012,9 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftSquareBracket` replaced.
   /// - param newChild: The new `leftSquareBracket` to replace the node's
   ///                   current `leftSquareBracket`, if present.
-  public func withLeftSquareBracket(_ newChild: TokenSyntax?) -> DictionaryTypeSyntax {
+  public func withLeftSquareBracket(_ newChild: TokenSyntax) -> DictionaryTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
@@ -1053,9 +1053,9 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `keyType` replaced.
   /// - param newChild: The new `keyType` to replace the node's
   ///                   current `keyType`, if present.
-  public func withKeyType(_ newChild: TypeSyntax?) -> DictionaryTypeSyntax {
+  public func withKeyType(_ newChild: TypeSyntax) -> DictionaryTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
@@ -1094,9 +1094,9 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `colon` replaced.
   /// - param newChild: The new `colon` to replace the node's
   ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> DictionaryTypeSyntax {
+  public func withColon(_ newChild: TokenSyntax) -> DictionaryTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
@@ -1135,9 +1135,9 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `valueType` replaced.
   /// - param newChild: The new `valueType` to replace the node's
   ///                   current `valueType`, if present.
-  public func withValueType(_ newChild: TypeSyntax?) -> DictionaryTypeSyntax {
+  public func withValueType(_ newChild: TypeSyntax) -> DictionaryTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 7, with: raw, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
@@ -1176,9 +1176,9 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightSquareBracket` replaced.
   /// - param newChild: The new `rightSquareBracket` to replace the node's
   ///                   current `rightSquareBracket`, if present.
-  public func withRightSquareBracket(_ newChild: TokenSyntax?) -> DictionaryTypeSyntax {
+  public func withRightSquareBracket(_ newChild: TokenSyntax) -> DictionaryTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 9, with: raw, arena: arena)
     return DictionaryTypeSyntax(newData)
   }
@@ -1351,9 +1351,9 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `baseType` replaced.
   /// - param newChild: The new `baseType` to replace the node's
   ///                   current `baseType`, if present.
-  public func withBaseType(_ newChild: TypeSyntax?) -> MetatypeTypeSyntax {
+  public func withBaseType(_ newChild: TypeSyntax) -> MetatypeTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return MetatypeTypeSyntax(newData)
   }
@@ -1392,9 +1392,9 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `period` replaced.
   /// - param newChild: The new `period` to replace the node's
   ///                   current `period`, if present.
-  public func withPeriod(_ newChild: TokenSyntax?) -> MetatypeTypeSyntax {
+  public func withPeriod(_ newChild: TokenSyntax) -> MetatypeTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return MetatypeTypeSyntax(newData)
   }
@@ -1433,9 +1433,9 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `typeOrProtocol` replaced.
   /// - param newChild: The new `typeOrProtocol` to replace the node's
   ///                   current `typeOrProtocol`, if present.
-  public func withTypeOrProtocol(_ newChild: TokenSyntax?) -> MetatypeTypeSyntax {
+  public func withTypeOrProtocol(_ newChild: TokenSyntax) -> MetatypeTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return MetatypeTypeSyntax(newData)
   }
@@ -1588,9 +1588,9 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `wrappedType` replaced.
   /// - param newChild: The new `wrappedType` to replace the node's
   ///                   current `wrappedType`, if present.
-  public func withWrappedType(_ newChild: TypeSyntax?) -> OptionalTypeSyntax {
+  public func withWrappedType(_ newChild: TypeSyntax) -> OptionalTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return OptionalTypeSyntax(newData)
   }
@@ -1629,9 +1629,9 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `questionMark` replaced.
   /// - param newChild: The new `questionMark` to replace the node's
   ///                   current `questionMark`, if present.
-  public func withQuestionMark(_ newChild: TokenSyntax?) -> OptionalTypeSyntax {
+  public func withQuestionMark(_ newChild: TokenSyntax) -> OptionalTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return OptionalTypeSyntax(newData)
   }
@@ -1776,9 +1776,9 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `someOrAnySpecifier` replaced.
   /// - param newChild: The new `someOrAnySpecifier` to replace the node's
   ///                   current `someOrAnySpecifier`, if present.
-  public func withSomeOrAnySpecifier(_ newChild: TokenSyntax?) -> ConstrainedSugarTypeSyntax {
+  public func withSomeOrAnySpecifier(_ newChild: TokenSyntax) -> ConstrainedSugarTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ConstrainedSugarTypeSyntax(newData)
   }
@@ -1817,9 +1817,9 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `baseType` replaced.
   /// - param newChild: The new `baseType` to replace the node's
   ///                   current `baseType`, if present.
-  public func withBaseType(_ newChild: TypeSyntax?) -> ConstrainedSugarTypeSyntax {
+  public func withBaseType(_ newChild: TypeSyntax) -> ConstrainedSugarTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return ConstrainedSugarTypeSyntax(newData)
   }
@@ -1964,9 +1964,9 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
   /// Returns a copy of the receiver with its `wrappedType` replaced.
   /// - param newChild: The new `wrappedType` to replace the node's
   ///                   current `wrappedType`, if present.
-  public func withWrappedType(_ newChild: TypeSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
+  public func withWrappedType(_ newChild: TypeSyntax) -> ImplicitlyUnwrappedOptionalTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
@@ -2005,9 +2005,9 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
   /// Returns a copy of the receiver with its `exclamationMark` replaced.
   /// - param newChild: The new `exclamationMark` to replace the node's
   ///                   current `exclamationMark`, if present.
-  public func withExclamationMark(_ newChild: TokenSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
+  public func withExclamationMark(_ newChild: TokenSyntax) -> ImplicitlyUnwrappedOptionalTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.exclamationMark, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
@@ -2167,9 +2167,9 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `elements` replaced.
   /// - param newChild: The new `elements` to replace the node's
   ///                   current `elements`, if present.
-  public func withElements(_ newChild: CompositionTypeElementListSyntax?) -> CompositionTypeSyntax {
+  public func withElements(_ newChild: CompositionTypeElementListSyntax) -> CompositionTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.compositionTypeElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return CompositionTypeSyntax(newData)
   }
@@ -2306,9 +2306,9 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `repeatKeyword` replaced.
   /// - param newChild: The new `repeatKeyword` to replace the node's
   ///                   current `repeatKeyword`, if present.
-  public func withRepeatKeyword(_ newChild: TokenSyntax?) -> PackExpansionTypeSyntax {
+  public func withRepeatKeyword(_ newChild: TokenSyntax) -> PackExpansionTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.repeatKeyword, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PackExpansionTypeSyntax(newData)
   }
@@ -2347,9 +2347,9 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `patternType` replaced.
   /// - param newChild: The new `patternType` to replace the node's
   ///                   current `patternType`, if present.
-  public func withPatternType(_ newChild: TypeSyntax?) -> PackExpansionTypeSyntax {
+  public func withPatternType(_ newChild: TypeSyntax) -> PackExpansionTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PackExpansionTypeSyntax(newData)
   }
@@ -2494,9 +2494,9 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `eachKeyword` replaced.
   /// - param newChild: The new `eachKeyword` to replace the node's
   ///                   current `eachKeyword`, if present.
-  public func withEachKeyword(_ newChild: TokenSyntax?) -> PackReferenceTypeSyntax {
+  public func withEachKeyword(_ newChild: TokenSyntax) -> PackReferenceTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return PackReferenceTypeSyntax(newData)
   }
@@ -2535,9 +2535,9 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `packType` replaced.
   /// - param newChild: The new `packType` to replace the node's
   ///                   current `packType`, if present.
-  public func withPackType(_ newChild: TypeSyntax?) -> PackReferenceTypeSyntax {
+  public func withPackType(_ newChild: TypeSyntax) -> PackReferenceTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return PackReferenceTypeSyntax(newData)
   }
@@ -2686,9 +2686,9 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> TupleTypeSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> TupleTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return TupleTypeSyntax(newData)
   }
@@ -2746,9 +2746,9 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `elements` replaced.
   /// - param newChild: The new `elements` to replace the node's
   ///                   current `elements`, if present.
-  public func withElements(_ newChild: TupleTypeElementListSyntax?) -> TupleTypeSyntax {
+  public func withElements(_ newChild: TupleTypeElementListSyntax) -> TupleTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleTypeElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return TupleTypeSyntax(newData)
   }
@@ -2787,9 +2787,9 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> TupleTypeSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> TupleTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return TupleTypeSyntax(newData)
   }
@@ -2962,9 +2962,9 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `leftParen` replaced.
   /// - param newChild: The new `leftParen` to replace the node's
   ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> FunctionTypeSyntax {
+  public func withLeftParen(_ newChild: TokenSyntax) -> FunctionTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return FunctionTypeSyntax(newData)
   }
@@ -3022,9 +3022,9 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `arguments` replaced.
   /// - param newChild: The new `arguments` to replace the node's
   ///                   current `arguments`, if present.
-  public func withArguments(_ newChild: TupleTypeElementListSyntax?) -> FunctionTypeSyntax {
+  public func withArguments(_ newChild: TupleTypeElementListSyntax) -> FunctionTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleTypeElementList, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return FunctionTypeSyntax(newData)
   }
@@ -3063,9 +3063,9 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `rightParen` replaced.
   /// - param newChild: The new `rightParen` to replace the node's
   ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> FunctionTypeSyntax {
+  public func withRightParen(_ newChild: TokenSyntax) -> FunctionTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return FunctionTypeSyntax(newData)
   }
@@ -3188,9 +3188,9 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `arrow` replaced.
   /// - param newChild: The new `arrow` to replace the node's
   ///                   current `arrow`, if present.
-  public func withArrow(_ newChild: TokenSyntax?) -> FunctionTypeSyntax {
+  public func withArrow(_ newChild: TokenSyntax) -> FunctionTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 11, with: raw, arena: arena)
     return FunctionTypeSyntax(newData)
   }
@@ -3229,9 +3229,9 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `returnType` replaced.
   /// - param newChild: The new `returnType` to replace the node's
   ///                   current `returnType`, if present.
-  public func withReturnType(_ newChild: TypeSyntax?) -> FunctionTypeSyntax {
+  public func withReturnType(_ newChild: TypeSyntax) -> FunctionTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 13, with: raw, arena: arena)
     return FunctionTypeSyntax(newData)
   }
@@ -3523,9 +3523,9 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `baseType` replaced.
   /// - param newChild: The new `baseType` to replace the node's
   ///                   current `baseType`, if present.
-  public func withBaseType(_ newChild: TypeSyntax?) -> AttributedTypeSyntax {
+  public func withBaseType(_ newChild: TypeSyntax) -> AttributedTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
     return AttributedTypeSyntax(newData)
   }
@@ -3678,9 +3678,9 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `genericParameters` replaced.
   /// - param newChild: The new `genericParameters` to replace the node's
   ///                   current `genericParameters`, if present.
-  public func withGenericParameters(_ newChild: GenericParameterClauseSyntax?) -> NamedOpaqueReturnTypeSyntax {
+  public func withGenericParameters(_ newChild: GenericParameterClauseSyntax) -> NamedOpaqueReturnTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericParameterClause, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
     return NamedOpaqueReturnTypeSyntax(newData)
   }
@@ -3719,9 +3719,9 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `baseType` replaced.
   /// - param newChild: The new `baseType` to replace the node's
   ///                   current `baseType`, if present.
-  public func withBaseType(_ newChild: TypeSyntax?) -> NamedOpaqueReturnTypeSyntax {
+  public func withBaseType(_ newChild: TypeSyntax) -> NamedOpaqueReturnTypeSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let raw = newChild.raw
     let newData = data.replacingChild(at: 3, with: raw, arena: arena)
     return NamedOpaqueReturnTypeSyntax(newData)
   }

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -28,7 +28,7 @@ extension AccessorDecl {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifier: UnexpectedNodes? = nil, modifier: DeclModifier? = nil, unexpectedBetweenModifierAndAccessorKind: UnexpectedNodes? = nil, accessorKind: Token, unexpectedBetweenAccessorKindAndParameter: UnexpectedNodes? = nil, parameter: AccessorParameter? = nil, unexpectedBetweenParameterAndAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: String?, unexpectedBetweenAsyncKeywordAndThrowsKeyword: UnexpectedNodes? = nil, throwsKeyword: Token? = nil, unexpectedBetweenThrowsKeywordAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax? = {
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifier: UnexpectedNodes? = nil, modifier: DeclModifier? = nil, unexpectedBetweenModifierAndAccessorKind: UnexpectedNodes? = nil, accessorKind: Token, unexpectedBetweenAccessorKindAndParameter: UnexpectedNodes? = nil, parameter: AccessorParameter? = nil, unexpectedBetweenParameterAndAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: Keyword?, unexpectedBetweenAsyncKeywordAndThrowsKeyword: UnexpectedNodes? = nil, throwsKeyword: Token? = nil, unexpectedBetweenThrowsKeywordAndBody: UnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemListSyntax? = {
       nil
     }, trailingTrivia: Trivia? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifier, modifier: modifier, unexpectedBetweenModifierAndAccessorKind, accessorKind: accessorKind, unexpectedBetweenAccessorKindAndParameter, parameter: parameter, unexpectedBetweenParameterAndAsyncKeyword, asyncKeyword: asyncKeyword.map { 
@@ -52,7 +52,7 @@ extension ActorDecl {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndActorKeyword: UnexpectedNodes? = nil, actorKeyword: String, unexpectedBetweenActorKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndActorKeyword: UnexpectedNodes? = nil, actorKeyword: Keyword, unexpectedBetweenActorKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodes? = nil, inheritanceClause: TypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodes? = nil, @MemberDeclListBuilder membersBuilder: () -> MemberDeclListSyntax = {
       MemberDeclListSyntax([])
     }, trailingTrivia: Trivia? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndActorKeyword, actorKeyword: Token.`contextualKeyword`(actorKeyword), unexpectedBetweenActorKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: MemberDeclBlockSyntax(members: membersBuilder()), trailingTrivia: trailingTrivia)
@@ -85,7 +85,7 @@ extension ArrowExpr {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: String?, unexpectedBetweenAsyncKeywordAndThrowsToken: UnexpectedNodes? = nil, throwsToken: Token? = nil, unexpectedBetweenThrowsTokenAndArrowToken: UnexpectedNodes? = nil, arrowToken: Token = Token.`arrow`, trailingTrivia: Trivia? = nil) {
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: Keyword?, unexpectedBetweenAsyncKeywordAndThrowsToken: UnexpectedNodes? = nil, throwsToken: Token? = nil, unexpectedBetweenThrowsTokenAndArrowToken: UnexpectedNodes? = nil, arrowToken: Token = Token.`arrow`, trailingTrivia: Trivia? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAsyncKeyword, asyncKeyword: asyncKeyword.map { 
         Token.`contextualKeyword`($0) 
       }, unexpectedBetweenAsyncKeywordAndThrowsToken, throwsToken: throwsToken, unexpectedBetweenThrowsTokenAndArrowToken, arrowToken: arrowToken, trailingTrivia: trailingTrivia)
@@ -135,7 +135,7 @@ extension AwaitExpr {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeAwaitKeyword: UnexpectedNodes? = nil, awaitKeyword: String, unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, trailingTrivia: Trivia? = nil) {
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeAwaitKeyword: UnexpectedNodes? = nil, awaitKeyword: Keyword, unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, trailingTrivia: Trivia? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAwaitKeyword, awaitKeyword: Token.`contextualKeyword`(awaitKeyword), unexpectedBetweenAwaitKeywordAndExpression, expression: ExprSyntax(fromProtocol: expression), trailingTrivia: trailingTrivia)
   }
 }
@@ -154,7 +154,7 @@ extension BorrowExpr {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeBorrowKeyword: UnexpectedNodes? = nil, borrowKeyword: String, unexpectedBetweenBorrowKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, trailingTrivia: Trivia? = nil) {
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeBorrowKeyword: UnexpectedNodes? = nil, borrowKeyword: Keyword, unexpectedBetweenBorrowKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, trailingTrivia: Trivia? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeBorrowKeyword, borrowKeyword: Token.`contextualKeyword`(borrowKeyword), unexpectedBetweenBorrowKeywordAndExpression, expression: ExprSyntax(fromProtocol: expression), trailingTrivia: trailingTrivia)
   }
 }
@@ -271,7 +271,7 @@ extension ClosureSignature {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndCapture: UnexpectedNodes? = nil, capture: ClosureCaptureSignature? = nil, unexpectedBetweenCaptureAndInput: UnexpectedNodes? = nil, input: Input? = nil, unexpectedBetweenInputAndAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: String?, unexpectedBetweenAsyncKeywordAndThrowsTok: UnexpectedNodes? = nil, throwsTok: Token? = nil, unexpectedBetweenThrowsTokAndOutput: UnexpectedNodes? = nil, output: ReturnClause? = nil, unexpectedBetweenOutputAndInTok: UnexpectedNodes? = nil, inTok: Token = Token.`in`, trailingTrivia: Trivia? = nil) {
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndCapture: UnexpectedNodes? = nil, capture: ClosureCaptureSignature? = nil, unexpectedBetweenCaptureAndInput: UnexpectedNodes? = nil, input: Input? = nil, unexpectedBetweenInputAndAsyncKeyword: UnexpectedNodes? = nil, asyncKeyword: Keyword?, unexpectedBetweenAsyncKeywordAndThrowsTok: UnexpectedNodes? = nil, throwsTok: Token? = nil, unexpectedBetweenThrowsTokAndOutput: UnexpectedNodes? = nil, output: ReturnClause? = nil, unexpectedBetweenOutputAndInTok: UnexpectedNodes? = nil, inTok: Token = Token.`in`, trailingTrivia: Trivia? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndCapture, capture: capture, unexpectedBetweenCaptureAndInput, input: input, unexpectedBetweenInputAndAsyncKeyword, asyncKeyword: asyncKeyword.map { 
         Token.`contextualKeyword`($0) 
       }, unexpectedBetweenAsyncKeywordAndThrowsTok, throwsTok: throwsTok, unexpectedBetweenThrowsTokAndOutput, output: output, unexpectedBetweenOutputAndInTok, inTok: inTok, trailingTrivia: trailingTrivia)
@@ -603,7 +603,7 @@ extension FunctionSignature {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeInput: UnexpectedNodes? = nil, input: ParameterClause, unexpectedBetweenInputAndAsyncOrReasyncKeyword: UnexpectedNodes? = nil, asyncOrReasyncKeyword: String?, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodes? = nil, throwsOrRethrowsKeyword: Token? = nil, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: UnexpectedNodes? = nil, output: ReturnClause? = nil, trailingTrivia: Trivia? = nil) {
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeInput: UnexpectedNodes? = nil, input: ParameterClause, unexpectedBetweenInputAndAsyncOrReasyncKeyword: UnexpectedNodes? = nil, asyncOrReasyncKeyword: Keyword?, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodes? = nil, throwsOrRethrowsKeyword: Token? = nil, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: UnexpectedNodes? = nil, output: ReturnClause? = nil, trailingTrivia: Trivia? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeInput, input: input, unexpectedBetweenInputAndAsyncOrReasyncKeyword, asyncOrReasyncKeyword: asyncOrReasyncKeyword.map { 
         Token.`contextualKeyword`($0) 
       }, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword, throwsOrRethrowsKeyword: throwsOrRethrowsKeyword, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput, output: output, trailingTrivia: trailingTrivia)
@@ -794,7 +794,7 @@ extension MacroDecl {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndMacroKeyword: UnexpectedNodes? = nil, macroKeyword: String, unexpectedBetweenMacroKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodes? = nil, signature: Signature, unexpectedBetweenSignatureAndDefinition: UnexpectedNodes? = nil, definition: InitializerClause? = nil, unexpectedBetweenDefinitionAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, trailingTrivia: Trivia? = nil) {
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeAttributes: UnexpectedNodes? = nil, attributes: AttributeList? = nil, unexpectedBetweenAttributesAndModifiers: UnexpectedNodes? = nil, modifiers: ModifierList? = nil, unexpectedBetweenModifiersAndMacroKeyword: UnexpectedNodes? = nil, macroKeyword: Keyword, unexpectedBetweenMacroKeywordAndIdentifier: UnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodes? = nil, genericParameterClause: GenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodes? = nil, signature: Signature, unexpectedBetweenSignatureAndDefinition: UnexpectedNodes? = nil, definition: InitializerClause? = nil, unexpectedBetweenDefinitionAndGenericWhereClause: UnexpectedNodes? = nil, genericWhereClause: GenericWhereClause? = nil, trailingTrivia: Trivia? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndMacroKeyword, macroKeyword: Token.`contextualKeyword`(macroKeyword), unexpectedBetweenMacroKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature, signature: signature, unexpectedBetweenSignatureAndDefinition, definition: definition, unexpectedBetweenDefinitionAndGenericWhereClause, genericWhereClause: genericWhereClause, trailingTrivia: trailingTrivia)
   }
 }
@@ -845,7 +845,7 @@ extension MoveExpr {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeMoveKeyword: UnexpectedNodes? = nil, moveKeyword: String, unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, trailingTrivia: Trivia? = nil) {
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeMoveKeyword: UnexpectedNodes? = nil, moveKeyword: Keyword, unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodes? = nil, expression: ExprSyntaxProtocol, trailingTrivia: Trivia? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeMoveKeyword, moveKeyword: Token.`contextualKeyword`(moveKeyword), unexpectedBetweenMoveKeywordAndExpression, expression: ExprSyntax(fromProtocol: expression), trailingTrivia: trailingTrivia)
   }
 }
@@ -886,7 +886,7 @@ extension PackElementExpr {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeEachKeyword: UnexpectedNodes? = nil, eachKeyword: String, unexpectedBetweenEachKeywordAndPackRefExpr: UnexpectedNodes? = nil, packRefExpr: ExprSyntaxProtocol, trailingTrivia: Trivia? = nil) {
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeEachKeyword: UnexpectedNodes? = nil, eachKeyword: Keyword, unexpectedBetweenEachKeywordAndPackRefExpr: UnexpectedNodes? = nil, packRefExpr: ExprSyntaxProtocol, trailingTrivia: Trivia? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeEachKeyword, eachKeyword: Token.`contextualKeyword`(eachKeyword), unexpectedBetweenEachKeywordAndPackRefExpr, packRefExpr: ExprSyntax(fromProtocol: packRefExpr), trailingTrivia: trailingTrivia)
   }
 }

--- a/Sources/SwiftSyntaxBuilder/generated/Token.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/Token.swift
@@ -543,6 +543,6 @@ public extension TokenSyntax {
   
   /// The `open` contextual token
   static var open: TokenSyntax {
-    return .contextualKeyword("open").withTrailingTrivia(.space)
+    return .contextualKeyword(.open).withTrailingTrivia(.space)
   }
 }

--- a/Tests/PerformanceTest/ParsingPerformanceTests.swift
+++ b/Tests/PerformanceTest/ParsingPerformanceTests.swift
@@ -24,7 +24,8 @@ public class ParsingPerformanceTests: XCTestCase {
       .appendingPathComponent("MinimalCollections.swift.input")
   }
 
-  func testParsingPerformance() {
+  func testParsingPerformance() throws {
+    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
     measure {
       do {
         _ = try SyntaxParser.parse(inputFile)
@@ -34,7 +35,8 @@ public class ParsingPerformanceTests: XCTestCase {
     }
   }
 
-  func testNativeParsingPerformance() {
+  func testNativeParsingPerformance() throws {
+    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
     measure {
       do {
         let source = try String(contentsOf: inputFile)

--- a/Tests/PerformanceTest/SyntaxClassifierPerformanceTests.swift
+++ b/Tests/PerformanceTest/SyntaxClassifierPerformanceTests.swift
@@ -24,7 +24,8 @@ public class SyntaxClassifierPerformanceTests: XCTestCase {
       .appendingPathComponent("MinimalCollections.swift.input")
   }
 
-  func testParsingPerformance() {
+  func testClassifierPerformance() throws {
+    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
     XCTAssertNoThrow(
       try {
         let parsed = try SyntaxParser.parse(inputFile)

--- a/Tests/PerformanceTest/VisitorPerformanceTests.swift
+++ b/Tests/PerformanceTest/VisitorPerformanceTests.swift
@@ -23,7 +23,8 @@ public class VisitorPerformanceTests: XCTestCase {
       .appendingPathComponent("MinimalCollections.swift.input")
   }
 
-  func testEmptyVisitorPerformance() {
+  func testEmptyVisitorPerformance() throws {
+    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
     class EmptyVisitor: SyntaxVisitor {}
 
     XCTAssertNoThrow(
@@ -39,7 +40,8 @@ public class VisitorPerformanceTests: XCTestCase {
     )
   }
 
-  func testEmptyRewriterPerformance() {
+  func testEmptyRewriterPerformance() throws {
+    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
     class EmptyRewriter: SyntaxRewriter {}
 
     XCTAssertNoThrow(
@@ -55,7 +57,8 @@ public class VisitorPerformanceTests: XCTestCase {
     )
   }
 
-  func testEmptyAnyVistorPerformance() {
+  func testEmptyAnyVistorPerformance() throws {
+    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
     class EmptyAnyVisitor: SyntaxAnyVisitor {}
 
     XCTAssertNoThrow(

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -20,7 +20,7 @@ import _SwiftSyntaxTestSupport
 // MARK: Lexing Assertions
 
 struct LexemeSpec {
-  let tokenKind: RawTokenKind
+  let rawTokenKind: RawTokenKind
   let leadingTrivia: SyntaxText
   let tokenText: SyntaxText
   let trailingTrivia: SyntaxText
@@ -33,7 +33,7 @@ struct LexemeSpec {
   let line: UInt
 
   init(
-    _ tokenKind: RawTokenKind,
+    _ rawTokenKind: RawTokenKind,
     leading: SyntaxText = "",
     text: SyntaxText,
     trailing: SyntaxText = "",
@@ -43,7 +43,7 @@ struct LexemeSpec {
     file: StaticString = #file,
     line: UInt = #line
   ) {
-    self.tokenKind = tokenKind
+    self.rawTokenKind = rawTokenKind
     self.leadingTrivia = leading
     self.tokenText = text
     self.trailingTrivia = trailing
@@ -86,9 +86,9 @@ private func AssertTokens(
     defer {
       lexemeStartOffset = actualLexeme.byteLength
     }
-    if actualLexeme.tokenKind != expectedLexeme.tokenKind {
+    if actualLexeme.rawTokenKind != expectedLexeme.rawTokenKind {
       XCTFail(
-        "Expected token kind \(expectedLexeme.tokenKind) but got \(actualLexeme.tokenKind)",
+        "Expected token kind \(expectedLexeme.rawTokenKind) but got \(actualLexeme.rawTokenKind)",
         file: expectedLexeme.file,
         line: expectedLexeme.line
       )
@@ -180,7 +180,7 @@ func AssertLexemes(
 ) {
   var (markerLocations, source) = extractMarkers(markedSource)
   var expectedLexemes = expectedLexemes
-  if expectedLexemes.last?.tokenKind != .eof {
+  if expectedLexemes.last?.rawTokenKind != .eof {
     expectedLexemes.append(LexemeSpec(.eof, text: ""))
   }
   source.withUTF8 { buf in
@@ -188,7 +188,7 @@ func AssertLexemes(
     for token in Lexer.tokenize(buf, from: 0) {
       lexemes.append(token)
 
-      if token.tokenKind == .eof {
+      if token.rawTokenKind == .eof {
         break
       }
     }

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -756,7 +756,7 @@ final class ExpressionTests: XCTestCase {
     AssertParse(
       "Foo 1️⃣async ->2️⃣",
       { ExprSyntax.parse(from: &$0) },
-      substructure: Syntax(TokenSyntax.contextualKeyword("async")),
+      substructure: Syntax(TokenSyntax.contextualKeyword(.async)),
       substructureAfterMarker: "1️⃣",
       diagnostics: [
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression")

--- a/Tests/SwiftParserTest/ParserTests.swift
+++ b/Tests/SwiftParserTest/ParserTests.swift
@@ -93,7 +93,7 @@ public class ParserTests: XCTestCase {
   func testSelfParse() throws {
     // Allow skipping the self parse test in local development environments
     // because it takes very long compared to all the other tests.
-    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_SELF_PARSE"] == "1")
+    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
     let currentDir =
       packageDir
       .appendingPathComponent("Sources")
@@ -108,7 +108,7 @@ public class ParserTests: XCTestCase {
   /// This requires the Swift compiler to have been checked out into the "swift"
   /// directory alongside swift-syntax.
   func testSwiftTestsuite() throws {
-    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_SELF_PARSE"] == "1")
+    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
     let testDir =
       packageDir
       .deletingLastPathComponent()
@@ -125,7 +125,7 @@ public class ParserTests: XCTestCase {
   /// Swift compiler. This requires the Swift compiler to have been checked
   /// out into the "swift" directory alongside swift-syntax.
   func testSwiftValidationTestsuite() throws {
-    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_SELF_PARSE"] == "1")
+    try XCTSkipIf(ProcessInfo.processInfo.environment["SKIP_LONG_TESTS"] == "1")
     let testDir =
       packageDir
       .deletingLastPathComponent()

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -415,7 +415,7 @@ final class StatementTests: XCTestCase {
       """,
       substructure: Syntax(
         YieldStmtSyntax(
-          yieldKeyword: .contextualKeyword("yield"),
+          yieldKeyword: .contextualKeyword(.yield),
           yields: .init(
             InOutExprSyntax(
               ampersand: .prefixAmpersandToken(),
@@ -449,7 +449,7 @@ final class StatementTests: XCTestCase {
       """,
       substructure: Syntax(
         YieldStmtSyntax(
-          yieldKeyword: .contextualKeyword("yield"),
+          yieldKeyword: .contextualKeyword(.yield),
           yields: .init(
             InOutExprSyntax(
               ampersand: .prefixAmpersandToken(),

--- a/Tests/SwiftParserTest/TypeMetatypeTests.swift
+++ b/Tests/SwiftParserTest/TypeMetatypeTests.swift
@@ -52,7 +52,7 @@ final class TypeMetatypeTests: XCTestCase {
       var parser = Parser(baseType)
       let baseTypeSyntax = TypeSyntax.parse(from: &parser)
 
-      for metaKind in ["Type", "Protocol"] {
+      for metaKind in [.`Type`, .`Protocol`] as [Keyword] {
         AssertParse(
           "\(baseType).\(metaKind)",
           TypeSyntax.parse,

--- a/Tests/SwiftParserTest/VariadicGenericsTests.swift
+++ b/Tests/SwiftParserTest/VariadicGenericsTests.swift
@@ -25,7 +25,7 @@ final class VariadicGenericsTests: XCTestCase {
         PackExpansionExprSyntax(
           repeatKeyword: .repeatKeyword(),
           patternExpr: PackElementExprSyntax(
-            eachKeyword: .contextualKeyword("each"),
+            eachKeyword: .contextualKeyword(.each),
             packRefExpr: IdentifierExprSyntax(
               identifier: .identifier("t")
             )
@@ -145,7 +145,7 @@ final class VariadicGenericsTests: XCTestCase {
       """,
       substructure: Syntax(
         PackElementExprSyntax(
-          eachKeyword: .contextualKeyword("each"),
+          eachKeyword: .contextualKeyword(.each),
           packRefExpr: IdentifierExprSyntax(
             identifier: .identifier("x")
           )
@@ -172,7 +172,7 @@ final class VariadicGenericsTests: XCTestCase {
                   elementList: .init([
                     TupleExprElementSyntax(
                       expression: PackElementExprSyntax(
-                        eachKeyword: .contextualKeyword("each"),
+                        eachKeyword: .contextualKeyword(.each),
                         packRefExpr: IdentifierExprSyntax(
                           identifier: .identifier("t")
                         )
@@ -199,7 +199,7 @@ final class VariadicGenericsTests: XCTestCase {
         PackExpansionExprSyntax(
           repeatKeyword: .repeatKeyword(),
           patternExpr: PackElementExprSyntax(
-            eachKeyword: .contextualKeyword("each"),
+            eachKeyword: .contextualKeyword(.each),
             packRefExpr: MemberAccessExprSyntax(
               base: ExprSyntax(
                 IdentifierExprSyntax(
@@ -237,7 +237,7 @@ final class VariadicGenericsTests: XCTestCase {
               ),
               ExprSyntax(
                 PackElementExprSyntax(
-                  eachKeyword: .contextualKeyword("each"),
+                  eachKeyword: .contextualKeyword(.each),
                   packRefExpr: IdentifierExprSyntax(
                     identifier: .identifier("t")
                   )

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -153,7 +153,7 @@ final class VariableTests: XCTestCase {
 
   func testAccessorList() {
     let buildable = VariableDecl(name: "test", type: TypeAnnotation(type: Type("Int"))) {
-      AccessorDecl(accessorKind: .contextualKeyword("get"), asyncKeyword: nil) {
+      AccessorDecl(accessorKind: .contextualKeyword(.get), asyncKeyword: nil) {
         SequenceExpr {
           IntegerLiteralExpr(4)
           BinaryOperatorExpr(text: "+")
@@ -161,7 +161,7 @@ final class VariableTests: XCTestCase {
         }
       }
 
-      AccessorDecl(accessorKind: .contextualKeyword("willSet"), asyncKeyword: nil) {}
+      AccessorDecl(accessorKind: .contextualKeyword(.willSet), asyncKeyword: nil) {}
     }
 
     AssertBuildResult(

--- a/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
@@ -39,7 +39,7 @@ fileprivate func cannedStructDecl(arena: SyntaxArena) -> RawStructDeclSyntax {
     arena: arena
   )
   let rBrace = RawTokenSyntax(
-    kind: .leftBrace,
+    kind: .rightBrace,
     text: arena.intern("}"),
     leadingTriviaPieces: [.newlines(1)],
     trailingTriviaPieces: [],
@@ -142,10 +142,10 @@ final class RawSyntaxTests: XCTestCase {
       XCTAssertEqual(ident.description, "\nfoo ")
 
       let identSyntax = Syntax(raw: ident.raw).as(TokenSyntax.self)!
-      let barIdentSyntax = identSyntax.withKind(.contextualKeyword("open"))
+      let barIdentSyntax = identSyntax.withKind(.contextualKeyword(.open))
       let barIdent = barIdentSyntax.raw.as(RawTokenSyntax.self)!
 
-      XCTAssertEqual(barIdent.tokenKind, .contextualKeyword)
+      XCTAssertEqual(barIdent.tokenKind, .contextualKeyword(.open))
       XCTAssertEqual(barIdent.tokenText, "open")
       XCTAssertEqual(barIdent.leadingTriviaPieces, [.unexpectedText("\n")])
       XCTAssertEqual(barIdent.trailingTriviaPieces, [.unexpectedText(" ")])

--- a/gyb_syntax_support/Child.py
+++ b/gyb_syntax_support/Child.py
@@ -130,6 +130,9 @@ class Child(object):
       if self.token.text:
         return f" = .{self.token.swift_kind()}Token()"
       if self.text_choices and len(self.text_choices) == 1:
-        return f" = .{self.token.swift_kind()}(\"{self.text_choices[0]}\")"
+        if self.token.associated_value_class:
+          return f" = .{self.token.swift_kind()}(.{self.text_choices[0]})"
+        else:
+          return f" = .{self.token.swift_kind()}(\"{self.text_choices[0]}\")"
 
       return ""

--- a/gyb_syntax_support/Token.py
+++ b/gyb_syntax_support/Token.py
@@ -11,7 +11,7 @@ class Token(object):
     def __init__(self, name, kind, name_for_diagnostics,
                  unprefixed_kind=None, text=None, classification='None',
                  is_keyword=False, requires_leading_space=False,
-                 requires_trailing_space=False):
+                 requires_trailing_space=False, associated_value_class=None):
         self.name = name
         self.kind = kind
         if unprefixed_kind is None:
@@ -24,6 +24,7 @@ class Token(object):
         self.is_keyword = is_keyword
         self.requires_leading_space = requires_leading_space
         self.requires_trailing_space = requires_trailing_space
+        self.associated_value_class = associated_value_class
 
     def swift_kind(self):
         name = lowercase_first_word(self.name)
@@ -358,7 +359,7 @@ SYNTAX_TOKENS = [
          classification='DollarIdentifier'),
 
     Misc('ContextualKeyword', 'contextual_keyword', name_for_diagnostics='keyword',
-         classification='Keyword'),
+         classification='Keyword', associated_value_class='Keyword'),
     Misc('RawStringDelimiter', 'raw_string_delimiter',
          name_for_diagnostics='raw string delimiter'),
     Misc('StringSegment', 'string_segment', name_for_diagnostics='string segment',

--- a/gyb_syntax_support/__init__.py
+++ b/gyb_syntax_support/__init__.py
@@ -120,7 +120,10 @@ def make_missing_swift_child(child):
     if child.is_token():
         token = child.main_token()
         tok_kind = token.swift_kind() if token else "unknown"
-        if not token or not token.text:
+        if token and token.associated_value_class:
+            assert len(child.text_choices) == 1, "Can only create missing child if text is known"
+            tok_kind += f'(.{child.text_choices[0]})'
+        elif not token or not token.text:
             tok_kind += '("")'
         return f'RawSyntax.makeMissingToken(kind: TokenKind.{tok_kind}, ' + \
             'arena: arena)'

--- a/utils/group.json
+++ b/utils/group.json
@@ -8,6 +8,7 @@
     "RawSyntaxValidation.swift",
   ],
   "Syntax": [
+    "Keyword.swift",
     "SyntaxChildren.swift",
     "SyntaxData.swift",
     "SyntaxEnum.swift",


### PR DESCRIPTION
The main change here is that the `contextualKeyword` `TokenKind` and `RawTokenKind` no longer have a string as an associated value but an enum that enumerates all known contextual keywords.

In follow-up commits, this allows us to rename `contextualKeyword` to `keyword` and merge all the other known keywords into the `Keyword` enum that currently enumerates all contextual keywords. That way we can remove the distinction between contextual keywords and keywords we currently have.

I’m also thinking that we can use this additional structure to guarantee a little more type safety in the parser, for example by generating `RawTokenKindSubset`s for children that have `text_choices` set, but I still need to look into that.