### PR TITLE
Refactor the lexer to store lexer errors in the tokens instead of having a diagnosticsHandler

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -96,7 +96,7 @@ let package = Package(
     ),
     .target(
       name: "SwiftParser",
-      dependencies: ["SwiftDiagnostics", "SwiftSyntax"],
+      dependencies: ["SwiftSyntax"],
       exclude: [
         "CMakeLists.txt",
         "README.md",

--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -14,7 +14,6 @@ add_swift_host_library(SwiftParser
   Directives.swift
   Expressions.swift
   Lexer.swift
-  LexerDiagnosticMessages.swift
   Lookahead.swift
   LoopProgressCondition.swift
   Modifiers.swift

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1222,9 +1222,8 @@ extension Parser {
       (buffer: UnsafeBufferPointer<UInt8>) -> Bool in
       var cursor = Lexer.Cursor(input: buffer, previous: 0)
       guard buffer[0] == UInt8(ascii: "/") else { return false }
-
-      switch (cursor.lexOperatorIdentifier(cursor, cursor)) {
-      case (.unknown, _):
+      switch cursor.lexOperatorIdentifier(cursor, cursor).tokenKind {
+      case .unknown:
         return false
 
       default:

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1584,7 +1584,7 @@ extension Parser {
       wholeText: wholeText,
       textRange: textRange,
       presence: .present,
-      hasLexerError: false,
+      lexerError: nil,
       arena: self.arena
     )
   }

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -187,7 +187,7 @@ public struct Parser {
       wholeText: tok.wholeText,
       textRange: tok.textRange,
       presence: .present,
-      hasLexerError: tok.flags.contains(.isErroneous),
+      lexerError: tok.error,
       arena: arena
     )
   }
@@ -539,12 +539,18 @@ extension Parser {
     assert(tokenText.hasPrefix(prefix))
 
     let endIndex = current.textRange.lowerBound.advanced(by: prefix.count)
+    var lexerError = current.error
+    if let error = lexerError, error.byteOffset > prefix.count {
+      // The lexer error isn't in the prefix. Drop it.
+      lexerError = nil
+    }
+
     let tok = RawTokenSyntax(
       kind: tokenKind,
       wholeText: SyntaxText(rebasing: current.wholeText[..<endIndex]),
       textRange: current.textRange.lowerBound..<endIndex,
       presence: .present,
-      hasLexerError: current.flags.contains(.isErroneous),
+      lexerError: lexerError,
       arena: self.arena
     )
 

--- a/Sources/SwiftParserDiagnostics/CMakeLists.txt
+++ b/Sources/SwiftParserDiagnostics/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 add_swift_host_library(SwiftParserDiagnostics
   DiagnosticExtensions.swift
+  LexerDiagnosticMessages.swift
   MissingNodesError.swift
   ParserDiagnosticMessages.swift
   ParseDiagnosticsGenerator.swift

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -232,19 +232,16 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     return .skipChildren
   }
 
-  public override func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
-    if shouldSkip(node) {
+  public override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
+    if shouldSkip(token) {
       return .skipChildren
     }
 
-    if node.presence == .missing {
-      handleMissingToken(node)
+    if token.presence == .missing {
+      handleMissingToken(token)
     } else {
-      node.syntaxTextBytes.withUnsafeBufferPointer { buf in
-        var cursor = Lexer.Cursor(input: buf, previous: 0)
-        _ = cursor.nextToken(cursor) { [self] offset, diagnostic in
-          self.addDiagnostic(node, position: node.position.advanced(by: offset), diagnostic)
-        }
+      if let lexerError = token.lexerError {
+        self.addDiagnostic(token, position: token.positionAfterSkippingLeadingTrivia.advanced(by: Int(lexerError.byteOffset)), lexerError.diagnostic(in: token))
       }
     }
 

--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -11,6 +11,7 @@ add_swift_host_library(SwiftSyntax
   BumpPtrAllocator.swift
   CommonAncestor.swift
   IncrementalParseTransition.swift
+  LexerError.swift
   SourceLength.swift
   SourceLocation.swift
   SourcePresence.swift

--- a/Sources/SwiftSyntax/LexerError.swift
+++ b/Sources/SwiftSyntax/LexerError.swift
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// If the token has a lexical error, this defines the type of the error.
+/// `lexerErrorOffset` in the token will specify at which offset the error
+/// occurred.
+public struct LexerError: Hashable {
+  public enum Kind {
+    // Please order these alphabetically
+
+    case expectedBinaryExponentInHexFloatLiteral
+    case expectedDigitInFloatLiteral
+    case invalidBinaryDigitInIntegerLiteral
+    case invalidDecimalDigitInIntegerLiteral
+    case invalidFloatingPointCharacter
+    case invalidFloatingPointDigit
+    case invalidFloatingPointExponentCharacter
+    case invalidFloatingPointExponentDigit
+    case invalidHexDigitInIntegerLiteral
+    case invalidOctalDigitInIntegerLiteral
+    /// The lexer dicovered an error but was not able to represent the offset of the error because it would overflow `LexerErrorOffset`.
+    case lexerErrorOffsetOverflow
+  }
+
+  public let kind: Kind
+
+  /// The offset at which the error is, in bytes relative to the token's content
+  /// start (i.e. relative to the tokens `positionAfterSkippingLeadingTrivia`)
+  public let byteOffset: UInt16
+
+  public init(_ kind: Kind, byteOffset: UInt16) {
+    self.kind = kind
+    self.byteOffset = byteOffset
+  }
+
+  public init(_ kind: Kind, byteOffset: Int) {
+    // `type(of: self.byteOffset).max` gets optimized to a constant
+    if byteOffset > type(of: self.byteOffset).max {
+      self.kind = .lexerErrorOffsetOverflow
+      self.byteOffset = 0
+    } else {
+      self.kind = kind
+      self.byteOffset = UInt16(byteOffset)
+    }
+  }
+}

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -55,7 +55,8 @@ internal struct RawSyntaxData {
 
     var presence: SourcePresence
 
-    var hasLexerError: Bool
+    /// If the token has a lexial error, the type of the error.
+    var lexerError: LexerError?
   }
 
   /// Token typically created with `TokenSyntax.<someToken>`.
@@ -160,7 +161,7 @@ extension RawSyntax {
     switch view {
     case .token(let tokenView):
       var recursiveFlags: RecursiveRawSyntaxFlags = []
-      if tokenView.hasLexerError || tokenView.presence == .missing {
+      if tokenView.lexerError != nil || tokenView.presence == .missing {
         recursiveFlags.insert(.hasError)
       }
       return recursiveFlags
@@ -451,7 +452,7 @@ extension RawSyntax {
     textRange: Range<SyntaxText.Index>,
     presence: SourcePresence,
     arena: SyntaxArena,
-    hasLexerError: Bool
+    lexerError: LexerError?
   ) -> RawSyntax {
     assert(
       arena.contains(text: wholeText),
@@ -466,7 +467,7 @@ extension RawSyntax {
       wholeText: wholeText,
       textRange: textRange,
       presence: presence,
-      hasLexerError: hasLexerError
+      lexerError: lexerError
     )
     return RawSyntax(arena: arena, payload: .parsedToken(payload))
   }

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -132,7 +132,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
     wholeText: SyntaxText,
     textRange: Range<SyntaxText.Index>,
     presence: SourcePresence,
-    hasLexerError: Bool,
+    lexerError: LexerError?,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.parsedToken(
@@ -141,7 +141,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
       textRange: textRange,
       presence: presence,
       arena: arena,
-      hasLexerError: hasLexerError
+      lexerError: lexerError
     )
     self = RawTokenSyntax(raw: raw)
   }
@@ -163,7 +163,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
         wholeText: text,
         textRange: 0..<text.count,
         presence: presence,
-        hasLexerError: false,
+        lexerError: nil,
         arena: arena
       )
     } else {

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -211,14 +211,14 @@ public struct RawSyntaxTokenView {
     }
   }
 
-  var hasLexerError: Bool {
+  var lexerError: LexerError? {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
-      return dat.hasLexerError
+      return dat.lexerError
     case .materializedToken(_):
-      return false
+      return nil
     case .layout(_):
-      preconditionFailure("'hasError' is a token-only property")
+      preconditionFailure("'lexerError' is a token-only property")
     }
   }
 }

--- a/Sources/SwiftSyntax/SyntaxOtherNodes.swift
+++ b/Sources/SwiftSyntax/SyntaxOtherNodes.swift
@@ -169,6 +169,11 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
+
+  /// If the token has a lexical error, the type of the error.
+  public var lexerError: LexerError? {
+    return tokenView.lexerError
+  }
 }
 
 extension TokenSyntax: CustomReflectable {

--- a/Tests/SwiftSyntaxTest/MemoryLayoutTest.swift
+++ b/Tests/SwiftSyntaxTest/MemoryLayoutTest.swift
@@ -28,7 +28,7 @@ final class MemoryLayoutTest: XCTestCase {
     /// If this fails, just update the numbers.
     let expected: [String: SyntaxMemoryLayout.Value] = [
       "RawSyntaxData.Layout": .init(size: 41, stride: 48, alignment: 8),
-      "RawSyntaxData.ParsedToken": .init(size: 42, stride: 48, alignment: 8),
+      "RawSyntaxData.ParsedToken": .init(size: 44, stride: 48, alignment: 8),
       "RawSyntaxData.MaterializedToken": .init(size: 49, stride: 56, alignment: 8),
       "RawSyntaxData": .init(size: 64, stride: 64, alignment: 8),
       "RawSyntax?": .init(size: 8, stride: 8, alignment: 8),

--- a/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
@@ -130,7 +130,7 @@ final class RawSyntaxTests: XCTestCase {
         wholeText: arena.intern("\nfoo "),
         textRange: 1..<4,
         presence: .present,
-        hasLexerError: false,
+        lexerError: nil,
         arena: arena
       )
 

--- a/utils/group.json
+++ b/utils/group.json
@@ -51,7 +51,8 @@
     "Utils.swift",
   ],
   "Parse": [
-    "IncrementalParseTransition.swift"
+    "IncrementalParseTransition.swift",
+    "LexerError.swift",
   ],
   "Internal": [
     "SyntaxArena.swift",


### PR DESCRIPTION
Instead of marking a token as having an error and relying on re-lexing to emit a diagnostic, store the type of error and the offset at which it occurred in the token itself.

This is a more sound design IMO and will continue to work even if we introduce state into the lexer (e.g. whether we are currently in a string literal or inside a conflict marker range).