### PR TITLE
CMake: amend Swift_MODULE_DIRECTORY to avoid unnecessary rebuilds

### DIFF
--- a/cmake/modules/AddSwiftHostLibrary.cmake
+++ b/cmake/modules/AddSwiftHostLibrary.cmake
@@ -32,7 +32,7 @@ function(add_swift_host_library name)
 
   # Install the Swift module into the appropriate location.
   set_target_properties(${name}
-    PROPERTIES Swift_MODULE_DIRECTORY ${module_base}
+    PROPERTIES Swift_MODULE_DIRECTORY ${module_dir}
   )
 
   # Configure the emission of the Swift module files.


### PR DESCRIPTION
CMake infers we are generating the swiftmodule folder at `$<TARGET_PROPERTY:Swift_MODULE_DIRECTORY,...>/$<TARGET_NAME:..>.swiftmodule`. If we set Swift_MODULE_DIRECTORY incorrectly, the build system will expect a file we never generate, and will trigger a rebuild of the associated targets even if no source changed.

Addresses rdar://103885024