### PR TITLE
Fix indentation of `AccessorList`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
@@ -1068,7 +1068,8 @@ public let DECL_NODES: [Node] = [
   Node(name: "AccessorList",
        nameForDiagnostics: nil,
        kind: "SyntaxCollection",
-       element: "AccessorDecl"),
+       element: "AccessorDecl",
+       elementsSeparatedByNewline: true),
 
   Node(name: "AccessorBlock",
        nameForDiagnostics: nil,
@@ -1084,12 +1085,14 @@ public let DECL_NODES: [Node] = [
                ]),
          Child(name: "Accessors",
                kind: "AccessorList",
-               collectionElementName: "Accessor"),
+               collectionElementName: "Accessor",
+               isIndented: true),
          Child(name: "RightBrace",
                kind: "RightBraceToken",
                tokenChoices: [
                  "RightBrace"
-               ])
+               ],
+               requiresLeadingNewline: true)
        ]),
 
   Node(name: "PatternBinding",

--- a/Sources/SwiftBasicFormat/generated/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat.swift
@@ -72,6 +72,8 @@ open class BasicFormat: SyntaxRewriter {
   
   open func shouldIndent(_ keyPath: AnyKeyPath) -> Bool {
     switch keyPath {
+    case \AccessorBlockSyntax.accessors: 
+      return true
     case \ArrayExprSyntax.elements: 
       return true
     case \ClosureExprSyntax.statements: 
@@ -103,6 +105,8 @@ open class BasicFormat: SyntaxRewriter {
   
   open func requiresLeadingNewline(_ keyPath: AnyKeyPath) -> Bool {
     switch keyPath {
+    case \AccessorBlockSyntax.rightBrace: 
+      return true
     case \ClosureExprSyntax.rightBrace: 
       return true
     case \CodeBlockSyntax.rightBrace: 
@@ -118,6 +122,8 @@ open class BasicFormat: SyntaxRewriter {
   
   open func childrenSeparatedByNewline(_ node: Syntax) -> Bool {
     switch node.as(SyntaxEnum.self) {
+    case .accessorList: 
+      return true
     case .codeBlockItemList: 
       return true
     case .memberDeclList: 

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -139,6 +139,33 @@ final class VariableTests: XCTestCase {
     )
   }
 
+  func testAccessorList() {
+    let buildable = VariableDecl(name: "test", type: TypeAnnotation(type: Type("Int"))) {
+      AccessorDecl(accessorKind: .contextualKeyword("get"),  asyncKeyword: nil) {
+        SequenceExpr {
+          IntegerLiteralExpr(4)
+          BinaryOperatorExpr(text: "+")
+          IntegerLiteralExpr(5)
+        }
+      }
+
+      AccessorDecl(accessorKind: .contextualKeyword("willSet"), asyncKeyword: nil) {}
+    }
+
+    AssertBuildResult(
+      buildable,
+      """
+      var test: Int {
+          get {
+              4 + 5
+          }
+          willSet {
+          }
+      }
+      """
+    )
+  }
+
   func testAttributedVariables() {
     let testCases: [UInt: (VariableDecl, String)] = [
       #line: (

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -141,7 +141,7 @@ final class VariableTests: XCTestCase {
 
   func testAccessorList() {
     let buildable = VariableDecl(name: "test", type: TypeAnnotation(type: Type("Int"))) {
-      AccessorDecl(accessorKind: .contextualKeyword("get"),  asyncKeyword: nil) {
+      AccessorDecl(accessorKind: .contextualKeyword("get"), asyncKeyword: nil) {
         SequenceExpr {
           IntegerLiteralExpr(4)
           BinaryOperatorExpr(text: "+")

--- a/gyb_syntax_support/DeclNodes.py
+++ b/gyb_syntax_support/DeclNodes.py
@@ -590,14 +590,14 @@ DECL_NODES = [
          ]),
 
     Node('AccessorList', name_for_diagnostics=None, kind="SyntaxCollection",
-         element='AccessorDecl'),
+         element='AccessorDecl', elements_separated_by_newline=True),
 
     Node('AccessorBlock', name_for_diagnostics=None, kind="Syntax", traits=['Braced'],
          children=[
              Child('LeftBrace', kind='LeftBraceToken'),
              Child('Accessors', kind='AccessorList',
-                   collection_element_name='Accessor'),
-             Child('RightBrace', kind='RightBraceToken'),
+                   collection_element_name='Accessor', is_indented=True),
+             Child('RightBrace', kind='RightBraceToken', requires_leading_newline=True),
          ]),
 
     # Pattern: Type = Value { get {} },


### PR DESCRIPTION
Add indentation level of `AccessorList`, so the previous:
```swift
var i: Int {
get {
    4 + 5
}
}
```
is now formatted as
```swift
var i: Int {
    get {
        4 + 5
    }
}
```