### PR TITLE
Remove stringInterpolationAnchor

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
@@ -979,9 +979,9 @@ public let EXPR_NODES: [Node] = [
                kind: "TupleExprElementList",
                collectionElementName: "Expression"),
          Child(name: "RightParen",
-               kind: "StringInterpolationAnchorToken",
+               kind: "RightParenToken",
                tokenChoices: [
-                 "StringInterpolationAnchor"
+                 "RightParen"
                ],
                classification: "StringInterpolationAnchor",
                forceClassification: true)

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/TokenSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/TokenSpec.swift
@@ -318,7 +318,6 @@ public let SYNTAX_TOKENS: [TokenSpec] = [
   MiscSpec(name: "ContextualKeyword", kind: "contextual_keyword", nameForDiagnostics: "keyword", classification: "Keyword"),
   MiscSpec(name: "RawStringDelimiter", kind: "raw_string_delimiter", nameForDiagnostics: "raw string delimiter"),
   MiscSpec(name: "StringSegment", kind: "string_segment", nameForDiagnostics: "string segment", classification: "StringLiteral"),
-  MiscSpec(name: "StringInterpolationAnchor", kind: "string_interpolation_anchor", nameForDiagnostics: "string interpolation anchor", text: ")", classification: "StringInterpolationAnchor"),
   MiscSpec(name: "Yield", kind: "kw_yield", nameForDiagnostics: "yield", text: "yield"),
 ]
 

--- a/Sources/IDEUtils/generated/SyntaxClassification.swift
+++ b/Sources/IDEUtils/generated/SyntaxClassification.swift
@@ -374,8 +374,6 @@ extension RawTokenKind {
       return .none
     case .stringSegment: 
       return .stringLiteral
-    case .stringInterpolationAnchor: 
-      return .stringInterpolationAnchor
     case .yield: 
       return .none
     case .eof: 

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -114,7 +114,7 @@ public enum TokenPrecedence: Comparable {
       // '_' can occur in types to replace a type identifier
       .wildcardKeyword,
       // String segment, string interpolation anchor and pound don't really fit anywhere else
-      .pound, .stringInterpolationAnchor, .stringSegment:
+      .pound, .stringSegment:
       self = .identifierLike
 
     // MARK: Expr keyword

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -2134,7 +2134,7 @@ public enum SyntaxFactory {
         nil,
         RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: arena),
         nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.stringInterpolationAnchor, arena: arena),
+        RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena),
         nil,
       ], arena: arena))
       return ExpressionSegmentSyntax(data)
@@ -9829,15 +9829,6 @@ public enum SyntaxFactory {
     trailingTrivia: Trivia = []
   ) -> TokenSyntax {
     return makeToken(.stringSegment(text), presence: .present,
-                     leadingTrivia: leadingTrivia,
-                     trailingTrivia: trailingTrivia)
-  }
-  @available(*, deprecated, message: "Use TokenSyntax.stringInterpolationAnchorToken instead")
-  public static func makeStringInterpolationAnchorToken(
-    leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []
-  ) -> TokenSyntax {
-    return makeToken(.stringInterpolationAnchor, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }

--- a/Sources/SwiftSyntax/gyb_generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/TokenKind.swift
@@ -133,7 +133,6 @@ public enum TokenKind: Hashable {
   case contextualKeyword(String)
   case rawStringDelimiter(String)
   case stringSegment(String)
-  case stringInterpolationAnchor
   case yield
 
   /// Initializes a keyword token kind from its string representation. If the
@@ -421,7 +420,6 @@ public enum TokenKind: Hashable {
     case .contextualKeyword(let text): return text
     case .rawStringDelimiter(let text): return text
     case .stringSegment(let text): return text
-    case .stringInterpolationAnchor: return ")"
     case .yield: return "yield"
     }
   }
@@ -551,7 +549,6 @@ public enum TokenKind: Hashable {
     case .contextualKeyword: return false
     case .rawStringDelimiter: return false
     case .stringSegment: return false
-    case .stringInterpolationAnchor: return false
     case .yield: return false
     }
   }
@@ -681,7 +678,6 @@ public enum TokenKind: Hashable {
     case .contextualKeyword: return false
     case .rawStringDelimiter: return false
     case .stringSegment: return false
-    case .stringInterpolationAnchor: return false
     case .yield: return false
     }
   }
@@ -806,7 +802,6 @@ public enum TokenKind: Hashable {
     case .contextualKeyword(_): return "contextual_keyword"
     case .rawStringDelimiter(_): return "raw_string_delimiter"
     case .stringSegment(_): return "string_segment"
-    case .stringInterpolationAnchor: return "string_interpolation_anchor"
     case .yield: return "kw_yield"
     }
   }
@@ -931,7 +926,6 @@ public enum TokenKind: Hashable {
     case .contextualKeyword(let text): return SourceLength(of: text)
     case .rawStringDelimiter(let text): return SourceLength(of: text)
     case .stringSegment(let text): return SourceLength(of: text)
-    case .stringInterpolationAnchor: return SourceLength(utf8Length: 1)
     case .yield: return SourceLength(utf8Length: 5)
     }
   }
@@ -1072,7 +1066,6 @@ extension TokenKind: Equatable {
       return lhsText == rhsText
     case (.stringSegment(let lhsText), .stringSegment(let rhsText)):
       return lhsText == rhsText
-    case (.stringInterpolationAnchor, .stringInterpolationAnchor): return true
     case (.yield, .yield): return true
     default: return false
     }
@@ -1200,7 +1193,6 @@ public enum RawTokenKind: Equatable, Hashable {
   case contextualKeyword
   case rawStringDelimiter
   case stringSegment
-  case stringInterpolationAnchor
   case yield
 
   @_spi(RawSyntax)
@@ -1310,7 +1302,6 @@ public enum RawTokenKind: Equatable, Hashable {
     case .poundImageLiteralKeyword: return "#imageLiteral"
     case .poundColorLiteralKeyword: return "#colorLiteral"
     case .poundHasSymbolKeyword: return "#_hasSymbol"
-    case .stringInterpolationAnchor: return ")"
     case .yield: return "yield"
     default: return nil
     }
@@ -1436,7 +1427,6 @@ public enum RawTokenKind: Equatable, Hashable {
     case .contextualKeyword: return "keyword"
     case .rawStringDelimiter: return "raw string delimiter"
     case .stringSegment: return "string segment"
-    case .stringInterpolationAnchor: return "string interpolation anchor"
     case .yield: return "yield"
     }
   }
@@ -1566,7 +1556,6 @@ public enum RawTokenKind: Equatable, Hashable {
     case .contextualKeyword: return false
     case .rawStringDelimiter: return false
     case .stringSegment: return false
-    case .stringInterpolationAnchor: return false
     case .yield: return false
     }
   }
@@ -1696,7 +1685,6 @@ public enum RawTokenKind: Equatable, Hashable {
     case .contextualKeyword: return false
     case .rawStringDelimiter: return false
     case .stringSegment: return false
-    case .stringInterpolationAnchor: return false
     case .yield: return false
     }
   }
@@ -2189,9 +2177,6 @@ extension TokenKind {
       return .rawStringDelimiter(text)
     case .stringSegment:
       return .stringSegment(text)
-    case .stringInterpolationAnchor:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
-      return .stringInterpolationAnchor
     case .yield:
       assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .yield
@@ -2321,7 +2306,6 @@ extension TokenKind {
     case .contextualKeyword(let str): return (.contextualKeyword, str)
     case .rawStringDelimiter(let str): return (.rawStringDelimiter, str)
     case .stringSegment(let str): return (.stringSegment, str)
-    case .stringInterpolationAnchor: return (.stringInterpolationAnchor, nil)
     case .yield: return (.yield, nil)
     }
   }

--- a/Sources/SwiftSyntax/gyb_generated/Tokens.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Tokens.swift
@@ -1440,18 +1440,6 @@ extension TokenSyntax {
       presence: presence
     )
   }
-  public static func stringInterpolationAnchorToken(
-    leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = [],
-    presence: SourcePresence = .present
-  ) -> TokenSyntax {
-    return TokenSyntax(
-      .stringInterpolationAnchor,
-      leadingTrivia: leadingTrivia,
-      trailingTrivia: trailingTrivia,
-      presence: presence
-    )
-  }
   public static func yieldToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = [],

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -3612,7 +3612,7 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndExpressions: UnexpectedNodesSyntax? = nil,
     expressions: TupleExprElementListSyntax,
     _ unexpectedBetweenExpressionsAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax = .stringInterpolationAnchorToken(),
+    rightParen: TokenSyntax = .rightParenToken(),
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
@@ -3858,7 +3858,7 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `rightParen`, if present.
   public func withRightParen(_ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
     let arena = SyntaxArena()
-    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringInterpolationAnchor, arena: arena)
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: arena)
     let newData = data.replacingChild(at: 9, with: raw, arena: arena)
     return ExpressionSegmentSyntax(newData)
   }

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -540,7 +540,7 @@ extension ExpressionSegment {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeBackslash: UnexpectedNodes? = nil, backslash: Token = Token.`backslash`, unexpectedBetweenBackslashAndDelimiter: UnexpectedNodes? = nil, delimiter: String?, unexpectedBetweenDelimiterAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndExpressions: UnexpectedNodes? = nil, unexpectedBetweenExpressionsAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`stringInterpolationAnchor`, @TupleExprElementListBuilder expressionsBuilder: () -> TupleExprElementListSyntax = {
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeBackslash: UnexpectedNodes? = nil, backslash: Token = Token.`backslash`, unexpectedBetweenBackslashAndDelimiter: UnexpectedNodes? = nil, delimiter: String?, unexpectedBetweenDelimiterAndLeftParen: UnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndExpressions: UnexpectedNodes? = nil, unexpectedBetweenExpressionsAndRightParen: UnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`, @TupleExprElementListBuilder expressionsBuilder: () -> TupleExprElementListSyntax = {
       TupleExprElementListSyntax([])
     }, trailingTrivia: Trivia? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeBackslash, backslash: backslash, unexpectedBetweenBackslashAndDelimiter, delimiter: delimiter.map { 

--- a/Sources/SwiftSyntaxBuilder/generated/Token.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/Token.swift
@@ -531,11 +531,6 @@ public extension TokenSyntax {
     return .poundHasSymbolKeyword()
   }
   
-  /// The `)` token
-  static var `stringInterpolationAnchor`: TokenSyntax {
-    return .stringInterpolationAnchorToken()
-  }
-  
   /// The `yield` token
   static var `yield`: TokenSyntax {
     return .yieldToken()

--- a/gyb_syntax_support/ExprNodes.py
+++ b/gyb_syntax_support/ExprNodes.py
@@ -558,7 +558,7 @@ EXPR_NODES = [
                    force_classification=True),
              Child('Expressions', kind='TupleExprElementList',
                    collection_element_name='Expression'),
-             Child('RightParen', kind='StringInterpolationAnchorToken',
+             Child('RightParen', kind='RightParenToken',
                    classification='StringInterpolationAnchor',
                    force_classification=True),
          ]),

--- a/gyb_syntax_support/Token.py
+++ b/gyb_syntax_support/Token.py
@@ -363,12 +363,8 @@ SYNTAX_TOKENS = [
          name_for_diagnostics='raw string delimiter'),
     Misc('StringSegment', 'string_segment', name_for_diagnostics='string segment',
          classification='StringLiteral'),
-    Misc('StringInterpolationAnchor', 'string_interpolation_anchor',
-         name_for_diagnostics='string interpolation anchor',
-         text=')', classification='StringInterpolationAnchor'),
     Misc('Yield', 'kw_yield', name_for_diagnostics='yield',
          text='yield'),
-
 ]
 
 SYNTAX_TOKEN_MAP = {token.name + 'Token': token for token in SYNTAX_TOKENS}


### PR DESCRIPTION
This token has a sordid history in the legacy parser being used to represent both the start and end of a string interpolation segment

```
\(...)
^    ^
```

SwiftSyntax has always interpreted this as just the closing delimiter

```
\(...)
     ^
```

Which isn't correct. The new lexer does not ever lex for these, and the new parser does not re-lex for them either, so let's just drop it for now. If we want the structure of a string interpolation segment's delimiters, we'd need new modeling for it anyways.