### PR TITLE
Improve `ArrayExpr` and `DictionaryExpr` format

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
@@ -380,7 +380,8 @@ public let EXPR_NODES: [Node] = [
                ]),
          Child(name: "Elements",
                kind: "ArrayElementList",
-               collectionElementName: "Element"),
+               collectionElementName: "Element",
+               isIndented: true),
          Child(name: "RightSquare",
                kind: "RightSquareBracketToken",
                tokenChoices: [
@@ -406,7 +407,8 @@ public let EXPR_NODES: [Node] = [
                          "Colon"
                        ]),
                  Child(name: "Elements",
-                       kind: "DictionaryElementList")
+                       kind: "DictionaryElementList",
+                       isIndented: true)
                ]),
          Child(name: "RightSquare",
                kind: "RightSquareBracketToken",
@@ -477,7 +479,8 @@ public let EXPR_NODES: [Node] = [
                  "Colon"
                ]),
          Child(name: "ValueExpression",
-               kind: "Expr"),
+               kind: "Expr",
+               isIndented: true),
          Child(name: "TrailingComma",
                kind: "CommaToken",
                isOptional: true,

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
@@ -407,9 +407,9 @@ public let EXPR_NODES: [Node] = [
                          "Colon"
                        ]),
                  Child(name: "Elements",
-                       kind: "DictionaryElementList",
-                       isIndented: true)
-               ]),
+                       kind: "DictionaryElementList")
+               ],
+               isIndented: true),
          Child(name: "RightSquare",
                kind: "RightSquareBracketToken",
                tokenChoices: [

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/basicformat/BasicFormatFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/basicformat/BasicFormatFile.swift
@@ -137,6 +137,12 @@ let basicFormatFile = SourceFile {
     }
 
     FunctionDecl("open func requiresTrailingSpace(_ token: TokenSyntax) -> Bool") {
+      IfStmt("""
+        if token.tokenKind == .colon && token.parent?.kind == .dictionaryExpr {
+          return false
+        }
+        """)
+
       SwitchStmt("""
         switch (token.tokenKind, token.nextToken(viewMode: .sourceAccurate)?.tokenKind) {
         case (.asKeyword, .exclamationMark),
@@ -150,7 +156,7 @@ let basicFormatFile = SourceFile {
           break
         }
         """)
-      
+
       SwitchStmt(expression: Expr("token.tokenKind")) {
         for token in SYNTAX_TOKENS {
           if token.requiresTrailingSpace {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/basicformat/BasicFormatFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/basicformat/BasicFormatFile.swift
@@ -138,6 +138,7 @@ let basicFormatFile = SourceFile {
 
     FunctionDecl("open func requiresTrailingSpace(_ token: TokenSyntax) -> Bool") {
       IfStmt("""
+        // Format `[:]` as-is.
         if token.tokenKind == .colon && token.parent?.kind == .dictionaryExpr {
           return false
         }

--- a/Sources/SwiftBasicFormat/generated/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat.swift
@@ -155,6 +155,9 @@ open class BasicFormat: SyntaxRewriter {
   }
   
   open func requiresTrailingSpace(_ token: TokenSyntax) -> Bool {
+    if token.tokenKind == .colon && token.parent?.kind == .dictionaryExpr {
+      return false
+    }
     switch (token.tokenKind, token.nextToken(viewMode: .sourceAccurate)?.tokenKind) {
     case (.asKeyword, .exclamationMark), 
      (.asKeyword, .postfixQuestionMark), 

--- a/Sources/SwiftBasicFormat/generated/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat.swift
@@ -80,6 +80,8 @@ open class BasicFormat: SyntaxRewriter {
       return true
     case \DictionaryElementSyntax.valueExpression: 
       return true
+    case \DictionaryExprSyntax.content: 
+      return true
     case \FunctionCallExprSyntax.argumentList: 
       return true
     case \FunctionTypeSyntax.arguments: 

--- a/Sources/SwiftBasicFormat/generated/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat.swift
@@ -155,6 +155,7 @@ open class BasicFormat: SyntaxRewriter {
   }
   
   open func requiresTrailingSpace(_ token: TokenSyntax) -> Bool {
+    // Format `[:]` as-is.
     if token.tokenKind == .colon && token.parent?.kind == .dictionaryExpr {
       return false
     }

--- a/Sources/SwiftBasicFormat/generated/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat.swift
@@ -72,9 +72,13 @@ open class BasicFormat: SyntaxRewriter {
   
   open func shouldIndent(_ keyPath: AnyKeyPath) -> Bool {
     switch keyPath {
+    case \ArrayExprSyntax.elements: 
+      return true
     case \ClosureExprSyntax.statements: 
       return true
     case \CodeBlockSyntax.statements: 
+      return true
+    case \DictionaryElementSyntax.valueExpression: 
       return true
     case \FunctionCallExprSyntax.argumentList: 
       return true

--- a/Tests/SwiftSyntaxBuilderTest/ArrayExprTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ArrayExprTests.swift
@@ -25,21 +25,26 @@ final class ArrayExprTests: XCTestCase {
   }
 
   func testMultilineArrayLiteral() {
-    let builder = ArrayExpr("""
+    let builder = ArrayExpr(
+      """
       [
         1,
         #"2"3"#,
         4,
       "五",
       ]
-      """)
-    AssertBuildResult(builder, """
+      """
+    )
+    AssertBuildResult(
+      builder,
+      """
       [
           1,
           #"2"3"#,
           4,
           "五",
       ]
-      """)
+      """
+    )
   }
 }

--- a/Tests/SwiftSyntaxBuilderTest/ArrayExprTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ArrayExprTests.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+final class ArrayExprTests: XCTestCase {
+  func testPlainArrayExpr() {
+    let buildable = ArrayExpr {
+      for i in 1...4 {
+        ArrayElement(expression: IntegerLiteralExpr(i))
+      }
+    }
+    AssertBuildResult(buildable, "[1, 2, 3, 4]")
+  }
+
+  func testMultilineArrayLiteral() {
+    let builder = ArrayExpr("""
+      [
+        1,
+        "23",
+        4,
+      #"5⃣️"#,
+      ]
+      """)
+    AssertBuildResult(builder, """
+      [
+          1,
+          "23",
+          4,
+          #"5⃣️"#,
+      ]
+      """)
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/ArrayExprTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ArrayExprTests.swift
@@ -28,17 +28,17 @@ final class ArrayExprTests: XCTestCase {
     let builder = ArrayExpr("""
       [
         1,
-        "23",
+        #"2"3"#,
         4,
-      #"5⃣️"#,
+      "五",
       ]
       """)
     AssertBuildResult(builder, """
       [
           1,
-          "23",
+          #"2"3"#,
           4,
-          #"5⃣️"#,
+          "五",
       ]
       """)
   }

--- a/Tests/SwiftSyntaxBuilderTest/DictionaryExprTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/DictionaryExprTests.swift
@@ -30,7 +30,8 @@ final class DictionaryExprTests: XCTestCase {
   }
 
   func testMultilineDictionaryLiteral() {
-    let builder = DictionaryExpr("""
+    let builder = DictionaryExpr(
+      """
       [
         1:1,
       2: "二",
@@ -38,8 +39,11 @@ final class DictionaryExprTests: XCTestCase {
       4:
         #"f"o"u"r"#,
       ]
-      """)
-    AssertBuildResult(builder, """
+      """
+    )
+    AssertBuildResult(
+      builder,
+      """
       [
           1: 1,
           2: "二",
@@ -47,6 +51,7 @@ final class DictionaryExprTests: XCTestCase {
           4:
               #"f"o"u"r"#,
       ]
-      """)
+      """
+    )
   }
 }

--- a/Tests/SwiftSyntaxBuilderTest/DictionaryExprTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/DictionaryExprTests.swift
@@ -33,7 +33,7 @@ final class DictionaryExprTests: XCTestCase {
     let builder = DictionaryExpr("""
       [
         1:1,
-      2: "2⃣️",
+      2: "二",
         "three": 3,
       4:
         #"f"o"u"r"#,
@@ -42,7 +42,7 @@ final class DictionaryExprTests: XCTestCase {
     AssertBuildResult(builder, """
       [
           1: 1,
-          2: "2⃣️",
+          2: "二",
           "three": 3,
           4:
               #"f"o"u"r"#,

--- a/Tests/SwiftSyntaxBuilderTest/DictionaryExprTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/DictionaryExprTests.swift
@@ -23,10 +23,10 @@ final class DictionaryExprTests: XCTestCase {
     }
     AssertBuildResult(buildable, "[1: 1, 2: 2, 3: 3]")
   }
-  
+
   func testEmptyDictionaryExpr() {
     let buildable = DictionaryExpr()
-    AssertBuildResult(buildable, "[: ]")
+    AssertBuildResult(buildable, "[:]")
   }
 
   func testMultilineDictionaryLiteral() {

--- a/Tests/SwiftSyntaxBuilderTest/DictionaryExprTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/DictionaryExprTests.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+final class DictionaryExprTests: XCTestCase {
+  func testPlainDictionaryExpr() {
+    let buildable = DictionaryExpr {
+      for i in 1...3 {
+        DictionaryElement(keyExpression: IntegerLiteralExpr(i), valueExpression: IntegerLiteralExpr(i))
+      }
+    }
+    AssertBuildResult(buildable, "[1: 1, 2: 2, 3: 3]")
+  }
+  
+  func testEmptyDictionaryExpr() {
+    let buildable = DictionaryExpr()
+    AssertBuildResult(buildable, "[: ]")
+  }
+
+  func testMultilineDictionaryLiteral() {
+    let builder = DictionaryExpr("""
+      [
+        1:1,
+      2: "2⃣️",
+        "three": 3,
+      4:
+        #"f"o"u"r"#,
+      ]
+      """)
+    AssertBuildResult(builder, """
+      [
+          1: 1,
+          2: "2⃣️",
+          "three": 3,
+          4:
+              #"f"o"u"r"#,
+      ]
+      """)
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -54,7 +54,7 @@ final class VariableTests: XCTestCase {
       )
     }
 
-    AssertBuildResult(buildable, "␣var d: [String: Int] = [: ]")
+    AssertBuildResult(buildable, "␣var d: [String: Int] = [:]")
   }
 
   func testVariableDeclWithExplicitTrailingCommas() {

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -64,13 +64,11 @@ final class VariableTests: XCTestCase {
         PatternBinding(
           pattern: PatternSyntax("a"),
           initializer: InitializerClause(
-            value: ArrayExpr(
-              leftSquare: .`leftSquareBracket`.withTrailingTrivia(.newline)
-            ) {
+            value: ArrayExpr {
               for i in 1...3 {
                 ArrayElement(
                   expression: IntegerLiteralExpr(i),
-                  trailingComma: .comma.withTrailingTrivia(.newline)
+                  trailingComma: .comma.withTrailingTrivia(.spaces(3))
                 )
               }
             }
@@ -81,11 +79,7 @@ final class VariableTests: XCTestCase {
     AssertBuildResult(
       buildable,
       """
-      let a = [
-      1,
-      2,
-      3,
-      ]
+      let a = [1,   2,   3,   ]
       """
     )
   }

--- a/gyb_syntax_support/ExprNodes.py
+++ b/gyb_syntax_support/ExprNodes.py
@@ -234,8 +234,8 @@ EXPR_NODES = [
              Child('Content', kind='Syntax',
                    node_choices=[
                        Child('Colon', kind='ColonToken'),
-                       Child('Elements', kind='DictionaryElementList', is_indented=True),
-                   ]),
+                       Child('Elements', kind='DictionaryElementList'),
+                   ], is_indented=True),
              Child('RightSquare', kind='RightSquareBracketToken'),
          ]),
 

--- a/gyb_syntax_support/ExprNodes.py
+++ b/gyb_syntax_support/ExprNodes.py
@@ -223,7 +223,7 @@ EXPR_NODES = [
          children=[
              Child('LeftSquare', kind='LeftSquareBracketToken'),
              Child('Elements', kind='ArrayElementList',
-                   collection_element_name='Element'),
+                   collection_element_name='Element', is_indented=True),
              Child('RightSquare', kind='RightSquareBracketToken'),
          ]),
 
@@ -234,7 +234,7 @@ EXPR_NODES = [
              Child('Content', kind='Syntax',
                    node_choices=[
                        Child('Colon', kind='ColonToken'),
-                       Child('Elements', kind='DictionaryElementList'),
+                       Child('Elements', kind='DictionaryElementList', is_indented=True),
                    ]),
              Child('RightSquare', kind='RightSquareBracketToken'),
          ]),
@@ -270,7 +270,7 @@ EXPR_NODES = [
          children=[
              Child('KeyExpression', kind='Expr', name_for_diagnostics='key'),
              Child('Colon', kind='ColonToken'),
-             Child('ValueExpression', kind='Expr', name_for_diagnostics='value'),
+             Child('ValueExpression', kind='Expr', name_for_diagnostics='value', is_indented=True),
              Child('TrailingComma', kind='CommaToken', is_optional=True),
          ]),
 


### PR DESCRIPTION
- Mark their elements as indented, just like tuples;
- Correct empty dictionary literal format from `[: ]` to `[:]`;
- Add builder tests for `ArrayExpr` and `DictionaryExpr`.