### PR TITLE
Fix memory corruption when constructing syntax nodes from different arenas

### DIFF
--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
@@ -114,18 +114,21 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
   }
 
   ${node.generate_initializer_decl(optional_base_as_missing=False, current_indentation="  ")} {
+%   parameters = ', '.join([child.swift_name for child in node.children])
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (${parameters}))) { (arena, _) in
 %     if node.children:
-    let layout: [RawSyntax?] = [
+      let layout: [RawSyntax?] = [
 %       for child in node.children:
 %         if child.is_optional:
-      ${child.swift_name}?.raw,
+        ${child.swift_name}?.raw,
 %         else:
-      ${child.swift_name}.raw,
+        ${child.swift_name}.raw,
 %         end
 %       end
-    ]
+      ]
 %     end
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
 %     if node.children:
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.${node.swift_syntax_kind}, from: layout, arena: arena,

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -40,14 +40,16 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterModifiers: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedAfterModifiers?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedAfterModifiers))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedAfterModifiers?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.missingDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -276,24 +278,26 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndTypealiasKeyword?.raw,
-      typealiasKeyword.raw,
-      unexpectedBetweenTypealiasKeywordAndIdentifier?.raw,
-      identifier.raw,
-      unexpectedBetweenIdentifierAndGenericParameterClause?.raw,
-      genericParameterClause?.raw,
-      unexpectedBetweenGenericParameterClauseAndInitializer?.raw,
-      initializer.raw,
-      unexpectedBetweenInitializerAndGenericWhereClause?.raw,
-      genericWhereClause?.raw,
-      unexpectedAfterGenericWhereClause?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndTypealiasKeyword, typealiasKeyword, unexpectedBetweenTypealiasKeywordAndIdentifier, identifier, unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause, unexpectedBetweenGenericParameterClauseAndInitializer, initializer, unexpectedBetweenInitializerAndGenericWhereClause, genericWhereClause, unexpectedAfterGenericWhereClause))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndTypealiasKeyword?.raw,
+        typealiasKeyword.raw,
+        unexpectedBetweenTypealiasKeywordAndIdentifier?.raw,
+        identifier.raw,
+        unexpectedBetweenIdentifierAndGenericParameterClause?.raw,
+        genericParameterClause?.raw,
+        unexpectedBetweenGenericParameterClauseAndInitializer?.raw,
+        initializer.raw,
+        unexpectedBetweenInitializerAndGenericWhereClause?.raw,
+        genericWhereClause?.raw,
+        unexpectedAfterGenericWhereClause?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.typealiasDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -769,24 +773,26 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndAssociatedtypeKeyword?.raw,
-      associatedtypeKeyword.raw,
-      unexpectedBetweenAssociatedtypeKeywordAndIdentifier?.raw,
-      identifier.raw,
-      unexpectedBetweenIdentifierAndInheritanceClause?.raw,
-      inheritanceClause?.raw,
-      unexpectedBetweenInheritanceClauseAndInitializer?.raw,
-      initializer?.raw,
-      unexpectedBetweenInitializerAndGenericWhereClause?.raw,
-      genericWhereClause?.raw,
-      unexpectedAfterGenericWhereClause?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndAssociatedtypeKeyword, associatedtypeKeyword, unexpectedBetweenAssociatedtypeKeywordAndIdentifier, identifier, unexpectedBetweenIdentifierAndInheritanceClause, inheritanceClause, unexpectedBetweenInheritanceClauseAndInitializer, initializer, unexpectedBetweenInitializerAndGenericWhereClause, genericWhereClause, unexpectedAfterGenericWhereClause))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndAssociatedtypeKeyword?.raw,
+        associatedtypeKeyword.raw,
+        unexpectedBetweenAssociatedtypeKeywordAndIdentifier?.raw,
+        identifier.raw,
+        unexpectedBetweenIdentifierAndInheritanceClause?.raw,
+        inheritanceClause?.raw,
+        unexpectedBetweenInheritanceClauseAndInitializer?.raw,
+        initializer?.raw,
+        unexpectedBetweenInitializerAndGenericWhereClause?.raw,
+        genericWhereClause?.raw,
+        unexpectedAfterGenericWhereClause?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.associatedtypeDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1253,14 +1259,16 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterPoundEndif: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeClauses?.raw,
-      clauses.raw,
-      unexpectedBetweenClausesAndPoundEndif?.raw,
-      poundEndif.raw,
-      unexpectedAfterPoundEndif?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeClauses, clauses, unexpectedBetweenClausesAndPoundEndif, poundEndif, unexpectedAfterPoundEndif))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeClauses?.raw,
+        clauses.raw,
+        unexpectedBetweenClausesAndPoundEndif?.raw,
+        poundEndif.raw,
+        unexpectedAfterPoundEndif?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.ifConfigDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1462,18 +1470,20 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePoundError?.raw,
-      poundError.raw,
-      unexpectedBetweenPoundErrorAndLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndMessage?.raw,
-      message.raw,
-      unexpectedBetweenMessageAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePoundError, poundError, unexpectedBetweenPoundErrorAndLeftParen, leftParen, unexpectedBetweenLeftParenAndMessage, message, unexpectedBetweenMessageAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePoundError?.raw,
+        poundError.raw,
+        unexpectedBetweenPoundErrorAndLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndMessage?.raw,
+        message.raw,
+        unexpectedBetweenMessageAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.poundErrorDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1754,18 +1764,20 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePoundWarning?.raw,
-      poundWarning.raw,
-      unexpectedBetweenPoundWarningAndLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndMessage?.raw,
-      message.raw,
-      unexpectedBetweenMessageAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePoundWarning, poundWarning, unexpectedBetweenPoundWarningAndLeftParen, leftParen, unexpectedBetweenLeftParenAndMessage, message, unexpectedBetweenMessageAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePoundWarning?.raw,
+        poundWarning.raw,
+        unexpectedBetweenPoundWarningAndLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndMessage?.raw,
+        message.raw,
+        unexpectedBetweenMessageAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.poundWarningDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2046,18 +2058,20 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePoundSourceLocation?.raw,
-      poundSourceLocation.raw,
-      unexpectedBetweenPoundSourceLocationAndLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndArgs?.raw,
-      args?.raw,
-      unexpectedBetweenArgsAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePoundSourceLocation, poundSourceLocation, unexpectedBetweenPoundSourceLocationAndLeftParen, leftParen, unexpectedBetweenLeftParenAndArgs, args, unexpectedBetweenArgsAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePoundSourceLocation?.raw,
+        poundSourceLocation.raw,
+        unexpectedBetweenPoundSourceLocationAndLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndArgs?.raw,
+        args?.raw,
+        unexpectedBetweenArgsAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.poundSourceLocation, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2347,26 +2361,28 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndClassKeyword?.raw,
-      classKeyword.raw,
-      unexpectedBetweenClassKeywordAndIdentifier?.raw,
-      identifier.raw,
-      unexpectedBetweenIdentifierAndGenericParameterClause?.raw,
-      genericParameterClause?.raw,
-      unexpectedBetweenGenericParameterClauseAndInheritanceClause?.raw,
-      inheritanceClause?.raw,
-      unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
-      genericWhereClause?.raw,
-      unexpectedBetweenGenericWhereClauseAndMembers?.raw,
-      members.raw,
-      unexpectedAfterMembers?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndClassKeyword, classKeyword, unexpectedBetweenClassKeywordAndIdentifier, identifier, unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members, unexpectedAfterMembers))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndClassKeyword?.raw,
+        classKeyword.raw,
+        unexpectedBetweenClassKeywordAndIdentifier?.raw,
+        identifier.raw,
+        unexpectedBetweenIdentifierAndGenericParameterClause?.raw,
+        genericParameterClause?.raw,
+        unexpectedBetweenGenericParameterClauseAndInheritanceClause?.raw,
+        inheritanceClause?.raw,
+        unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
+        genericWhereClause?.raw,
+        unexpectedBetweenGenericWhereClauseAndMembers?.raw,
+        members.raw,
+        unexpectedAfterMembers?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.classDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2894,26 +2910,28 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndActorKeyword?.raw,
-      actorKeyword.raw,
-      unexpectedBetweenActorKeywordAndIdentifier?.raw,
-      identifier.raw,
-      unexpectedBetweenIdentifierAndGenericParameterClause?.raw,
-      genericParameterClause?.raw,
-      unexpectedBetweenGenericParameterClauseAndInheritanceClause?.raw,
-      inheritanceClause?.raw,
-      unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
-      genericWhereClause?.raw,
-      unexpectedBetweenGenericWhereClauseAndMembers?.raw,
-      members.raw,
-      unexpectedAfterMembers?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndActorKeyword, actorKeyword, unexpectedBetweenActorKeywordAndIdentifier, identifier, unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members, unexpectedAfterMembers))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndActorKeyword?.raw,
+        actorKeyword.raw,
+        unexpectedBetweenActorKeywordAndIdentifier?.raw,
+        identifier.raw,
+        unexpectedBetweenIdentifierAndGenericParameterClause?.raw,
+        genericParameterClause?.raw,
+        unexpectedBetweenGenericParameterClauseAndInheritanceClause?.raw,
+        inheritanceClause?.raw,
+        unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
+        genericWhereClause?.raw,
+        unexpectedBetweenGenericWhereClauseAndMembers?.raw,
+        members.raw,
+        unexpectedAfterMembers?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.actorDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3441,26 +3459,28 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndStructKeyword?.raw,
-      structKeyword.raw,
-      unexpectedBetweenStructKeywordAndIdentifier?.raw,
-      identifier.raw,
-      unexpectedBetweenIdentifierAndGenericParameterClause?.raw,
-      genericParameterClause?.raw,
-      unexpectedBetweenGenericParameterClauseAndInheritanceClause?.raw,
-      inheritanceClause?.raw,
-      unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
-      genericWhereClause?.raw,
-      unexpectedBetweenGenericWhereClauseAndMembers?.raw,
-      members.raw,
-      unexpectedAfterMembers?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndStructKeyword, structKeyword, unexpectedBetweenStructKeywordAndIdentifier, identifier, unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members, unexpectedAfterMembers))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndStructKeyword?.raw,
+        structKeyword.raw,
+        unexpectedBetweenStructKeywordAndIdentifier?.raw,
+        identifier.raw,
+        unexpectedBetweenIdentifierAndGenericParameterClause?.raw,
+        genericParameterClause?.raw,
+        unexpectedBetweenGenericParameterClauseAndInheritanceClause?.raw,
+        inheritanceClause?.raw,
+        unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
+        genericWhereClause?.raw,
+        unexpectedBetweenGenericWhereClauseAndMembers?.raw,
+        members.raw,
+        unexpectedAfterMembers?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.structDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3988,26 +4008,28 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndProtocolKeyword?.raw,
-      protocolKeyword.raw,
-      unexpectedBetweenProtocolKeywordAndIdentifier?.raw,
-      identifier.raw,
-      unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause?.raw,
-      primaryAssociatedTypeClause?.raw,
-      unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause?.raw,
-      inheritanceClause?.raw,
-      unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
-      genericWhereClause?.raw,
-      unexpectedBetweenGenericWhereClauseAndMembers?.raw,
-      members.raw,
-      unexpectedAfterMembers?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndProtocolKeyword, protocolKeyword, unexpectedBetweenProtocolKeywordAndIdentifier, identifier, unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause, primaryAssociatedTypeClause, unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause, inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members, unexpectedAfterMembers))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndProtocolKeyword?.raw,
+        protocolKeyword.raw,
+        unexpectedBetweenProtocolKeywordAndIdentifier?.raw,
+        identifier.raw,
+        unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause?.raw,
+        primaryAssociatedTypeClause?.raw,
+        unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause?.raw,
+        inheritanceClause?.raw,
+        unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
+        genericWhereClause?.raw,
+        unexpectedBetweenGenericWhereClauseAndMembers?.raw,
+        members.raw,
+        unexpectedAfterMembers?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.protocolDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -4533,24 +4555,26 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndExtensionKeyword?.raw,
-      extensionKeyword.raw,
-      unexpectedBetweenExtensionKeywordAndExtendedType?.raw,
-      extendedType.raw,
-      unexpectedBetweenExtendedTypeAndInheritanceClause?.raw,
-      inheritanceClause?.raw,
-      unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
-      genericWhereClause?.raw,
-      unexpectedBetweenGenericWhereClauseAndMembers?.raw,
-      members.raw,
-      unexpectedAfterMembers?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndExtensionKeyword, extensionKeyword, unexpectedBetweenExtensionKeywordAndExtendedType, extendedType, unexpectedBetweenExtendedTypeAndInheritanceClause, inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members, unexpectedAfterMembers))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndExtensionKeyword?.raw,
+        extensionKeyword.raw,
+        unexpectedBetweenExtensionKeywordAndExtendedType?.raw,
+        extendedType.raw,
+        unexpectedBetweenExtendedTypeAndInheritanceClause?.raw,
+        inheritanceClause?.raw,
+        unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
+        genericWhereClause?.raw,
+        unexpectedBetweenGenericWhereClauseAndMembers?.raw,
+        members.raw,
+        unexpectedAfterMembers?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.extensionDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -5028,26 +5052,28 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndFuncKeyword?.raw,
-      funcKeyword.raw,
-      unexpectedBetweenFuncKeywordAndIdentifier?.raw,
-      identifier.raw,
-      unexpectedBetweenIdentifierAndGenericParameterClause?.raw,
-      genericParameterClause?.raw,
-      unexpectedBetweenGenericParameterClauseAndSignature?.raw,
-      signature.raw,
-      unexpectedBetweenSignatureAndGenericWhereClause?.raw,
-      genericWhereClause?.raw,
-      unexpectedBetweenGenericWhereClauseAndBody?.raw,
-      body?.raw,
-      unexpectedAfterBody?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndFuncKeyword, funcKeyword, unexpectedBetweenFuncKeywordAndIdentifier, identifier, unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature, signature, unexpectedBetweenSignatureAndGenericWhereClause, genericWhereClause, unexpectedBetweenGenericWhereClauseAndBody, body, unexpectedAfterBody))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndFuncKeyword?.raw,
+        funcKeyword.raw,
+        unexpectedBetweenFuncKeywordAndIdentifier?.raw,
+        identifier.raw,
+        unexpectedBetweenIdentifierAndGenericParameterClause?.raw,
+        genericParameterClause?.raw,
+        unexpectedBetweenGenericParameterClauseAndSignature?.raw,
+        signature.raw,
+        unexpectedBetweenSignatureAndGenericWhereClause?.raw,
+        genericWhereClause?.raw,
+        unexpectedBetweenGenericWhereClauseAndBody?.raw,
+        body?.raw,
+        unexpectedAfterBody?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.functionDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -5575,26 +5601,28 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndInitKeyword?.raw,
-      initKeyword.raw,
-      unexpectedBetweenInitKeywordAndOptionalMark?.raw,
-      optionalMark?.raw,
-      unexpectedBetweenOptionalMarkAndGenericParameterClause?.raw,
-      genericParameterClause?.raw,
-      unexpectedBetweenGenericParameterClauseAndSignature?.raw,
-      signature.raw,
-      unexpectedBetweenSignatureAndGenericWhereClause?.raw,
-      genericWhereClause?.raw,
-      unexpectedBetweenGenericWhereClauseAndBody?.raw,
-      body?.raw,
-      unexpectedAfterBody?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndInitKeyword, initKeyword, unexpectedBetweenInitKeywordAndOptionalMark, optionalMark, unexpectedBetweenOptionalMarkAndGenericParameterClause, genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature, signature, unexpectedBetweenSignatureAndGenericWhereClause, genericWhereClause, unexpectedBetweenGenericWhereClauseAndBody, body, unexpectedAfterBody))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndInitKeyword?.raw,
+        initKeyword.raw,
+        unexpectedBetweenInitKeywordAndOptionalMark?.raw,
+        optionalMark?.raw,
+        unexpectedBetweenOptionalMarkAndGenericParameterClause?.raw,
+        genericParameterClause?.raw,
+        unexpectedBetweenGenericParameterClauseAndSignature?.raw,
+        signature.raw,
+        unexpectedBetweenSignatureAndGenericWhereClause?.raw,
+        genericWhereClause?.raw,
+        unexpectedBetweenGenericWhereClauseAndBody?.raw,
+        body?.raw,
+        unexpectedAfterBody?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.initializerDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -6115,18 +6143,20 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndDeinitKeyword?.raw,
-      deinitKeyword.raw,
-      unexpectedBetweenDeinitKeywordAndBody?.raw,
-      body?.raw,
-      unexpectedAfterBody?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndDeinitKeyword, deinitKeyword, unexpectedBetweenDeinitKeywordAndBody, body, unexpectedAfterBody))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndDeinitKeyword?.raw,
+        deinitKeyword.raw,
+        unexpectedBetweenDeinitKeywordAndBody?.raw,
+        body?.raw,
+        unexpectedAfterBody?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.deinitializerDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -6492,26 +6522,28 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterAccessor: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndSubscriptKeyword?.raw,
-      subscriptKeyword.raw,
-      unexpectedBetweenSubscriptKeywordAndGenericParameterClause?.raw,
-      genericParameterClause?.raw,
-      unexpectedBetweenGenericParameterClauseAndIndices?.raw,
-      indices.raw,
-      unexpectedBetweenIndicesAndResult?.raw,
-      result.raw,
-      unexpectedBetweenResultAndGenericWhereClause?.raw,
-      genericWhereClause?.raw,
-      unexpectedBetweenGenericWhereClauseAndAccessor?.raw,
-      accessor?.raw,
-      unexpectedAfterAccessor?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndSubscriptKeyword, subscriptKeyword, unexpectedBetweenSubscriptKeywordAndGenericParameterClause, genericParameterClause, unexpectedBetweenGenericParameterClauseAndIndices, indices, unexpectedBetweenIndicesAndResult, result, unexpectedBetweenResultAndGenericWhereClause, genericWhereClause, unexpectedBetweenGenericWhereClauseAndAccessor, accessor, unexpectedAfterAccessor))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndSubscriptKeyword?.raw,
+        subscriptKeyword.raw,
+        unexpectedBetweenSubscriptKeywordAndGenericParameterClause?.raw,
+        genericParameterClause?.raw,
+        unexpectedBetweenGenericParameterClauseAndIndices?.raw,
+        indices.raw,
+        unexpectedBetweenIndicesAndResult?.raw,
+        result.raw,
+        unexpectedBetweenResultAndGenericWhereClause?.raw,
+        genericWhereClause?.raw,
+        unexpectedBetweenGenericWhereClauseAndAccessor?.raw,
+        accessor?.raw,
+        unexpectedAfterAccessor?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.subscriptDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -7033,20 +7065,22 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterPath: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndImportTok?.raw,
-      importTok.raw,
-      unexpectedBetweenImportTokAndImportKind?.raw,
-      importKind?.raw,
-      unexpectedBetweenImportKindAndPath?.raw,
-      path.raw,
-      unexpectedAfterPath?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndImportTok, importTok, unexpectedBetweenImportTokAndImportKind, importKind, unexpectedBetweenImportKindAndPath, path, unexpectedAfterPath))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndImportTok?.raw,
+        importTok.raw,
+        unexpectedBetweenImportTokAndImportKind?.raw,
+        importKind?.raw,
+        unexpectedBetweenImportKindAndPath?.raw,
+        path.raw,
+        unexpectedAfterPath?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.importDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -7442,24 +7476,26 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifier?.raw,
-      modifier?.raw,
-      unexpectedBetweenModifierAndAccessorKind?.raw,
-      accessorKind.raw,
-      unexpectedBetweenAccessorKindAndParameter?.raw,
-      parameter?.raw,
-      unexpectedBetweenParameterAndAsyncKeyword?.raw,
-      asyncKeyword?.raw,
-      unexpectedBetweenAsyncKeywordAndThrowsKeyword?.raw,
-      throwsKeyword?.raw,
-      unexpectedBetweenThrowsKeywordAndBody?.raw,
-      body?.raw,
-      unexpectedAfterBody?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifier, modifier, unexpectedBetweenModifierAndAccessorKind, accessorKind, unexpectedBetweenAccessorKindAndParameter, parameter, unexpectedBetweenParameterAndAsyncKeyword, asyncKeyword, unexpectedBetweenAsyncKeywordAndThrowsKeyword, throwsKeyword, unexpectedBetweenThrowsKeywordAndBody, body, unexpectedAfterBody))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifier?.raw,
+        modifier?.raw,
+        unexpectedBetweenModifierAndAccessorKind?.raw,
+        accessorKind.raw,
+        unexpectedBetweenAccessorKindAndParameter?.raw,
+        parameter?.raw,
+        unexpectedBetweenParameterAndAsyncKeyword?.raw,
+        asyncKeyword?.raw,
+        unexpectedBetweenAsyncKeywordAndThrowsKeyword?.raw,
+        throwsKeyword?.raw,
+        unexpectedBetweenThrowsKeywordAndBody?.raw,
+        body?.raw,
+        unexpectedAfterBody?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.accessorDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -7912,18 +7948,20 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterBindings: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndLetOrVarKeyword?.raw,
-      letOrVarKeyword.raw,
-      unexpectedBetweenLetOrVarKeywordAndBindings?.raw,
-      bindings.raw,
-      unexpectedAfterBindings?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndLetOrVarKeyword, letOrVarKeyword, unexpectedBetweenLetOrVarKeywordAndBindings, bindings, unexpectedAfterBindings))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndLetOrVarKeyword?.raw,
+        letOrVarKeyword.raw,
+        unexpectedBetweenLetOrVarKeywordAndBindings?.raw,
+        bindings.raw,
+        unexpectedAfterBindings?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.variableDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -8268,18 +8306,20 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndCaseKeyword?.raw,
-      caseKeyword.raw,
-      unexpectedBetweenCaseKeywordAndElements?.raw,
-      elements.raw,
-      unexpectedAfterElements?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndCaseKeyword, caseKeyword, unexpectedBetweenCaseKeywordAndElements, elements, unexpectedAfterElements))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndCaseKeyword?.raw,
+        caseKeyword.raw,
+        unexpectedBetweenCaseKeywordAndElements?.raw,
+        elements.raw,
+        unexpectedAfterElements?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.enumCaseDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -8636,26 +8676,28 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndEnumKeyword?.raw,
-      enumKeyword.raw,
-      unexpectedBetweenEnumKeywordAndIdentifier?.raw,
-      identifier.raw,
-      unexpectedBetweenIdentifierAndGenericParameters?.raw,
-      genericParameters?.raw,
-      unexpectedBetweenGenericParametersAndInheritanceClause?.raw,
-      inheritanceClause?.raw,
-      unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
-      genericWhereClause?.raw,
-      unexpectedBetweenGenericWhereClauseAndMembers?.raw,
-      members.raw,
-      unexpectedAfterMembers?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndEnumKeyword, enumKeyword, unexpectedBetweenEnumKeywordAndIdentifier, identifier, unexpectedBetweenIdentifierAndGenericParameters, genericParameters, unexpectedBetweenGenericParametersAndInheritanceClause, inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members, unexpectedAfterMembers))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndEnumKeyword?.raw,
+        enumKeyword.raw,
+        unexpectedBetweenEnumKeywordAndIdentifier?.raw,
+        identifier.raw,
+        unexpectedBetweenIdentifierAndGenericParameters?.raw,
+        genericParameters?.raw,
+        unexpectedBetweenGenericParametersAndInheritanceClause?.raw,
+        inheritanceClause?.raw,
+        unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw,
+        genericWhereClause?.raw,
+        unexpectedBetweenGenericWhereClauseAndMembers?.raw,
+        members.raw,
+        unexpectedAfterMembers?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.enumDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -9204,20 +9246,22 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterOperatorPrecedenceAndTypes: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndOperatorKeyword?.raw,
-      operatorKeyword.raw,
-      unexpectedBetweenOperatorKeywordAndIdentifier?.raw,
-      identifier.raw,
-      unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes?.raw,
-      operatorPrecedenceAndTypes?.raw,
-      unexpectedAfterOperatorPrecedenceAndTypes?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndOperatorKeyword, operatorKeyword, unexpectedBetweenOperatorKeywordAndIdentifier, identifier, unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes, operatorPrecedenceAndTypes, unexpectedAfterOperatorPrecedenceAndTypes))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndOperatorKeyword?.raw,
+        operatorKeyword.raw,
+        unexpectedBetweenOperatorKeywordAndIdentifier?.raw,
+        identifier.raw,
+        unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes?.raw,
+        operatorPrecedenceAndTypes?.raw,
+        unexpectedAfterOperatorPrecedenceAndTypes?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.operatorDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -9605,24 +9649,26 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndPrecedencegroupKeyword?.raw,
-      precedencegroupKeyword.raw,
-      unexpectedBetweenPrecedencegroupKeywordAndIdentifier?.raw,
-      identifier.raw,
-      unexpectedBetweenIdentifierAndLeftBrace?.raw,
-      leftBrace.raw,
-      unexpectedBetweenLeftBraceAndGroupAttributes?.raw,
-      groupAttributes.raw,
-      unexpectedBetweenGroupAttributesAndRightBrace?.raw,
-      rightBrace.raw,
-      unexpectedAfterRightBrace?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndPrecedencegroupKeyword, precedencegroupKeyword, unexpectedBetweenPrecedencegroupKeywordAndIdentifier, identifier, unexpectedBetweenIdentifierAndLeftBrace, leftBrace, unexpectedBetweenLeftBraceAndGroupAttributes, groupAttributes, unexpectedBetweenGroupAttributesAndRightBrace, rightBrace, unexpectedAfterRightBrace))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndPrecedencegroupKeyword?.raw,
+        precedencegroupKeyword.raw,
+        unexpectedBetweenPrecedencegroupKeywordAndIdentifier?.raw,
+        identifier.raw,
+        unexpectedBetweenIdentifierAndLeftBrace?.raw,
+        leftBrace.raw,
+        unexpectedBetweenLeftBraceAndGroupAttributes?.raw,
+        groupAttributes.raw,
+        unexpectedBetweenGroupAttributesAndRightBrace?.raw,
+        rightBrace.raw,
+        unexpectedAfterRightBrace?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.precedenceGroupDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -10166,26 +10212,28 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndMacroKeyword?.raw,
-      macroKeyword.raw,
-      unexpectedBetweenMacroKeywordAndIdentifier?.raw,
-      identifier.raw,
-      unexpectedBetweenIdentifierAndGenericParameterClause?.raw,
-      genericParameterClause?.raw,
-      unexpectedBetweenGenericParameterClauseAndSignature?.raw,
-      signature.raw,
-      unexpectedBetweenSignatureAndDefinition?.raw,
-      definition?.raw,
-      unexpectedBetweenDefinitionAndGenericWhereClause?.raw,
-      genericWhereClause?.raw,
-      unexpectedAfterGenericWhereClause?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndMacroKeyword, macroKeyword, unexpectedBetweenMacroKeywordAndIdentifier, identifier, unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature, signature, unexpectedBetweenSignatureAndDefinition, definition, unexpectedBetweenDefinitionAndGenericWhereClause, genericWhereClause, unexpectedAfterGenericWhereClause))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndMacroKeyword?.raw,
+        macroKeyword.raw,
+        unexpectedBetweenMacroKeywordAndIdentifier?.raw,
+        identifier.raw,
+        unexpectedBetweenIdentifierAndGenericParameterClause?.raw,
+        genericParameterClause?.raw,
+        unexpectedBetweenGenericParameterClauseAndSignature?.raw,
+        signature.raw,
+        unexpectedBetweenSignatureAndDefinition?.raw,
+        definition?.raw,
+        unexpectedBetweenDefinitionAndGenericWhereClause?.raw,
+        genericWhereClause?.raw,
+        unexpectedAfterGenericWhereClause?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.macroDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -10713,26 +10761,28 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePoundToken?.raw,
-      poundToken.raw,
-      unexpectedBetweenPoundTokenAndMacro?.raw,
-      macro.raw,
-      unexpectedBetweenMacroAndGenericArguments?.raw,
-      genericArguments?.raw,
-      unexpectedBetweenGenericArgumentsAndLeftParen?.raw,
-      leftParen?.raw,
-      unexpectedBetweenLeftParenAndArgumentList?.raw,
-      argumentList.raw,
-      unexpectedBetweenArgumentListAndRightParen?.raw,
-      rightParen?.raw,
-      unexpectedBetweenRightParenAndTrailingClosure?.raw,
-      trailingClosure?.raw,
-      unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.raw,
-      additionalTrailingClosures?.raw,
-      unexpectedAfterAdditionalTrailingClosures?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePoundToken, poundToken, unexpectedBetweenPoundTokenAndMacro, macro, unexpectedBetweenMacroAndGenericArguments, genericArguments, unexpectedBetweenGenericArgumentsAndLeftParen, leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList, unexpectedBetweenArgumentListAndRightParen, rightParen, unexpectedBetweenRightParenAndTrailingClosure, trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures, unexpectedAfterAdditionalTrailingClosures))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePoundToken?.raw,
+        poundToken.raw,
+        unexpectedBetweenPoundTokenAndMacro?.raw,
+        macro.raw,
+        unexpectedBetweenMacroAndGenericArguments?.raw,
+        genericArguments?.raw,
+        unexpectedBetweenGenericArgumentsAndLeftParen?.raw,
+        leftParen?.raw,
+        unexpectedBetweenLeftParenAndArgumentList?.raw,
+        argumentList.raw,
+        unexpectedBetweenArgumentListAndRightParen?.raw,
+        rightParen?.raw,
+        unexpectedBetweenRightParenAndTrailingClosure?.raw,
+        trailingClosure?.raw,
+        unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.raw,
+        additionalTrailingClosures?.raw,
+        unexpectedAfterAdditionalTrailingClosures?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.macroExpansionDecl, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -32,7 +32,9 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
 
   public init() {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), ())) { (arena, _) in
       let raw = RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: arena)
       return SyntaxData.forRoot(raw)
     }
@@ -86,14 +88,16 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAmpersand?.raw,
-      ampersand.raw,
-      unexpectedBetweenAmpersandAndExpression?.raw,
-      expression.raw,
-      unexpectedAfterExpression?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAmpersand, ampersand, unexpectedBetweenAmpersandAndExpression, expression, unexpectedAfterExpression))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAmpersand?.raw,
+        ampersand.raw,
+        unexpectedBetweenAmpersandAndExpression?.raw,
+        expression.raw,
+        unexpectedAfterExpression?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.inOutExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -270,12 +274,14 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterPoundColumn: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePoundColumn?.raw,
-      poundColumn.raw,
-      unexpectedAfterPoundColumn?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePoundColumn, poundColumn, unexpectedAfterPoundColumn))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePoundColumn?.raw,
+        poundColumn.raw,
+        unexpectedAfterPoundColumn?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.poundColumnExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -407,16 +413,18 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeTryKeyword?.raw,
-      tryKeyword.raw,
-      unexpectedBetweenTryKeywordAndQuestionOrExclamationMark?.raw,
-      questionOrExclamationMark?.raw,
-      unexpectedBetweenQuestionOrExclamationMarkAndExpression?.raw,
-      expression.raw,
-      unexpectedAfterExpression?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeTryKeyword, tryKeyword, unexpectedBetweenTryKeywordAndQuestionOrExclamationMark, questionOrExclamationMark, unexpectedBetweenQuestionOrExclamationMarkAndExpression, expression, unexpectedAfterExpression))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeTryKeyword?.raw,
+        tryKeyword.raw,
+        unexpectedBetweenTryKeywordAndQuestionOrExclamationMark?.raw,
+        questionOrExclamationMark?.raw,
+        unexpectedBetweenQuestionOrExclamationMarkAndExpression?.raw,
+        expression.raw,
+        unexpectedAfterExpression?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.tryExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -645,14 +653,16 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAwaitKeyword?.raw,
-      awaitKeyword.raw,
-      unexpectedBetweenAwaitKeywordAndExpression?.raw,
-      expression.raw,
-      unexpectedAfterExpression?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAwaitKeyword, awaitKeyword, unexpectedBetweenAwaitKeywordAndExpression, expression, unexpectedAfterExpression))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAwaitKeyword?.raw,
+        awaitKeyword.raw,
+        unexpectedBetweenAwaitKeywordAndExpression?.raw,
+        expression.raw,
+        unexpectedAfterExpression?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.awaitExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -831,14 +841,16 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeMoveKeyword?.raw,
-      moveKeyword.raw,
-      unexpectedBetweenMoveKeywordAndExpression?.raw,
-      expression.raw,
-      unexpectedAfterExpression?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeMoveKeyword, moveKeyword, unexpectedBetweenMoveKeywordAndExpression, expression, unexpectedAfterExpression))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeMoveKeyword?.raw,
+        moveKeyword.raw,
+        unexpectedBetweenMoveKeywordAndExpression?.raw,
+        expression.raw,
+        unexpectedAfterExpression?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.moveExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1017,14 +1029,16 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeBorrowKeyword?.raw,
-      borrowKeyword.raw,
-      unexpectedBetweenBorrowKeywordAndExpression?.raw,
-      expression.raw,
-      unexpectedAfterExpression?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeBorrowKeyword, borrowKeyword, unexpectedBetweenBorrowKeywordAndExpression, expression, unexpectedAfterExpression))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeBorrowKeyword?.raw,
+        borrowKeyword.raw,
+        unexpectedBetweenBorrowKeywordAndExpression?.raw,
+        expression.raw,
+        unexpectedAfterExpression?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.borrowExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1203,14 +1217,16 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeIdentifier?.raw,
-      identifier.raw,
-      unexpectedBetweenIdentifierAndDeclNameArguments?.raw,
-      declNameArguments?.raw,
-      unexpectedAfterDeclNameArguments?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIdentifier, identifier, unexpectedBetweenIdentifierAndDeclNameArguments, declNameArguments, unexpectedAfterDeclNameArguments))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeIdentifier?.raw,
+        identifier.raw,
+        unexpectedBetweenIdentifierAndDeclNameArguments?.raw,
+        declNameArguments?.raw,
+        unexpectedAfterDeclNameArguments?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.identifierExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1388,12 +1404,14 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterSuperKeyword: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeSuperKeyword?.raw,
-      superKeyword.raw,
-      unexpectedAfterSuperKeyword?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeSuperKeyword, superKeyword, unexpectedAfterSuperKeyword))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeSuperKeyword?.raw,
+        superKeyword.raw,
+        unexpectedAfterSuperKeyword?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.superRefExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1521,12 +1539,14 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterNilKeyword: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeNilKeyword?.raw,
-      nilKeyword.raw,
-      unexpectedAfterNilKeyword?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeNilKeyword, nilKeyword, unexpectedAfterNilKeyword))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeNilKeyword?.raw,
+        nilKeyword.raw,
+        unexpectedAfterNilKeyword?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.nilLiteralExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1654,12 +1674,14 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterWildcard: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeWildcard?.raw,
-      wildcard.raw,
-      unexpectedAfterWildcard?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeWildcard, wildcard, unexpectedAfterWildcard))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeWildcard?.raw,
+        wildcard.raw,
+        unexpectedAfterWildcard?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.discardAssignmentExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1787,12 +1809,14 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterAssignToken: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAssignToken?.raw,
-      assignToken.raw,
-      unexpectedAfterAssignToken?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAssignToken, assignToken, unexpectedAfterAssignToken))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAssignToken?.raw,
+        assignToken.raw,
+        unexpectedAfterAssignToken?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.assignmentExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1922,14 +1946,16 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterPackRefExpr: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeEachKeyword?.raw,
-      eachKeyword.raw,
-      unexpectedBetweenEachKeywordAndPackRefExpr?.raw,
-      packRefExpr.raw,
-      unexpectedAfterPackRefExpr?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeEachKeyword, eachKeyword, unexpectedBetweenEachKeywordAndPackRefExpr, packRefExpr, unexpectedAfterPackRefExpr))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeEachKeyword?.raw,
+        eachKeyword.raw,
+        unexpectedBetweenEachKeywordAndPackRefExpr?.raw,
+        packRefExpr.raw,
+        unexpectedAfterPackRefExpr?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.packElementExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2106,12 +2132,14 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeElements?.raw,
-      elements.raw,
-      unexpectedAfterElements?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeElements, elements, unexpectedAfterElements))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeElements?.raw,
+        elements.raw,
+        unexpectedAfterElements?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.sequenceExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2260,14 +2288,16 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeIdentifier?.raw,
-      identifier.raw,
-      unexpectedBetweenIdentifierAndGenericArgumentClause?.raw,
-      genericArgumentClause?.raw,
-      unexpectedAfterGenericArgumentClause?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIdentifier, identifier, unexpectedBetweenIdentifierAndGenericArgumentClause, genericArgumentClause, unexpectedAfterGenericArgumentClause))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeIdentifier?.raw,
+        identifier.raw,
+        unexpectedBetweenIdentifierAndGenericArgumentClause?.raw,
+        genericArgumentClause?.raw,
+        unexpectedAfterGenericArgumentClause?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.symbolicReferenceExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2447,14 +2477,16 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterPostfixExpression: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeOperatorToken?.raw,
-      operatorToken?.raw,
-      unexpectedBetweenOperatorTokenAndPostfixExpression?.raw,
-      postfixExpression.raw,
-      unexpectedAfterPostfixExpression?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeOperatorToken, operatorToken, unexpectedBetweenOperatorTokenAndPostfixExpression, postfixExpression, unexpectedAfterPostfixExpression))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeOperatorToken?.raw,
+        operatorToken?.raw,
+        unexpectedBetweenOperatorTokenAndPostfixExpression?.raw,
+        postfixExpression.raw,
+        unexpectedAfterPostfixExpression?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.prefixOperatorExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2632,12 +2664,14 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterOperatorToken: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeOperatorToken?.raw,
-      operatorToken.raw,
-      unexpectedAfterOperatorToken?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeOperatorToken, operatorToken, unexpectedAfterOperatorToken))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeOperatorToken?.raw,
+        operatorToken.raw,
+        unexpectedAfterOperatorToken?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.binaryOperatorExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2769,16 +2803,18 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterArrowToken: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAsyncKeyword?.raw,
-      asyncKeyword?.raw,
-      unexpectedBetweenAsyncKeywordAndThrowsToken?.raw,
-      throwsToken?.raw,
-      unexpectedBetweenThrowsTokenAndArrowToken?.raw,
-      arrowToken.raw,
-      unexpectedAfterArrowToken?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAsyncKeyword, asyncKeyword, unexpectedBetweenAsyncKeywordAndThrowsToken, throwsToken, unexpectedBetweenThrowsTokenAndArrowToken, arrowToken, unexpectedAfterArrowToken))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAsyncKeyword?.raw,
+        asyncKeyword?.raw,
+        unexpectedBetweenAsyncKeywordAndThrowsToken?.raw,
+        throwsToken?.raw,
+        unexpectedBetweenThrowsTokenAndArrowToken?.raw,
+        arrowToken.raw,
+        unexpectedAfterArrowToken?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.arrowExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3010,16 +3046,18 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightOperand: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftOperand?.raw,
-      leftOperand.raw,
-      unexpectedBetweenLeftOperandAndOperatorOperand?.raw,
-      operatorOperand.raw,
-      unexpectedBetweenOperatorOperandAndRightOperand?.raw,
-      rightOperand.raw,
-      unexpectedAfterRightOperand?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftOperand, leftOperand, unexpectedBetweenLeftOperandAndOperatorOperand, operatorOperand, unexpectedBetweenOperatorOperandAndRightOperand, rightOperand, unexpectedAfterRightOperand))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftOperand?.raw,
+        leftOperand.raw,
+        unexpectedBetweenLeftOperandAndOperatorOperand?.raw,
+        operatorOperand.raw,
+        unexpectedBetweenOperatorOperandAndRightOperand?.raw,
+        rightOperand.raw,
+        unexpectedAfterRightOperand?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.infixOperatorExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3245,12 +3283,14 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterFloatingDigits: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeFloatingDigits?.raw,
-      floatingDigits.raw,
-      unexpectedAfterFloatingDigits?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeFloatingDigits, floatingDigits, unexpectedAfterFloatingDigits))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeFloatingDigits?.raw,
+        floatingDigits.raw,
+        unexpectedAfterFloatingDigits?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.floatLiteralExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3382,16 +3422,18 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndElementList?.raw,
-      elementList.raw,
-      unexpectedBetweenElementListAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftParen, leftParen, unexpectedBetweenLeftParenAndElementList, elementList, unexpectedBetweenElementListAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndElementList?.raw,
+        elementList.raw,
+        unexpectedBetweenElementListAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.tupleExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3640,16 +3682,18 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftSquare?.raw,
-      leftSquare.raw,
-      unexpectedBetweenLeftSquareAndElements?.raw,
-      elements.raw,
-      unexpectedBetweenElementsAndRightSquare?.raw,
-      rightSquare.raw,
-      unexpectedAfterRightSquare?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftSquare, leftSquare, unexpectedBetweenLeftSquareAndElements, elements, unexpectedBetweenElementsAndRightSquare, rightSquare, unexpectedAfterRightSquare))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftSquare?.raw,
+        leftSquare.raw,
+        unexpectedBetweenLeftSquareAndElements?.raw,
+        elements.raw,
+        unexpectedBetweenElementsAndRightSquare?.raw,
+        rightSquare.raw,
+        unexpectedAfterRightSquare?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.arrayExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3934,16 +3978,18 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftSquare?.raw,
-      leftSquare.raw,
-      unexpectedBetweenLeftSquareAndContent?.raw,
-      content.raw,
-      unexpectedBetweenContentAndRightSquare?.raw,
-      rightSquare.raw,
-      unexpectedAfterRightSquare?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftSquare, leftSquare, unexpectedBetweenLeftSquareAndContent, content, unexpectedBetweenContentAndRightSquare, rightSquare, unexpectedAfterRightSquare))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftSquare?.raw,
+        leftSquare.raw,
+        unexpectedBetweenLeftSquareAndContent?.raw,
+        content.raw,
+        unexpectedBetweenContentAndRightSquare?.raw,
+        rightSquare.raw,
+        unexpectedAfterRightSquare?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.dictionaryExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -4169,12 +4215,14 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterDigits: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeDigits?.raw,
-      digits.raw,
-      unexpectedAfterDigits?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeDigits, digits, unexpectedAfterDigits))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeDigits?.raw,
+        digits.raw,
+        unexpectedAfterDigits?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.integerLiteralExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -4302,12 +4350,14 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterBooleanLiteral: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeBooleanLiteral?.raw,
-      booleanLiteral.raw,
-      unexpectedAfterBooleanLiteral?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeBooleanLiteral, booleanLiteral, unexpectedAfterBooleanLiteral))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeBooleanLiteral?.raw,
+        booleanLiteral.raw,
+        unexpectedAfterBooleanLiteral?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.booleanLiteralExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -4439,16 +4489,18 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterColonMark: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeQuestionMark?.raw,
-      questionMark.raw,
-      unexpectedBetweenQuestionMarkAndFirstChoice?.raw,
-      firstChoice.raw,
-      unexpectedBetweenFirstChoiceAndColonMark?.raw,
-      colonMark.raw,
-      unexpectedAfterColonMark?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeQuestionMark, questionMark, unexpectedBetweenQuestionMarkAndFirstChoice, firstChoice, unexpectedBetweenFirstChoiceAndColonMark, colonMark, unexpectedAfterColonMark))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeQuestionMark?.raw,
+        questionMark.raw,
+        unexpectedBetweenQuestionMarkAndFirstChoice?.raw,
+        firstChoice.raw,
+        unexpectedBetweenFirstChoiceAndColonMark?.raw,
+        colonMark.raw,
+        unexpectedAfterColonMark?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.unresolvedTernaryExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -4682,20 +4734,22 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterSecondChoice: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeConditionExpression?.raw,
-      conditionExpression.raw,
-      unexpectedBetweenConditionExpressionAndQuestionMark?.raw,
-      questionMark.raw,
-      unexpectedBetweenQuestionMarkAndFirstChoice?.raw,
-      firstChoice.raw,
-      unexpectedBetweenFirstChoiceAndColonMark?.raw,
-      colonMark.raw,
-      unexpectedBetweenColonMarkAndSecondChoice?.raw,
-      secondChoice.raw,
-      unexpectedAfterSecondChoice?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeConditionExpression, conditionExpression, unexpectedBetweenConditionExpressionAndQuestionMark, questionMark, unexpectedBetweenQuestionMarkAndFirstChoice, firstChoice, unexpectedBetweenFirstChoiceAndColonMark, colonMark, unexpectedBetweenColonMarkAndSecondChoice, secondChoice, unexpectedAfterSecondChoice))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeConditionExpression?.raw,
+        conditionExpression.raw,
+        unexpectedBetweenConditionExpressionAndQuestionMark?.raw,
+        questionMark.raw,
+        unexpectedBetweenQuestionMarkAndFirstChoice?.raw,
+        firstChoice.raw,
+        unexpectedBetweenFirstChoiceAndColonMark?.raw,
+        colonMark.raw,
+        unexpectedBetweenColonMarkAndSecondChoice?.raw,
+        secondChoice.raw,
+        unexpectedAfterSecondChoice?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.ternaryExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -5025,18 +5079,20 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeBase?.raw,
-      base?.raw,
-      unexpectedBetweenBaseAndDot?.raw,
-      dot.raw,
-      unexpectedBetweenDotAndName?.raw,
-      name.raw,
-      unexpectedBetweenNameAndDeclNameArguments?.raw,
-      declNameArguments?.raw,
-      unexpectedAfterDeclNameArguments?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeBase, base, unexpectedBetweenBaseAndDot, dot, unexpectedBetweenDotAndName, name, unexpectedBetweenNameAndDeclNameArguments, declNameArguments, unexpectedAfterDeclNameArguments))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeBase?.raw,
+        base?.raw,
+        unexpectedBetweenBaseAndDot?.raw,
+        dot.raw,
+        unexpectedBetweenDotAndName?.raw,
+        name.raw,
+        unexpectedBetweenNameAndDeclNameArguments?.raw,
+        declNameArguments?.raw,
+        unexpectedAfterDeclNameArguments?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.memberAccessExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -5351,12 +5407,14 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterIsTok: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeIsTok?.raw,
-      isTok.raw,
-      unexpectedAfterIsTok?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIsTok, isTok, unexpectedAfterIsTok))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeIsTok?.raw,
+        isTok.raw,
+        unexpectedAfterIsTok?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.unresolvedIsExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -5488,16 +5546,18 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeExpression?.raw,
-      expression.raw,
-      unexpectedBetweenExpressionAndIsTok?.raw,
-      isTok.raw,
-      unexpectedBetweenIsTokAndTypeName?.raw,
-      typeName.raw,
-      unexpectedAfterTypeName?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeExpression, expression, unexpectedBetweenExpressionAndIsTok, isTok, unexpectedBetweenIsTokAndTypeName, typeName, unexpectedAfterTypeName))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeExpression?.raw,
+        expression.raw,
+        unexpectedBetweenExpressionAndIsTok?.raw,
+        isTok.raw,
+        unexpectedBetweenIsTokAndTypeName?.raw,
+        typeName.raw,
+        unexpectedAfterTypeName?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.isExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -5725,14 +5785,16 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAsTok?.raw,
-      asTok.raw,
-      unexpectedBetweenAsTokAndQuestionOrExclamationMark?.raw,
-      questionOrExclamationMark?.raw,
-      unexpectedAfterQuestionOrExclamationMark?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAsTok, asTok, unexpectedBetweenAsTokAndQuestionOrExclamationMark, questionOrExclamationMark, unexpectedAfterQuestionOrExclamationMark))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAsTok?.raw,
+        asTok.raw,
+        unexpectedBetweenAsTokAndQuestionOrExclamationMark?.raw,
+        questionOrExclamationMark?.raw,
+        unexpectedAfterQuestionOrExclamationMark?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.unresolvedAsExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -5916,18 +5978,20 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeExpression?.raw,
-      expression.raw,
-      unexpectedBetweenExpressionAndAsTok?.raw,
-      asTok.raw,
-      unexpectedBetweenAsTokAndQuestionOrExclamationMark?.raw,
-      questionOrExclamationMark?.raw,
-      unexpectedBetweenQuestionOrExclamationMarkAndTypeName?.raw,
-      typeName.raw,
-      unexpectedAfterTypeName?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeExpression, expression, unexpectedBetweenExpressionAndAsTok, asTok, unexpectedBetweenAsTokAndQuestionOrExclamationMark, questionOrExclamationMark, unexpectedBetweenQuestionOrExclamationMarkAndTypeName, typeName, unexpectedAfterTypeName))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeExpression?.raw,
+        expression.raw,
+        unexpectedBetweenExpressionAndAsTok?.raw,
+        asTok.raw,
+        unexpectedBetweenAsTokAndQuestionOrExclamationMark?.raw,
+        questionOrExclamationMark?.raw,
+        unexpectedBetweenQuestionOrExclamationMarkAndTypeName?.raw,
+        typeName.raw,
+        unexpectedAfterTypeName?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.asExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -6203,12 +6267,14 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterType: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeType?.raw,
-      type.raw,
-      unexpectedAfterType?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeType, type, unexpectedAfterType))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeType?.raw,
+        type.raw,
+        unexpectedAfterType?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.typeExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -6342,18 +6408,20 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftBrace?.raw,
-      leftBrace.raw,
-      unexpectedBetweenLeftBraceAndSignature?.raw,
-      signature?.raw,
-      unexpectedBetweenSignatureAndStatements?.raw,
-      statements.raw,
-      unexpectedBetweenStatementsAndRightBrace?.raw,
-      rightBrace.raw,
-      unexpectedAfterRightBrace?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftBrace, leftBrace, unexpectedBetweenLeftBraceAndSignature, signature, unexpectedBetweenSignatureAndStatements, statements, unexpectedBetweenStatementsAndRightBrace, rightBrace, unexpectedAfterRightBrace))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftBrace?.raw,
+        leftBrace.raw,
+        unexpectedBetweenLeftBraceAndSignature?.raw,
+        signature?.raw,
+        unexpectedBetweenSignatureAndStatements?.raw,
+        statements.raw,
+        unexpectedBetweenStatementsAndRightBrace?.raw,
+        rightBrace.raw,
+        unexpectedAfterRightBrace?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.closureExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -6648,12 +6716,14 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterPattern: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePattern?.raw,
-      pattern.raw,
-      unexpectedAfterPattern?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePattern, pattern, unexpectedAfterPattern))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePattern?.raw,
+        pattern.raw,
+        unexpectedAfterPattern?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.unresolvedPatternExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -6791,22 +6861,24 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeCalledExpression?.raw,
-      calledExpression.raw,
-      unexpectedBetweenCalledExpressionAndLeftParen?.raw,
-      leftParen?.raw,
-      unexpectedBetweenLeftParenAndArgumentList?.raw,
-      argumentList.raw,
-      unexpectedBetweenArgumentListAndRightParen?.raw,
-      rightParen?.raw,
-      unexpectedBetweenRightParenAndTrailingClosure?.raw,
-      trailingClosure?.raw,
-      unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.raw,
-      additionalTrailingClosures?.raw,
-      unexpectedAfterAdditionalTrailingClosures?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeCalledExpression, calledExpression, unexpectedBetweenCalledExpressionAndLeftParen, leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList, unexpectedBetweenArgumentListAndRightParen, rightParen, unexpectedBetweenRightParenAndTrailingClosure, trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures, unexpectedAfterAdditionalTrailingClosures))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeCalledExpression?.raw,
+        calledExpression.raw,
+        unexpectedBetweenCalledExpressionAndLeftParen?.raw,
+        leftParen?.raw,
+        unexpectedBetweenLeftParenAndArgumentList?.raw,
+        argumentList.raw,
+        unexpectedBetweenArgumentListAndRightParen?.raw,
+        rightParen?.raw,
+        unexpectedBetweenRightParenAndTrailingClosure?.raw,
+        trailingClosure?.raw,
+        unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.raw,
+        additionalTrailingClosures?.raw,
+        unexpectedAfterAdditionalTrailingClosures?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.functionCallExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -7231,22 +7303,24 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeCalledExpression?.raw,
-      calledExpression.raw,
-      unexpectedBetweenCalledExpressionAndLeftBracket?.raw,
-      leftBracket.raw,
-      unexpectedBetweenLeftBracketAndArgumentList?.raw,
-      argumentList.raw,
-      unexpectedBetweenArgumentListAndRightBracket?.raw,
-      rightBracket.raw,
-      unexpectedBetweenRightBracketAndTrailingClosure?.raw,
-      trailingClosure?.raw,
-      unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.raw,
-      additionalTrailingClosures?.raw,
-      unexpectedAfterAdditionalTrailingClosures?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeCalledExpression, calledExpression, unexpectedBetweenCalledExpressionAndLeftBracket, leftBracket, unexpectedBetweenLeftBracketAndArgumentList, argumentList, unexpectedBetweenArgumentListAndRightBracket, rightBracket, unexpectedBetweenRightBracketAndTrailingClosure, trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures, unexpectedAfterAdditionalTrailingClosures))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeCalledExpression?.raw,
+        calledExpression.raw,
+        unexpectedBetweenCalledExpressionAndLeftBracket?.raw,
+        leftBracket.raw,
+        unexpectedBetweenLeftBracketAndArgumentList?.raw,
+        argumentList.raw,
+        unexpectedBetweenArgumentListAndRightBracket?.raw,
+        rightBracket.raw,
+        unexpectedBetweenRightBracketAndTrailingClosure?.raw,
+        trailingClosure?.raw,
+        unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.raw,
+        additionalTrailingClosures?.raw,
+        unexpectedAfterAdditionalTrailingClosures?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.subscriptExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -7661,14 +7735,16 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeExpression?.raw,
-      expression.raw,
-      unexpectedBetweenExpressionAndQuestionMark?.raw,
-      questionMark.raw,
-      unexpectedAfterQuestionMark?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeExpression, expression, unexpectedBetweenExpressionAndQuestionMark, questionMark, unexpectedAfterQuestionMark))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeExpression?.raw,
+        expression.raw,
+        unexpectedBetweenExpressionAndQuestionMark?.raw,
+        questionMark.raw,
+        unexpectedAfterQuestionMark?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.optionalChainingExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -7847,14 +7923,16 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeExpression?.raw,
-      expression.raw,
-      unexpectedBetweenExpressionAndExclamationMark?.raw,
-      exclamationMark.raw,
-      unexpectedAfterExclamationMark?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeExpression, expression, unexpectedBetweenExpressionAndExclamationMark, exclamationMark, unexpectedAfterExclamationMark))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeExpression?.raw,
+        expression.raw,
+        unexpectedBetweenExpressionAndExclamationMark?.raw,
+        exclamationMark.raw,
+        unexpectedAfterExclamationMark?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.forcedValueExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -8033,14 +8111,16 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterOperatorToken: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeExpression?.raw,
-      expression.raw,
-      unexpectedBetweenExpressionAndOperatorToken?.raw,
-      operatorToken.raw,
-      unexpectedAfterOperatorToken?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeExpression, expression, unexpectedBetweenExpressionAndOperatorToken, operatorToken, unexpectedAfterOperatorToken))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeExpression?.raw,
+        expression.raw,
+        unexpectedBetweenExpressionAndOperatorToken?.raw,
+        operatorToken.raw,
+        unexpectedAfterOperatorToken?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.postfixUnaryExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -8219,14 +8299,16 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeExpression?.raw,
-      expression.raw,
-      unexpectedBetweenExpressionAndGenericArgumentClause?.raw,
-      genericArgumentClause.raw,
-      unexpectedAfterGenericArgumentClause?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeExpression, expression, unexpectedBetweenExpressionAndGenericArgumentClause, genericArgumentClause, unexpectedAfterGenericArgumentClause))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeExpression?.raw,
+        expression.raw,
+        unexpectedBetweenExpressionAndGenericArgumentClause?.raw,
+        genericArgumentClause.raw,
+        unexpectedAfterGenericArgumentClause?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.specializeExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -8411,20 +8493,22 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterCloseDelimiter: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeOpenDelimiter?.raw,
-      openDelimiter?.raw,
-      unexpectedBetweenOpenDelimiterAndOpenQuote?.raw,
-      openQuote.raw,
-      unexpectedBetweenOpenQuoteAndSegments?.raw,
-      segments.raw,
-      unexpectedBetweenSegmentsAndCloseQuote?.raw,
-      closeQuote.raw,
-      unexpectedBetweenCloseQuoteAndCloseDelimiter?.raw,
-      closeDelimiter?.raw,
-      unexpectedAfterCloseDelimiter?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeOpenDelimiter, openDelimiter, unexpectedBetweenOpenDelimiterAndOpenQuote, openQuote, unexpectedBetweenOpenQuoteAndSegments, segments, unexpectedBetweenSegmentsAndCloseQuote, closeQuote, unexpectedBetweenCloseQuoteAndCloseDelimiter, closeDelimiter, unexpectedAfterCloseDelimiter))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeOpenDelimiter?.raw,
+        openDelimiter?.raw,
+        unexpectedBetweenOpenDelimiterAndOpenQuote?.raw,
+        openQuote.raw,
+        unexpectedBetweenOpenQuoteAndSegments?.raw,
+        segments.raw,
+        unexpectedBetweenSegmentsAndCloseQuote?.raw,
+        closeQuote.raw,
+        unexpectedBetweenCloseQuoteAndCloseDelimiter?.raw,
+        closeDelimiter?.raw,
+        unexpectedAfterCloseDelimiter?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.stringLiteralExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -8769,12 +8853,14 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRegex: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeRegex?.raw,
-      regex.raw,
-      unexpectedAfterRegex?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeRegex, regex, unexpectedAfterRegex))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeRegex?.raw,
+        regex.raw,
+        unexpectedAfterRegex?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.regexLiteralExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -8906,16 +8992,18 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterComponents: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeBackslash?.raw,
-      backslash.raw,
-      unexpectedBetweenBackslashAndRoot?.raw,
-      root?.raw,
-      unexpectedBetweenRootAndComponents?.raw,
-      components.raw,
-      unexpectedAfterComponents?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeBackslash, backslash, unexpectedBetweenBackslashAndRoot, root, unexpectedBetweenRootAndComponents, components, unexpectedAfterComponents))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeBackslash?.raw,
+        backslash.raw,
+        unexpectedBetweenBackslashAndRoot?.raw,
+        root?.raw,
+        unexpectedBetweenRootAndComponents?.raw,
+        components.raw,
+        unexpectedAfterComponents?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.keyPathExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -9209,26 +9297,28 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePoundToken?.raw,
-      poundToken.raw,
-      unexpectedBetweenPoundTokenAndMacro?.raw,
-      macro.raw,
-      unexpectedBetweenMacroAndGenericArguments?.raw,
-      genericArguments?.raw,
-      unexpectedBetweenGenericArgumentsAndLeftParen?.raw,
-      leftParen?.raw,
-      unexpectedBetweenLeftParenAndArgumentList?.raw,
-      argumentList.raw,
-      unexpectedBetweenArgumentListAndRightParen?.raw,
-      rightParen?.raw,
-      unexpectedBetweenRightParenAndTrailingClosure?.raw,
-      trailingClosure?.raw,
-      unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.raw,
-      additionalTrailingClosures?.raw,
-      unexpectedAfterAdditionalTrailingClosures?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePoundToken, poundToken, unexpectedBetweenPoundTokenAndMacro, macro, unexpectedBetweenMacroAndGenericArguments, genericArguments, unexpectedBetweenGenericArgumentsAndLeftParen, leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList, unexpectedBetweenArgumentListAndRightParen, rightParen, unexpectedBetweenRightParenAndTrailingClosure, trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures, unexpectedAfterAdditionalTrailingClosures))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePoundToken?.raw,
+        poundToken.raw,
+        unexpectedBetweenPoundTokenAndMacro?.raw,
+        macro.raw,
+        unexpectedBetweenMacroAndGenericArguments?.raw,
+        genericArguments?.raw,
+        unexpectedBetweenGenericArgumentsAndLeftParen?.raw,
+        leftParen?.raw,
+        unexpectedBetweenLeftParenAndArgumentList?.raw,
+        argumentList.raw,
+        unexpectedBetweenArgumentListAndRightParen?.raw,
+        rightParen?.raw,
+        unexpectedBetweenRightParenAndTrailingClosure?.raw,
+        trailingClosure?.raw,
+        unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.raw,
+        additionalTrailingClosures?.raw,
+        unexpectedAfterAdditionalTrailingClosures?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.macroExpansionExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -9745,14 +9835,16 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterConfig: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeBase?.raw,
-      base?.raw,
-      unexpectedBetweenBaseAndConfig?.raw,
-      config.raw,
-      unexpectedAfterConfig?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeBase, base, unexpectedBetweenBaseAndConfig, config, unexpectedAfterConfig))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeBase?.raw,
+        base?.raw,
+        unexpectedBetweenBaseAndConfig?.raw,
+        config.raw,
+        unexpectedAfterConfig?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.postfixIfConfigExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -9960,12 +10052,14 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterIdentifier: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeIdentifier?.raw,
-      identifier.raw,
-      unexpectedAfterIdentifier?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIdentifier, identifier, unexpectedAfterIdentifier))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeIdentifier?.raw,
+        identifier.raw,
+        unexpectedAfterIdentifier?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.editorPlaceholderExpr, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -32,7 +32,9 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
   }
 
   public init() {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), ())) { (arena, _) in
       let raw = RawSyntax.makeEmptyLayout(kind: SyntaxKind.missing, arena: arena)
       return SyntaxData.forRoot(raw)
     }
@@ -158,16 +160,18 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterErrorTokens: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeItem?.raw,
-      item.raw,
-      unexpectedBetweenItemAndSemicolon?.raw,
-      semicolon?.raw,
-      unexpectedBetweenSemicolonAndErrorTokens?.raw,
-      errorTokens?.raw,
-      unexpectedAfterErrorTokens?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeItem, item, unexpectedBetweenItemAndSemicolon, semicolon, unexpectedBetweenSemicolonAndErrorTokens, errorTokens, unexpectedAfterErrorTokens))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeItem?.raw,
+        item.raw,
+        unexpectedBetweenItemAndSemicolon?.raw,
+        semicolon?.raw,
+        unexpectedBetweenSemicolonAndErrorTokens?.raw,
+        errorTokens?.raw,
+        unexpectedAfterErrorTokens?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.codeBlockItem, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -437,16 +441,18 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftBrace?.raw,
-      leftBrace.raw,
-      unexpectedBetweenLeftBraceAndStatements?.raw,
-      statements.raw,
-      unexpectedBetweenStatementsAndRightBrace?.raw,
-      rightBrace.raw,
-      unexpectedAfterRightBrace?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftBrace, leftBrace, unexpectedBetweenLeftBraceAndStatements, statements, unexpectedBetweenStatementsAndRightBrace, rightBrace, unexpectedAfterRightBrace))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftBrace?.raw,
+        leftBrace.raw,
+        unexpectedBetweenLeftBraceAndStatements?.raw,
+        statements.raw,
+        unexpectedBetweenStatementsAndRightBrace?.raw,
+        rightBrace.raw,
+        unexpectedAfterRightBrace?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.codeBlock, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -693,14 +699,16 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeName?.raw,
-      name.raw,
-      unexpectedBetweenNameAndColon?.raw,
-      colon.raw,
-      unexpectedAfterColon?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeName, name, unexpectedBetweenNameAndColon, colon, unexpectedAfterColon))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeName?.raw,
+        name.raw,
+        unexpectedBetweenNameAndColon?.raw,
+        colon.raw,
+        unexpectedAfterColon?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.declNameArgument, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -881,16 +889,18 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndArguments?.raw,
-      arguments.raw,
-      unexpectedBetweenArgumentsAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftParen, leftParen, unexpectedBetweenLeftParenAndArguments, arguments, unexpectedBetweenArgumentsAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndArguments?.raw,
+        arguments.raw,
+        unexpectedBetweenArgumentsAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.declNameArguments, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1141,18 +1151,20 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLabel?.raw,
-      label?.raw,
-      unexpectedBetweenLabelAndColon?.raw,
-      colon?.raw,
-      unexpectedBetweenColonAndExpression?.raw,
-      expression.raw,
-      unexpectedBetweenExpressionAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLabel, label, unexpectedBetweenLabelAndColon, colon, unexpectedBetweenColonAndExpression, expression, unexpectedBetweenExpressionAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLabel?.raw,
+        label?.raw,
+        unexpectedBetweenLabelAndColon?.raw,
+        colon?.raw,
+        unexpectedBetweenColonAndExpression?.raw,
+        expression.raw,
+        unexpectedBetweenExpressionAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.tupleExprElement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1432,14 +1444,16 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeExpression?.raw,
-      expression.raw,
-      unexpectedBetweenExpressionAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeExpression, expression, unexpectedBetweenExpressionAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeExpression?.raw,
+        expression.raw,
+        unexpectedBetweenExpressionAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.arrayElement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1623,18 +1637,20 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeKeyExpression?.raw,
-      keyExpression.raw,
-      unexpectedBetweenKeyExpressionAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndValueExpression?.raw,
-      valueExpression.raw,
-      unexpectedBetweenValueExpressionAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeKeyExpression, keyExpression, unexpectedBetweenKeyExpressionAndColon, colon, unexpectedBetweenColonAndValueExpression, valueExpression, unexpectedBetweenValueExpressionAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeKeyExpression?.raw,
+        keyExpression.raw,
+        unexpectedBetweenKeyExpressionAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndValueExpression?.raw,
+        valueExpression.raw,
+        unexpectedBetweenValueExpressionAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.dictionaryElement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1918,20 +1934,22 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeSpecifier?.raw,
-      specifier?.raw,
-      unexpectedBetweenSpecifierAndName?.raw,
-      name?.raw,
-      unexpectedBetweenNameAndAssignToken?.raw,
-      assignToken?.raw,
-      unexpectedBetweenAssignTokenAndExpression?.raw,
-      expression.raw,
-      unexpectedBetweenExpressionAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeSpecifier, specifier, unexpectedBetweenSpecifierAndName, name, unexpectedBetweenNameAndAssignToken, assignToken, unexpectedBetweenAssignTokenAndExpression, expression, unexpectedBetweenExpressionAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeSpecifier?.raw,
+        specifier?.raw,
+        unexpectedBetweenSpecifierAndName?.raw,
+        name?.raw,
+        unexpectedBetweenNameAndAssignToken?.raw,
+        assignToken?.raw,
+        unexpectedBetweenAssignTokenAndExpression?.raw,
+        expression.raw,
+        unexpectedBetweenExpressionAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.closureCaptureItem, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2282,16 +2300,18 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftSquare?.raw,
-      leftSquare.raw,
-      unexpectedBetweenLeftSquareAndItems?.raw,
-      items?.raw,
-      unexpectedBetweenItemsAndRightSquare?.raw,
-      rightSquare.raw,
-      unexpectedAfterRightSquare?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftSquare, leftSquare, unexpectedBetweenLeftSquareAndItems, items, unexpectedBetweenItemsAndRightSquare, rightSquare, unexpectedAfterRightSquare))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftSquare?.raw,
+        leftSquare.raw,
+        unexpectedBetweenLeftSquareAndItems?.raw,
+        items?.raw,
+        unexpectedBetweenItemsAndRightSquare?.raw,
+        rightSquare.raw,
+        unexpectedAfterRightSquare?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.closureCaptureSignature, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2539,14 +2559,16 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeName?.raw,
-      name.raw,
-      unexpectedBetweenNameAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeName, name, unexpectedBetweenNameAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeName?.raw,
+        name.raw,
+        unexpectedBetweenNameAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.closureParam, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2772,24 +2794,26 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterInTok: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndCapture?.raw,
-      capture?.raw,
-      unexpectedBetweenCaptureAndInput?.raw,
-      input?.raw,
-      unexpectedBetweenInputAndAsyncKeyword?.raw,
-      asyncKeyword?.raw,
-      unexpectedBetweenAsyncKeywordAndThrowsTok?.raw,
-      throwsTok?.raw,
-      unexpectedBetweenThrowsTokAndOutput?.raw,
-      output?.raw,
-      unexpectedBetweenOutputAndInTok?.raw,
-      inTok.raw,
-      unexpectedAfterInTok?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndCapture, capture, unexpectedBetweenCaptureAndInput, input, unexpectedBetweenInputAndAsyncKeyword, asyncKeyword, unexpectedBetweenAsyncKeywordAndThrowsTok, throwsTok, unexpectedBetweenThrowsTokAndOutput, output, unexpectedBetweenOutputAndInTok, inTok, unexpectedAfterInTok))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndCapture?.raw,
+        capture?.raw,
+        unexpectedBetweenCaptureAndInput?.raw,
+        input?.raw,
+        unexpectedBetweenInputAndAsyncKeyword?.raw,
+        asyncKeyword?.raw,
+        unexpectedBetweenAsyncKeywordAndThrowsTok?.raw,
+        throwsTok?.raw,
+        unexpectedBetweenThrowsTokAndOutput?.raw,
+        output?.raw,
+        unexpectedBetweenOutputAndInTok?.raw,
+        inTok.raw,
+        unexpectedAfterInTok?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.closureSignature, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3240,16 +3264,18 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
     _ unexpectedAfterClosure: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLabel?.raw,
-      label.raw,
-      unexpectedBetweenLabelAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndClosure?.raw,
-      closure.raw,
-      unexpectedAfterClosure?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLabel, label, unexpectedBetweenLabelAndColon, colon, unexpectedBetweenColonAndClosure, closure, unexpectedAfterClosure))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLabel?.raw,
+        label.raw,
+        unexpectedBetweenLabelAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndClosure?.raw,
+        closure.raw,
+        unexpectedAfterClosure?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.multipleTrailingClosureElement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3475,12 +3501,14 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterContent: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeContent?.raw,
-      content.raw,
-      unexpectedAfterContent?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeContent, content, unexpectedAfterContent))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeContent?.raw,
+        content.raw,
+        unexpectedAfterContent?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.stringSegment, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3616,20 +3644,22 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeBackslash?.raw,
-      backslash.raw,
-      unexpectedBetweenBackslashAndDelimiter?.raw,
-      delimiter?.raw,
-      unexpectedBetweenDelimiterAndLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndExpressions?.raw,
-      expressions.raw,
-      unexpectedBetweenExpressionsAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeBackslash, backslash, unexpectedBetweenBackslashAndDelimiter, delimiter, unexpectedBetweenDelimiterAndLeftParen, leftParen, unexpectedBetweenLeftParenAndExpressions, expressions, unexpectedBetweenExpressionsAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeBackslash?.raw,
+        backslash.raw,
+        unexpectedBetweenBackslashAndDelimiter?.raw,
+        delimiter?.raw,
+        unexpectedBetweenDelimiterAndLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndExpressions?.raw,
+        expressions.raw,
+        unexpectedBetweenExpressionsAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.expressionSegment, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -4021,14 +4051,16 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterComponent: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePeriod?.raw,
-      period?.raw,
-      unexpectedBetweenPeriodAndComponent?.raw,
-      component.raw,
-      unexpectedAfterComponent?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePeriod, period, unexpectedBetweenPeriodAndComponent, component, unexpectedAfterComponent))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePeriod?.raw,
+        period?.raw,
+        unexpectedBetweenPeriodAndComponent?.raw,
+        component.raw,
+        unexpectedAfterComponent?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.keyPathComponent, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -4210,16 +4242,18 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeIdentifier?.raw,
-      identifier.raw,
-      unexpectedBetweenIdentifierAndDeclNameArguments?.raw,
-      declNameArguments?.raw,
-      unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause?.raw,
-      genericArgumentClause?.raw,
-      unexpectedAfterGenericArgumentClause?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIdentifier, identifier, unexpectedBetweenIdentifierAndDeclNameArguments, declNameArguments, unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause, genericArgumentClause, unexpectedAfterGenericArgumentClause))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeIdentifier?.raw,
+        identifier.raw,
+        unexpectedBetweenIdentifierAndDeclNameArguments?.raw,
+        declNameArguments?.raw,
+        unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause?.raw,
+        genericArgumentClause?.raw,
+        unexpectedAfterGenericArgumentClause?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.keyPathPropertyComponent, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -4451,16 +4485,18 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightBracket: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftBracket?.raw,
-      leftBracket.raw,
-      unexpectedBetweenLeftBracketAndArgumentList?.raw,
-      argumentList.raw,
-      unexpectedBetweenArgumentListAndRightBracket?.raw,
-      rightBracket.raw,
-      unexpectedAfterRightBracket?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftBracket, leftBracket, unexpectedBetweenLeftBracketAndArgumentList, argumentList, unexpectedBetweenArgumentListAndRightBracket, rightBracket, unexpectedAfterRightBracket))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftBracket?.raw,
+        leftBracket.raw,
+        unexpectedBetweenLeftBracketAndArgumentList?.raw,
+        argumentList.raw,
+        unexpectedBetweenArgumentListAndRightBracket?.raw,
+        rightBracket.raw,
+        unexpectedAfterRightBracket?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.keyPathSubscriptComponent, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -4705,12 +4741,14 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeQuestionOrExclamationMark?.raw,
-      questionOrExclamationMark.raw,
-      unexpectedAfterQuestionOrExclamationMark?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeQuestionOrExclamationMark, questionOrExclamationMark, unexpectedAfterQuestionOrExclamationMark))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeQuestionOrExclamationMark?.raw,
+        questionOrExclamationMark.raw,
+        unexpectedAfterQuestionOrExclamationMark?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.keyPathOptionalComponent, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -4840,14 +4878,16 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeExpression?.raw,
-      expression.raw,
-      unexpectedBetweenExpressionAndComma?.raw,
-      comma?.raw,
-      unexpectedAfterComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeExpression, expression, unexpectedBetweenExpressionAndComma, comma, unexpectedAfterComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeExpression?.raw,
+        expression.raw,
+        unexpectedBetweenExpressionAndComma?.raw,
+        comma?.raw,
+        unexpectedAfterComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.yieldExprListElement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -5027,14 +5067,16 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeEqual?.raw,
-      equal.raw,
-      unexpectedBetweenEqualAndValue?.raw,
-      value.raw,
-      unexpectedAfterValue?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeEqual, equal, unexpectedBetweenEqualAndValue, value, unexpectedAfterValue))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeEqual?.raw,
+        equal.raw,
+        unexpectedBetweenEqualAndValue?.raw,
+        value.raw,
+        unexpectedAfterValue?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.typeInitializerClause, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -5215,16 +5257,18 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndParameterList?.raw,
-      parameterList.raw,
-      unexpectedBetweenParameterListAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftParen, leftParen, unexpectedBetweenLeftParenAndParameterList, parameterList, unexpectedBetweenParameterListAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndParameterList?.raw,
+        parameterList.raw,
+        unexpectedBetweenParameterListAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.parameterClause, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -5471,14 +5515,16 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterReturnType: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeArrow?.raw,
-      arrow.raw,
-      unexpectedBetweenArrowAndReturnType?.raw,
-      returnType.raw,
-      unexpectedAfterReturnType?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeArrow, arrow, unexpectedBetweenArrowAndReturnType, returnType, unexpectedAfterReturnType))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeArrow?.raw,
+        arrow.raw,
+        unexpectedBetweenArrowAndReturnType?.raw,
+        returnType.raw,
+        unexpectedAfterReturnType?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.returnClause, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -5661,18 +5707,20 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterOutput: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeInput?.raw,
-      input.raw,
-      unexpectedBetweenInputAndAsyncOrReasyncKeyword?.raw,
-      asyncOrReasyncKeyword?.raw,
-      unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword?.raw,
-      throwsOrRethrowsKeyword?.raw,
-      unexpectedBetweenThrowsOrRethrowsKeywordAndOutput?.raw,
-      output?.raw,
-      unexpectedAfterOutput?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeInput, input, unexpectedBetweenInputAndAsyncOrReasyncKeyword, asyncOrReasyncKeyword, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword, throwsOrRethrowsKeyword, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput, output, unexpectedAfterOutput))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeInput?.raw,
+        input.raw,
+        unexpectedBetweenInputAndAsyncOrReasyncKeyword?.raw,
+        asyncOrReasyncKeyword?.raw,
+        unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword?.raw,
+        throwsOrRethrowsKeyword?.raw,
+        unexpectedBetweenThrowsOrRethrowsKeywordAndOutput?.raw,
+        output?.raw,
+        unexpectedAfterOutput?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.functionSignature, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -6020,16 +6068,18 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePoundKeyword?.raw,
-      poundKeyword.raw,
-      unexpectedBetweenPoundKeywordAndCondition?.raw,
-      condition?.raw,
-      unexpectedBetweenConditionAndElements?.raw,
-      elements?.raw,
-      unexpectedAfterElements?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePoundKeyword, poundKeyword, unexpectedBetweenPoundKeywordAndCondition, condition, unexpectedBetweenConditionAndElements, elements, unexpectedAfterElements))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePoundKeyword?.raw,
+        poundKeyword.raw,
+        unexpectedBetweenPoundKeywordAndCondition?.raw,
+        condition?.raw,
+        unexpectedBetweenConditionAndElements?.raw,
+        elements?.raw,
+        unexpectedAfterElements?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.ifConfigClause, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -6303,24 +6353,26 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterLineNumber: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeFileArgLabel?.raw,
-      fileArgLabel.raw,
-      unexpectedBetweenFileArgLabelAndFileArgColon?.raw,
-      fileArgColon.raw,
-      unexpectedBetweenFileArgColonAndFileName?.raw,
-      fileName.raw,
-      unexpectedBetweenFileNameAndComma?.raw,
-      comma.raw,
-      unexpectedBetweenCommaAndLineArgLabel?.raw,
-      lineArgLabel.raw,
-      unexpectedBetweenLineArgLabelAndLineArgColon?.raw,
-      lineArgColon.raw,
-      unexpectedBetweenLineArgColonAndLineNumber?.raw,
-      lineNumber.raw,
-      unexpectedAfterLineNumber?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeFileArgLabel, fileArgLabel, unexpectedBetweenFileArgLabelAndFileArgColon, fileArgColon, unexpectedBetweenFileArgColonAndFileName, fileName, unexpectedBetweenFileNameAndComma, comma, unexpectedBetweenCommaAndLineArgLabel, lineArgLabel, unexpectedBetweenLineArgLabelAndLineArgColon, lineArgColon, unexpectedBetweenLineArgColonAndLineNumber, lineNumber, unexpectedAfterLineNumber))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeFileArgLabel?.raw,
+        fileArgLabel.raw,
+        unexpectedBetweenFileArgLabelAndFileArgColon?.raw,
+        fileArgColon.raw,
+        unexpectedBetweenFileArgColonAndFileName?.raw,
+        fileName.raw,
+        unexpectedBetweenFileNameAndComma?.raw,
+        comma.raw,
+        unexpectedBetweenCommaAndLineArgLabel?.raw,
+        lineArgLabel.raw,
+        unexpectedBetweenLineArgLabelAndLineArgColon?.raw,
+        lineArgColon.raw,
+        unexpectedBetweenLineArgColonAndLineNumber?.raw,
+        lineNumber.raw,
+        unexpectedAfterLineNumber?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.poundSourceLocationArgs, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -6746,16 +6798,18 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndDetail?.raw,
-      detail.raw,
-      unexpectedBetweenDetailAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftParen, leftParen, unexpectedBetweenLeftParenAndDetail, detail, unexpectedBetweenDetailAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndDetail?.raw,
+        detail.raw,
+        unexpectedBetweenDetailAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.declModifierDetail, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -6983,14 +7037,16 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterDetail: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeName?.raw,
-      name.raw,
-      unexpectedBetweenNameAndDetail?.raw,
-      detail?.raw,
-      unexpectedAfterDetail?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeName, name, unexpectedBetweenNameAndDetail, detail, unexpectedAfterDetail))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeName?.raw,
+        name.raw,
+        unexpectedBetweenNameAndDetail?.raw,
+        detail?.raw,
+        unexpectedAfterDetail?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.declModifier, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -7170,14 +7226,16 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeTypeName?.raw,
-      typeName.raw,
-      unexpectedBetweenTypeNameAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeTypeName, typeName, unexpectedBetweenTypeNameAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeTypeName?.raw,
+        typeName.raw,
+        unexpectedBetweenTypeNameAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.inheritedType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -7357,14 +7415,16 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterInheritedTypeCollection: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndInheritedTypeCollection?.raw,
-      inheritedTypeCollection.raw,
-      unexpectedAfterInheritedTypeCollection?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeColon, colon, unexpectedBetweenColonAndInheritedTypeCollection, inheritedTypeCollection, unexpectedAfterInheritedTypeCollection))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndInheritedTypeCollection?.raw,
+        inheritedTypeCollection.raw,
+        unexpectedAfterInheritedTypeCollection?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.typeInheritanceClause, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -7564,16 +7624,18 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftBrace?.raw,
-      leftBrace.raw,
-      unexpectedBetweenLeftBraceAndMembers?.raw,
-      members.raw,
-      unexpectedBetweenMembersAndRightBrace?.raw,
-      rightBrace.raw,
-      unexpectedAfterRightBrace?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftBrace, leftBrace, unexpectedBetweenLeftBraceAndMembers, members, unexpectedBetweenMembersAndRightBrace, rightBrace, unexpectedAfterRightBrace))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftBrace?.raw,
+        leftBrace.raw,
+        unexpectedBetweenLeftBraceAndMembers?.raw,
+        members.raw,
+        unexpectedBetweenMembersAndRightBrace?.raw,
+        rightBrace.raw,
+        unexpectedAfterRightBrace?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.memberDeclBlock, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -7824,14 +7886,16 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterSemicolon: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeDecl?.raw,
-      decl.raw,
-      unexpectedBetweenDeclAndSemicolon?.raw,
-      semicolon?.raw,
-      unexpectedAfterSemicolon?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeDecl, decl, unexpectedBetweenDeclAndSemicolon, semicolon, unexpectedAfterSemicolon))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeDecl?.raw,
+        decl.raw,
+        unexpectedBetweenDeclAndSemicolon?.raw,
+        semicolon?.raw,
+        unexpectedAfterSemicolon?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.memberDeclListItem, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -8013,14 +8077,16 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterEOFToken: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeStatements?.raw,
-      statements.raw,
-      unexpectedBetweenStatementsAndEOFToken?.raw,
-      eofToken.raw,
-      unexpectedAfterEOFToken?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeStatements, statements, unexpectedBetweenStatementsAndEOFToken, eofToken, unexpectedAfterEOFToken))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeStatements?.raw,
+        statements.raw,
+        unexpectedBetweenStatementsAndEOFToken?.raw,
+        eofToken.raw,
+        unexpectedAfterEOFToken?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.sourceFile, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -8218,14 +8284,16 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeEqual?.raw,
-      equal.raw,
-      unexpectedBetweenEqualAndValue?.raw,
-      value.raw,
-      unexpectedAfterValue?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeEqual, equal, unexpectedBetweenEqualAndValue, value, unexpectedAfterValue))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeEqual?.raw,
+        equal.raw,
+        unexpectedBetweenEqualAndValue?.raw,
+        value.raw,
+        unexpectedAfterValue?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.initializerClause, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -8418,28 +8486,30 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndModifiers?.raw,
-      modifiers?.raw,
-      unexpectedBetweenModifiersAndFirstName?.raw,
-      firstName?.raw,
-      unexpectedBetweenFirstNameAndSecondName?.raw,
-      secondName?.raw,
-      unexpectedBetweenSecondNameAndColon?.raw,
-      colon?.raw,
-      unexpectedBetweenColonAndType?.raw,
-      type?.raw,
-      unexpectedBetweenTypeAndEllipsis?.raw,
-      ellipsis?.raw,
-      unexpectedBetweenEllipsisAndDefaultArgument?.raw,
-      defaultArgument?.raw,
-      unexpectedBetweenDefaultArgumentAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndModifiers, modifiers, unexpectedBetweenModifiersAndFirstName, firstName, unexpectedBetweenFirstNameAndSecondName, secondName, unexpectedBetweenSecondNameAndColon, colon, unexpectedBetweenColonAndType, type, unexpectedBetweenTypeAndEllipsis, ellipsis, unexpectedBetweenEllipsisAndDefaultArgument, defaultArgument, unexpectedBetweenDefaultArgumentAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndModifiers?.raw,
+        modifiers?.raw,
+        unexpectedBetweenModifiersAndFirstName?.raw,
+        firstName?.raw,
+        unexpectedBetweenFirstNameAndSecondName?.raw,
+        secondName?.raw,
+        unexpectedBetweenSecondNameAndColon?.raw,
+        colon?.raw,
+        unexpectedBetweenColonAndType?.raw,
+        type?.raw,
+        unexpectedBetweenTypeAndEllipsis?.raw,
+        ellipsis?.raw,
+        unexpectedBetweenEllipsisAndDefaultArgument?.raw,
+        defaultArgument?.raw,
+        unexpectedBetweenDefaultArgumentAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.functionParameter, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -9066,14 +9136,16 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterModifier: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeName?.raw,
-      name.raw,
-      unexpectedBetweenNameAndModifier?.raw,
-      modifier?.raw,
-      unexpectedAfterModifier?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeName, name, unexpectedBetweenNameAndModifier, modifier, unexpectedAfterModifier))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeName?.raw,
+        name.raw,
+        unexpectedBetweenNameAndModifier?.raw,
+        modifier?.raw,
+        unexpectedAfterModifier?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.accessLevelModifier, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -9253,14 +9325,16 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingDot: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeName?.raw,
-      name.raw,
-      unexpectedBetweenNameAndTrailingDot?.raw,
-      trailingDot?.raw,
-      unexpectedAfterTrailingDot?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeName, name, unexpectedBetweenNameAndTrailingDot, trailingDot, unexpectedAfterTrailingDot))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeName?.raw,
+        name.raw,
+        unexpectedBetweenNameAndTrailingDot?.raw,
+        trailingDot?.raw,
+        unexpectedAfterTrailingDot?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.accessPathComponent, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -9442,16 +9516,18 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndName?.raw,
-      name.raw,
-      unexpectedBetweenNameAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftParen, leftParen, unexpectedBetweenLeftParenAndName, name, unexpectedBetweenNameAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndName?.raw,
+        name.raw,
+        unexpectedBetweenNameAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.accessorParameter, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -9681,16 +9757,18 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftBrace?.raw,
-      leftBrace.raw,
-      unexpectedBetweenLeftBraceAndAccessors?.raw,
-      accessors.raw,
-      unexpectedBetweenAccessorsAndRightBrace?.raw,
-      rightBrace.raw,
-      unexpectedAfterRightBrace?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftBrace, leftBrace, unexpectedBetweenLeftBraceAndAccessors, accessors, unexpectedBetweenAccessorsAndRightBrace, rightBrace, unexpectedAfterRightBrace))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftBrace?.raw,
+        leftBrace.raw,
+        unexpectedBetweenLeftBraceAndAccessors?.raw,
+        accessors.raw,
+        unexpectedBetweenAccessorsAndRightBrace?.raw,
+        rightBrace.raw,
+        unexpectedAfterRightBrace?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.accessorBlock, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -9979,20 +10057,22 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePattern?.raw,
-      pattern.raw,
-      unexpectedBetweenPatternAndTypeAnnotation?.raw,
-      typeAnnotation?.raw,
-      unexpectedBetweenTypeAnnotationAndInitializer?.raw,
-      initializer?.raw,
-      unexpectedBetweenInitializerAndAccessor?.raw,
-      accessor?.raw,
-      unexpectedBetweenAccessorAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePattern, pattern, unexpectedBetweenPatternAndTypeAnnotation, typeAnnotation, unexpectedBetweenTypeAnnotationAndInitializer, initializer, unexpectedBetweenInitializerAndAccessor, accessor, unexpectedBetweenAccessorAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePattern?.raw,
+        pattern.raw,
+        unexpectedBetweenPatternAndTypeAnnotation?.raw,
+        typeAnnotation?.raw,
+        unexpectedBetweenTypeAnnotationAndInitializer?.raw,
+        initializer?.raw,
+        unexpectedBetweenInitializerAndAccessor?.raw,
+        accessor?.raw,
+        unexpectedBetweenAccessorAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.patternBinding, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -10330,18 +10410,20 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeIdentifier?.raw,
-      identifier.raw,
-      unexpectedBetweenIdentifierAndAssociatedValue?.raw,
-      associatedValue?.raw,
-      unexpectedBetweenAssociatedValueAndRawValue?.raw,
-      rawValue?.raw,
-      unexpectedBetweenRawValueAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIdentifier, identifier, unexpectedBetweenIdentifierAndAssociatedValue, associatedValue, unexpectedBetweenAssociatedValueAndRawValue, rawValue, unexpectedBetweenRawValueAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeIdentifier?.raw,
+        identifier.raw,
+        unexpectedBetweenIdentifierAndAssociatedValue?.raw,
+        associatedValue?.raw,
+        unexpectedBetweenAssociatedValueAndRawValue?.raw,
+        rawValue?.raw,
+        unexpectedBetweenRawValueAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.enumCaseElement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -10630,14 +10712,16 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterName: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeadingComma?.raw,
-      leadingComma.raw,
-      unexpectedBetweenLeadingCommaAndName?.raw,
-      name.raw,
-      unexpectedAfterName?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeadingComma, leadingComma, unexpectedBetweenLeadingCommaAndName, name, unexpectedAfterName))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeadingComma?.raw,
+        leadingComma.raw,
+        unexpectedBetweenLeadingCommaAndName?.raw,
+        name.raw,
+        unexpectedAfterName?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.designatedTypeElement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -10821,16 +10905,18 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterDesignatedTypes: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndPrecedenceGroup?.raw,
-      precedenceGroup.raw,
-      unexpectedBetweenPrecedenceGroupAndDesignatedTypes?.raw,
-      designatedTypes.raw,
-      unexpectedAfterDesignatedTypes?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeColon, colon, unexpectedBetweenColonAndPrecedenceGroup, precedenceGroup, unexpectedBetweenPrecedenceGroupAndDesignatedTypes, designatedTypes, unexpectedAfterDesignatedTypes))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndPrecedenceGroup?.raw,
+        precedenceGroup.raw,
+        unexpectedBetweenPrecedenceGroupAndDesignatedTypes?.raw,
+        designatedTypes.raw,
+        unexpectedAfterDesignatedTypes?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.operatorPrecedenceAndTypes, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -11089,16 +11175,18 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterOtherNames: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeHigherThanOrLowerThan?.raw,
-      higherThanOrLowerThan.raw,
-      unexpectedBetweenHigherThanOrLowerThanAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndOtherNames?.raw,
-      otherNames.raw,
-      unexpectedAfterOtherNames?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeHigherThanOrLowerThan, higherThanOrLowerThan, unexpectedBetweenHigherThanOrLowerThanAndColon, colon, unexpectedBetweenColonAndOtherNames, otherNames, unexpectedAfterOtherNames))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeHigherThanOrLowerThan?.raw,
+        higherThanOrLowerThan.raw,
+        unexpectedBetweenHigherThanOrLowerThanAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndOtherNames?.raw,
+        otherNames.raw,
+        unexpectedAfterOtherNames?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.precedenceGroupRelation, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -11352,14 +11440,16 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeName?.raw,
-      name.raw,
-      unexpectedBetweenNameAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeName, name, unexpectedBetweenNameAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeName?.raw,
+        name.raw,
+        unexpectedBetweenNameAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.precedenceGroupNameElement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -11545,16 +11635,18 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterFlag: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAssignmentKeyword?.raw,
-      assignmentKeyword.raw,
-      unexpectedBetweenAssignmentKeywordAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndFlag?.raw,
-      flag.raw,
-      unexpectedAfterFlag?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAssignmentKeyword, assignmentKeyword, unexpectedBetweenAssignmentKeywordAndColon, colon, unexpectedBetweenColonAndFlag, flag, unexpectedAfterFlag))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAssignmentKeyword?.raw,
+        assignmentKeyword.raw,
+        unexpectedBetweenAssignmentKeywordAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndFlag?.raw,
+        flag.raw,
+        unexpectedAfterFlag?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.precedenceGroupAssignment, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -11795,16 +11887,18 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
     _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAssociativityKeyword?.raw,
-      associativityKeyword.raw,
-      unexpectedBetweenAssociativityKeywordAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndValue?.raw,
-      value.raw,
-      unexpectedAfterValue?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAssociativityKeyword, associativityKeyword, unexpectedBetweenAssociativityKeywordAndColon, colon, unexpectedBetweenColonAndValue, value, unexpectedAfterValue))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAssociativityKeyword?.raw,
+        associativityKeyword.raw,
+        unexpectedBetweenAssociativityKeywordAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndValue?.raw,
+        value.raw,
+        unexpectedAfterValue?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.precedenceGroupAssociativity, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -12047,20 +12141,22 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAtSignToken?.raw,
-      atSignToken.raw,
-      unexpectedBetweenAtSignTokenAndAttributeName?.raw,
-      attributeName.raw,
-      unexpectedBetweenAttributeNameAndLeftParen?.raw,
-      leftParen?.raw,
-      unexpectedBetweenLeftParenAndArgumentList?.raw,
-      argumentList?.raw,
-      unexpectedBetweenArgumentListAndRightParen?.raw,
-      rightParen?.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAtSignToken, atSignToken, unexpectedBetweenAtSignTokenAndAttributeName, attributeName, unexpectedBetweenAttributeNameAndLeftParen, leftParen, unexpectedBetweenLeftParenAndArgumentList, argumentList, unexpectedBetweenArgumentListAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAtSignToken?.raw,
+        atSignToken.raw,
+        unexpectedBetweenAtSignTokenAndAttributeName?.raw,
+        attributeName.raw,
+        unexpectedBetweenAttributeNameAndLeftParen?.raw,
+        leftParen?.raw,
+        unexpectedBetweenLeftParenAndArgumentList?.raw,
+        argumentList?.raw,
+        unexpectedBetweenArgumentListAndRightParen?.raw,
+        rightParen?.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.customAttribute, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -12577,22 +12673,24 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTokenList: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAtSignToken?.raw,
-      atSignToken.raw,
-      unexpectedBetweenAtSignTokenAndAttributeName?.raw,
-      attributeName.raw,
-      unexpectedBetweenAttributeNameAndLeftParen?.raw,
-      leftParen?.raw,
-      unexpectedBetweenLeftParenAndArgument?.raw,
-      argument?.raw,
-      unexpectedBetweenArgumentAndRightParen?.raw,
-      rightParen?.raw,
-      unexpectedBetweenRightParenAndTokenList?.raw,
-      tokenList?.raw,
-      unexpectedAfterTokenList?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAtSignToken, atSignToken, unexpectedBetweenAtSignTokenAndAttributeName, attributeName, unexpectedBetweenAttributeNameAndLeftParen, leftParen, unexpectedBetweenLeftParenAndArgument, argument, unexpectedBetweenArgumentAndRightParen, rightParen, unexpectedBetweenRightParenAndTokenList, tokenList, unexpectedAfterTokenList))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAtSignToken?.raw,
+        atSignToken.raw,
+        unexpectedBetweenAtSignTokenAndAttributeName?.raw,
+        attributeName.raw,
+        unexpectedBetweenAttributeNameAndLeftParen?.raw,
+        leftParen?.raw,
+        unexpectedBetweenLeftParenAndArgument?.raw,
+        argument?.raw,
+        unexpectedBetweenArgumentAndRightParen?.raw,
+        rightParen?.raw,
+        unexpectedBetweenRightParenAndTokenList?.raw,
+        tokenList?.raw,
+        unexpectedAfterTokenList?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.attribute, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -13010,18 +13108,20 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterSemicolon: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLabel?.raw,
-      label.raw,
-      unexpectedBetweenLabelAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndAvailabilityList?.raw,
-      availabilityList.raw,
-      unexpectedBetweenAvailabilityListAndSemicolon?.raw,
-      semicolon.raw,
-      unexpectedAfterSemicolon?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLabel, label, unexpectedBetweenLabelAndColon, colon, unexpectedBetweenColonAndAvailabilityList, availabilityList, unexpectedBetweenAvailabilityListAndSemicolon, semicolon, unexpectedAfterSemicolon))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLabel?.raw,
+        label.raw,
+        unexpectedBetweenLabelAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndAvailabilityList?.raw,
+        availabilityList.raw,
+        unexpectedBetweenAvailabilityListAndSemicolon?.raw,
+        semicolon.raw,
+        unexpectedAfterSemicolon?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.availabilityEntry, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -13327,18 +13427,20 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLabel?.raw,
-      label.raw,
-      unexpectedBetweenLabelAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndValue?.raw,
-      value.raw,
-      unexpectedBetweenValueAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLabel, label, unexpectedBetweenLabelAndColon, colon, unexpectedBetweenColonAndValue, value, unexpectedBetweenValueAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLabel?.raw,
+        label.raw,
+        unexpectedBetweenLabelAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndValue?.raw,
+        value.raw,
+        unexpectedBetweenValueAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.labeledSpecializeEntry, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -13631,18 +13733,20 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLabel?.raw,
-      label.raw,
-      unexpectedBetweenLabelAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndDeclname?.raw,
-      declname.raw,
-      unexpectedBetweenDeclnameAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLabel, label, unexpectedBetweenLabelAndColon, colon, unexpectedBetweenColonAndDeclname, declname, unexpectedBetweenDeclnameAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLabel?.raw,
+        label.raw,
+        unexpectedBetweenLabelAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndDeclname?.raw,
+        declname.raw,
+        unexpectedBetweenDeclnameAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.targetFunctionEntry, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -13969,16 +14073,18 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
     _ unexpectedAfterStringOrDeclname: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeNameTok?.raw,
-      nameTok.raw,
-      unexpectedBetweenNameTokAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndStringOrDeclname?.raw,
-      stringOrDeclname.raw,
-      unexpectedAfterStringOrDeclname?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeNameTok, nameTok, unexpectedBetweenNameTokAndColon, colon, unexpectedBetweenColonAndStringOrDeclname, stringOrDeclname, unexpectedAfterStringOrDeclname))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeNameTok?.raw,
+        nameTok.raw,
+        unexpectedBetweenNameTokAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndStringOrDeclname?.raw,
+        stringOrDeclname.raw,
+        unexpectedAfterStringOrDeclname?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.namedAttributeStringArgument, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -14208,14 +14314,16 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeDeclBaseName?.raw,
-      declBaseName.raw,
-      unexpectedBetweenDeclBaseNameAndDeclNameArguments?.raw,
-      declNameArguments?.raw,
-      unexpectedAfterDeclNameArguments?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeDeclBaseName, declBaseName, unexpectedBetweenDeclBaseNameAndDeclNameArguments, declNameArguments, unexpectedAfterDeclNameArguments))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeDeclBaseName?.raw,
+        declBaseName.raw,
+        unexpectedBetweenDeclBaseNameAndDeclNameArguments?.raw,
+        declNameArguments?.raw,
+        unexpectedAfterDeclNameArguments?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.declName, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -14410,18 +14518,20 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeType?.raw,
-      type.raw,
-      unexpectedBetweenTypeAndComma?.raw,
-      comma.raw,
-      unexpectedBetweenCommaAndDeclBaseName?.raw,
-      declBaseName.raw,
-      unexpectedBetweenDeclBaseNameAndDeclNameArguments?.raw,
-      declNameArguments?.raw,
-      unexpectedAfterDeclNameArguments?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeType, type, unexpectedBetweenTypeAndComma, comma, unexpectedBetweenCommaAndDeclBaseName, declBaseName, unexpectedBetweenDeclBaseNameAndDeclNameArguments, declNameArguments, unexpectedAfterDeclNameArguments))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeType?.raw,
+        type.raw,
+        unexpectedBetweenTypeAndComma?.raw,
+        comma.raw,
+        unexpectedBetweenCommaAndDeclBaseName?.raw,
+        declBaseName.raw,
+        unexpectedBetweenDeclBaseNameAndDeclNameArguments?.raw,
+        declNameArguments?.raw,
+        unexpectedAfterDeclNameArguments?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.implementsAttributeArguments, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -14718,14 +14828,16 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeName?.raw,
-      name?.raw,
-      unexpectedBetweenNameAndColon?.raw,
-      colon?.raw,
-      unexpectedAfterColon?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeName, name, unexpectedBetweenNameAndColon, colon, unexpectedAfterColon))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeName?.raw,
+        name?.raw,
+        unexpectedBetweenNameAndColon?.raw,
+        colon?.raw,
+        unexpectedAfterColon?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.objCSelectorPiece, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -14917,20 +15029,22 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
     _ unexpectedAfterWhereClause: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeDiffKind?.raw,
-      diffKind?.raw,
-      unexpectedBetweenDiffKindAndDiffKindComma?.raw,
-      diffKindComma?.raw,
-      unexpectedBetweenDiffKindCommaAndDiffParams?.raw,
-      diffParams?.raw,
-      unexpectedBetweenDiffParamsAndDiffParamsComma?.raw,
-      diffParamsComma?.raw,
-      unexpectedBetweenDiffParamsCommaAndWhereClause?.raw,
-      whereClause?.raw,
-      unexpectedAfterWhereClause?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeDiffKind, diffKind, unexpectedBetweenDiffKindAndDiffKindComma, diffKindComma, unexpectedBetweenDiffKindCommaAndDiffParams, diffParams, unexpectedBetweenDiffParamsAndDiffParamsComma, diffParamsComma, unexpectedBetweenDiffParamsCommaAndWhereClause, whereClause, unexpectedAfterWhereClause))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeDiffKind?.raw,
+        diffKind?.raw,
+        unexpectedBetweenDiffKindAndDiffKindComma?.raw,
+        diffKindComma?.raw,
+        unexpectedBetweenDiffKindCommaAndDiffParams?.raw,
+        diffParams?.raw,
+        unexpectedBetweenDiffParamsAndDiffParamsComma?.raw,
+        diffParamsComma?.raw,
+        unexpectedBetweenDiffParamsCommaAndWhereClause?.raw,
+        whereClause?.raw,
+        unexpectedAfterWhereClause?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.differentiableAttributeArguments, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -15307,16 +15421,18 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
     _ unexpectedAfterParameters: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeWrtLabel?.raw,
-      wrtLabel.raw,
-      unexpectedBetweenWrtLabelAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndParameters?.raw,
-      parameters.raw,
-      unexpectedAfterParameters?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeWrtLabel, wrtLabel, unexpectedBetweenWrtLabelAndColon, colon, unexpectedBetweenColonAndParameters, parameters, unexpectedAfterParameters))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeWrtLabel?.raw,
+        wrtLabel.raw,
+        unexpectedBetweenWrtLabelAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndParameters?.raw,
+        parameters.raw,
+        unexpectedAfterParameters?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.differentiabilityParamsClause, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -15551,16 +15667,18 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndDiffParams?.raw,
-      diffParams.raw,
-      unexpectedBetweenDiffParamsAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftParen, leftParen, unexpectedBetweenLeftParenAndDiffParams, diffParams, unexpectedBetweenDiffParamsAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndDiffParams?.raw,
+        diffParams.raw,
+        unexpectedBetweenDiffParamsAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.differentiabilityParams, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -15812,14 +15930,16 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeParameter?.raw,
-      parameter.raw,
-      unexpectedBetweenParameterAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeParameter, parameter, unexpectedBetweenParameterAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeParameter?.raw,
+        parameter.raw,
+        unexpectedBetweenParameterAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.differentiabilityParam, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -16014,24 +16134,26 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
     _ unexpectedAfterDiffParams: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeOfLabel?.raw,
-      ofLabel.raw,
-      unexpectedBetweenOfLabelAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndOriginalDeclName?.raw,
-      originalDeclName.raw,
-      unexpectedBetweenOriginalDeclNameAndPeriod?.raw,
-      period?.raw,
-      unexpectedBetweenPeriodAndAccessorKind?.raw,
-      accessorKind?.raw,
-      unexpectedBetweenAccessorKindAndComma?.raw,
-      comma?.raw,
-      unexpectedBetweenCommaAndDiffParams?.raw,
-      diffParams?.raw,
-      unexpectedAfterDiffParams?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeOfLabel, ofLabel, unexpectedBetweenOfLabelAndColon, colon, unexpectedBetweenColonAndOriginalDeclName, originalDeclName, unexpectedBetweenOriginalDeclNameAndPeriod, period, unexpectedBetweenPeriodAndAccessorKind, accessorKind, unexpectedBetweenAccessorKindAndComma, comma, unexpectedBetweenCommaAndDiffParams, diffParams, unexpectedAfterDiffParams))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeOfLabel?.raw,
+        ofLabel.raw,
+        unexpectedBetweenOfLabelAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndOriginalDeclName?.raw,
+        originalDeclName.raw,
+        unexpectedBetweenOriginalDeclNameAndPeriod?.raw,
+        period?.raw,
+        unexpectedBetweenPeriodAndAccessorKind?.raw,
+        accessorKind?.raw,
+        unexpectedBetweenAccessorKindAndComma?.raw,
+        comma?.raw,
+        unexpectedBetweenCommaAndDiffParams?.raw,
+        diffParams?.raw,
+        unexpectedAfterDiffParams?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.derivativeRegistrationAttributeArguments, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -16478,18 +16600,20 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterArguments: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeBaseType?.raw,
-      baseType?.raw,
-      unexpectedBetweenBaseTypeAndDot?.raw,
-      dot?.raw,
-      unexpectedBetweenDotAndName?.raw,
-      name.raw,
-      unexpectedBetweenNameAndArguments?.raw,
-      arguments?.raw,
-      unexpectedAfterArguments?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeBaseType, baseType, unexpectedBetweenBaseTypeAndDot, dot, unexpectedBetweenDotAndName, name, unexpectedBetweenNameAndArguments, arguments, unexpectedAfterArguments))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeBaseType?.raw,
+        baseType?.raw,
+        unexpectedBetweenBaseTypeAndDot?.raw,
+        dot?.raw,
+        unexpectedBetweenDotAndName?.raw,
+        name.raw,
+        unexpectedBetweenNameAndArguments?.raw,
+        arguments?.raw,
+        unexpectedAfterArguments?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.qualifiedDeclName, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -16818,14 +16942,16 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterArguments: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeName?.raw,
-      name.raw,
-      unexpectedBetweenNameAndArguments?.raw,
-      arguments?.raw,
-      unexpectedAfterArguments?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeName, name, unexpectedBetweenNameAndArguments, arguments, unexpectedAfterArguments))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeName?.raw,
+        name.raw,
+        unexpectedBetweenNameAndArguments?.raw,
+        arguments?.raw,
+        unexpectedAfterArguments?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.functionDeclName, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -17017,16 +17143,18 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
     _ unexpectedAfterVersionList: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeBeforeLabel?.raw,
-      beforeLabel.raw,
-      unexpectedBetweenBeforeLabelAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndVersionList?.raw,
-      versionList.raw,
-      unexpectedAfterVersionList?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeBeforeLabel, beforeLabel, unexpectedBetweenBeforeLabelAndColon, colon, unexpectedBetweenColonAndVersionList, versionList, unexpectedAfterVersionList))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeBeforeLabel?.raw,
+        beforeLabel.raw,
+        unexpectedBetweenBeforeLabelAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndVersionList?.raw,
+        versionList.raw,
+        unexpectedAfterVersionList?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.backDeployAttributeSpecList, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -17285,14 +17413,16 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAvailabilityVersionRestriction?.raw,
-      availabilityVersionRestriction.raw,
-      unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAvailabilityVersionRestriction, availabilityVersionRestriction, unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAvailabilityVersionRestriction?.raw,
+        availabilityVersionRestriction.raw,
+        unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.backDeployVersionArgument, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -17481,16 +17611,18 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
     _ unexpectedAfterOrdinal: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeMangledName?.raw,
-      mangledName.raw,
-      unexpectedBetweenMangledNameAndComma?.raw,
-      comma.raw,
-      unexpectedBetweenCommaAndOrdinal?.raw,
-      ordinal.raw,
-      unexpectedAfterOrdinal?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeMangledName, mangledName, unexpectedBetweenMangledNameAndComma, comma, unexpectedBetweenCommaAndOrdinal, ordinal, unexpectedAfterOrdinal))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeMangledName?.raw,
+        mangledName.raw,
+        unexpectedBetweenMangledNameAndComma?.raw,
+        comma.raw,
+        unexpectedBetweenCommaAndOrdinal?.raw,
+        ordinal.raw,
+        unexpectedAfterOrdinal?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.opaqueReturnTypeOfAttributeArguments, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -17729,20 +17861,22 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     _ unexpectedAfterCTypeString: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeConventionLabel?.raw,
-      conventionLabel.raw,
-      unexpectedBetweenConventionLabelAndComma?.raw,
-      comma?.raw,
-      unexpectedBetweenCommaAndCTypeLabel?.raw,
-      cTypeLabel?.raw,
-      unexpectedBetweenCTypeLabelAndColon?.raw,
-      colon?.raw,
-      unexpectedBetweenColonAndCTypeString?.raw,
-      cTypeString?.raw,
-      unexpectedAfterCTypeString?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeConventionLabel, conventionLabel, unexpectedBetweenConventionLabelAndComma, comma, unexpectedBetweenCommaAndCTypeLabel, cTypeLabel, unexpectedBetweenCTypeLabelAndColon, colon, unexpectedBetweenColonAndCTypeString, cTypeString, unexpectedAfterCTypeString))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeConventionLabel?.raw,
+        conventionLabel.raw,
+        unexpectedBetweenConventionLabelAndComma?.raw,
+        comma?.raw,
+        unexpectedBetweenCommaAndCTypeLabel?.raw,
+        cTypeLabel?.raw,
+        unexpectedBetweenCTypeLabelAndColon?.raw,
+        colon?.raw,
+        unexpectedBetweenColonAndCTypeString?.raw,
+        cTypeString?.raw,
+        unexpectedAfterCTypeString?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.conventionAttributeArguments, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -18078,16 +18212,18 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
     _ unexpectedAfterProtocolName: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeWitnessMethodLabel?.raw,
-      witnessMethodLabel.raw,
-      unexpectedBetweenWitnessMethodLabelAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndProtocolName?.raw,
-      protocolName.raw,
-      unexpectedAfterProtocolName?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeWitnessMethodLabel, witnessMethodLabel, unexpectedBetweenWitnessMethodLabelAndColon, colon, unexpectedBetweenColonAndProtocolName, protocolName, unexpectedAfterProtocolName))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeWitnessMethodLabel?.raw,
+        witnessMethodLabel.raw,
+        unexpectedBetweenWitnessMethodLabelAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndProtocolName?.raw,
+        protocolName.raw,
+        unexpectedAfterProtocolName?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.conventionWitnessMethodAttributeArguments, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -18315,14 +18451,16 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterGuardResult: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeWhereKeyword?.raw,
-      whereKeyword.raw,
-      unexpectedBetweenWhereKeywordAndGuardResult?.raw,
-      guardResult.raw,
-      unexpectedAfterGuardResult?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeWhereKeyword, whereKeyword, unexpectedBetweenWhereKeywordAndGuardResult, guardResult, unexpectedAfterGuardResult))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeWhereKeyword?.raw,
+        whereKeyword.raw,
+        unexpectedBetweenWhereKeywordAndGuardResult?.raw,
+        guardResult.raw,
+        unexpectedAfterGuardResult?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.whereClause, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -18503,16 +18641,18 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndElementList?.raw,
-      elementList.raw,
-      unexpectedBetweenElementListAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftParen, leftParen, unexpectedBetweenLeftParenAndElementList, elementList, unexpectedBetweenElementListAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndElementList?.raw,
+        elementList.raw,
+        unexpectedBetweenElementListAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.yieldList, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -18835,14 +18975,16 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeCondition?.raw,
-      condition.raw,
-      unexpectedBetweenConditionAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeCondition, condition, unexpectedBetweenConditionAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeCondition?.raw,
+        condition.raw,
+        unexpectedBetweenConditionAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.conditionElement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -19026,18 +19168,20 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePoundAvailableKeyword?.raw,
-      poundAvailableKeyword.raw,
-      unexpectedBetweenPoundAvailableKeywordAndLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndAvailabilitySpec?.raw,
-      availabilitySpec.raw,
-      unexpectedBetweenAvailabilitySpecAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePoundAvailableKeyword, poundAvailableKeyword, unexpectedBetweenPoundAvailableKeywordAndLeftParen, leftParen, unexpectedBetweenLeftParenAndAvailabilitySpec, availabilitySpec, unexpectedBetweenAvailabilitySpecAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePoundAvailableKeyword?.raw,
+        poundAvailableKeyword.raw,
+        unexpectedBetweenPoundAvailableKeywordAndLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndAvailabilitySpec?.raw,
+        availabilitySpec.raw,
+        unexpectedBetweenAvailabilitySpecAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.availabilityCondition, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -19337,18 +19481,20 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterInitializer: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeCaseKeyword?.raw,
-      caseKeyword.raw,
-      unexpectedBetweenCaseKeywordAndPattern?.raw,
-      pattern.raw,
-      unexpectedBetweenPatternAndTypeAnnotation?.raw,
-      typeAnnotation?.raw,
-      unexpectedBetweenTypeAnnotationAndInitializer?.raw,
-      initializer.raw,
-      unexpectedAfterInitializer?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeCaseKeyword, caseKeyword, unexpectedBetweenCaseKeywordAndPattern, pattern, unexpectedBetweenPatternAndTypeAnnotation, typeAnnotation, unexpectedBetweenTypeAnnotationAndInitializer, initializer, unexpectedAfterInitializer))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeCaseKeyword?.raw,
+        caseKeyword.raw,
+        unexpectedBetweenCaseKeywordAndPattern?.raw,
+        pattern.raw,
+        unexpectedBetweenPatternAndTypeAnnotation?.raw,
+        typeAnnotation?.raw,
+        unexpectedBetweenTypeAnnotationAndInitializer?.raw,
+        initializer.raw,
+        unexpectedAfterInitializer?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.matchingPatternCondition, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -19630,18 +19776,20 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterInitializer: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLetOrVarKeyword?.raw,
-      letOrVarKeyword.raw,
-      unexpectedBetweenLetOrVarKeywordAndPattern?.raw,
-      pattern.raw,
-      unexpectedBetweenPatternAndTypeAnnotation?.raw,
-      typeAnnotation?.raw,
-      unexpectedBetweenTypeAnnotationAndInitializer?.raw,
-      initializer?.raw,
-      unexpectedAfterInitializer?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLetOrVarKeyword, letOrVarKeyword, unexpectedBetweenLetOrVarKeywordAndPattern, pattern, unexpectedBetweenPatternAndTypeAnnotation, typeAnnotation, unexpectedBetweenTypeAnnotationAndInitializer, initializer, unexpectedAfterInitializer))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLetOrVarKeyword?.raw,
+        letOrVarKeyword.raw,
+        unexpectedBetweenLetOrVarKeywordAndPattern?.raw,
+        pattern.raw,
+        unexpectedBetweenPatternAndTypeAnnotation?.raw,
+        typeAnnotation?.raw,
+        unexpectedBetweenTypeAnnotationAndInitializer?.raw,
+        initializer?.raw,
+        unexpectedAfterInitializer?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.optionalBindingCondition, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -19924,18 +20072,20 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePoundUnavailableKeyword?.raw,
-      poundUnavailableKeyword.raw,
-      unexpectedBetweenPoundUnavailableKeywordAndLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndAvailabilitySpec?.raw,
-      availabilitySpec.raw,
-      unexpectedBetweenAvailabilitySpecAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePoundUnavailableKeyword, poundUnavailableKeyword, unexpectedBetweenPoundUnavailableKeywordAndLeftParen, leftParen, unexpectedBetweenLeftParenAndAvailabilitySpec, availabilitySpec, unexpectedBetweenAvailabilitySpecAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePoundUnavailableKeyword?.raw,
+        poundUnavailableKeyword.raw,
+        unexpectedBetweenPoundUnavailableKeywordAndLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndAvailabilitySpec?.raw,
+        availabilitySpec.raw,
+        unexpectedBetweenAvailabilitySpecAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.unavailabilityCondition, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -20235,18 +20385,20 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeHasSymbolKeyword?.raw,
-      hasSymbolKeyword.raw,
-      unexpectedBetweenHasSymbolKeywordAndLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndExpression?.raw,
-      expression.raw,
-      unexpectedBetweenExpressionAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeHasSymbolKeyword, hasSymbolKeyword, unexpectedBetweenHasSymbolKeywordAndLeftParen, leftParen, unexpectedBetweenLeftParenAndExpression, expression, unexpectedBetweenExpressionAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeHasSymbolKeyword?.raw,
+        hasSymbolKeyword.raw,
+        unexpectedBetweenHasSymbolKeywordAndLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndExpression?.raw,
+        expression.raw,
+        unexpectedBetweenExpressionAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.hasSymbolCondition, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -20561,16 +20713,18 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterStatements: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeUnknownAttr?.raw,
-      unknownAttr?.raw,
-      unexpectedBetweenUnknownAttrAndLabel?.raw,
-      label.raw,
-      unexpectedBetweenLabelAndStatements?.raw,
-      statements.raw,
-      unexpectedAfterStatements?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeUnknownAttr, unknownAttr, unexpectedBetweenUnknownAttrAndLabel, label, unexpectedBetweenLabelAndStatements, statements, unexpectedAfterStatements))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeUnknownAttr?.raw,
+        unknownAttr?.raw,
+        unexpectedBetweenUnknownAttrAndLabel?.raw,
+        label.raw,
+        unexpectedBetweenLabelAndStatements?.raw,
+        statements.raw,
+        unexpectedAfterStatements?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.switchCase, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -20818,14 +20972,16 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeDefaultKeyword?.raw,
-      defaultKeyword.raw,
-      unexpectedBetweenDefaultKeywordAndColon?.raw,
-      colon.raw,
-      unexpectedAfterColon?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeDefaultKeyword, defaultKeyword, unexpectedBetweenDefaultKeywordAndColon, colon, unexpectedAfterColon))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeDefaultKeyword?.raw,
+        defaultKeyword.raw,
+        unexpectedBetweenDefaultKeywordAndColon?.raw,
+        colon.raw,
+        unexpectedAfterColon?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.switchDefaultLabel, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -21006,16 +21162,18 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePattern?.raw,
-      pattern.raw,
-      unexpectedBetweenPatternAndWhereClause?.raw,
-      whereClause?.raw,
-      unexpectedBetweenWhereClauseAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePattern, pattern, unexpectedBetweenPatternAndWhereClause, whereClause, unexpectedBetweenWhereClauseAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePattern?.raw,
+        pattern.raw,
+        unexpectedBetweenPatternAndWhereClause?.raw,
+        whereClause?.raw,
+        unexpectedBetweenWhereClauseAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.caseItem, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -21247,16 +21405,18 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePattern?.raw,
-      pattern?.raw,
-      unexpectedBetweenPatternAndWhereClause?.raw,
-      whereClause?.raw,
-      unexpectedBetweenWhereClauseAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePattern, pattern, unexpectedBetweenPatternAndWhereClause, whereClause, unexpectedBetweenWhereClauseAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePattern?.raw,
+        pattern?.raw,
+        unexpectedBetweenPatternAndWhereClause?.raw,
+        whereClause?.raw,
+        unexpectedBetweenWhereClauseAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.catchItem, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -21523,16 +21683,18 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeCaseKeyword?.raw,
-      caseKeyword.raw,
-      unexpectedBetweenCaseKeywordAndCaseItems?.raw,
-      caseItems.raw,
-      unexpectedBetweenCaseItemsAndColon?.raw,
-      colon.raw,
-      unexpectedAfterColon?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeCaseKeyword, caseKeyword, unexpectedBetweenCaseKeywordAndCaseItems, caseItems, unexpectedBetweenCaseItemsAndColon, colon, unexpectedAfterColon))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeCaseKeyword?.raw,
+        caseKeyword.raw,
+        unexpectedBetweenCaseKeywordAndCaseItems?.raw,
+        caseItems.raw,
+        unexpectedBetweenCaseItemsAndColon?.raw,
+        colon.raw,
+        unexpectedAfterColon?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.switchCaseLabel, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -21781,16 +21943,18 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeCatchKeyword?.raw,
-      catchKeyword.raw,
-      unexpectedBetweenCatchKeywordAndCatchItems?.raw,
-      catchItems?.raw,
-      unexpectedBetweenCatchItemsAndBody?.raw,
-      body.raw,
-      unexpectedAfterBody?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeCatchKeyword, catchKeyword, unexpectedBetweenCatchKeywordAndCatchItems, catchItems, unexpectedBetweenCatchItemsAndBody, body, unexpectedAfterBody))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeCatchKeyword?.raw,
+        catchKeyword.raw,
+        unexpectedBetweenCatchKeywordAndCatchItems?.raw,
+        catchItems?.raw,
+        unexpectedBetweenCatchItemsAndBody?.raw,
+        body.raw,
+        unexpectedAfterBody?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.catchClause, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -22038,14 +22202,16 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRequirementList: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeWhereKeyword?.raw,
-      whereKeyword.raw,
-      unexpectedBetweenWhereKeywordAndRequirementList?.raw,
-      requirementList.raw,
-      unexpectedAfterRequirementList?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeWhereKeyword, whereKeyword, unexpectedBetweenWhereKeywordAndRequirementList, requirementList, unexpectedAfterRequirementList))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeWhereKeyword?.raw,
+        whereKeyword.raw,
+        unexpectedBetweenWhereKeywordAndRequirementList?.raw,
+        requirementList.raw,
+        unexpectedAfterRequirementList?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.genericWhereClause, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -22289,14 +22455,16 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeBody?.raw,
-      body.raw,
-      unexpectedBetweenBodyAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeBody, body, unexpectedBetweenBodyAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeBody?.raw,
+        body.raw,
+        unexpectedBetweenBodyAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.genericRequirement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -22478,16 +22646,18 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftTypeIdentifier?.raw,
-      leftTypeIdentifier.raw,
-      unexpectedBetweenLeftTypeIdentifierAndEqualityToken?.raw,
-      equalityToken.raw,
-      unexpectedBetweenEqualityTokenAndRightTypeIdentifier?.raw,
-      rightTypeIdentifier.raw,
-      unexpectedAfterRightTypeIdentifier?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftTypeIdentifier, leftTypeIdentifier, unexpectedBetweenLeftTypeIdentifierAndEqualityToken, equalityToken, unexpectedBetweenEqualityTokenAndRightTypeIdentifier, rightTypeIdentifier, unexpectedAfterRightTypeIdentifier))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftTypeIdentifier?.raw,
+        leftTypeIdentifier.raw,
+        unexpectedBetweenLeftTypeIdentifierAndEqualityToken?.raw,
+        equalityToken.raw,
+        unexpectedBetweenEqualityTokenAndRightTypeIdentifier?.raw,
+        rightTypeIdentifier.raw,
+        unexpectedAfterRightTypeIdentifier?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.sameTypeRequirement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -22727,26 +22897,28 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeTypeIdentifier?.raw,
-      typeIdentifier.raw,
-      unexpectedBetweenTypeIdentifierAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndLayoutConstraint?.raw,
-      layoutConstraint.raw,
-      unexpectedBetweenLayoutConstraintAndLeftParen?.raw,
-      leftParen?.raw,
-      unexpectedBetweenLeftParenAndSize?.raw,
-      size?.raw,
-      unexpectedBetweenSizeAndComma?.raw,
-      comma?.raw,
-      unexpectedBetweenCommaAndAlignment?.raw,
-      alignment?.raw,
-      unexpectedBetweenAlignmentAndRightParen?.raw,
-      rightParen?.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeTypeIdentifier, typeIdentifier, unexpectedBetweenTypeIdentifierAndColon, colon, unexpectedBetweenColonAndLayoutConstraint, layoutConstraint, unexpectedBetweenLayoutConstraintAndLeftParen, leftParen, unexpectedBetweenLeftParenAndSize, size, unexpectedBetweenSizeAndComma, comma, unexpectedBetweenCommaAndAlignment, alignment, unexpectedBetweenAlignmentAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeTypeIdentifier?.raw,
+        typeIdentifier.raw,
+        unexpectedBetweenTypeIdentifierAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndLayoutConstraint?.raw,
+        layoutConstraint.raw,
+        unexpectedBetweenLayoutConstraintAndLeftParen?.raw,
+        leftParen?.raw,
+        unexpectedBetweenLeftParenAndSize?.raw,
+        size?.raw,
+        unexpectedBetweenSizeAndComma?.raw,
+        comma?.raw,
+        unexpectedBetweenCommaAndAlignment?.raw,
+        alignment?.raw,
+        unexpectedBetweenAlignmentAndRightParen?.raw,
+        rightParen?.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.layoutRequirement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -23232,22 +23404,24 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndName?.raw,
-      name.raw,
-      unexpectedBetweenNameAndEllipsis?.raw,
-      ellipsis?.raw,
-      unexpectedBetweenEllipsisAndColon?.raw,
-      colon?.raw,
-      unexpectedBetweenColonAndInheritedType?.raw,
-      inheritedType?.raw,
-      unexpectedBetweenInheritedTypeAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeAttributes, attributes, unexpectedBetweenAttributesAndName, name, unexpectedBetweenNameAndEllipsis, ellipsis, unexpectedBetweenEllipsisAndColon, colon, unexpectedBetweenColonAndInheritedType, inheritedType, unexpectedBetweenInheritedTypeAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndName?.raw,
+        name.raw,
+        unexpectedBetweenNameAndEllipsis?.raw,
+        ellipsis?.raw,
+        unexpectedBetweenEllipsisAndColon?.raw,
+        colon?.raw,
+        unexpectedBetweenColonAndInheritedType?.raw,
+        inheritedType?.raw,
+        unexpectedBetweenInheritedTypeAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.genericParameter, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -23692,14 +23866,16 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeName?.raw,
-      name.raw,
-      unexpectedBetweenNameAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeName, name, unexpectedBetweenNameAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeName?.raw,
+        name.raw,
+        unexpectedBetweenNameAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.primaryAssociatedType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -23883,18 +24059,20 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftAngleBracket?.raw,
-      leftAngleBracket.raw,
-      unexpectedBetweenLeftAngleBracketAndGenericParameterList?.raw,
-      genericParameterList.raw,
-      unexpectedBetweenGenericParameterListAndGenericWhereClause?.raw,
-      genericWhereClause?.raw,
-      unexpectedBetweenGenericWhereClauseAndRightAngleBracket?.raw,
-      rightAngleBracket.raw,
-      unexpectedAfterRightAngleBracket?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftAngleBracket, leftAngleBracket, unexpectedBetweenLeftAngleBracketAndGenericParameterList, genericParameterList, unexpectedBetweenGenericParameterListAndGenericWhereClause, genericWhereClause, unexpectedBetweenGenericWhereClauseAndRightAngleBracket, rightAngleBracket, unexpectedAfterRightAngleBracket))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftAngleBracket?.raw,
+        leftAngleBracket.raw,
+        unexpectedBetweenLeftAngleBracketAndGenericParameterList?.raw,
+        genericParameterList.raw,
+        unexpectedBetweenGenericParameterListAndGenericWhereClause?.raw,
+        genericWhereClause?.raw,
+        unexpectedBetweenGenericWhereClauseAndRightAngleBracket?.raw,
+        rightAngleBracket.raw,
+        unexpectedAfterRightAngleBracket?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.genericParameterClause, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -24193,16 +24371,18 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftTypeIdentifier?.raw,
-      leftTypeIdentifier.raw,
-      unexpectedBetweenLeftTypeIdentifierAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndRightTypeIdentifier?.raw,
-      rightTypeIdentifier.raw,
-      unexpectedAfterRightTypeIdentifier?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftTypeIdentifier, leftTypeIdentifier, unexpectedBetweenLeftTypeIdentifierAndColon, colon, unexpectedBetweenColonAndRightTypeIdentifier, rightTypeIdentifier, unexpectedAfterRightTypeIdentifier))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftTypeIdentifier?.raw,
+        leftTypeIdentifier.raw,
+        unexpectedBetweenLeftTypeIdentifierAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndRightTypeIdentifier?.raw,
+        rightTypeIdentifier.raw,
+        unexpectedAfterRightTypeIdentifier?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.conformanceRequirement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -24432,16 +24612,18 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
     _ unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftAngleBracket?.raw,
-      leftAngleBracket.raw,
-      unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList?.raw,
-      primaryAssociatedTypeList.raw,
-      unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket?.raw,
-      rightAngleBracket.raw,
-      unexpectedAfterRightAngleBracket?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftAngleBracket, leftAngleBracket, unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList, primaryAssociatedTypeList, unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket, rightAngleBracket, unexpectedAfterRightAngleBracket))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftAngleBracket?.raw,
+        leftAngleBracket.raw,
+        unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList?.raw,
+        primaryAssociatedTypeList.raw,
+        unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket?.raw,
+        rightAngleBracket.raw,
+        unexpectedAfterRightAngleBracket?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.primaryAssociatedTypeClause, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -24688,14 +24870,16 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterAmpersand: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeType?.raw,
-      type.raw,
-      unexpectedBetweenTypeAndAmpersand?.raw,
-      ampersand?.raw,
-      unexpectedAfterAmpersand?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeType, type, unexpectedBetweenTypeAndAmpersand, ampersand, unexpectedAfterAmpersand))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeType?.raw,
+        type.raw,
+        unexpectedBetweenTypeAndAmpersand?.raw,
+        ampersand?.raw,
+        unexpectedAfterAmpersand?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.compositionTypeElement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -24887,26 +25071,28 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeInOut?.raw,
-      inOut?.raw,
-      unexpectedBetweenInOutAndName?.raw,
-      name?.raw,
-      unexpectedBetweenNameAndSecondName?.raw,
-      secondName?.raw,
-      unexpectedBetweenSecondNameAndColon?.raw,
-      colon?.raw,
-      unexpectedBetweenColonAndType?.raw,
-      type.raw,
-      unexpectedBetweenTypeAndEllipsis?.raw,
-      ellipsis?.raw,
-      unexpectedBetweenEllipsisAndInitializer?.raw,
-      initializer?.raw,
-      unexpectedBetweenInitializerAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeInOut, inOut, unexpectedBetweenInOutAndName, name, unexpectedBetweenNameAndSecondName, secondName, unexpectedBetweenSecondNameAndColon, colon, unexpectedBetweenColonAndType, type, unexpectedBetweenTypeAndEllipsis, ellipsis, unexpectedBetweenEllipsisAndInitializer, initializer, unexpectedBetweenInitializerAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeInOut?.raw,
+        inOut?.raw,
+        unexpectedBetweenInOutAndName?.raw,
+        name?.raw,
+        unexpectedBetweenNameAndSecondName?.raw,
+        secondName?.raw,
+        unexpectedBetweenSecondNameAndColon?.raw,
+        colon?.raw,
+        unexpectedBetweenColonAndType?.raw,
+        type.raw,
+        unexpectedBetweenTypeAndEllipsis?.raw,
+        ellipsis?.raw,
+        unexpectedBetweenEllipsisAndInitializer?.raw,
+        initializer?.raw,
+        unexpectedBetweenInitializerAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.tupleTypeElement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -25386,14 +25572,16 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeArgumentType?.raw,
-      argumentType.raw,
-      unexpectedBetweenArgumentTypeAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeArgumentType, argumentType, unexpectedBetweenArgumentTypeAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeArgumentType?.raw,
+        argumentType.raw,
+        unexpectedBetweenArgumentTypeAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.genericArgument, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -25575,16 +25763,18 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftAngleBracket?.raw,
-      leftAngleBracket.raw,
-      unexpectedBetweenLeftAngleBracketAndArguments?.raw,
-      arguments.raw,
-      unexpectedBetweenArgumentsAndRightAngleBracket?.raw,
-      rightAngleBracket.raw,
-      unexpectedAfterRightAngleBracket?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftAngleBracket, leftAngleBracket, unexpectedBetweenLeftAngleBracketAndArguments, arguments, unexpectedBetweenArgumentsAndRightAngleBracket, rightAngleBracket, unexpectedAfterRightAngleBracket))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftAngleBracket?.raw,
+        leftAngleBracket.raw,
+        unexpectedBetweenLeftAngleBracketAndArguments?.raw,
+        arguments.raw,
+        unexpectedBetweenArgumentsAndRightAngleBracket?.raw,
+        rightAngleBracket.raw,
+        unexpectedAfterRightAngleBracket?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.genericArgumentClause, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -25831,14 +26021,16 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterType: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndType?.raw,
-      type.raw,
-      unexpectedAfterType?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeColon, colon, unexpectedBetweenColonAndType, type, unexpectedAfterType))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndType?.raw,
+        type.raw,
+        unexpectedAfterType?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.typeAnnotation, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -26021,18 +26213,20 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLabelName?.raw,
-      labelName?.raw,
-      unexpectedBetweenLabelNameAndLabelColon?.raw,
-      labelColon?.raw,
-      unexpectedBetweenLabelColonAndPattern?.raw,
-      pattern.raw,
-      unexpectedBetweenPatternAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLabelName, labelName, unexpectedBetweenLabelNameAndLabelColon, labelColon, unexpectedBetweenLabelColonAndPattern, pattern, unexpectedBetweenPatternAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLabelName?.raw,
+        labelName?.raw,
+        unexpectedBetweenLabelNameAndLabelColon?.raw,
+        labelColon?.raw,
+        unexpectedBetweenLabelColonAndPattern?.raw,
+        pattern.raw,
+        unexpectedBetweenPatternAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.tuplePatternElement, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -26372,14 +26566,16 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeEntry?.raw,
-      entry.raw,
-      unexpectedBetweenEntryAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedAfterTrailingComma?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeEntry, entry, unexpectedBetweenEntryAndTrailingComma, trailingComma, unexpectedAfterTrailingComma))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeEntry?.raw,
+        entry.raw,
+        unexpectedBetweenEntryAndTrailingComma?.raw,
+        trailingComma?.raw,
+        unexpectedAfterTrailingComma?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.availabilityArgument, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -26606,16 +26802,18 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
     _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLabel?.raw,
-      label.raw,
-      unexpectedBetweenLabelAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndValue?.raw,
-      value.raw,
-      unexpectedAfterValue?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLabel, label, unexpectedBetweenLabelAndColon, colon, unexpectedBetweenColonAndValue, value, unexpectedAfterValue))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLabel?.raw,
+        label.raw,
+        unexpectedBetweenLabelAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndValue?.raw,
+        value.raw,
+        unexpectedAfterValue?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.availabilityLabeledArgument, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -26850,14 +27048,16 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
     _ unexpectedAfterVersion: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePlatform?.raw,
-      platform.raw,
-      unexpectedBetweenPlatformAndVersion?.raw,
-      version?.raw,
-      unexpectedAfterVersion?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePlatform, platform, unexpectedBetweenPlatformAndVersion, version, unexpectedAfterVersion))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePlatform?.raw,
+        platform.raw,
+        unexpectedBetweenPlatformAndVersion?.raw,
+        version?.raw,
+        unexpectedAfterVersion?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.availabilityVersionRestriction, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -27048,16 +27248,18 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterPatchVersion: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeMajorMinor?.raw,
-      majorMinor.raw,
-      unexpectedBetweenMajorMinorAndPatchPeriod?.raw,
-      patchPeriod?.raw,
-      unexpectedBetweenPatchPeriodAndPatchVersion?.raw,
-      patchVersion?.raw,
-      unexpectedAfterPatchVersion?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeMajorMinor, majorMinor, unexpectedBetweenMajorMinorAndPatchPeriod, patchPeriod, unexpectedBetweenPatchPeriodAndPatchVersion, patchVersion, unexpectedAfterPatchVersion))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeMajorMinor?.raw,
+        majorMinor.raw,
+        unexpectedBetweenMajorMinorAndPatchPeriod?.raw,
+        patchPeriod?.raw,
+        unexpectedBetweenPatchPeriodAndPatchVersion?.raw,
+        patchVersion?.raw,
+        unexpectedAfterPatchVersion?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.versionTuple, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
@@ -32,7 +32,9 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   }
 
   public init() {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), ())) { (arena, _) in
       let raw = RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
       return SyntaxData.forRoot(raw)
     }
@@ -90,18 +92,20 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterAssociatedTuple: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeType?.raw,
-      type?.raw,
-      unexpectedBetweenTypeAndPeriod?.raw,
-      period.raw,
-      unexpectedBetweenPeriodAndCaseName?.raw,
-      caseName.raw,
-      unexpectedBetweenCaseNameAndAssociatedTuple?.raw,
-      associatedTuple?.raw,
-      unexpectedAfterAssociatedTuple?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeType, type, unexpectedBetweenTypeAndPeriod, period, unexpectedBetweenPeriodAndCaseName, caseName, unexpectedBetweenCaseNameAndAssociatedTuple, associatedTuple, unexpectedAfterAssociatedTuple))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeType?.raw,
+        type?.raw,
+        unexpectedBetweenTypeAndPeriod?.raw,
+        period.raw,
+        unexpectedBetweenPeriodAndCaseName?.raw,
+        caseName.raw,
+        unexpectedBetweenCaseNameAndAssociatedTuple?.raw,
+        associatedTuple?.raw,
+        unexpectedAfterAssociatedTuple?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.enumCasePattern, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -418,14 +422,16 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterType: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeIsKeyword?.raw,
-      isKeyword.raw,
-      unexpectedBetweenIsKeywordAndType?.raw,
-      type.raw,
-      unexpectedAfterType?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIsKeyword, isKeyword, unexpectedBetweenIsKeywordAndType, type, unexpectedAfterType))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeIsKeyword?.raw,
+        isKeyword.raw,
+        unexpectedBetweenIsKeywordAndType?.raw,
+        type.raw,
+        unexpectedAfterType?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.isTypePattern, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -604,14 +610,16 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeSubPattern?.raw,
-      subPattern.raw,
-      unexpectedBetweenSubPatternAndQuestionMark?.raw,
-      questionMark.raw,
-      unexpectedAfterQuestionMark?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeSubPattern, subPattern, unexpectedBetweenSubPatternAndQuestionMark, questionMark, unexpectedAfterQuestionMark))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeSubPattern?.raw,
+        subPattern.raw,
+        unexpectedBetweenSubPatternAndQuestionMark?.raw,
+        questionMark.raw,
+        unexpectedAfterQuestionMark?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.optionalPattern, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -788,12 +796,14 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterIdentifier: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeIdentifier?.raw,
-      identifier.raw,
-      unexpectedAfterIdentifier?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIdentifier, identifier, unexpectedAfterIdentifier))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeIdentifier?.raw,
+        identifier.raw,
+        unexpectedAfterIdentifier?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.identifierPattern, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -925,16 +935,18 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterType: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePattern?.raw,
-      pattern.raw,
-      unexpectedBetweenPatternAndAsKeyword?.raw,
-      asKeyword.raw,
-      unexpectedBetweenAsKeywordAndType?.raw,
-      type.raw,
-      unexpectedAfterType?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePattern, pattern, unexpectedBetweenPatternAndAsKeyword, asKeyword, unexpectedBetweenAsKeywordAndType, type, unexpectedAfterType))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePattern?.raw,
+        pattern.raw,
+        unexpectedBetweenPatternAndAsKeyword?.raw,
+        asKeyword.raw,
+        unexpectedBetweenAsKeywordAndType?.raw,
+        type.raw,
+        unexpectedAfterType?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.asTypePattern, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1164,16 +1176,18 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndElements?.raw,
-      elements.raw,
-      unexpectedBetweenElementsAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftParen, leftParen, unexpectedBetweenLeftParenAndElements, elements, unexpectedBetweenElementsAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndElements?.raw,
+        elements.raw,
+        unexpectedBetweenElementsAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.tuplePattern, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1420,14 +1434,16 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTypeAnnotation: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeWildcard?.raw,
-      wildcard.raw,
-      unexpectedBetweenWildcardAndTypeAnnotation?.raw,
-      typeAnnotation?.raw,
-      unexpectedAfterTypeAnnotation?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeWildcard, wildcard, unexpectedBetweenWildcardAndTypeAnnotation, typeAnnotation, unexpectedAfterTypeAnnotation))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeWildcard?.raw,
+        wildcard.raw,
+        unexpectedBetweenWildcardAndTypeAnnotation?.raw,
+        typeAnnotation?.raw,
+        unexpectedAfterTypeAnnotation?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.wildcardPattern, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1605,12 +1621,14 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeExpression?.raw,
-      expression.raw,
-      unexpectedAfterExpression?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeExpression, expression, unexpectedAfterExpression))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeExpression?.raw,
+        expression.raw,
+        unexpectedAfterExpression?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.expressionPattern, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1740,14 +1758,16 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterValuePattern: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLetOrVarKeyword?.raw,
-      letOrVarKeyword.raw,
-      unexpectedBetweenLetOrVarKeywordAndValuePattern?.raw,
-      valuePattern.raw,
-      unexpectedAfterValuePattern?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLetOrVarKeyword, letOrVarKeyword, unexpectedBetweenLetOrVarKeywordAndValuePattern, valuePattern, unexpectedAfterValuePattern))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLetOrVarKeyword?.raw,
+        letOrVarKeyword.raw,
+        unexpectedBetweenLetOrVarKeywordAndValuePattern?.raw,
+        valuePattern.raw,
+        unexpectedAfterValuePattern?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.valueBindingPattern, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -32,7 +32,9 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
 
   public init() {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), ())) { (arena, _) in
       let raw = RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingStmt, arena: arena)
       return SyntaxData.forRoot(raw)
     }
@@ -88,16 +90,18 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterStatement: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLabelName?.raw,
-      labelName.raw,
-      unexpectedBetweenLabelNameAndLabelColon?.raw,
-      labelColon.raw,
-      unexpectedBetweenLabelColonAndStatement?.raw,
-      statement.raw,
-      unexpectedAfterStatement?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLabelName, labelName, unexpectedBetweenLabelNameAndLabelColon, labelColon, unexpectedBetweenLabelColonAndStatement, statement, unexpectedAfterStatement))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLabelName?.raw,
+        labelName.raw,
+        unexpectedBetweenLabelNameAndLabelColon?.raw,
+        labelColon.raw,
+        unexpectedBetweenLabelColonAndStatement?.raw,
+        statement.raw,
+        unexpectedAfterStatement?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.labeledStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -325,14 +329,16 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterLabel: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeContinueKeyword?.raw,
-      continueKeyword.raw,
-      unexpectedBetweenContinueKeywordAndLabel?.raw,
-      label?.raw,
-      unexpectedAfterLabel?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeContinueKeyword, continueKeyword, unexpectedBetweenContinueKeywordAndLabel, label, unexpectedAfterLabel))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeContinueKeyword?.raw,
+        continueKeyword.raw,
+        unexpectedBetweenContinueKeywordAndLabel?.raw,
+        label?.raw,
+        unexpectedAfterLabel?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.continueStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -514,16 +520,18 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeWhileKeyword?.raw,
-      whileKeyword.raw,
-      unexpectedBetweenWhileKeywordAndConditions?.raw,
-      conditions.raw,
-      unexpectedBetweenConditionsAndBody?.raw,
-      body.raw,
-      unexpectedAfterBody?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeWhileKeyword, whileKeyword, unexpectedBetweenWhileKeywordAndConditions, conditions, unexpectedBetweenConditionsAndBody, body, unexpectedAfterBody))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeWhileKeyword?.raw,
+        whileKeyword.raw,
+        unexpectedBetweenWhileKeywordAndConditions?.raw,
+        conditions.raw,
+        unexpectedBetweenConditionsAndBody?.raw,
+        body.raw,
+        unexpectedAfterBody?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.whileStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -770,14 +778,16 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeDeferKeyword?.raw,
-      deferKeyword.raw,
-      unexpectedBetweenDeferKeywordAndBody?.raw,
-      body.raw,
-      unexpectedAfterBody?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeDeferKeyword, deferKeyword, unexpectedBetweenDeferKeywordAndBody, body, unexpectedAfterBody))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeDeferKeyword?.raw,
+        deferKeyword.raw,
+        unexpectedBetweenDeferKeywordAndBody?.raw,
+        body.raw,
+        unexpectedAfterBody?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.deferStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -954,12 +964,14 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeExpression?.raw,
-      expression.raw,
-      unexpectedAfterExpression?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeExpression, expression, unexpectedAfterExpression))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeExpression?.raw,
+        expression.raw,
+        unexpectedAfterExpression?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.expressionStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1093,18 +1105,20 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterCondition: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeRepeatKeyword?.raw,
-      repeatKeyword.raw,
-      unexpectedBetweenRepeatKeywordAndBody?.raw,
-      body.raw,
-      unexpectedBetweenBodyAndWhileKeyword?.raw,
-      whileKeyword.raw,
-      unexpectedBetweenWhileKeywordAndCondition?.raw,
-      condition.raw,
-      unexpectedAfterCondition?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeRepeatKeyword, repeatKeyword, unexpectedBetweenRepeatKeywordAndBody, body, unexpectedBetweenBodyAndWhileKeyword, whileKeyword, unexpectedBetweenWhileKeywordAndCondition, condition, unexpectedAfterCondition))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeRepeatKeyword?.raw,
+        repeatKeyword.raw,
+        unexpectedBetweenRepeatKeywordAndBody?.raw,
+        body.raw,
+        unexpectedBetweenBodyAndWhileKeyword?.raw,
+        whileKeyword.raw,
+        unexpectedBetweenWhileKeywordAndCondition?.raw,
+        condition.raw,
+        unexpectedAfterCondition?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.repeatWhileStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1385,18 +1399,20 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeGuardKeyword?.raw,
-      guardKeyword.raw,
-      unexpectedBetweenGuardKeywordAndConditions?.raw,
-      conditions.raw,
-      unexpectedBetweenConditionsAndElseKeyword?.raw,
-      elseKeyword.raw,
-      unexpectedBetweenElseKeywordAndBody?.raw,
-      body.raw,
-      unexpectedAfterBody?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeGuardKeyword, guardKeyword, unexpectedBetweenGuardKeywordAndConditions, conditions, unexpectedBetweenConditionsAndElseKeyword, elseKeyword, unexpectedBetweenElseKeywordAndBody, body, unexpectedAfterBody))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeGuardKeyword?.raw,
+        guardKeyword.raw,
+        unexpectedBetweenGuardKeywordAndConditions?.raw,
+        conditions.raw,
+        unexpectedBetweenConditionsAndElseKeyword?.raw,
+        elseKeyword.raw,
+        unexpectedBetweenElseKeywordAndBody?.raw,
+        body.raw,
+        unexpectedAfterBody?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.guardStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1708,30 +1724,32 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeForKeyword?.raw,
-      forKeyword.raw,
-      unexpectedBetweenForKeywordAndTryKeyword?.raw,
-      tryKeyword?.raw,
-      unexpectedBetweenTryKeywordAndAwaitKeyword?.raw,
-      awaitKeyword?.raw,
-      unexpectedBetweenAwaitKeywordAndCaseKeyword?.raw,
-      caseKeyword?.raw,
-      unexpectedBetweenCaseKeywordAndPattern?.raw,
-      pattern.raw,
-      unexpectedBetweenPatternAndTypeAnnotation?.raw,
-      typeAnnotation?.raw,
-      unexpectedBetweenTypeAnnotationAndInKeyword?.raw,
-      inKeyword.raw,
-      unexpectedBetweenInKeywordAndSequenceExpr?.raw,
-      sequenceExpr.raw,
-      unexpectedBetweenSequenceExprAndWhereClause?.raw,
-      whereClause?.raw,
-      unexpectedBetweenWhereClauseAndBody?.raw,
-      body.raw,
-      unexpectedAfterBody?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeForKeyword, forKeyword, unexpectedBetweenForKeywordAndTryKeyword, tryKeyword, unexpectedBetweenTryKeywordAndAwaitKeyword, awaitKeyword, unexpectedBetweenAwaitKeywordAndCaseKeyword, caseKeyword, unexpectedBetweenCaseKeywordAndPattern, pattern, unexpectedBetweenPatternAndTypeAnnotation, typeAnnotation, unexpectedBetweenTypeAnnotationAndInKeyword, inKeyword, unexpectedBetweenInKeywordAndSequenceExpr, sequenceExpr, unexpectedBetweenSequenceExprAndWhereClause, whereClause, unexpectedBetweenWhereClauseAndBody, body, unexpectedAfterBody))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeForKeyword?.raw,
+        forKeyword.raw,
+        unexpectedBetweenForKeywordAndTryKeyword?.raw,
+        tryKeyword?.raw,
+        unexpectedBetweenTryKeywordAndAwaitKeyword?.raw,
+        awaitKeyword?.raw,
+        unexpectedBetweenAwaitKeywordAndCaseKeyword?.raw,
+        caseKeyword?.raw,
+        unexpectedBetweenCaseKeywordAndPattern?.raw,
+        pattern.raw,
+        unexpectedBetweenPatternAndTypeAnnotation?.raw,
+        typeAnnotation?.raw,
+        unexpectedBetweenTypeAnnotationAndInKeyword?.raw,
+        inKeyword.raw,
+        unexpectedBetweenInKeywordAndSequenceExpr?.raw,
+        sequenceExpr.raw,
+        unexpectedBetweenSequenceExprAndWhereClause?.raw,
+        whereClause?.raw,
+        unexpectedBetweenWhereClauseAndBody?.raw,
+        body.raw,
+        unexpectedAfterBody?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.forInStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2313,20 +2331,22 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeSwitchKeyword?.raw,
-      switchKeyword.raw,
-      unexpectedBetweenSwitchKeywordAndExpression?.raw,
-      expression.raw,
-      unexpectedBetweenExpressionAndLeftBrace?.raw,
-      leftBrace.raw,
-      unexpectedBetweenLeftBraceAndCases?.raw,
-      cases.raw,
-      unexpectedBetweenCasesAndRightBrace?.raw,
-      rightBrace.raw,
-      unexpectedAfterRightBrace?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeSwitchKeyword, switchKeyword, unexpectedBetweenSwitchKeywordAndExpression, expression, unexpectedBetweenExpressionAndLeftBrace, leftBrace, unexpectedBetweenLeftBraceAndCases, cases, unexpectedBetweenCasesAndRightBrace, rightBrace, unexpectedAfterRightBrace))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeSwitchKeyword?.raw,
+        switchKeyword.raw,
+        unexpectedBetweenSwitchKeywordAndExpression?.raw,
+        expression.raw,
+        unexpectedBetweenExpressionAndLeftBrace?.raw,
+        leftBrace.raw,
+        unexpectedBetweenLeftBraceAndCases?.raw,
+        cases.raw,
+        unexpectedBetweenCasesAndRightBrace?.raw,
+        rightBrace.raw,
+        unexpectedAfterRightBrace?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.switchStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2673,16 +2693,18 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterCatchClauses: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeDoKeyword?.raw,
-      doKeyword.raw,
-      unexpectedBetweenDoKeywordAndBody?.raw,
-      body.raw,
-      unexpectedBetweenBodyAndCatchClauses?.raw,
-      catchClauses?.raw,
-      unexpectedAfterCatchClauses?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeDoKeyword, doKeyword, unexpectedBetweenDoKeywordAndBody, body, unexpectedBetweenBodyAndCatchClauses, catchClauses, unexpectedAfterCatchClauses))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeDoKeyword?.raw,
+        doKeyword.raw,
+        unexpectedBetweenDoKeywordAndBody?.raw,
+        body.raw,
+        unexpectedBetweenBodyAndCatchClauses?.raw,
+        catchClauses?.raw,
+        unexpectedAfterCatchClauses?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.doStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2930,14 +2952,16 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeReturnKeyword?.raw,
-      returnKeyword.raw,
-      unexpectedBetweenReturnKeywordAndExpression?.raw,
-      expression?.raw,
-      unexpectedAfterExpression?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeReturnKeyword, returnKeyword, unexpectedBetweenReturnKeywordAndExpression, expression, unexpectedAfterExpression))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeReturnKeyword?.raw,
+        returnKeyword.raw,
+        unexpectedBetweenReturnKeywordAndExpression?.raw,
+        expression?.raw,
+        unexpectedAfterExpression?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.returnStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3183,14 +3207,16 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterYields: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeYieldKeyword?.raw,
-      yieldKeyword.raw,
-      unexpectedBetweenYieldKeywordAndYields?.raw,
-      yields.raw,
-      unexpectedAfterYields?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeYieldKeyword, yieldKeyword, unexpectedBetweenYieldKeywordAndYields, yields, unexpectedAfterYields))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeYieldKeyword?.raw,
+        yieldKeyword.raw,
+        unexpectedBetweenYieldKeywordAndYields?.raw,
+        yields.raw,
+        unexpectedAfterYields?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.yieldStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3367,12 +3393,14 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterFallthroughKeyword: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeFallthroughKeyword?.raw,
-      fallthroughKeyword.raw,
-      unexpectedAfterFallthroughKeyword?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeFallthroughKeyword, fallthroughKeyword, unexpectedAfterFallthroughKeyword))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeFallthroughKeyword?.raw,
+        fallthroughKeyword.raw,
+        unexpectedAfterFallthroughKeyword?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.fallthroughStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3502,14 +3530,16 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterLabel: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeBreakKeyword?.raw,
-      breakKeyword.raw,
-      unexpectedBetweenBreakKeywordAndLabel?.raw,
-      label?.raw,
-      unexpectedAfterLabel?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeBreakKeyword, breakKeyword, unexpectedBetweenBreakKeywordAndLabel, label, unexpectedAfterLabel))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeBreakKeyword?.raw,
+        breakKeyword.raw,
+        unexpectedBetweenBreakKeywordAndLabel?.raw,
+        label?.raw,
+        unexpectedAfterLabel?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.breakStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3687,12 +3717,14 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterDeclaration: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeDeclaration?.raw,
-      declaration.raw,
-      unexpectedAfterDeclaration?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeDeclaration, declaration, unexpectedAfterDeclaration))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeDeclaration?.raw,
+        declaration.raw,
+        unexpectedAfterDeclaration?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.declarationStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3822,14 +3854,16 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeThrowKeyword?.raw,
-      throwKeyword.raw,
-      unexpectedBetweenThrowKeywordAndExpression?.raw,
-      expression.raw,
-      unexpectedAfterExpression?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeThrowKeyword, throwKeyword, unexpectedBetweenThrowKeywordAndExpression, expression, unexpectedAfterExpression))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeThrowKeyword?.raw,
+        throwKeyword.raw,
+        unexpectedBetweenThrowKeywordAndExpression?.raw,
+        expression.raw,
+        unexpectedAfterExpression?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.throwStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -4050,20 +4084,22 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterElseBody: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeIfKeyword?.raw,
-      ifKeyword.raw,
-      unexpectedBetweenIfKeywordAndConditions?.raw,
-      conditions.raw,
-      unexpectedBetweenConditionsAndBody?.raw,
-      body.raw,
-      unexpectedBetweenBodyAndElseKeyword?.raw,
-      elseKeyword?.raw,
-      unexpectedBetweenElseKeywordAndElseBody?.raw,
-      elseBody?.raw,
-      unexpectedAfterElseBody?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeIfKeyword, ifKeyword, unexpectedBetweenIfKeywordAndConditions, conditions, unexpectedBetweenConditionsAndBody, body, unexpectedBetweenBodyAndElseKeyword, elseKeyword, unexpectedBetweenElseKeywordAndElseBody, elseBody, unexpectedAfterElseBody))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeIfKeyword?.raw,
+        ifKeyword.raw,
+        unexpectedBetweenIfKeywordAndConditions?.raw,
+        conditions.raw,
+        unexpectedBetweenConditionsAndBody?.raw,
+        body.raw,
+        unexpectedBetweenBodyAndElseKeyword?.raw,
+        elseKeyword?.raw,
+        unexpectedBetweenElseKeywordAndElseBody?.raw,
+        elseBody?.raw,
+        unexpectedAfterElseBody?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.ifStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -4418,22 +4454,24 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePoundAssert?.raw,
-      poundAssert.raw,
-      unexpectedBetweenPoundAssertAndLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndCondition?.raw,
-      condition.raw,
-      unexpectedBetweenConditionAndComma?.raw,
-      comma?.raw,
-      unexpectedBetweenCommaAndMessage?.raw,
-      message?.raw,
-      unexpectedBetweenMessageAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePoundAssert, poundAssert, unexpectedBetweenPoundAssertAndLeftParen, leftParen, unexpectedBetweenLeftParenAndCondition, condition, unexpectedBetweenConditionAndComma, comma, unexpectedBetweenCommaAndMessage, message, unexpectedBetweenMessageAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePoundAssert?.raw,
+        poundAssert.raw,
+        unexpectedBetweenPoundAssertAndLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndCondition?.raw,
+        condition.raw,
+        unexpectedBetweenConditionAndComma?.raw,
+        comma?.raw,
+        unexpectedBetweenCommaAndMessage?.raw,
+        message?.raw,
+        unexpectedBetweenMessageAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.poundAssertStmt, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -32,7 +32,9 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   }
 
   public init() {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), ())) { (arena, _) in
       let raw = RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
       return SyntaxData.forRoot(raw)
     }
@@ -86,14 +88,16 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeName?.raw,
-      name.raw,
-      unexpectedBetweenNameAndGenericArgumentClause?.raw,
-      genericArgumentClause?.raw,
-      unexpectedAfterGenericArgumentClause?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeName, name, unexpectedBetweenNameAndGenericArgumentClause, genericArgumentClause, unexpectedAfterGenericArgumentClause))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeName?.raw,
+        name.raw,
+        unexpectedBetweenNameAndGenericArgumentClause?.raw,
+        genericArgumentClause?.raw,
+        unexpectedAfterGenericArgumentClause?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.simpleTypeIdentifier, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -277,18 +281,20 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeBaseType?.raw,
-      baseType.raw,
-      unexpectedBetweenBaseTypeAndPeriod?.raw,
-      period.raw,
-      unexpectedBetweenPeriodAndName?.raw,
-      name.raw,
-      unexpectedBetweenNameAndGenericArgumentClause?.raw,
-      genericArgumentClause?.raw,
-      unexpectedAfterGenericArgumentClause?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeBaseType, baseType, unexpectedBetweenBaseTypeAndPeriod, period, unexpectedBetweenPeriodAndName, name, unexpectedBetweenNameAndGenericArgumentClause, genericArgumentClause, unexpectedAfterGenericArgumentClause))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeBaseType?.raw,
+        baseType.raw,
+        unexpectedBetweenBaseTypeAndPeriod?.raw,
+        period.raw,
+        unexpectedBetweenPeriodAndName?.raw,
+        name.raw,
+        unexpectedBetweenNameAndGenericArgumentClause?.raw,
+        genericArgumentClause?.raw,
+        unexpectedAfterGenericArgumentClause?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.memberTypeIdentifier, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -564,12 +570,14 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterClassKeyword: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeClassKeyword?.raw,
-      classKeyword.raw,
-      unexpectedAfterClassKeyword?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeClassKeyword, classKeyword, unexpectedAfterClassKeyword))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeClassKeyword?.raw,
+        classKeyword.raw,
+        unexpectedAfterClassKeyword?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.classRestrictionType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -701,16 +709,18 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftSquareBracket?.raw,
-      leftSquareBracket.raw,
-      unexpectedBetweenLeftSquareBracketAndElementType?.raw,
-      elementType.raw,
-      unexpectedBetweenElementTypeAndRightSquareBracket?.raw,
-      rightSquareBracket.raw,
-      unexpectedAfterRightSquareBracket?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftSquareBracket, leftSquareBracket, unexpectedBetweenLeftSquareBracketAndElementType, elementType, unexpectedBetweenElementTypeAndRightSquareBracket, rightSquareBracket, unexpectedAfterRightSquareBracket))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftSquareBracket?.raw,
+        leftSquareBracket.raw,
+        unexpectedBetweenLeftSquareBracketAndElementType?.raw,
+        elementType.raw,
+        unexpectedBetweenElementTypeAndRightSquareBracket?.raw,
+        rightSquareBracket.raw,
+        unexpectedAfterRightSquareBracket?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.arrayType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -944,20 +954,22 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftSquareBracket?.raw,
-      leftSquareBracket.raw,
-      unexpectedBetweenLeftSquareBracketAndKeyType?.raw,
-      keyType.raw,
-      unexpectedBetweenKeyTypeAndColon?.raw,
-      colon.raw,
-      unexpectedBetweenColonAndValueType?.raw,
-      valueType.raw,
-      unexpectedBetweenValueTypeAndRightSquareBracket?.raw,
-      rightSquareBracket.raw,
-      unexpectedAfterRightSquareBracket?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftSquareBracket, leftSquareBracket, unexpectedBetweenLeftSquareBracketAndKeyType, keyType, unexpectedBetweenKeyTypeAndColon, colon, unexpectedBetweenColonAndValueType, valueType, unexpectedBetweenValueTypeAndRightSquareBracket, rightSquareBracket, unexpectedAfterRightSquareBracket))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftSquareBracket?.raw,
+        leftSquareBracket.raw,
+        unexpectedBetweenLeftSquareBracketAndKeyType?.raw,
+        keyType.raw,
+        unexpectedBetweenKeyTypeAndColon?.raw,
+        colon.raw,
+        unexpectedBetweenColonAndValueType?.raw,
+        valueType.raw,
+        unexpectedBetweenValueTypeAndRightSquareBracket?.raw,
+        rightSquareBracket.raw,
+        unexpectedAfterRightSquareBracket?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.dictionaryType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1285,16 +1297,18 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterTypeOrProtocol: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeBaseType?.raw,
-      baseType.raw,
-      unexpectedBetweenBaseTypeAndPeriod?.raw,
-      period.raw,
-      unexpectedBetweenPeriodAndTypeOrProtocol?.raw,
-      typeOrProtocol.raw,
-      unexpectedAfterTypeOrProtocol?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeBaseType, baseType, unexpectedBetweenBaseTypeAndPeriod, period, unexpectedBetweenPeriodAndTypeOrProtocol, typeOrProtocol, unexpectedAfterTypeOrProtocol))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeBaseType?.raw,
+        baseType.raw,
+        unexpectedBetweenBaseTypeAndPeriod?.raw,
+        period.raw,
+        unexpectedBetweenPeriodAndTypeOrProtocol?.raw,
+        typeOrProtocol.raw,
+        unexpectedAfterTypeOrProtocol?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.metatypeType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1522,14 +1536,16 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeWrappedType?.raw,
-      wrappedType.raw,
-      unexpectedBetweenWrappedTypeAndQuestionMark?.raw,
-      questionMark.raw,
-      unexpectedAfterQuestionMark?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeWrappedType, wrappedType, unexpectedBetweenWrappedTypeAndQuestionMark, questionMark, unexpectedAfterQuestionMark))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeWrappedType?.raw,
+        wrappedType.raw,
+        unexpectedBetweenWrappedTypeAndQuestionMark?.raw,
+        questionMark.raw,
+        unexpectedAfterQuestionMark?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.optionalType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1708,14 +1724,16 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeSomeOrAnySpecifier?.raw,
-      someOrAnySpecifier.raw,
-      unexpectedBetweenSomeOrAnySpecifierAndBaseType?.raw,
-      baseType.raw,
-      unexpectedAfterBaseType?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeSomeOrAnySpecifier, someOrAnySpecifier, unexpectedBetweenSomeOrAnySpecifierAndBaseType, baseType, unexpectedAfterBaseType))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeSomeOrAnySpecifier?.raw,
+        someOrAnySpecifier.raw,
+        unexpectedBetweenSomeOrAnySpecifierAndBaseType?.raw,
+        baseType.raw,
+        unexpectedAfterBaseType?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.constrainedSugarType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -1894,14 +1912,16 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
     _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeWrappedType?.raw,
-      wrappedType.raw,
-      unexpectedBetweenWrappedTypeAndExclamationMark?.raw,
-      exclamationMark.raw,
-      unexpectedAfterExclamationMark?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeWrappedType, wrappedType, unexpectedBetweenWrappedTypeAndExclamationMark, exclamationMark, unexpectedAfterExclamationMark))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeWrappedType?.raw,
+        wrappedType.raw,
+        unexpectedBetweenWrappedTypeAndExclamationMark?.raw,
+        exclamationMark.raw,
+        unexpectedAfterExclamationMark?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.implicitlyUnwrappedOptionalType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2078,12 +2098,14 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeElements?.raw,
-      elements.raw,
-      unexpectedAfterElements?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeElements, elements, unexpectedAfterElements))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeElements?.raw,
+        elements.raw,
+        unexpectedAfterElements?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.compositionType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2232,14 +2254,16 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterEllipsis: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforePatternType?.raw,
-      patternType.raw,
-      unexpectedBetweenPatternTypeAndEllipsis?.raw,
-      ellipsis.raw,
-      unexpectedAfterEllipsis?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforePatternType, patternType, unexpectedBetweenPatternTypeAndEllipsis, ellipsis, unexpectedAfterEllipsis))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforePatternType?.raw,
+        patternType.raw,
+        unexpectedBetweenPatternTypeAndEllipsis?.raw,
+        ellipsis.raw,
+        unexpectedAfterEllipsis?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.packExpansionType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2418,14 +2442,16 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterPackType: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeEachKeyword?.raw,
-      eachKeyword.raw,
-      unexpectedBetweenEachKeywordAndPackType?.raw,
-      packType.raw,
-      unexpectedAfterPackType?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeEachKeyword, eachKeyword, unexpectedBetweenEachKeywordAndPackType, packType, unexpectedAfterPackType))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeEachKeyword?.raw,
+        eachKeyword.raw,
+        unexpectedBetweenEachKeywordAndPackType?.raw,
+        packType.raw,
+        unexpectedAfterPackType?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.packReferenceType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2606,16 +2632,18 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndElements?.raw,
-      elements.raw,
-      unexpectedBetweenElementsAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedAfterRightParen?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftParen, leftParen, unexpectedBetweenLeftParenAndElements, elements, unexpectedBetweenElementsAndRightParen, rightParen, unexpectedAfterRightParen))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndElements?.raw,
+        elements.raw,
+        unexpectedBetweenElementsAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedAfterRightParen?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.tupleType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -2872,24 +2900,26 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterReturnType: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeLeftParen?.raw,
-      leftParen.raw,
-      unexpectedBetweenLeftParenAndArguments?.raw,
-      arguments.raw,
-      unexpectedBetweenArgumentsAndRightParen?.raw,
-      rightParen.raw,
-      unexpectedBetweenRightParenAndAsyncKeyword?.raw,
-      asyncKeyword?.raw,
-      unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword?.raw,
-      throwsOrRethrowsKeyword?.raw,
-      unexpectedBetweenThrowsOrRethrowsKeywordAndArrow?.raw,
-      arrow.raw,
-      unexpectedBetweenArrowAndReturnType?.raw,
-      returnType.raw,
-      unexpectedAfterReturnType?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeLeftParen, leftParen, unexpectedBetweenLeftParenAndArguments, arguments, unexpectedBetweenArgumentsAndRightParen, rightParen, unexpectedBetweenRightParenAndAsyncKeyword, asyncKeyword, unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword, throwsOrRethrowsKeyword, unexpectedBetweenThrowsOrRethrowsKeywordAndArrow, arrow, unexpectedBetweenArrowAndReturnType, returnType, unexpectedAfterReturnType))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeLeftParen?.raw,
+        leftParen.raw,
+        unexpectedBetweenLeftParenAndArguments?.raw,
+        arguments.raw,
+        unexpectedBetweenArgumentsAndRightParen?.raw,
+        rightParen.raw,
+        unexpectedBetweenRightParenAndAsyncKeyword?.raw,
+        asyncKeyword?.raw,
+        unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword?.raw,
+        throwsOrRethrowsKeyword?.raw,
+        unexpectedBetweenThrowsOrRethrowsKeywordAndArrow?.raw,
+        arrow.raw,
+        unexpectedBetweenArrowAndReturnType?.raw,
+        returnType.raw,
+        unexpectedAfterReturnType?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.functionType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3336,16 +3366,18 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeSpecifier?.raw,
-      specifier?.raw,
-      unexpectedBetweenSpecifierAndAttributes?.raw,
-      attributes?.raw,
-      unexpectedBetweenAttributesAndBaseType?.raw,
-      baseType.raw,
-      unexpectedAfterBaseType?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeSpecifier, specifier, unexpectedBetweenSpecifierAndAttributes, attributes, unexpectedBetweenAttributesAndBaseType, baseType, unexpectedAfterBaseType))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeSpecifier?.raw,
+        specifier?.raw,
+        unexpectedBetweenSpecifierAndAttributes?.raw,
+        attributes?.raw,
+        unexpectedBetweenAttributesAndBaseType?.raw,
+        baseType.raw,
+        unexpectedAfterBaseType?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.attributedType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
@@ -3594,14 +3626,16 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
-    let layout: [RawSyntax?] = [
-      unexpectedBeforeGenericParameters?.raw,
-      genericParameters.raw,
-      unexpectedBetweenGenericParametersAndBaseType?.raw,
-      baseType.raw,
-      unexpectedAfterBaseType?.raw,
-    ]
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+    // Extend the lifetime of all parameters so their arenas don't get destroyed 
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpectedBeforeGenericParameters, genericParameters, unexpectedBetweenGenericParametersAndBaseType, baseType, unexpectedAfterBaseType))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpectedBeforeGenericParameters?.raw,
+        genericParameters.raw,
+        unexpectedBetweenGenericParametersAndBaseType?.raw,
+        baseType.raw,
+        unexpectedAfterBaseType?.raw,
+      ]
       let raw = RawSyntax.makeLayout(
         kind: SyntaxKind.namedOpaqueReturnType, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)


### PR DESCRIPTION
The initializers of the syntax nodes didn’t retain the parameters until the end of the initializer call. This means that their arenas could be deallocated before they were added as children to the newly created arena, causing memory corruption.

Fixes https://github.com/apple/swift-syntax/issues/1184 
Fixes rdar://103878350