### PR TITLE
Produce separate tokens for raw string delimiters and string quotes in the lexer

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/AttributeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/AttributeNodes.swift
@@ -45,6 +45,8 @@ public let ATTRIBUTE_NODES: [Node] = [
                        kind: "TupleExprElementList"),
                  Child(name: "Token",
                        kind: "Token"),
+                 Child(name: "String",
+                       kind: "StringLiteralExpr"),
                  Child(name: "Availability",
                        kind: "AvailabilitySpecList"),
                  Child(name: "SpecializeArguments",
@@ -513,11 +515,8 @@ public let ATTRIBUTE_NODES: [Node] = [
        kind: "Syntax",
        children: [
          Child(name: "MangledName",
-               kind: "StringLiteralToken",
-               description: "The mangled name of a declaration.",
-               tokenChoices: [
-                 "StringLiteral"
-               ]),
+               kind: "StringLiteralExpr",
+               description: "The mangled name of a declaration."),
          Child(name: "Comma",
                kind: "CommaToken",
                tokenChoices: [
@@ -571,11 +570,8 @@ public let ATTRIBUTE_NODES: [Node] = [
                  "Colon"
                ]),
          Child(name: "CTypeString",
-               kind: "StringLiteralToken",
-               isOptional: true,
-               tokenChoices: [
-                 "StringLiteral"
-               ])
+               kind: "StringLiteralExpr",
+               isOptional: true)
        ]),
 
   Node(name: "ConventionWitnessMethodAttributeArguments",
@@ -614,11 +610,8 @@ public let ATTRIBUTE_NODES: [Node] = [
                  "Comma"
                ]),
          Child(name: "CxxName",
-               kind: "StringLiteralToken",
-               isOptional: true,
-               tokenChoices: [
-                 "StringLiteral"
-               ])
+               kind: "StringLiteralExpr",
+               isOptional: true)
        ]),
 
   Node(name: "OriginallyDefinedInArguments",
@@ -640,10 +633,7 @@ public let ATTRIBUTE_NODES: [Node] = [
                  "Colon"
                ]),
          Child(name: "ModuleName",
-               kind: "StringLiteralToken",
-               tokenChoices: [
-                 "StringLiteral"
-               ]),
+               kind: "StringLiteralExpr"),
          Child(name: "Comma",
                kind: "CommaToken",
                tokenChoices: [
@@ -673,10 +663,7 @@ public let ATTRIBUTE_NODES: [Node] = [
                  "Colon"
                ]),
          Child(name: "Filename",
-               kind: "StringLiteralToken",
-               tokenChoices: [
-                 "StringLiteral"
-               ])
+               kind: "StringLiteralExpr")
        ]),
 
   Node(name: "DynamicReplacementArguments",
@@ -720,10 +707,7 @@ public let ATTRIBUTE_NODES: [Node] = [
                  "Colon"
                ]),
          Child(name: "Message",
-               kind: "StringLiteralToken",
-               tokenChoices: [
-                 "StringLiteral"
-               ])
+               kind: "StringLiteralExpr")
        ]),
 
   Node(name: "EffectsArguments",
@@ -754,11 +738,16 @@ public let ATTRIBUTE_NODES: [Node] = [
                  "Colon"
                ]),
          Child(name: "Value",
-               kind: "Token",
-               tokenChoices: [
-                 "Identifier",
-                 "Keyword",
-                 "StringLiteral"
+               kind: "Syntax",
+               nodeChoices: [
+                 Child(name: "Token",
+                       kind: "Token",
+                       tokenChoices: [
+                         "Identifier",
+                         "Keyword"
+                       ]),
+                 Child(name: "String",
+                       kind: "StringLiteralExpr")
                ]),
          Child(name: "TrailingComma",
                kind: "CommaToken",

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/AvailabilityNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/AvailabilityNodes.swift
@@ -69,10 +69,7 @@ public let AVAILABILITY_NODES: [Node] = [
                description: "The value of this labeled argument",
                nodeChoices: [
                  Child(name: "String",
-                       kind: "StringLiteralToken",
-                       tokenChoices: [
-                         "StringLiteral"
-                       ]),
+                       kind: "StringLiteralExpr"),
                  Child(name: "Version",
                        kind: "VersionTuple")
                ])

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
@@ -327,10 +327,7 @@ public let DECL_NODES: [Node] = [
                  "Colon"
                ]),
          Child(name: "FileName",
-               kind: "StringLiteralToken",
-               tokenChoices: [
-                 "StringLiteral"
-               ]),
+               kind: "StringLiteralExpr"),
          Child(name: "Comma",
                kind: "CommaToken",
                tokenChoices: [

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/StmtNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/StmtNodes.swift
@@ -720,12 +720,9 @@ public let STMT_NODES: [Node] = [
                  "Comma"
                ]),
          Child(name: "Message",
-               kind: "StringLiteralToken",
+               kind: "StringLiteralExpr",
                description: "The assertion message.",
-               isOptional: true,
-               tokenChoices: [
-                 "StringLiteral"
-               ]),
+               isOptional: true),
          Child(name: "RightParen",
                kind: "RightParenToken",
                tokenChoices: [

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/TokenSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/TokenSpec.swift
@@ -221,7 +221,7 @@ public let SYNTAX_TOKENS: [TokenSpec] = [
   PoundConfigSpec(name: "PoundHasSymbol", kind: "pound__hasSymbol", text: "#_hasSymbol"),
   LiteralSpec(name: "IntegerLiteral", kind: "integer_literal", nameForDiagnostics: "integer literal", classification: "IntegerLiteral"),
   LiteralSpec(name: "FloatingLiteral", kind: "floating_literal", nameForDiagnostics: "floating literal", classification: "FloatingLiteral"),
-  LiteralSpec(name: "StringLiteral", kind: "string_literal", nameForDiagnostics: "string literal", classification: "StringLiteral"),
+  LiteralSpec(name: "StringLiteralContents", kind: "string_literal", nameForDiagnostics: "string literal", classification: "StringLiteral"),
   LiteralSpec(name: "RegexLiteral", kind: "regex_literal", nameForDiagnostics: "regex literal"),
   MiscSpec(name: "Unknown", kind: "unknown", nameForDiagnostics: "token"),
   MiscSpec(name: "Identifier", kind: "identifier", nameForDiagnostics: "identifier", classification: "Identifier"),

--- a/Sources/IDEUtils/generated/SyntaxClassification.swift
+++ b/Sources/IDEUtils/generated/SyntaxClassification.swift
@@ -242,7 +242,7 @@ extension RawTokenKind {
       return .integerLiteral
     case .floatingLiteral: 
       return .floatingLiteral
-    case .stringLiteral: 
+    case .stringLiteralContents: 
       return .stringLiteral
     case .regexLiteral: 
       return .none

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -108,7 +108,7 @@ extension Parser {
         let argumentLabel = self.eat(handle)
         let (unexpectedBeforeColon, colon) = self.expect(.colon)
         // FIXME: Make sure this is a string literal with no interpolation.
-        let stringValue = self.consumeAnyToken()
+        let stringValue = self.parseStringLiteral()
 
         entry = .availabilityLabeledArgument(
           RawAvailabilityLabeledArgumentSyntax(

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1251,7 +1251,7 @@ extension Parser {
     /// consumes the entire regex literal, we're done.
     return self.currentToken.tokenText.withBuffer {
       (buffer: UnsafeBufferPointer<UInt8>) -> Bool in
-      var cursor = Lexer.Cursor(input: buffer, previous: 0)
+      var cursor = Lexer.Cursor(input: buffer, previous: 0, state: .normal)
       guard buffer[0] == UInt8(ascii: "/") else { return false }
       switch cursor.lexOperatorIdentifier(cursor, cursor).tokenKind {
       case .unknown:
@@ -2151,19 +2151,7 @@ extension Parser {
     }
 
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
-    let stringLiteral: RawStringLiteralExprSyntax
-    if self.at(.stringLiteral) {
-      stringLiteral = self.parseStringLiteral()
-    } else {
-      stringLiteral = RawStringLiteralExprSyntax(
-        openDelimiter: nil,
-        openQuote: RawTokenSyntax(missing: .stringQuote, arena: self.arena),
-        segments: RawStringLiteralSegmentsSyntax(elements: [], arena: self.arena),
-        closeQuote: RawTokenSyntax(missing: .stringQuote, arena: self.arena),
-        closeDelimiter: nil,
-        arena: self.arena
-      )
-    }
+    let stringLiteral = self.parseStringLiteral()
     let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
 
     switch directive {

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -154,7 +154,7 @@ extension Parser {
     if !self.at(.rightParen) {
       let (unexpectedBeforeFile, file) = self.expectIdentifier()
       let (unexpectedBeforeFileColon, fileColon) = self.expect(.colon)
-      let (unexpectedBeforeFileName, fileName) = self.expect(.stringLiteral)
+      let fileName = self.parseStringLiteral()
       let (unexpectedBeforeComma, comma) = self.expect(.comma)
 
       let (unexpectedBeforeLine, line) = self.expectIdentifier()
@@ -166,7 +166,6 @@ extension Parser {
         fileArgLabel: file,
         unexpectedBeforeFileColon,
         fileArgColon: fileColon,
-        unexpectedBeforeFileName,
         fileName: fileName,
         unexpectedBeforeComma,
         comma: comma,

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1756,7 +1756,14 @@ extension Parser {
           var runexpectedTokens = [RawSyntax]()
           let runexpected: RawUnexpectedNodesSyntax?
           var loopProgress = LoopProgressCondition()
-          while !subparser.at(any: [.eof, .rightParen]) && loopProgress.evaluate(subparser.currentToken) {
+          var openParens = 0
+          // Terminate the loop when we've reached EOF or are at a ')' with no more open '(' that we need to skip
+          while !subparser.at(.eof) && !(subparser.at(.rightParen) && openParens == 0) && loopProgress.evaluate(subparser.currentToken) {
+            if subparser.at(.leftParen) {
+              openParens += 1
+            } else if subparser.at(.rightParen) {
+              openParens -= 1
+            }
             runexpectedTokens.append(RawSyntax(subparser.consumeAnyToken()))
           }
           if !runexpectedTokens.isEmpty {

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -697,10 +697,14 @@ enum PrimaryExpressionStart: RawTokenKindSubset {
   case poundUnavailableKeyword  // For recovery
   case regexLiteral
   case selfKeyword
-  case stringLiteral
+  case stringLiteralContents
   case superKeyword
   case trueKeyword
   case wildcard
+  case rawStringDelimiter
+  case stringQuote
+  case multilineStringQuote
+  case singleQuote
 
   init?(lexeme: Lexer.Lexeme) {
     switch lexeme {
@@ -722,10 +726,14 @@ enum PrimaryExpressionStart: RawTokenKindSubset {
     case RawTokenKindMatch(.poundUnavailableKeyword): self = .poundUnavailableKeyword
     case RawTokenKindMatch(.regexLiteral): self = .regexLiteral
     case RawTokenKindMatch(.self): self = .selfKeyword
-    case RawTokenKindMatch(.stringLiteral): self = .stringLiteral
+    case RawTokenKindMatch(.stringLiteralContents): self = .stringLiteralContents
     case RawTokenKindMatch(.super): self = .superKeyword
     case RawTokenKindMatch(.true): self = .trueKeyword
     case RawTokenKindMatch(.wildcard): self = .wildcard
+    case RawTokenKindMatch(.rawStringDelimiter): self = .rawStringDelimiter
+    case RawTokenKindMatch(.stringQuote): self = .stringQuote
+    case RawTokenKindMatch(.multilineStringQuote): self = .multilineStringQuote
+    case RawTokenKindMatch(.singleQuote): self = .singleQuote
     default: return nil
     }
   }
@@ -750,10 +758,14 @@ enum PrimaryExpressionStart: RawTokenKindSubset {
     case .poundUnavailableKeyword: return .poundUnavailableKeyword
     case .regexLiteral: return .regexLiteral
     case .selfKeyword: return .keyword(.self)
-    case .stringLiteral: return .stringLiteral
+    case .stringLiteralContents: return .stringLiteralContents
     case .superKeyword: return .keyword(.super)
     case .trueKeyword: return .keyword(.true)
     case .wildcard: return .wildcard
+    case .rawStringDelimiter: return .rawStringDelimiter
+    case .stringQuote: return .stringQuote
+    case .multilineStringQuote: return .multilineStringQuote
+    case .singleQuote: return .singleQuote
     }
   }
 }

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -1182,9 +1182,9 @@ extension Parser {
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
     let condition = self.parseExpression()
     let comma = self.consume(if: .comma)
-    let message: RawTokenSyntax?
+    let message: RawStringLiteralExprSyntax?
     if comma != nil {
-      message = self.consumeAnyToken()
+      message = self.parseStringLiteral()
     } else {
       message = nil
     }

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -106,7 +106,7 @@ public enum TokenPrecedence: Comparable {
       self = .unknownToken
     // MARK: Identifier like
     case  // Literals
-    .keyword(.Self), .keyword(.false), .floatingLiteral, .integerLiteral, .keyword(.nil), .regexLiteral, .keyword(.self), .stringLiteral, .keyword(.super), .keyword(.true),
+    .keyword(.Self), .keyword(.false), .floatingLiteral, .integerLiteral, .keyword(.nil), .regexLiteral, .keyword(.self), .stringLiteralContents, .keyword(.super), .keyword(.true),
       // Pound literals
       .poundAvailableKeyword, .poundColorLiteralKeyword, .poundColumnKeyword, .poundDsohandleKeyword, .poundFileIDKeyword, .poundFileKeyword, .poundFileLiteralKeyword, .poundFilePathKeyword, .poundFunctionKeyword, .poundImageLiteralKeyword, .poundKeyPathKeyword, .poundLineKeyword, .poundSelectorKeyword, .poundSourceLocationKeyword, .poundUnavailableKeyword, .poundHasSymbolKeyword,
       // Identifiers

--- a/Sources/SwiftParser/TriviaParser.swift
+++ b/Sources/SwiftParser/TriviaParser.swift
@@ -20,7 +20,8 @@ public struct TriviaParser {
     var pieces: [RawTriviaPiece] = []
     var cursor = Lexer.Cursor(
       input: UnsafeBufferPointer(start: source.baseAddress, count: source.count),
-      previous: 0
+      previous: 0,
+      state: .normal
     )
 
     while true {

--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -354,6 +354,21 @@ extension ParseDiagnosticsGenerator {
         let fixIt = FixIt(message: .removeExtraneousWhitespace, changes: changes)
         addDiagnostic(invalidToken, .invalidWhitespaceAfterPeriod, fixIts: [fixIt], handledNodes: [unexpectedTokens.id])
       }
+    } else if node.rawTokenKind == .rawStringDelimiter, invalidToken.rawTokenKind == .rawStringDelimiter {
+      let fixIt = FixIt(
+        message: .removeExtraneousDelimiters,
+        changes: [
+          .makeMissing(invalidToken),
+          .makePresentBeforeTrivia(node),
+        ]
+      )
+      addDiagnostic(
+        invalidToken,
+        position: invalidToken.positionAfterSkippingLeadingTrivia.advanced(by: node.contentLength.utf8Length),
+        .tooManyClosingRawStringDelimiters,
+        fixIts: [fixIt],
+        handledNodes: [unexpectedTokens.id]
+      )
     } else {
       _ = handleMissingSyntax(node)
     }

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -140,6 +140,9 @@ extension DiagnosticMessage where Self == StaticParserError {
   public static var joinPlatformsUsingComma: Self {
     .init("expected ',' joining platforms in availability condition")
   }
+  public static var maximumNestingLevelOverflow: Self {
+    .init("parsing has exceeded the maximum nesting level")
+  }
   public static var missingColonAndExprInTernaryExpr: Self {
     .init("expected ':' and expression after '? ...' in ternary expression")
   }
@@ -152,14 +155,14 @@ extension DiagnosticMessage where Self == StaticParserError {
   public static var standaloneSemicolonStatement: Self {
     .init("standalone ';' statements are not allowed")
   }
-  public static var maximumNestingLevelOverflow: Self {
-    .init("parsing has exceeded the maximum nesting level")
-  }
   public static var subscriptsCannotHaveNames: Self {
     .init("subscripts cannot have a name")
   }
   public static var throwsInReturnPosition: Self {
     .init("'throws' may only occur before '->'")
+  }
+  public static var tooManyClosingRawStringDelimiters: Self {
+    .init("too many '#' characters in closing delimiter")
   }
   public static var tryMustBePlacedOnReturnedExpr: Self {
     .init("'try' must be placed on the returned expression")
@@ -344,6 +347,9 @@ extension FixItMessage where Self == StaticParserFixIt {
   }
   public static var joinIdentifiersWithCamelCase: Self {
     .init("join the identifiers together with camel-case")
+  }
+  public static var removeExtraneousDelimiters: Self {
+    .init("remove extraneous delimiters")
   }
   public static var removeExtraneousWhitespace: Self {
     .init("remove whitespace")

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -6412,7 +6412,7 @@ public struct RawPoundSourceLocationArgsSyntax: RawSyntaxNodeProtocol {
     _ unexpectedBetweenFileArgLabelAndFileArgColon: RawUnexpectedNodesSyntax? = nil,
     fileArgColon: RawTokenSyntax,
     _ unexpectedBetweenFileArgColonAndFileName: RawUnexpectedNodesSyntax? = nil,
-    fileName: RawTokenSyntax,
+    fileName: RawStringLiteralExprSyntax,
     _ unexpectedBetweenFileNameAndComma: RawUnexpectedNodesSyntax? = nil,
     comma: RawTokenSyntax,
     _ unexpectedBetweenCommaAndLineArgLabel: RawUnexpectedNodesSyntax? = nil,
@@ -6461,8 +6461,8 @@ public struct RawPoundSourceLocationArgsSyntax: RawSyntaxNodeProtocol {
   public var unexpectedBetweenFileArgColonAndFileName: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
-  public var fileName: RawTokenSyntax {
-    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  public var fileName: RawStringLiteralExprSyntax {
+    layoutView.children[5].map(RawStringLiteralExprSyntax.init(raw:))!
   }
   public var unexpectedBetweenFileNameAndComma: RawUnexpectedNodesSyntax? {
     layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
@@ -10421,6 +10421,7 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
   public enum Argument: RawSyntaxNodeProtocol {
     case `argumentList`(RawTupleExprElementListSyntax)
     case `token`(RawTokenSyntax)
+    case `string`(RawStringLiteralExprSyntax)
     case `availability`(RawAvailabilitySpecListSyntax)
     case `specializeArguments`(RawSpecializeAttributeSpecListSyntax)
     case `objCName`(RawObjCSelectorSyntax)
@@ -10440,13 +10441,14 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
     case `documentationArguments`(RawDocumentationAttributeArgumentsSyntax)
 
     public static func isKindOf(_ raw: RawSyntax) -> Bool {
-      return RawTupleExprElementListSyntax.isKindOf(raw) || RawTokenSyntax.isKindOf(raw) || RawAvailabilitySpecListSyntax.isKindOf(raw) || RawSpecializeAttributeSpecListSyntax.isKindOf(raw) || RawObjCSelectorSyntax.isKindOf(raw) || RawImplementsAttributeArgumentsSyntax.isKindOf(raw) || RawDifferentiableAttributeArgumentsSyntax.isKindOf(raw) || RawDerivativeRegistrationAttributeArgumentsSyntax.isKindOf(raw) || RawBackDeployAttributeSpecListSyntax.isKindOf(raw) || RawConventionAttributeArgumentsSyntax.isKindOf(raw) || RawConventionWitnessMethodAttributeArgumentsSyntax.isKindOf(raw) || RawOpaqueReturnTypeOfAttributeArgumentsSyntax.isKindOf(raw) || RawExposeAttributeArgumentsSyntax.isKindOf(raw) || RawOriginallyDefinedInArgumentsSyntax.isKindOf(raw) || RawUnderscorePrivateAttributeArgumentsSyntax.isKindOf(raw) || RawDynamicReplacementArgumentsSyntax.isKindOf(raw) || RawUnavailableFromAsyncArgumentsSyntax.isKindOf(raw) || RawEffectsArgumentsSyntax.isKindOf(raw) || RawDocumentationAttributeArgumentsSyntax.isKindOf(raw)
+      return RawTupleExprElementListSyntax.isKindOf(raw) || RawTokenSyntax.isKindOf(raw) || RawStringLiteralExprSyntax.isKindOf(raw) || RawAvailabilitySpecListSyntax.isKindOf(raw) || RawSpecializeAttributeSpecListSyntax.isKindOf(raw) || RawObjCSelectorSyntax.isKindOf(raw) || RawImplementsAttributeArgumentsSyntax.isKindOf(raw) || RawDifferentiableAttributeArgumentsSyntax.isKindOf(raw) || RawDerivativeRegistrationAttributeArgumentsSyntax.isKindOf(raw) || RawBackDeployAttributeSpecListSyntax.isKindOf(raw) || RawConventionAttributeArgumentsSyntax.isKindOf(raw) || RawConventionWitnessMethodAttributeArgumentsSyntax.isKindOf(raw) || RawOpaqueReturnTypeOfAttributeArgumentsSyntax.isKindOf(raw) || RawExposeAttributeArgumentsSyntax.isKindOf(raw) || RawOriginallyDefinedInArgumentsSyntax.isKindOf(raw) || RawUnderscorePrivateAttributeArgumentsSyntax.isKindOf(raw) || RawDynamicReplacementArgumentsSyntax.isKindOf(raw) || RawUnavailableFromAsyncArgumentsSyntax.isKindOf(raw) || RawEffectsArgumentsSyntax.isKindOf(raw) || RawDocumentationAttributeArgumentsSyntax.isKindOf(raw)
     }
 
     public var raw: RawSyntax {
       switch self {
       case .argumentList(let node): return node.raw
       case .token(let node): return node.raw
+      case .string(let node): return node.raw
       case .availability(let node): return node.raw
       case .specializeArguments(let node): return node.raw
       case .objCName(let node): return node.raw
@@ -10474,6 +10476,10 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
       }
       if let node = RawTokenSyntax(other) {
         self = .token(node)
+        return
+      }
+      if let node = RawStringLiteralExprSyntax(other) {
+        self = .string(node)
         return
       }
       if let node = RawAvailabilitySpecListSyntax(other) {
@@ -12010,7 +12016,7 @@ public struct RawOpaqueReturnTypeOfAttributeArgumentsSyntax: RawSyntaxNodeProtoc
 
   public init(
     _ unexpectedBeforeMangledName: RawUnexpectedNodesSyntax? = nil,
-    mangledName: RawTokenSyntax,
+    mangledName: RawStringLiteralExprSyntax,
     _ unexpectedBetweenMangledNameAndComma: RawUnexpectedNodesSyntax? = nil,
     comma: RawTokenSyntax,
     _ unexpectedBetweenCommaAndOrdinal: RawUnexpectedNodesSyntax? = nil,
@@ -12035,8 +12041,8 @@ public struct RawOpaqueReturnTypeOfAttributeArgumentsSyntax: RawSyntaxNodeProtoc
   public var unexpectedBeforeMangledName: RawUnexpectedNodesSyntax? {
     layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
   }
-  public var mangledName: RawTokenSyntax {
-    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  public var mangledName: RawStringLiteralExprSyntax {
+    layoutView.children[1].map(RawStringLiteralExprSyntax.init(raw:))!
   }
   public var unexpectedBetweenMangledNameAndComma: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
@@ -12088,7 +12094,7 @@ public struct RawConventionAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     _ unexpectedBetweenCTypeLabelAndColon: RawUnexpectedNodesSyntax? = nil,
     colon: RawTokenSyntax?,
     _ unexpectedBetweenColonAndCTypeString: RawUnexpectedNodesSyntax? = nil,
-    cTypeString: RawTokenSyntax?,
+    cTypeString: RawStringLiteralExprSyntax?,
     _ unexpectedAfterCTypeString: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
@@ -12137,8 +12143,8 @@ public struct RawConventionAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
   public var unexpectedBetweenColonAndCTypeString: RawUnexpectedNodesSyntax? {
     layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
-  public var cTypeString: RawTokenSyntax? {
-    layoutView.children[9].map(RawTokenSyntax.init(raw:))
+  public var cTypeString: RawStringLiteralExprSyntax? {
+    layoutView.children[9].map(RawStringLiteralExprSyntax.init(raw:))
   }
   public var unexpectedAfterCTypeString: RawUnexpectedNodesSyntax? {
     layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
@@ -12244,7 +12250,7 @@ public struct RawExposeAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     _ unexpectedBetweenLanguageAndComma: RawUnexpectedNodesSyntax? = nil,
     comma: RawTokenSyntax?,
     _ unexpectedBetweenCommaAndCxxName: RawUnexpectedNodesSyntax? = nil,
-    cxxName: RawTokenSyntax?,
+    cxxName: RawStringLiteralExprSyntax?,
     _ unexpectedAfterCxxName: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
@@ -12277,8 +12283,8 @@ public struct RawExposeAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
   public var unexpectedBetweenCommaAndCxxName: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
-  public var cxxName: RawTokenSyntax? {
-    layoutView.children[5].map(RawTokenSyntax.init(raw:))
+  public var cxxName: RawStringLiteralExprSyntax? {
+    layoutView.children[5].map(RawStringLiteralExprSyntax.init(raw:))
   }
   public var unexpectedAfterCxxName: RawUnexpectedNodesSyntax? {
     layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
@@ -12314,7 +12320,7 @@ public struct RawOriginallyDefinedInArgumentsSyntax: RawSyntaxNodeProtocol {
     _ unexpectedBetweenModuleLabelAndColon: RawUnexpectedNodesSyntax? = nil,
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndModuleName: RawUnexpectedNodesSyntax? = nil,
-    moduleName: RawTokenSyntax,
+    moduleName: RawStringLiteralExprSyntax,
     _ unexpectedBetweenModuleNameAndComma: RawUnexpectedNodesSyntax? = nil,
     comma: RawTokenSyntax,
     _ unexpectedBetweenCommaAndPlatforms: RawUnexpectedNodesSyntax? = nil,
@@ -12355,8 +12361,8 @@ public struct RawOriginallyDefinedInArgumentsSyntax: RawSyntaxNodeProtocol {
   public var unexpectedBetweenColonAndModuleName: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
-  public var moduleName: RawTokenSyntax {
-    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  public var moduleName: RawStringLiteralExprSyntax {
+    layoutView.children[5].map(RawStringLiteralExprSyntax.init(raw:))!
   }
   public var unexpectedBetweenModuleNameAndComma: RawUnexpectedNodesSyntax? {
     layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
@@ -12404,7 +12410,7 @@ public struct RawUnderscorePrivateAttributeArgumentsSyntax: RawSyntaxNodeProtoco
     _ unexpectedBetweenSourceFileLabelAndColon: RawUnexpectedNodesSyntax? = nil,
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndFilename: RawUnexpectedNodesSyntax? = nil,
-    filename: RawTokenSyntax,
+    filename: RawStringLiteralExprSyntax,
     _ unexpectedAfterFilename: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
@@ -12437,8 +12443,8 @@ public struct RawUnderscorePrivateAttributeArgumentsSyntax: RawSyntaxNodeProtoco
   public var unexpectedBetweenColonAndFilename: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
-  public var filename: RawTokenSyntax {
-    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  public var filename: RawStringLiteralExprSyntax {
+    layoutView.children[5].map(RawStringLiteralExprSyntax.init(raw:))!
   }
   public var unexpectedAfterFilename: RawUnexpectedNodesSyntax? {
     layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
@@ -12544,7 +12550,7 @@ public struct RawUnavailableFromAsyncArgumentsSyntax: RawSyntaxNodeProtocol {
     _ unexpectedBetweenMessageLabelAndColon: RawUnexpectedNodesSyntax? = nil,
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndMessage: RawUnexpectedNodesSyntax? = nil,
-    message: RawTokenSyntax,
+    message: RawStringLiteralExprSyntax,
     _ unexpectedAfterMessage: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
@@ -12577,8 +12583,8 @@ public struct RawUnavailableFromAsyncArgumentsSyntax: RawSyntaxNodeProtocol {
   public var unexpectedBetweenColonAndMessage: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
-  public var message: RawTokenSyntax {
-    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  public var message: RawStringLiteralExprSyntax {
+    layoutView.children[5].map(RawStringLiteralExprSyntax.init(raw:))!
   }
   public var unexpectedAfterMessage: RawUnexpectedNodesSyntax? {
     layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
@@ -12627,6 +12633,35 @@ public struct RawEffectsArgumentsSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawDocumentationAttributeArgumentSyntax: RawSyntaxNodeProtocol {
+  @frozen // FIXME: Not actually stable, works around a miscompile
+  public enum Value: RawSyntaxNodeProtocol {
+    case `token`(RawTokenSyntax)
+    case `string`(RawStringLiteralExprSyntax)
+
+    public static func isKindOf(_ raw: RawSyntax) -> Bool {
+      return RawTokenSyntax.isKindOf(raw) || RawStringLiteralExprSyntax.isKindOf(raw)
+    }
+
+    public var raw: RawSyntax {
+      switch self {
+      case .token(let node): return node.raw
+      case .string(let node): return node.raw
+      }
+    }
+
+    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+      if let node = RawTokenSyntax(other) {
+        self = .token(node)
+        return
+      }
+      if let node = RawStringLiteralExprSyntax(other) {
+        self = .string(node)
+        return
+      }
+      return nil
+    }
+  }
+
 
   @_spi(RawSyntax)
   public var layoutView: RawSyntaxLayoutView {
@@ -12654,7 +12689,7 @@ public struct RawDocumentationAttributeArgumentSyntax: RawSyntaxNodeProtocol {
     _ unexpectedBetweenLabelAndColon: RawUnexpectedNodesSyntax? = nil,
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndValue: RawUnexpectedNodesSyntax? = nil,
-    value: RawTokenSyntax,
+    value: Value,
     _ unexpectedBetweenValueAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
@@ -12691,8 +12726,8 @@ public struct RawDocumentationAttributeArgumentSyntax: RawSyntaxNodeProtocol {
   public var unexpectedBetweenColonAndValue: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
-  public var value: RawTokenSyntax {
-    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  public var value: RawSyntax {
+    layoutView.children[5]!
   }
   public var unexpectedBetweenValueAndTrailingComma: RawUnexpectedNodesSyntax? {
     layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
@@ -15161,7 +15196,7 @@ public struct RawPoundAssertStmtSyntax: RawStmtSyntaxNodeProtocol {
     _ unexpectedBetweenConditionAndComma: RawUnexpectedNodesSyntax? = nil,
     comma: RawTokenSyntax?,
     _ unexpectedBetweenCommaAndMessage: RawUnexpectedNodesSyntax? = nil,
-    message: RawTokenSyntax?,
+    message: RawStringLiteralExprSyntax?,
     _ unexpectedBetweenMessageAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
@@ -15214,8 +15249,8 @@ public struct RawPoundAssertStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var unexpectedBetweenCommaAndMessage: RawUnexpectedNodesSyntax? {
     layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
-  public var message: RawTokenSyntax? {
-    layoutView.children[9].map(RawTokenSyntax.init(raw:))
+  public var message: RawStringLiteralExprSyntax? {
+    layoutView.children[9].map(RawStringLiteralExprSyntax.init(raw:))
   }
   public var unexpectedBetweenMessageAndRightParen: RawUnexpectedNodesSyntax? {
     layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
@@ -18252,11 +18287,11 @@ public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol {
 public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol {
   @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Value: RawSyntaxNodeProtocol {
-    case `string`(RawTokenSyntax)
+    case `string`(RawStringLiteralExprSyntax)
     case `version`(RawVersionTupleSyntax)
 
     public static func isKindOf(_ raw: RawSyntax) -> Bool {
-      return RawTokenSyntax.isKindOf(raw) || RawVersionTupleSyntax.isKindOf(raw)
+      return RawStringLiteralExprSyntax.isKindOf(raw) || RawVersionTupleSyntax.isKindOf(raw)
     }
 
     public var raw: RawSyntax {
@@ -18267,7 +18302,7 @@ public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol {
     }
 
     public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
-      if let node = RawTokenSyntax(other) {
+      if let node = RawStringLiteralExprSyntax(other) {
         self = .string(node)
         return
       }

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
@@ -947,7 +947,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawStringLiteralExprSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 7, verify(layout[7], as: RawTokenSyntax.self))
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
@@ -1574,6 +1574,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
       verify(layout[7], as: RawSyntax?.self),
       verify(layout[7], as: RawSyntax?.self),
       verify(layout[7], as: RawSyntax?.self),
+      verify(layout[7], as: RawSyntax?.self),
     ])
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 9, verify(layout[9], as: RawTokenSyntax?.self))
@@ -1772,7 +1773,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .opaqueReturnTypeOfAttributeArguments:
     assert(layout.count == 7)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawStringLiteralExprSyntax.self))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -1790,7 +1791,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 7, verify(layout[7], as: RawTokenSyntax?.self))
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 9, verify(layout[9], as: RawTokenSyntax?.self))
+    assertNoError(kind, 9, verify(layout[9], as: RawStringLiteralExprSyntax?.self))
     assertNoError(kind, 10, verify(layout[10], as: RawUnexpectedNodesSyntax?.self))
     break
   case .conventionWitnessMethodAttributeArguments:
@@ -1810,7 +1811,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax?.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawStringLiteralExprSyntax?.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     break
   case .originallyDefinedInArguments:
@@ -1820,7 +1821,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawStringLiteralExprSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 7, verify(layout[7], as: RawTokenSyntax.self))
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
@@ -1834,7 +1835,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawStringLiteralExprSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     break
   case .dynamicReplacementArguments:
@@ -1854,7 +1855,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawStringLiteralExprSyntax.self))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     break
   case .effectsArguments:
@@ -1869,7 +1870,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self))
+    assertAnyHasNoError(kind, 5, [
+      verify(layout[5], as: RawSyntax.self),
+      verify(layout[5], as: RawSyntax.self),
+    ])
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 7, verify(layout[7], as: RawTokenSyntax?.self))
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
@@ -2225,7 +2229,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 7, verify(layout[7], as: RawTokenSyntax?.self))
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 9, verify(layout[9], as: RawTokenSyntax?.self))
+    assertNoError(kind, 9, verify(layout[9], as: RawStringLiteralExprSyntax?.self))
     assertNoError(kind, 10, verify(layout[10], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 11, verify(layout[11], as: RawTokenSyntax.self))
     assertNoError(kind, 12, verify(layout[12], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/generated/TokenKind.swift
@@ -109,7 +109,7 @@ public enum TokenKind: Hashable {
   
   case floatingLiteral(String)
   
-  case stringLiteral(String)
+  case stringLiteralContents(String)
   
   case regexLiteral(String)
   
@@ -294,7 +294,7 @@ public enum TokenKind: Hashable {
       return text
     case .floatingLiteral(let text): 
       return text
-    case .stringLiteral(let text): 
+    case .stringLiteralContents(let text): 
       return text
     case .regexLiteral(let text): 
       return text
@@ -547,7 +547,7 @@ public enum TokenKind: Hashable {
       return false
     case .floatingLiteral: 
       return false
-    case .stringLiteral: 
+    case .stringLiteralContents: 
       return false
     case .regexLiteral: 
       return false
@@ -685,7 +685,7 @@ public enum TokenKind: Hashable {
       return false
     case .floatingLiteral: 
       return false
-    case .stringLiteral: 
+    case .stringLiteralContents: 
       return false
     case .regexLiteral: 
       return false
@@ -820,7 +820,7 @@ extension TokenKind: Equatable {
       return lhsText == rhsText
     case (.floatingLiteral(let lhsText), .floatingLiteral(let rhsText)): 
       return lhsText == rhsText
-    case (.stringLiteral(let lhsText), .stringLiteral(let rhsText)): 
+    case (.stringLiteralContents(let lhsText), .stringLiteralContents(let rhsText)): 
       return lhsText == rhsText
     case (.regexLiteral(let lhsText), .regexLiteral(let rhsText)): 
       return lhsText == rhsText
@@ -957,7 +957,7 @@ public enum RawTokenKind: Equatable, Hashable {
   
   case floatingLiteral
   
-  case stringLiteral
+  case stringLiteralContents
   
   case regexLiteral
   
@@ -1199,7 +1199,7 @@ public enum RawTokenKind: Equatable, Hashable {
       return #"integer literal"#
     case .floatingLiteral: 
       return #"floating literal"#
-    case .stringLiteral: 
+    case .stringLiteralContents: 
       return #"string literal"#
     case .regexLiteral: 
       return #"regex literal"#
@@ -1337,7 +1337,7 @@ public enum RawTokenKind: Equatable, Hashable {
       return false
     case .floatingLiteral: 
       return false
-    case .stringLiteral: 
+    case .stringLiteralContents: 
       return false
     case .regexLiteral: 
       return false
@@ -1475,7 +1475,7 @@ public enum RawTokenKind: Equatable, Hashable {
       return false
     case .floatingLiteral: 
       return false
-    case .stringLiteral: 
+    case .stringLiteralContents: 
       return false
     case .regexLiteral: 
       return false
@@ -1771,8 +1771,8 @@ extension TokenKind {
       return .integerLiteral(text)
     case .floatingLiteral: 
       return .floatingLiteral(text)
-    case .stringLiteral: 
-      return .stringLiteral(text)
+    case .stringLiteralContents: 
+      return .stringLiteralContents(text)
     case .regexLiteral: 
       return .regexLiteral(text)
     case .unknown: 
@@ -1908,8 +1908,8 @@ extension TokenKind {
       return (.integerLiteral, str)
     case .floatingLiteral(let str): 
       return (.floatingLiteral, str)
-    case .stringLiteral(let str): 
-      return (.stringLiteral, str)
+    case .stringLiteralContents(let str): 
+      return (.stringLiteralContents, str)
     case .regexLiteral(let str): 
       return (.regexLiteral, str)
     case .unknown(let str): 

--- a/Sources/SwiftSyntax/generated/Tokens.swift
+++ b/Sources/SwiftSyntax/generated/Tokens.swift
@@ -693,14 +693,14 @@ extension TokenSyntax {
     )
   }
   
-  public static func stringLiteral(
+  public static func stringLiteralContents(
     _ text: String, 
     leadingTrivia: Trivia = [], 
     trailingTrivia: Trivia = [], 
     presence: SourcePresence = .present
   ) -> TokenSyntax {
     return TokenSyntax(
-      .stringLiteral(text), 
+      .stringLiteralContents(text), 
       leadingTrivia: leadingTrivia, 
       trailingTrivia: trailingTrivia, 
       presence: presence

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -3027,7 +3027,7 @@ public enum SyntaxFactory {
     }
   }
   @available(*, deprecated, message: "Use initializer on PoundSourceLocationArgsSyntax")
-  public static func makePoundSourceLocationArgs(_ unexpectedBeforeFileArgLabel: UnexpectedNodesSyntax? = nil, fileArgLabel: TokenSyntax, _ unexpectedBetweenFileArgLabelAndFileArgColon: UnexpectedNodesSyntax? = nil, fileArgColon: TokenSyntax, _ unexpectedBetweenFileArgColonAndFileName: UnexpectedNodesSyntax? = nil, fileName: TokenSyntax, _ unexpectedBetweenFileNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndLineArgLabel: UnexpectedNodesSyntax? = nil, lineArgLabel: TokenSyntax, _ unexpectedBetweenLineArgLabelAndLineArgColon: UnexpectedNodesSyntax? = nil, lineArgColon: TokenSyntax, _ unexpectedBetweenLineArgColonAndLineNumber: UnexpectedNodesSyntax? = nil, lineNumber: TokenSyntax, _ unexpectedAfterLineNumber: UnexpectedNodesSyntax? = nil) -> PoundSourceLocationArgsSyntax {
+  public static func makePoundSourceLocationArgs(_ unexpectedBeforeFileArgLabel: UnexpectedNodesSyntax? = nil, fileArgLabel: TokenSyntax, _ unexpectedBetweenFileArgLabelAndFileArgColon: UnexpectedNodesSyntax? = nil, fileArgColon: TokenSyntax, _ unexpectedBetweenFileArgColonAndFileName: UnexpectedNodesSyntax? = nil, fileName: StringLiteralExprSyntax, _ unexpectedBetweenFileNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndLineArgLabel: UnexpectedNodesSyntax? = nil, lineArgLabel: TokenSyntax, _ unexpectedBetweenLineArgLabelAndLineArgColon: UnexpectedNodesSyntax? = nil, lineArgColon: TokenSyntax, _ unexpectedBetweenLineArgColonAndLineNumber: UnexpectedNodesSyntax? = nil, lineNumber: TokenSyntax, _ unexpectedAfterLineNumber: UnexpectedNodesSyntax? = nil) -> PoundSourceLocationArgsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeFileArgLabel?.raw,
       fileArgLabel.raw,
@@ -3063,7 +3063,7 @@ public enum SyntaxFactory {
         nil,
         RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
         nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: arena),
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: arena),
         nil,
         RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: arena),
         nil,
@@ -5572,7 +5572,7 @@ public enum SyntaxFactory {
     }
   }
   @available(*, deprecated, message: "Use initializer on OpaqueReturnTypeOfAttributeArgumentsSyntax")
-  public static func makeOpaqueReturnTypeOfAttributeArguments(_ unexpectedBeforeMangledName: UnexpectedNodesSyntax? = nil, mangledName: TokenSyntax, _ unexpectedBetweenMangledNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndOrdinal: UnexpectedNodesSyntax? = nil, ordinal: TokenSyntax, _ unexpectedAfterOrdinal: UnexpectedNodesSyntax? = nil) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+  public static func makeOpaqueReturnTypeOfAttributeArguments(_ unexpectedBeforeMangledName: UnexpectedNodesSyntax? = nil, mangledName: StringLiteralExprSyntax, _ unexpectedBetweenMangledNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndOrdinal: UnexpectedNodesSyntax? = nil, ordinal: TokenSyntax, _ unexpectedAfterOrdinal: UnexpectedNodesSyntax? = nil) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeMangledName?.raw,
       mangledName.raw,
@@ -5596,7 +5596,7 @@ public enum SyntaxFactory {
       let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .opaqueReturnTypeOfAttributeArguments,
         from: [
         nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: arena),
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: arena),
         nil,
         RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: arena),
         nil,
@@ -5607,7 +5607,7 @@ public enum SyntaxFactory {
     }
   }
   @available(*, deprecated, message: "Use initializer on ConventionAttributeArgumentsSyntax")
-  public static func makeConventionAttributeArguments(_ unexpectedBeforeConventionLabel: UnexpectedNodesSyntax? = nil, conventionLabel: TokenSyntax, _ unexpectedBetweenConventionLabelAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndCTypeLabel: UnexpectedNodesSyntax? = nil, cTypeLabel: TokenSyntax?, _ unexpectedBetweenCTypeLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndCTypeString: UnexpectedNodesSyntax? = nil, cTypeString: TokenSyntax?, _ unexpectedAfterCTypeString: UnexpectedNodesSyntax? = nil) -> ConventionAttributeArgumentsSyntax {
+  public static func makeConventionAttributeArguments(_ unexpectedBeforeConventionLabel: UnexpectedNodesSyntax? = nil, conventionLabel: TokenSyntax, _ unexpectedBetweenConventionLabelAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndCTypeLabel: UnexpectedNodesSyntax? = nil, cTypeLabel: TokenSyntax?, _ unexpectedBetweenCTypeLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndCTypeString: UnexpectedNodesSyntax? = nil, cTypeString: StringLiteralExprSyntax?, _ unexpectedAfterCTypeString: UnexpectedNodesSyntax? = nil) -> ConventionAttributeArgumentsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeConventionLabel?.raw,
       conventionLabel.raw,
@@ -5685,7 +5685,7 @@ public enum SyntaxFactory {
     }
   }
   @available(*, deprecated, message: "Use initializer on ExposeAttributeArgumentsSyntax")
-  public static func makeExposeAttributeArguments(_ unexpectedBeforeLanguage: UnexpectedNodesSyntax? = nil, language: TokenSyntax, _ unexpectedBetweenLanguageAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndCxxName: UnexpectedNodesSyntax? = nil, cxxName: TokenSyntax?, _ unexpectedAfterCxxName: UnexpectedNodesSyntax? = nil) -> ExposeAttributeArgumentsSyntax {
+  public static func makeExposeAttributeArguments(_ unexpectedBeforeLanguage: UnexpectedNodesSyntax? = nil, language: TokenSyntax, _ unexpectedBetweenLanguageAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndCxxName: UnexpectedNodesSyntax? = nil, cxxName: StringLiteralExprSyntax?, _ unexpectedAfterCxxName: UnexpectedNodesSyntax? = nil) -> ExposeAttributeArgumentsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLanguage?.raw,
       language.raw,
@@ -5720,7 +5720,7 @@ public enum SyntaxFactory {
     }
   }
   @available(*, deprecated, message: "Use initializer on OriginallyDefinedInArgumentsSyntax")
-  public static func makeOriginallyDefinedInArguments(_ unexpectedBeforeModuleLabel: UnexpectedNodesSyntax? = nil, moduleLabel: TokenSyntax, _ unexpectedBetweenModuleLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndModuleName: UnexpectedNodesSyntax? = nil, moduleName: TokenSyntax, _ unexpectedBetweenModuleNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndPlatforms: UnexpectedNodesSyntax? = nil, platforms: AvailabilityVersionRestrictionListSyntax, _ unexpectedAfterPlatforms: UnexpectedNodesSyntax? = nil) -> OriginallyDefinedInArgumentsSyntax {
+  public static func makeOriginallyDefinedInArguments(_ unexpectedBeforeModuleLabel: UnexpectedNodesSyntax? = nil, moduleLabel: TokenSyntax, _ unexpectedBetweenModuleLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndModuleName: UnexpectedNodesSyntax? = nil, moduleName: StringLiteralExprSyntax, _ unexpectedBetweenModuleNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndPlatforms: UnexpectedNodesSyntax? = nil, platforms: AvailabilityVersionRestrictionListSyntax, _ unexpectedAfterPlatforms: UnexpectedNodesSyntax? = nil) -> OriginallyDefinedInArgumentsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeModuleLabel?.raw,
       moduleLabel.raw,
@@ -5752,7 +5752,7 @@ public enum SyntaxFactory {
         nil,
         RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
         nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: arena),
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: arena),
         nil,
         RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: arena),
         nil,
@@ -5763,7 +5763,7 @@ public enum SyntaxFactory {
     }
   }
   @available(*, deprecated, message: "Use initializer on UnderscorePrivateAttributeArgumentsSyntax")
-  public static func makeUnderscorePrivateAttributeArguments(_ unexpectedBeforeSourceFileLabel: UnexpectedNodesSyntax? = nil, sourceFileLabel: TokenSyntax, _ unexpectedBetweenSourceFileLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndFilename: UnexpectedNodesSyntax? = nil, filename: TokenSyntax, _ unexpectedAfterFilename: UnexpectedNodesSyntax? = nil) -> UnderscorePrivateAttributeArgumentsSyntax {
+  public static func makeUnderscorePrivateAttributeArguments(_ unexpectedBeforeSourceFileLabel: UnexpectedNodesSyntax? = nil, sourceFileLabel: TokenSyntax, _ unexpectedBetweenSourceFileLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndFilename: UnexpectedNodesSyntax? = nil, filename: StringLiteralExprSyntax, _ unexpectedAfterFilename: UnexpectedNodesSyntax? = nil) -> UnderscorePrivateAttributeArgumentsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSourceFileLabel?.raw,
       sourceFileLabel.raw,
@@ -5791,7 +5791,7 @@ public enum SyntaxFactory {
         nil,
         RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
         nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: arena),
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: arena),
         nil,
       ], arena: arena))
       return UnderscorePrivateAttributeArgumentsSyntax(data)
@@ -5833,7 +5833,7 @@ public enum SyntaxFactory {
     }
   }
   @available(*, deprecated, message: "Use initializer on UnavailableFromAsyncArgumentsSyntax")
-  public static func makeUnavailableFromAsyncArguments(_ unexpectedBeforeMessageLabel: UnexpectedNodesSyntax? = nil, messageLabel: TokenSyntax, _ unexpectedBetweenMessageLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndMessage: UnexpectedNodesSyntax? = nil, message: TokenSyntax, _ unexpectedAfterMessage: UnexpectedNodesSyntax? = nil) -> UnavailableFromAsyncArgumentsSyntax {
+  public static func makeUnavailableFromAsyncArguments(_ unexpectedBeforeMessageLabel: UnexpectedNodesSyntax? = nil, messageLabel: TokenSyntax, _ unexpectedBetweenMessageLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndMessage: UnexpectedNodesSyntax? = nil, message: StringLiteralExprSyntax, _ unexpectedAfterMessage: UnexpectedNodesSyntax? = nil) -> UnavailableFromAsyncArgumentsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeMessageLabel?.raw,
       messageLabel.raw,
@@ -5861,7 +5861,7 @@ public enum SyntaxFactory {
         nil,
         RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
         nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: arena),
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: arena),
         nil,
       ], arena: arena))
       return UnavailableFromAsyncArgumentsSyntax(data)
@@ -5888,7 +5888,7 @@ public enum SyntaxFactory {
     }
   }
   @available(*, deprecated, message: "Use initializer on DocumentationAttributeArgumentSyntax")
-  public static func makeDocumentationAttributeArgument(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil, value: TokenSyntax, _ unexpectedBetweenValueAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> DocumentationAttributeArgumentSyntax {
+  public static func makeDocumentationAttributeArgument(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil, value: Syntax, _ unexpectedBetweenValueAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> DocumentationAttributeArgumentSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabel?.raw,
       label.raw,
@@ -5918,7 +5918,7 @@ public enum SyntaxFactory {
         nil,
         RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: arena),
         nil,
-        RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: arena),
+        RawSyntax.makeEmptyLayout(kind: SyntaxKind.missing, arena: arena),
         nil,
         nil,
         nil,
@@ -7051,7 +7051,7 @@ public enum SyntaxFactory {
     }
   }
   @available(*, deprecated, message: "Use initializer on PoundAssertStmtSyntax")
-  public static func makePoundAssertStmt(_ unexpectedBeforePoundAssert: UnexpectedNodesSyntax? = nil, poundAssert: TokenSyntax, _ unexpectedBetweenPoundAssertAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndCondition: UnexpectedNodesSyntax? = nil, condition: ExprSyntax, _ unexpectedBetweenConditionAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndMessage: UnexpectedNodesSyntax? = nil, message: TokenSyntax?, _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> PoundAssertStmtSyntax {
+  public static func makePoundAssertStmt(_ unexpectedBeforePoundAssert: UnexpectedNodesSyntax? = nil, poundAssert: TokenSyntax, _ unexpectedBetweenPoundAssertAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndCondition: UnexpectedNodesSyntax? = nil, condition: ExprSyntax, _ unexpectedBetweenConditionAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndMessage: UnexpectedNodesSyntax? = nil, message: StringLiteralExprSyntax?, _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> PoundAssertStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundAssert?.raw,
       poundAssert.raw,
@@ -9150,13 +9150,13 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  @available(*, deprecated, message: "Use TokenSyntax.stringLiteral instead")
-  public static func makeStringLiteral(
+  @available(*, deprecated, message: "Use TokenSyntax.stringLiteralContents instead")
+  public static func makeStringLiteralContents(
     _ text: String,
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
   ) -> TokenSyntax {
-    return makeToken(.stringLiteral(text), presence: .present,
+    return makeToken(.stringLiteralContents(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -6511,7 +6511,7 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenFileArgLabelAndFileArgColon: UnexpectedNodesSyntax? = nil,
     fileArgColon: TokenSyntax = .colonToken(),
     _ unexpectedBetweenFileArgColonAndFileName: UnexpectedNodesSyntax? = nil,
-    fileName: TokenSyntax,
+    fileName: StringLiteralExprSyntax,
     _ unexpectedBetweenFileNameAndComma: UnexpectedNodesSyntax? = nil,
     comma: TokenSyntax = .commaToken(),
     _ unexpectedBetweenCommaAndLineArgLabel: UnexpectedNodesSyntax? = nil,
@@ -6654,10 +6654,10 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
     return PoundSourceLocationArgsSyntax(newData)
   }
 
-  public var fileName: TokenSyntax {
+  public var fileName: StringLiteralExprSyntax {
     get {
       let childData = data.child(at: 5, parent: Syntax(self))
-      return TokenSyntax(childData!)
+      return StringLiteralExprSyntax(childData!)
     }
     set(value) {
       self = withFileName(value)
@@ -6667,7 +6667,7 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `fileName` replaced.
   /// - param newChild: The new `fileName` to replace the node's
   ///                   current `fileName`, if present.
-  public func withFileName(_ newChild: TokenSyntax) -> PoundSourceLocationArgsSyntax {
+  public func withFileName(_ newChild: StringLiteralExprSyntax) -> PoundSourceLocationArgsSyntax {
     let arena = SyntaxArena()
     let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
@@ -12095,6 +12095,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Argument: SyntaxChildChoices {
     case `argumentList`(TupleExprElementListSyntax)
     case `token`(TokenSyntax)
+    case `string`(StringLiteralExprSyntax)
     case `availability`(AvailabilitySpecListSyntax)
     case `specializeArguments`(SpecializeAttributeSpecListSyntax)
     case `objCName`(ObjCSelectorSyntax)
@@ -12116,6 +12117,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       switch self {
       case .argumentList(let node): return node._syntaxNode
       case .token(let node): return node._syntaxNode
+      case .string(let node): return node._syntaxNode
       case .availability(let node): return node._syntaxNode
       case .specializeArguments(let node): return node._syntaxNode
       case .objCName(let node): return node._syntaxNode
@@ -12141,6 +12143,9 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
     }
     public init(_ node: TokenSyntax) {
       self = .token(node)
+    }
+    public init(_ node: StringLiteralExprSyntax) {
+      self = .string(node)
     }
     public init(_ node: AvailabilitySpecListSyntax) {
       self = .availability(node)
@@ -12200,6 +12205,10 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       }
       if let node = node.as(TokenSyntax.self) {
         self = .token(node)
+        return
+      }
+      if let node = node.as(StringLiteralExprSyntax.self) {
+        self = .string(node)
         return
       }
       if let node = node.as(AvailabilitySpecListSyntax.self) {
@@ -12277,6 +12286,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       return .choices([
         .node(TupleExprElementListSyntax.self),
         .node(TokenSyntax.self),
+        .node(StringLiteralExprSyntax.self),
         .node(AvailabilitySpecListSyntax.self),
         .node(SpecializeAttributeSpecListSyntax.self),
         .node(ObjCSelectorSyntax.self),
@@ -16705,7 +16715,7 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
   public init(
     leadingTrivia: Trivia? = nil,
     _ unexpectedBeforeMangledName: UnexpectedNodesSyntax? = nil,
-    mangledName: TokenSyntax,
+    mangledName: StringLiteralExprSyntax,
     _ unexpectedBetweenMangledNameAndComma: UnexpectedNodesSyntax? = nil,
     comma: TokenSyntax = .commaToken(),
     _ unexpectedBetweenCommaAndOrdinal: UnexpectedNodesSyntax? = nil,
@@ -16755,10 +16765,10 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
   }
 
   /// The mangled name of a declaration.
-  public var mangledName: TokenSyntax {
+  public var mangledName: StringLiteralExprSyntax {
     get {
       let childData = data.child(at: 1, parent: Syntax(self))
-      return TokenSyntax(childData!)
+      return StringLiteralExprSyntax(childData!)
     }
     set(value) {
       self = withMangledName(value)
@@ -16768,7 +16778,7 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
   /// Returns a copy of the receiver with its `mangledName` replaced.
   /// - param newChild: The new `mangledName` to replace the node's
   ///                   current `mangledName`, if present.
-  public func withMangledName(_ newChild: TokenSyntax) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+  public func withMangledName(_ newChild: StringLiteralExprSyntax) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
     let arena = SyntaxArena()
     let raw = newChild.raw
     let newData = data.replacingChild(at: 1, with: raw, arena: arena)
@@ -16959,7 +16969,7 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     _ unexpectedBetweenCTypeLabelAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax? = nil,
     _ unexpectedBetweenColonAndCTypeString: UnexpectedNodesSyntax? = nil,
-    cTypeString: TokenSyntax? = nil,
+    cTypeString: StringLiteralExprSyntax? = nil,
     _ unexpectedAfterCTypeString: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
@@ -17176,11 +17186,11 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     return ConventionAttributeArgumentsSyntax(newData)
   }
 
-  public var cTypeString: TokenSyntax? {
+  public var cTypeString: StringLiteralExprSyntax? {
     get {
       let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
-      return TokenSyntax(childData!)
+      return StringLiteralExprSyntax(childData!)
     }
     set(value) {
       self = withCTypeString(value)
@@ -17190,7 +17200,7 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `cTypeString` replaced.
   /// - param newChild: The new `cTypeString` to replace the node's
   ///                   current `cTypeString`, if present.
-  public func withCTypeString(_ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+  public func withCTypeString(_ newChild: StringLiteralExprSyntax?) -> ConventionAttributeArgumentsSyntax {
     let arena = SyntaxArena()
     let raw = newChild?.raw
     let newData = data.replacingChild(at: 9, with: raw, arena: arena)
@@ -17554,7 +17564,7 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLanguageAndComma: UnexpectedNodesSyntax? = nil,
     comma: TokenSyntax? = nil,
     _ unexpectedBetweenCommaAndCxxName: UnexpectedNodesSyntax? = nil,
-    cxxName: TokenSyntax? = nil,
+    cxxName: StringLiteralExprSyntax? = nil,
     _ unexpectedAfterCxxName: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
@@ -17682,11 +17692,11 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
     return ExposeAttributeArgumentsSyntax(newData)
   }
 
-  public var cxxName: TokenSyntax? {
+  public var cxxName: StringLiteralExprSyntax? {
     get {
       let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
-      return TokenSyntax(childData!)
+      return StringLiteralExprSyntax(childData!)
     }
     set(value) {
       self = withCxxName(value)
@@ -17696,7 +17706,7 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `cxxName` replaced.
   /// - param newChild: The new `cxxName` to replace the node's
   ///                   current `cxxName`, if present.
-  public func withCxxName(_ newChild: TokenSyntax?) -> ExposeAttributeArgumentsSyntax {
+  public func withCxxName(_ newChild: StringLiteralExprSyntax?) -> ExposeAttributeArgumentsSyntax {
     let arena = SyntaxArena()
     let raw = newChild?.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
@@ -17800,7 +17810,7 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     _ unexpectedBetweenModuleLabelAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax = .colonToken(),
     _ unexpectedBetweenColonAndModuleName: UnexpectedNodesSyntax? = nil,
-    moduleName: TokenSyntax,
+    moduleName: StringLiteralExprSyntax,
     _ unexpectedBetweenModuleNameAndComma: UnexpectedNodesSyntax? = nil,
     comma: TokenSyntax = .commaToken(),
     _ unexpectedBetweenCommaAndPlatforms: UnexpectedNodesSyntax? = nil,
@@ -17935,10 +17945,10 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     return OriginallyDefinedInArgumentsSyntax(newData)
   }
 
-  public var moduleName: TokenSyntax {
+  public var moduleName: StringLiteralExprSyntax {
     get {
       let childData = data.child(at: 5, parent: Syntax(self))
-      return TokenSyntax(childData!)
+      return StringLiteralExprSyntax(childData!)
     }
     set(value) {
       self = withModuleName(value)
@@ -17948,7 +17958,7 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// Returns a copy of the receiver with its `moduleName` replaced.
   /// - param newChild: The new `moduleName` to replace the node's
   ///                   current `moduleName`, if present.
-  public func withModuleName(_ newChild: TokenSyntax) -> OriginallyDefinedInArgumentsSyntax {
+  public func withModuleName(_ newChild: StringLiteralExprSyntax) -> OriginallyDefinedInArgumentsSyntax {
     let arena = SyntaxArena()
     let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
@@ -18169,7 +18179,7 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
     _ unexpectedBetweenSourceFileLabelAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax = .colonToken(),
     _ unexpectedBetweenColonAndFilename: UnexpectedNodesSyntax? = nil,
-    filename: TokenSyntax,
+    filename: StringLiteralExprSyntax,
     _ unexpectedAfterFilename: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
@@ -18296,10 +18306,10 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
     return UnderscorePrivateAttributeArgumentsSyntax(newData)
   }
 
-  public var filename: TokenSyntax {
+  public var filename: StringLiteralExprSyntax {
     get {
       let childData = data.child(at: 5, parent: Syntax(self))
-      return TokenSyntax(childData!)
+      return StringLiteralExprSyntax(childData!)
     }
     set(value) {
       self = withFilename(value)
@@ -18309,7 +18319,7 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
   /// Returns a copy of the receiver with its `filename` replaced.
   /// - param newChild: The new `filename` to replace the node's
   ///                   current `filename`, if present.
-  public func withFilename(_ newChild: TokenSyntax) -> UnderscorePrivateAttributeArgumentsSyntax {
+  public func withFilename(_ newChild: StringLiteralExprSyntax) -> UnderscorePrivateAttributeArgumentsSyntax {
     let arena = SyntaxArena()
     let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
@@ -18657,7 +18667,7 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
     _ unexpectedBetweenMessageLabelAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax = .colonToken(),
     _ unexpectedBetweenColonAndMessage: UnexpectedNodesSyntax? = nil,
-    message: TokenSyntax,
+    message: StringLiteralExprSyntax,
     _ unexpectedAfterMessage: UnexpectedNodesSyntax? = nil,
     trailingTrivia: Trivia? = nil
   ) {
@@ -18784,10 +18794,10 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
     return UnavailableFromAsyncArgumentsSyntax(newData)
   }
 
-  public var message: TokenSyntax {
+  public var message: StringLiteralExprSyntax {
     get {
       let childData = data.child(at: 5, parent: Syntax(self))
-      return TokenSyntax(childData!)
+      return StringLiteralExprSyntax(childData!)
     }
     set(value) {
       self = withMessage(value)
@@ -18797,7 +18807,7 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
   /// Returns a copy of the receiver with its `message` replaced.
   /// - param newChild: The new `message` to replace the node's
   ///                   current `message`, if present.
-  public func withMessage(_ newChild: TokenSyntax) -> UnavailableFromAsyncArgumentsSyntax {
+  public func withMessage(_ newChild: StringLiteralExprSyntax) -> UnavailableFromAsyncArgumentsSyntax {
     let arena = SyntaxArena()
     let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
@@ -18876,6 +18886,42 @@ extension UnavailableFromAsyncArgumentsSyntax: CustomReflectable {
 // MARK: - DocumentationAttributeArgumentSyntax
 
 public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashable {
+  public enum Value: SyntaxChildChoices {
+    case `token`(TokenSyntax)
+    case `string`(StringLiteralExprSyntax)
+    public var _syntaxNode: Syntax {
+      switch self {
+      case .token(let node): return node._syntaxNode
+      case .string(let node): return node._syntaxNode
+      }
+    }
+    init(_ data: SyntaxData) { self.init(Syntax(data))! }
+    public init(_ node: TokenSyntax) {
+      self = .token(node)
+    }
+    public init(_ node: StringLiteralExprSyntax) {
+      self = .string(node)
+    }
+    public init?<S: SyntaxProtocol>(_ node: S) {
+      if let node = node.as(TokenSyntax.self) {
+        self = .token(node)
+        return
+      }
+      if let node = node.as(StringLiteralExprSyntax.self) {
+        self = .string(node)
+        return
+      }
+      return nil
+    }
+
+    public static var structure: SyntaxNodeStructure {
+      return .choices([
+        .node(TokenSyntax.self),
+        .node(StringLiteralExprSyntax.self),
+      ])
+    }
+  }
+
   public let _syntaxNode: Syntax
 
   public init?<S: SyntaxProtocol>(_ node: S) {
@@ -18898,7 +18944,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
     _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax = .colonToken(),
     _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil,
-    value: TokenSyntax,
+    value: Value,
     _ unexpectedBetweenValueAndTrailingComma: UnexpectedNodesSyntax? = nil,
     trailingComma: TokenSyntax? = nil,
     _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -19029,10 +19075,10 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
     return DocumentationAttributeArgumentSyntax(newData)
   }
 
-  public var value: TokenSyntax {
+  public var value: Value {
     get {
       let childData = data.child(at: 5, parent: Syntax(self))
-      return TokenSyntax(childData!)
+      return Value(childData!)
     }
     set(value) {
       self = withValue(value)
@@ -19042,7 +19088,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
   /// Returns a copy of the receiver with its `value` replaced.
   /// - param newChild: The new `value` to replace the node's
   ///                   current `value`, if present.
-  public func withValue(_ newChild: TokenSyntax) -> DocumentationAttributeArgumentSyntax {
+  public func withValue(_ newChild: Value) -> DocumentationAttributeArgumentSyntax {
     let arena = SyntaxArena()
     let raw = newChild.raw
     let newData = data.replacingChild(at: 5, with: raw, arena: arena)
@@ -19142,7 +19188,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
     case 4:
       return nil
     case 5:
-      return "value"
+      return nil
     case 6:
       return nil
     case 7:
@@ -27155,7 +27201,7 @@ extension AvailabilityArgumentSyntax: CustomReflectable {
 /// 
 public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public enum Value: SyntaxChildChoices {
-    case `string`(TokenSyntax)
+    case `string`(StringLiteralExprSyntax)
     case `version`(VersionTupleSyntax)
     public var _syntaxNode: Syntax {
       switch self {
@@ -27164,14 +27210,14 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
       }
     }
     init(_ data: SyntaxData) { self.init(Syntax(data))! }
-    public init(_ node: TokenSyntax) {
+    public init(_ node: StringLiteralExprSyntax) {
       self = .string(node)
     }
     public init(_ node: VersionTupleSyntax) {
       self = .version(node)
     }
     public init?<S: SyntaxProtocol>(_ node: S) {
-      if let node = node.as(TokenSyntax.self) {
+      if let node = node.as(StringLiteralExprSyntax.self) {
         self = .string(node)
         return
       }
@@ -27184,7 +27230,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
 
     public static var structure: SyntaxNodeStructure {
       return .choices([
-        .node(TokenSyntax.self),
+        .node(StringLiteralExprSyntax.self),
         .node(VersionTupleSyntax.self),
       ])
     }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -4178,7 +4178,7 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenConditionAndComma: UnexpectedNodesSyntax? = nil,
     comma: TokenSyntax? = nil,
     _ unexpectedBetweenCommaAndMessage: UnexpectedNodesSyntax? = nil,
-    message: TokenSyntax? = nil,
+    message: StringLiteralExprSyntax? = nil,
     _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil,
     rightParen: TokenSyntax = .rightParenToken(),
     _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil,
@@ -4399,11 +4399,11 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
 
   /// The assertion message.
-  public var message: TokenSyntax? {
+  public var message: StringLiteralExprSyntax? {
     get {
       let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
-      return TokenSyntax(childData!)
+      return StringLiteralExprSyntax(childData!)
     }
     set(value) {
       self = withMessage(value)
@@ -4413,7 +4413,7 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// Returns a copy of the receiver with its `message` replaced.
   /// - param newChild: The new `message` to replace the node's
   ///                   current `message`, if present.
-  public func withMessage(_ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
+  public func withMessage(_ newChild: StringLiteralExprSyntax?) -> PoundAssertStmtSyntax {
     let arena = SyntaxArena()
     let raw = newChild?.raw
     let newData = data.replacingChild(at: 9, with: raw, arena: arena)

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -303,12 +303,10 @@ extension ConventionAttributeArgumentsSyntax {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeConventionLabel: UnexpectedNodesSyntax? = nil, conventionLabel: String, unexpectedBetweenConventionLabelAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax? = nil, unexpectedBetweenCommaAndCTypeLabel: UnexpectedNodesSyntax? = nil, cTypeLabel: String? = nil, unexpectedBetweenCTypeLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax? = nil, unexpectedBetweenColonAndCTypeString: UnexpectedNodesSyntax? = nil, cTypeString: String? = nil, trailingTrivia: Trivia? = nil) {
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeConventionLabel: UnexpectedNodesSyntax? = nil, conventionLabel: String, unexpectedBetweenConventionLabelAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax? = nil, unexpectedBetweenCommaAndCTypeLabel: UnexpectedNodesSyntax? = nil, cTypeLabel: String? = nil, unexpectedBetweenCTypeLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax? = nil, unexpectedBetweenColonAndCTypeString: UnexpectedNodesSyntax? = nil, cTypeString: StringLiteralExprSyntax? = nil, trailingTrivia: Trivia? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeConventionLabel, conventionLabel: TokenSyntax.`identifier`(conventionLabel), unexpectedBetweenConventionLabelAndComma, comma: comma, unexpectedBetweenCommaAndCTypeLabel, cTypeLabel: cTypeLabel.map { 
         TokenSyntax.`identifier`($0) 
-      }, unexpectedBetweenCTypeLabelAndColon, colon: colon, unexpectedBetweenColonAndCTypeString, cTypeString: cTypeString.map { 
-        TokenSyntax.`stringLiteral`($0) 
-      }, trailingTrivia: trailingTrivia)
+      }, unexpectedBetweenCTypeLabelAndColon, colon: colon, unexpectedBetweenColonAndCTypeString, cTypeString: cTypeString, trailingTrivia: trailingTrivia)
   }
 }
 
@@ -436,7 +434,7 @@ extension DocumentationAttributeArgumentSyntax: HasTrailingComma {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: String, unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax = .colonToken(), unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil, value: TokenSyntax, unexpectedBetweenValueAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax? = nil, trailingTrivia: Trivia? = nil) {
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: String, unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax = .colonToken(), unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil, value: Value, unexpectedBetweenValueAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax? = nil, trailingTrivia: Trivia? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLabel, label: TokenSyntax.`identifier`(label), unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndValue, value: value, unexpectedBetweenValueAndTrailingComma, trailingComma: trailingComma, trailingTrivia: trailingTrivia)
   }
   
@@ -518,18 +516,6 @@ extension EnumDeclSyntax {
       MemberDeclListSyntax([])
     }, trailingTrivia: Trivia? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndEnumKeyword, enumKeyword: enumKeyword, unexpectedBetweenEnumKeywordAndIdentifier, identifier: TokenSyntax.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameters, genericParameters: genericParameters, unexpectedBetweenGenericParametersAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers, members: MemberDeclBlockSyntax(members: membersBuilder()), trailingTrivia: trailingTrivia)
-  }
-}
-
-/// The arguments for the '@_expose' attribute
-extension ExposeAttributeArgumentsSyntax {
-  /// A convenience initializer that allows:
-  ///  - Initializing syntax collections using result builders
-  ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeLanguage: UnexpectedNodesSyntax? = nil, language: TokenSyntax, unexpectedBetweenLanguageAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax? = nil, unexpectedBetweenCommaAndCxxName: UnexpectedNodesSyntax? = nil, cxxName: String? = nil, trailingTrivia: Trivia? = nil) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLanguage, language: language, unexpectedBetweenLanguageAndComma, comma: comma, unexpectedBetweenCommaAndCxxName, cxxName: cxxName.map { 
-        TokenSyntax.`stringLiteral`($0) 
-      }, trailingTrivia: trailingTrivia)
   }
 }
 
@@ -897,8 +883,8 @@ extension OpaqueReturnTypeOfAttributeArgumentsSyntax {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeMangledName: UnexpectedNodesSyntax? = nil, mangledName: String, unexpectedBetweenMangledNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax = .commaToken(), unexpectedBetweenCommaAndOrdinal: UnexpectedNodesSyntax? = nil, ordinal: String, trailingTrivia: Trivia? = nil) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeMangledName, mangledName: TokenSyntax.`stringLiteral`(mangledName), unexpectedBetweenMangledNameAndComma, comma: comma, unexpectedBetweenCommaAndOrdinal, ordinal: TokenSyntax.`integerLiteral`(ordinal), trailingTrivia: trailingTrivia)
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeMangledName: UnexpectedNodesSyntax? = nil, mangledName: StringLiteralExprSyntax, unexpectedBetweenMangledNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax = .commaToken(), unexpectedBetweenCommaAndOrdinal: UnexpectedNodesSyntax? = nil, ordinal: String, trailingTrivia: Trivia? = nil) {
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeMangledName, mangledName: mangledName, unexpectedBetweenMangledNameAndComma, comma: comma, unexpectedBetweenCommaAndOrdinal, ordinal: TokenSyntax.`integerLiteral`(ordinal), trailingTrivia: trailingTrivia)
   }
 }
 
@@ -926,8 +912,8 @@ extension OriginallyDefinedInArgumentsSyntax {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeModuleLabel: UnexpectedNodesSyntax? = nil, moduleLabel: String, unexpectedBetweenModuleLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax = .colonToken(), unexpectedBetweenColonAndModuleName: UnexpectedNodesSyntax? = nil, moduleName: String, unexpectedBetweenModuleNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax = .commaToken(), unexpectedBetweenCommaAndPlatforms: UnexpectedNodesSyntax? = nil, platforms: AvailabilityVersionRestrictionListSyntax, trailingTrivia: Trivia? = nil) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeModuleLabel, moduleLabel: TokenSyntax.`identifier`(moduleLabel), unexpectedBetweenModuleLabelAndColon, colon: colon, unexpectedBetweenColonAndModuleName, moduleName: TokenSyntax.`stringLiteral`(moduleName), unexpectedBetweenModuleNameAndComma, comma: comma, unexpectedBetweenCommaAndPlatforms, platforms: platforms, trailingTrivia: trailingTrivia)
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeModuleLabel: UnexpectedNodesSyntax? = nil, moduleLabel: String, unexpectedBetweenModuleLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax = .colonToken(), unexpectedBetweenColonAndModuleName: UnexpectedNodesSyntax? = nil, moduleName: StringLiteralExprSyntax, unexpectedBetweenModuleNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax = .commaToken(), unexpectedBetweenCommaAndPlatforms: UnexpectedNodesSyntax? = nil, platforms: AvailabilityVersionRestrictionListSyntax, trailingTrivia: Trivia? = nil) {
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeModuleLabel, moduleLabel: TokenSyntax.`identifier`(moduleLabel), unexpectedBetweenModuleLabelAndColon, colon: colon, unexpectedBetweenColonAndModuleName, moduleName: moduleName, unexpectedBetweenModuleNameAndComma, comma: comma, unexpectedBetweenCommaAndPlatforms, platforms: platforms, trailingTrivia: trailingTrivia)
   }
 }
 
@@ -962,23 +948,12 @@ extension PostfixUnaryExprSyntax {
   }
 }
 
-extension PoundAssertStmtSyntax {
-  /// A convenience initializer that allows:
-  ///  - Initializing syntax collections using result builders
-  ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforePoundAssert: UnexpectedNodesSyntax? = nil, poundAssert: TokenSyntax = .poundAssertKeyword(), unexpectedBetweenPoundAssertAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax = .leftParenToken(), unexpectedBetweenLeftParenAndCondition: UnexpectedNodesSyntax? = nil, condition: ExprSyntaxProtocol, unexpectedBetweenConditionAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax? = nil, unexpectedBetweenCommaAndMessage: UnexpectedNodesSyntax? = nil, message: String? = nil, unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax = .rightParenToken(), trailingTrivia: Trivia? = nil) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforePoundAssert, poundAssert: poundAssert, unexpectedBetweenPoundAssertAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndCondition, condition: ExprSyntax(fromProtocol: condition), unexpectedBetweenConditionAndComma, comma: comma, unexpectedBetweenCommaAndMessage, message: message.map { 
-        TokenSyntax.`stringLiteral`($0) 
-      }, unexpectedBetweenMessageAndRightParen, rightParen: rightParen, trailingTrivia: trailingTrivia)
-  }
-}
-
 extension PoundSourceLocationArgsSyntax {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeFileArgLabel: UnexpectedNodesSyntax? = nil, fileArgLabel: String, unexpectedBetweenFileArgLabelAndFileArgColon: UnexpectedNodesSyntax? = nil, fileArgColon: TokenSyntax = .colonToken(), unexpectedBetweenFileArgColonAndFileName: UnexpectedNodesSyntax? = nil, fileName: String, unexpectedBetweenFileNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax = .commaToken(), unexpectedBetweenCommaAndLineArgLabel: UnexpectedNodesSyntax? = nil, lineArgLabel: String, unexpectedBetweenLineArgLabelAndLineArgColon: UnexpectedNodesSyntax? = nil, lineArgColon: TokenSyntax = .colonToken(), unexpectedBetweenLineArgColonAndLineNumber: UnexpectedNodesSyntax? = nil, lineNumber: String, trailingTrivia: Trivia? = nil) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeFileArgLabel, fileArgLabel: TokenSyntax.`identifier`(fileArgLabel), unexpectedBetweenFileArgLabelAndFileArgColon, fileArgColon: fileArgColon, unexpectedBetweenFileArgColonAndFileName, fileName: TokenSyntax.`stringLiteral`(fileName), unexpectedBetweenFileNameAndComma, comma: comma, unexpectedBetweenCommaAndLineArgLabel, lineArgLabel: TokenSyntax.`identifier`(lineArgLabel), unexpectedBetweenLineArgLabelAndLineArgColon, lineArgColon: lineArgColon, unexpectedBetweenLineArgColonAndLineNumber, lineNumber: TokenSyntax.`integerLiteral`(lineNumber), trailingTrivia: trailingTrivia)
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeFileArgLabel: UnexpectedNodesSyntax? = nil, fileArgLabel: String, unexpectedBetweenFileArgLabelAndFileArgColon: UnexpectedNodesSyntax? = nil, fileArgColon: TokenSyntax = .colonToken(), unexpectedBetweenFileArgColonAndFileName: UnexpectedNodesSyntax? = nil, fileName: StringLiteralExprSyntax, unexpectedBetweenFileNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax = .commaToken(), unexpectedBetweenCommaAndLineArgLabel: UnexpectedNodesSyntax? = nil, lineArgLabel: String, unexpectedBetweenLineArgLabelAndLineArgColon: UnexpectedNodesSyntax? = nil, lineArgColon: TokenSyntax = .colonToken(), unexpectedBetweenLineArgColonAndLineNumber: UnexpectedNodesSyntax? = nil, lineNumber: String, trailingTrivia: Trivia? = nil) {
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeFileArgLabel, fileArgLabel: TokenSyntax.`identifier`(fileArgLabel), unexpectedBetweenFileArgLabelAndFileArgColon, fileArgColon: fileArgColon, unexpectedBetweenFileArgColonAndFileName, fileName: fileName, unexpectedBetweenFileNameAndComma, comma: comma, unexpectedBetweenCommaAndLineArgLabel, lineArgLabel: TokenSyntax.`identifier`(lineArgLabel), unexpectedBetweenLineArgLabelAndLineArgColon, lineArgColon: lineArgColon, unexpectedBetweenLineArgColonAndLineNumber, lineNumber: TokenSyntax.`integerLiteral`(lineNumber), trailingTrivia: trailingTrivia)
   }
 }
 
@@ -1298,8 +1273,8 @@ extension UnavailableFromAsyncArgumentsSyntax {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeMessageLabel: UnexpectedNodesSyntax? = nil, messageLabel: String, unexpectedBetweenMessageLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax = .colonToken(), unexpectedBetweenColonAndMessage: UnexpectedNodesSyntax? = nil, message: String, trailingTrivia: Trivia? = nil) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeMessageLabel, messageLabel: TokenSyntax.`identifier`(messageLabel), unexpectedBetweenMessageLabelAndColon, colon: colon, unexpectedBetweenColonAndMessage, message: TokenSyntax.`stringLiteral`(message), trailingTrivia: trailingTrivia)
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeMessageLabel: UnexpectedNodesSyntax? = nil, messageLabel: String, unexpectedBetweenMessageLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax = .colonToken(), unexpectedBetweenColonAndMessage: UnexpectedNodesSyntax? = nil, message: StringLiteralExprSyntax, trailingTrivia: Trivia? = nil) {
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeMessageLabel, messageLabel: TokenSyntax.`identifier`(messageLabel), unexpectedBetweenMessageLabelAndColon, colon: colon, unexpectedBetweenColonAndMessage, message: message, trailingTrivia: trailingTrivia)
   }
 }
 
@@ -1308,8 +1283,8 @@ extension UnderscorePrivateAttributeArgumentsSyntax {
   /// A convenience initializer that allows:
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
-  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeSourceFileLabel: UnexpectedNodesSyntax? = nil, sourceFileLabel: String, unexpectedBetweenSourceFileLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax = .colonToken(), unexpectedBetweenColonAndFilename: UnexpectedNodesSyntax? = nil, filename: String, trailingTrivia: Trivia? = nil) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeSourceFileLabel, sourceFileLabel: TokenSyntax.`identifier`(sourceFileLabel), unexpectedBetweenSourceFileLabelAndColon, colon: colon, unexpectedBetweenColonAndFilename, filename: TokenSyntax.`stringLiteral`(filename), trailingTrivia: trailingTrivia)
+  public init(leadingTrivia: Trivia? = nil, unexpectedBeforeSourceFileLabel: UnexpectedNodesSyntax? = nil, sourceFileLabel: String, unexpectedBetweenSourceFileLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax = .colonToken(), unexpectedBetweenColonAndFilename: UnexpectedNodesSyntax? = nil, filename: StringLiteralExprSyntax, trailingTrivia: Trivia? = nil) {
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeSourceFileLabel, sourceFileLabel: TokenSyntax.`identifier`(sourceFileLabel), unexpectedBetweenSourceFileLabelAndColon, colon: colon, unexpectedBetweenColonAndFilename, filename: filename, trailingTrivia: trailingTrivia)
   }
 }
 

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -74,7 +74,10 @@ private func AssertTokens(
 ) {
   guard actual.count == expected.count else {
     return XCTFail(
-      "Expected \(expected.count) tokens but got \(actual.count)",
+      """
+      Expected \(expected.count) tokens but got \(actual.count):
+      \(actual.map(\.debugDescription).joined(separator: "\n"))
+      """,
       file: file,
       line: line
     )

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -310,7 +310,7 @@ final class AttributeTests: XCTestCase {
     )
   }
 
-  func testObjcImplementationAttribute() throws {
+  func testObjcImplementationAttribute() {
     AssertParse(
       """
       @_objcImplementation extension MyClass {
@@ -338,6 +338,12 @@ final class AttributeTests: XCTestCase {
       """
       @_silgen_name("testExclusivityBogusPC")
       private static func _testExclusivityBogusPC()
+      """
+    )
+
+    AssertParse(
+      """
+      @_silgen_name("") func foo() {}
       """
     )
   }
@@ -390,7 +396,7 @@ final class AttributeTests: XCTestCase {
       @_expose(Cxx, 1️⃣baz) func foo() {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected string literal in @_expose arguments"),
+        DiagnosticSpec(message: "expected string literal to end @_expose arguments"),
         DiagnosticSpec(message: "unexpected code 'baz' in attribute"),
       ]
     )
@@ -462,7 +468,7 @@ final class AttributeTests: XCTestCase {
       func foo() {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected string literal in @_unavailableFromAsync argument"),
+        DiagnosticSpec(message: "expected string literal to end @_unavailableFromAsync argument"),
         DiagnosticSpec(message: "unexpected code 'abc' in attribute"),
       ]
     )

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -425,15 +425,22 @@ final class ExpressionTests: XCTestCase {
 
     AssertParse(
       #"""
-      1️⃣"\(()
+      "\(()1️⃣
       """#,
       diagnostics: [
-        DiagnosticSpec(message: #"extraneous code '"\(()' at top level"#)
+        DiagnosticSpec(message: #"expected ')' in string literal"#),
+        DiagnosticSpec(message: #"expected '"' to end string literal"#),
       ]
     )
   }
 
   func testStringLiterals() {
+    AssertParse(
+      #"""
+      "–"
+      """#
+    )
+
     AssertParse(
       #"""
       ""
@@ -603,6 +610,22 @@ final class ExpressionTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(message: #"expected '"' to end string literal"#)
       ]
+    )
+  }
+
+  func testAdjacentRawStringLiterals() {
+    AssertParse(
+      """
+      "normal literal"
+      #"raw literal"#
+      """
+    )
+
+    AssertParse(
+      """
+      #"raw literal"#
+      #"second raw literal"#
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -83,7 +83,9 @@ public class LexerTests: XCTestCase {
       "\u{1234}"
       """#,
       lexemes: [
-        LexemeSpec(.stringLiteral, text: #""\u{1234}""#)
+        LexemeSpec(.stringQuote, text: #"""#),
+        LexemeSpec(.stringLiteralContents, text: #"\u{1234}"#),
+        LexemeSpec(.stringQuote, text: #"""#),
       ]
     )
 
@@ -93,7 +95,9 @@ public class LexerTests: XCTestCase {
       """#,
       lexemes: [
         // FIXME: We should diagnose invalid unicode characters in string literals
-        LexemeSpec(.stringLiteral, text: #""\u{12341234}""#)
+        LexemeSpec(.stringQuote, text: #"""#),
+        LexemeSpec(.stringLiteralContents, text: #"\u{12341234}"#),
+        LexemeSpec(.stringQuote, text: #"""#),
       ]
     )
   }
@@ -175,7 +179,11 @@ public class LexerTests: XCTestCase {
       ###"this is a ##"raw"## string"###
       """,
       lexemes: [
-        LexemeSpec(.stringLiteral, text: ####"###"this is a ##"raw"## string"###"####)
+        LexemeSpec(.rawStringDelimiter, text: "###"),
+        LexemeSpec(.stringQuote, text: #"""#),
+        LexemeSpec(.stringLiteralContents, text: ###"this is a ##"raw"## string"###),
+        LexemeSpec(.stringQuote, text: #"""#),
+        LexemeSpec(.rawStringDelimiter, text: "###"),
       ]
     )
 
@@ -184,7 +192,11 @@ public class LexerTests: XCTestCase {
       #"#"abc"#
       """,
       lexemes: [
-        LexemeSpec(.stringLiteral, text: ####"#"#"abc"#"####)
+        LexemeSpec(.rawStringDelimiter, text: "#"),
+        LexemeSpec(.stringQuote, text: #"""#),
+        LexemeSpec(.stringLiteralContents, text: #"#"abc"#),
+        LexemeSpec(.stringQuote, text: #"""#),
+        LexemeSpec(.rawStringDelimiter, text: "#"),
       ]
     )
 
@@ -193,7 +205,11 @@ public class LexerTests: XCTestCase {
       ###"##"abc"###
       """,
       lexemes: [
-        LexemeSpec(.stringLiteral, text: ####"###"##"abc"###"####)
+        LexemeSpec(.rawStringDelimiter, text: "###"),
+        LexemeSpec(.stringQuote, text: #"""#),
+        LexemeSpec(.stringLiteralContents, text: #"##"abc"#),
+        LexemeSpec(.stringQuote, text: #"""#),
+        LexemeSpec(.rawStringDelimiter, text: "###"),
       ]
     )
 
@@ -202,9 +218,11 @@ public class LexerTests: XCTestCase {
       ##"""abc"####
       """#####,
       lexemes: [
-        LexemeSpec(.stringLiteral, text: ###"##"""abc"##"###),
-        LexemeSpec(.pound, text: "#"),
-        LexemeSpec(.pound, text: "#"),
+        LexemeSpec(.rawStringDelimiter, text: "##"),
+        LexemeSpec(.stringQuote, text: #"""#),
+        LexemeSpec(.stringLiteralContents, text: ###"""abc"###),
+        LexemeSpec(.stringQuote, text: #"""#),
+        LexemeSpec(.rawStringDelimiter, text: "####"),
       ]
     )
   }
@@ -265,7 +283,9 @@ public class LexerTests: XCTestCase {
         LexemeSpec(.leftBrace, text: "{"),
         LexemeSpec(.identifier, leading: "\n    ", text: "print", flags: [.isAtStartOfLine]),
         LexemeSpec(.leftParen, text: "("),
-        LexemeSpec(.stringLiteral, text: "\"Hello World\""),
+        LexemeSpec(.stringQuote, text: #"""#),
+        LexemeSpec(.stringLiteralContents, text: "Hello World"),
+        LexemeSpec(.stringQuote, text: #"""#),
         LexemeSpec(.rightParen, text: ")"),
         LexemeSpec(.rightBrace, leading: "\n  ", text: "}", flags: [.isAtStartOfLine]),
         LexemeSpec(.rightBrace, leading: "\n", text: "}", flags: [.isAtStartOfLine]),
@@ -470,7 +490,9 @@ public class LexerTests: XCTestCase {
       "\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))"
       """#,
       lexemes: [
-        LexemeSpec(.stringLiteral, text: #""\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))""#)
+        LexemeSpec(.stringQuote, text: #"""#),
+        LexemeSpec(.stringLiteralContents, text: #"\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))"#),
+        LexemeSpec(.stringQuote, text: #"""#),
       ]
     )
   }
@@ -590,7 +612,9 @@ public class LexerTests: XCTestCase {
       lexemes: [
         LexemeSpec(.identifier, text: "myString"),
         LexemeSpec(.binaryOperator, text: "=="),
-        LexemeSpec(.stringLiteral, text: #""""#),
+        LexemeSpec(.stringQuote, text: #"""#),
+        LexemeSpec(.stringLiteralContents, text: ""),
+        LexemeSpec(.stringQuote, text: #"""#),
       ]
     )
   }
@@ -707,6 +731,19 @@ public class LexerTests: XCTestCase {
     AssertLexemes(
       "0x147AD1️⃣G0",
       lexemes: [LexemeSpec(.integerLiteral, text: "0x147ADG0", error: "'G' is not a valid hexadecimal digit (0-9, A-F) in integer literal")]
+    )
+  }
+
+  func testStringLiteralWithBlockCommentStart() {
+    AssertLexemes(
+      """
+      "/*"
+      """,
+      lexemes: [
+        LexemeSpec(.stringQuote, text: #"""#),
+        LexemeSpec(.stringLiteralContents, text: "/*"),
+        LexemeSpec(.stringQuote, text: #"""#),
+      ]
     )
   }
 }

--- a/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
@@ -287,17 +287,15 @@ final class MultilineErrorsTests: XCTestCase {
   func testMultilineErrors18() {
     AssertParse(
       ##"""
-      _ = 1️⃣"hello\("""
+      _ = "hello\("""
                   world
-                  """
-                  )!"
+                  """1️⃣
+                  2️⃣)!"
       """##,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
-        // TODO: Old parser expected error on line 1: unterminated string literal
-        DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: "extraneous code at top level"),
-        // TODO: Old parser expected error on line 4: unterminated string literal
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ')' in string literal"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: #"expected '"' to end string literal"#),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"extraneous code ')!"' at top level"#),
       ]
     )
   }
@@ -305,17 +303,15 @@ final class MultilineErrorsTests: XCTestCase {
   func testMultilineErrors19() {
     AssertParse(
       ##"""
-      _ = 1️⃣"hello\(
+      _ = "h\(1️⃣
                   """
                   world
-                  """)!"
+                  """2️⃣)!"
       """##,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
-        // TODO: Old parser expected error on line 1: unterminated string literal
-        DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: "extraneous code at top level"),
-        // TODO: Old parser expected error on line 4: unterminated string literal
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected value and ')' in string literal"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: #"expected '"' to end string literal"#),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"extraneous code ')!"' at top level"#),
       ]
     )
   }
@@ -458,17 +454,16 @@ final class MultilineErrorsTests: XCTestCase {
       ##"""
       let _ = """
         foo
-        \(1️⃣"bar2️⃣
-      3️⃣  baz
+        \ℹ️("1️⃣bar
+      2️⃣  baz
         """
       """##,
       diagnostics: [
         // TODO: Old parser expected error on line 3: cannot find ')' to match opening '(' in string interpolation
         // TODO: Old parser expected error on line 3: unterminated string literal
-        DiagnosticSpec(locationMarker: "1️⃣", message: #"expected value in string literal"#),
-        DiagnosticSpec(locationMarker: "1️⃣", message: #"unexpected code '"bar' in string literal"#),
-        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected ')' in string literal"#),
-        DiagnosticSpec(locationMarker: "3️⃣", message: #"unexpected code '' in string literal"#),
+        DiagnosticSpec(locationMarker: "1️⃣", message: #"expected '"' to end string literal"#),
+        DiagnosticSpec(locationMarker: "1️⃣", message: #"unexpected code in string literal"#),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected ')' in string literal"#, notes: [NoteSpec(message: "to match this opening '('")]),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/PoundAssertTests.swift
+++ b/Tests/SwiftParserTest/translated/PoundAssertTests.swift
@@ -18,8 +18,12 @@ final class PoundAssertTests: XCTestCase {
   func testPoundAssert1() {
     AssertParse(
       """
-      #assert(true, 123)
-      """
+      #assert(true, 1️⃣123)
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected string literal in '#assert' directive"),
+        DiagnosticSpec(message: "unexpected code '123' in '#assert' directive"),
+      ]
     )
   }
 

--- a/Tests/SwiftParserTest/translated/RawStringErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/RawStringErrorsTests.swift
@@ -21,10 +21,7 @@ final class RawStringErrorsTests: XCTestCase {
       let _ = "foo\(#"bar"#1️⃣#)baz"
       """###,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: too many '#' characters in closing delimiter
-        // TODO: Old parser expected error on line 1: expected ',' separator
-        // TODO: Old parser expected error on line 1: expected expression in list of expressions
-        DiagnosticSpec(message: "unexpected code '#' in string literal")
+        DiagnosticSpec(message: "too many '#' characters in closing delimiter")
       ]
     )
   }
@@ -44,17 +41,14 @@ final class RawStringErrorsTests: XCTestCase {
   func testRawStringErrors3() {
     AssertParse(
       #####"""
-      let _ = ###"""invalid"###1️⃣#2️⃣#3️⃣#4️⃣
+      let _ = ###"""invalid"###1️⃣###
       """#####,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: too many '#' characters in closing delimiter, Fix-It replacements: 26 - 29 = ''
-        // TODO: Old parser expected error on line 1: consecutive statements on a line must be separated by ';'
-        // TODO: Old parser expected error on line 1: expected expression
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in pound literal expression"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in pound literal expression"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected identifier in pound literal expression"),
-      ]
+        DiagnosticSpec(message: "too many '#' characters in closing delimiter", fixIts: ["remove extraneous delimiters"])
+      ],
+      fixedSource: #####"""
+        let _ = ###"""invalid"###
+        """#####
     )
   }
 
@@ -73,16 +67,13 @@ final class RawStringErrorsTests: XCTestCase {
   func testRawStringErrors5() {
     AssertParse(
       #####"""
-      let _ = ###"invalid"###1️⃣#2️⃣#3️⃣#4️⃣
+      let _ = ###"invalid"###1️⃣###
       """#####,
       diagnostics: [
         // TODO: Old parser expected error on line 1: too many '#' characters in closing delimiter, Fix-It replacements: 24 - 27 = ''
         // TODO: Old parser expected error on line 1: consecutive statements on a line must be separated by ';'
         // TODO: Old parser expected error on line 1: expected expression
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in pound literal expression"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in pound literal expression"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected identifier in pound literal expression"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "too many '#' characters in closing delimiter")
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/RawStringTests.swift
+++ b/Tests/SwiftParserTest/translated/RawStringTests.swift
@@ -1,0 +1,325 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This test file has been translated from swift/test/StringProcessing/Parse/raw_string.swift
+
+import XCTest
+
+final class RawStringTests: XCTestCase {
+  func testRawString1() {
+    AssertParse(
+      """
+      import Swift
+      """
+    )
+  }
+
+  func testRawString2() {
+    AssertParse(
+      ##"""
+      _ = #"""
+      ###################################################################
+      ## This source file is part of the Swift.org open source project ##
+      ###################################################################
+      """#
+      """##
+    )
+  }
+
+  func testRawString3() {
+    AssertParse(
+      ####"""
+      _ = #"""
+          # H1 #
+          ## H2 ##
+          ### H3 ###
+          """#
+      """####
+    )
+  }
+
+  func testRawString5() {
+    AssertParse(
+      ###"""
+      _ = ##"""
+          One
+          ""Alpha""
+          """##
+      """###
+    )
+  }
+
+  func testRawString6() {
+    AssertParse(
+      ###"""
+      _ = ##"""
+          Two
+        Beta
+        """##
+      """###
+    )
+  }
+
+  func testRawString7() {
+    AssertParse(
+      ##"""
+      _ = #"""
+          Three\r
+          Gamma\
+        """#
+      """##
+    )
+  }
+
+  func testRawString8() {
+    AssertParse(
+      ####"""
+      _ = ###"""
+          Four \(foo)
+          Delta
+      """###
+      """####
+    )
+  }
+
+  func testRawString9() {
+    AssertParse(
+      ###"""
+      _ = ##"""
+        print("""
+          Five\##n\##n\##nEpsilon
+          """)
+        """##
+      """###
+    )
+  }
+
+  func testRawString10() {
+    AssertParse(
+      """
+      // ===---------- Single line --------===
+      """
+    )
+  }
+
+  func testRawString11() {
+    AssertParse(
+      ##"""
+      _ = #""Zeta""#
+      """##
+    )
+  }
+
+  func testRawString12() {
+    AssertParse(
+      ##"""
+      _ = #""Eta"\#n\#n\#n\#""#
+      """##
+    )
+  }
+
+  func testRawString13() {
+    AssertParse(
+      ##"""
+      _ = #""Iota"\n\n\n\""#
+      """##
+    )
+  }
+
+  func testRawString14() {
+    AssertParse(
+      ##"""
+      _ = #"a raw string with \" in it"#
+      """##
+    )
+  }
+
+  func testRawString15() {
+    AssertParse(
+      ###"""
+      _ = ##"""
+            a raw string with """ in it
+            """##
+      """###
+    )
+  }
+
+  func testRawString16() {
+    AssertParse(
+      """
+      // ===---------- False Multiline Delimiters --------===
+      """
+    )
+  }
+
+  func testRawString17() {
+    AssertParse(
+      ##"""
+      /// Source code contains zero-width character in this format: `#"[U+200B]"[U+200B]"#`
+      /// The check contains zero-width character in this format: `"[U+200B]\"[U+200B]"`
+      /// If this check fails after you implement `diagnoseZeroWidthMatchAndAdvance`,
+      /// then you may need to tweak how to test for single-line string literals that
+      /// resemble a multiline delimiter in `advanceIfMultilineDelimiter` so that it
+      /// passes again.
+      /// See https://github.com/apple/swift/issues/51192.
+      _ = #"​"​"#
+      """##
+    )
+  }
+
+  func testRawString18() {
+    AssertParse(
+      ##"""
+      _ = #""""#
+      """##
+    )
+  }
+
+  func testRawString19() {
+    AssertParse(
+      ##"""
+      _ = #"""""#
+      """##
+    )
+  }
+
+  func testRawString20() {
+    AssertParse(
+      ##"""
+      _ = #""""""#
+      """##
+    )
+  }
+
+  func testRawString21() {
+    AssertParse(
+      ##"""
+      _ = #"""#
+      """##
+    )
+  }
+
+  func testRawString22() {
+    AssertParse(
+      ###"""
+      _ = ##""" foo # "# "##
+      """###
+    )
+  }
+
+  func testRawString23() {
+    AssertParse(
+      ####"""
+      _ = ###""" "# "## "###
+      """####
+    )
+  }
+
+  func testRawString24() {
+    AssertParse(
+      ####"""
+      _ = ###"""##"###
+      """####
+    )
+  }
+
+  func testRawString25() {
+    AssertParse(
+      ##"""
+      _ = "interpolating \(#"""false delimiter"#)"
+      """##
+    )
+  }
+
+  func testRawString26() {
+    AssertParse(
+      ##"""
+      _ = """
+        interpolating \(#"""false delimiters"""#)
+        """
+      """##
+    )
+  }
+
+  func testRawString27() {
+    AssertParse(
+      ##"""
+      let foo = "Interpolation"
+      _ = #"\b\b \#(foo)\#(foo) Kappa"#
+      """##
+    )
+  }
+
+  func testRawString28() {
+    AssertParse(
+      ###"""
+      _ = """
+        interpolating \(##"""
+          delimited \##("string")\#n\##n
+          """##)
+        """
+      """###
+    )
+  }
+
+  func testRawString30() {
+    AssertParse(
+      ##"""
+      #"unused literal"#
+      """##
+    )
+  }
+
+  func testRawString32() {
+    AssertParse(
+      ##"""
+      _ = #"This is a string"#
+      """##
+    )
+  }
+
+  func testRawString33() {
+    AssertParse(
+      ######"""
+      _ = #####"This is a string"#####
+      """######
+    )
+  }
+
+  func testRawString34() {
+    AssertParse(
+      ###"""
+      _ = #"enum\s+.+\{.*case\s+[:upper:]"#
+      _ = #"Alice: "How long is forever?" White Rabbit: "Sometimes, just one second.""#
+      _ = #"\#\#1"#
+      _ = ##"\#1"##
+      _ = #"c:\windows\system32"#
+      _ = #"\d{3) \d{3} \d{4}"#
+      _ = #"""
+          a string with
+          """
+          in it
+          """#
+      _ = #"a raw string containing \r\n"#
+      _ = #"""
+          [
+              {
+                  "id": "12345",
+                  "title": "A title that \"contains\" \\\""
+              }
+          ]
+          """#
+      _ = #"# #"#
+      """###
+    )
+  }
+}

--- a/Tests/SwiftParserTest/translated/StringLiteralEofTests.swift
+++ b/Tests/SwiftParserTest/translated/StringLiteralEofTests.swift
@@ -19,29 +19,33 @@ final class StringLiteralEofTests: XCTestCase {
     AssertParse(
       ##"""
       // NOTE: DO NOT add a newline at EOF.
-      _ = 1️⃣"foo\(
+      _ = "foo\(1️⃣
       """##,
       diagnostics: [
         // TODO: Old parser expected error on line 2: unterminated string literal
         // TODO: Old parser expected error on line 2: cannot find ')' to match opening '(' in string interpolation
-        DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: #"extraneous code '"foo\(' at top level"#),
+        DiagnosticSpec(message: "expected value and ')' in string literal"),
+        DiagnosticSpec(message: #"expected '"' to end string literal"#),
       ]
     )
   }
 
   func testStringLiteralEof2() {
     AssertParse(
-      ##"""
       // NOTE: DO NOT add a newline at EOF.
-      _ = 1️⃣"foo\("bar
+      ##"""
+      _ = 9️⃣"foo\8️⃣(7️⃣"bar1️⃣
       """##,
       diagnostics: [
         // TODO: Old parser expected error on line 2: cannot find ')' to match opening '(' in string interpolation
         // TODO: Old parser expected error on line 2: unterminated string literal
-        DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: #"extraneous code '"foo\("bar' at top level"#),
-      ]
+        DiagnosticSpec(message: #"expected '"' to end string literal"#, notes: [NoteSpec(locationMarker: "7️⃣", message: #"to match this opening '"'"#)]),
+        DiagnosticSpec(message: #"expected ')' in string literal"#, notes: [NoteSpec(locationMarker: "8️⃣", message: "to match this opening '('")]),
+        DiagnosticSpec(message: #"expected '"' to end string literal"#, notes: [NoteSpec(locationMarker: "9️⃣", message: #"to match this opening '"'"#)]),
+      ],
+      fixedSource: ##"""
+        _ = "foo\("bar")"
+        """##
     )
   }
 
@@ -86,35 +90,38 @@ final class StringLiteralEofTests: XCTestCase {
   }
 
   func testStringLiteralEof6() {
+    // NOTE: DO NOT add a newline at EOF.
     AssertParse(
       ##"""
-      // NOTE: DO NOT add a newline at EOF.
-      _ = 1️⃣"""
+      _ = """
           foo
-          \(
+          \(1️⃣
       """##,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: unterminated string literal
-        DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: "extraneous code at top level"),
-        // TODO: Old parser expected error on line 4: cannot find ')' to match opening '(' in string interpolation
-      ]
+        DiagnosticSpec(message: "expected value and ')' in string literal"),
+        DiagnosticSpec(message: #"expected '"""' to end string literal"#),
+      ],
+      fixedSource: ##"""
+        _ = """
+            foo
+            \(<#expression#>)"""
+        """##
+        // FIXME: The closing delimiter should be put on the new line
     )
   }
 
   func testStringLiteralEof7() {
+    // NOTE: DO NOT add a newline at EOF.
     AssertParse(
       ##"""
-      // NOTE: DO NOT add a newline at EOF.
-      _ = 1️⃣"""
+      _ = """
           foo
-          \("bar
+          \("bar1️⃣
       """##,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: unterminated string literal
-        DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: "extraneous code at top level"),
-        // TODO: Old parser expected error on line 4: cannot find ')' to match opening '(' in string interpolation
+        DiagnosticSpec(message: #"expected '"' to end string literal"#),
+        DiagnosticSpec(message: "expected ')' in string literal"),
+        DiagnosticSpec(message: #"expected '"""' to end string literal"#),
       ]
     )
   }
@@ -123,18 +130,14 @@ final class StringLiteralEofTests: XCTestCase {
     AssertParse(
       ##"""
       _ = """
-          \(1️⃣"bar2️⃣
-      3️⃣    baz4️⃣
+          \("1️⃣bar
+      2️⃣    baz3️⃣
       """##,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: unterminated string literal
-        DiagnosticSpec(message: "expected value in string literal"),
-        DiagnosticSpec(message: #"unexpected code '"bar' in string literal"#),
-        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected ')' in string literal"#),
-        DiagnosticSpec(locationMarker: "3️⃣", message: #"unexpected code '' in string literal"#),
-        DiagnosticSpec(locationMarker: "4️⃣", message: #"expected '"""' to end string literal"#),
-        // TODO: Old parser expected error on line 3: cannot find ')' to match opening '(' in string interpolation
-        // TODO: Old parser expected error on line 3: unterminated string literal
+        DiagnosticSpec(locationMarker: "1️⃣", message: #"expected '"' to end string literal"#),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code in string literal"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' in string literal"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: #"expected '"""' to end string literal"#),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/UnclosedStringInterpolationTests.swift
+++ b/Tests/SwiftParserTest/translated/UnclosedStringInterpolationTests.swift
@@ -81,7 +81,8 @@ final class UnclosedStringInterpolationTests: XCTestCase {
       let zzz = "\(x1️⃣; print(x)2️⃣
       """##,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '; print(x' in string literal"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '; print(x)' in string literal"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' in string literal"),
         DiagnosticSpec(locationMarker: "2️⃣", message: #"expected '"' to end string literal"#),
       ]
     )
@@ -114,4 +115,16 @@ final class UnclosedStringInterpolationTests: XCTestCase {
     )
   }
 
+  func testSkipUnexpectedOpeningParensInStringLiteral() {
+    AssertParse(
+      #"""
+      "\(e 1️⃣H()r2️⃣
+      """#,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code 'H()r' in string literal"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' in string literal"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected '"' to end string literal"#),
+      ]
+    )
+  }
 }

--- a/Tests/SwiftParserTest/translated/UnclosedStringInterpolationTests.swift
+++ b/Tests/SwiftParserTest/translated/UnclosedStringInterpolationTests.swift
@@ -26,13 +26,12 @@ final class UnclosedStringInterpolationTests: XCTestCase {
   func testUnclosedStringInterpolation2() {
     AssertParse(
       ##"""
-      _ = 1️⃣"mid == \(pete"
+      _ = "mid == \(pete1️⃣"2️⃣
       """##,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
-        // TODO: Old parser expected error on line 1: unterminated string literal
-        DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: #"extraneous code '"mid == \(pete"' at top level"#),
+        DiagnosticSpec(locationMarker: "1️⃣", message: #"unexpected code '"' in string literal"#),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' in string literal"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected '"' to end string literal"#),
       ]
     )
   }
@@ -40,13 +39,12 @@ final class UnclosedStringInterpolationTests: XCTestCase {
   func testUnclosedStringInterpolation3() {
     AssertParse(
       ##"""
-      let theGoat = 1️⃣"kanye \("
+      let theGoat = "kanye \("1️⃣
       """##,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
-        // TODO: Old parser expected error on line 1: unterminated string literal
-        DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: #"extraneous code '"kanye \("' at top level"#),
+        DiagnosticSpec(message: #"expected '"' to end string literal"#),
+        DiagnosticSpec(message: "expected ')' in string literal"),
+        DiagnosticSpec(message: #"expected '"' to end string literal"#),
       ]
     )
   }
@@ -54,13 +52,12 @@ final class UnclosedStringInterpolationTests: XCTestCase {
   func testUnclosedStringInterpolation4() {
     AssertParse(
       ##"""
-      let equation1 = 1️⃣"2 + 2 = \(2 + 2"
+      let equation1 = "2 + 2 = \(2 + 21️⃣"2️⃣
       """##,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
-        // TODO: Old parser expected error on line 1: unterminated string literal
-        DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: #"extraneous code '"2 + 2 = \(2 + 2"' at top level"#),
+        DiagnosticSpec(locationMarker: "1️⃣", message: #"unexpected code '"' in string literal"#),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' in string literal"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected '"' to end string literal"#),
       ]
     )
   }
@@ -68,13 +65,12 @@ final class UnclosedStringInterpolationTests: XCTestCase {
   func testUnclosedStringInterpolation5() {
     AssertParse(
       ##"""
-      let s = 1️⃣"\(x"; print(x)
+      let s = "\(x1️⃣"; print(x)2️⃣
       """##,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
-        // TODO: Old parser expected error on line 1: unterminated string literal
-        DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: #"extraneous code '"\(x"; print(x)' at top level"#),
+        DiagnosticSpec(locationMarker: "1️⃣", message: #"unexpected code '"; print(x)' in string literal"#),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' in string literal"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected '"' to end string literal"#),
       ]
     )
   }
@@ -82,13 +78,11 @@ final class UnclosedStringInterpolationTests: XCTestCase {
   func testUnclosedStringInterpolation6() {
     AssertParse(
       ##"""
-      let zzz = 1️⃣"\(x; print(x)
+      let zzz = "\(x1️⃣; print(x)2️⃣
       """##,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
-        // TODO: Old parser expected error on line 1: unterminated string literal
-        DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: #"extraneous code '"\(x; print(x)' at top level"#),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code '; print(x' in string literal"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected '"' to end string literal"#),
       ]
     )
   }
@@ -96,13 +90,11 @@ final class UnclosedStringInterpolationTests: XCTestCase {
   func testUnclosedStringInterpolation7() {
     AssertParse(
       ##"""
-      let goatedAlbum = 1️⃣"The Life Of \("Pablo"
+      let goatedAlbum = "The Life Of \("Pablo"1️⃣
       """##,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
-        // TODO: Old parser expected error on line 1: unterminated string literal
-        DiagnosticSpec(message: "expected expression in variable"),
-        DiagnosticSpec(message: #"extraneous code '"The Life Of \("Pablo"' at top level"#),
+        DiagnosticSpec(message: "expected ')' in string literal"),
+        DiagnosticSpec(message: #"expected '"' to end string literal"#),
       ]
     )
   }
@@ -110,15 +102,14 @@ final class UnclosedStringInterpolationTests: XCTestCase {
   func testUnclosedStringInterpolation8() {
     AssertParse(
       ##"""
-      _ = 1️⃣"""
+      _ = """
       \(
-      """
+      """1️⃣
       """##,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: unterminated string literal
-        DiagnosticSpec(message: "expected expression"),
-        DiagnosticSpec(message: "extraneous code at top level"),
-        // TODO: Old parser expected error on line 2: cannot find ')' to match opening '(' in string interpolation
+        DiagnosticSpec(message: #"expected '"""' to end string literal"#),
+        DiagnosticSpec(message: "expected ')' in string literal"),
+        DiagnosticSpec(message: #"expected '"""' to end string literal"#),
       ]
     )
   }

--- a/gyb_syntax_support/AttributeNodes.py
+++ b/gyb_syntax_support/AttributeNodes.py
@@ -31,6 +31,7 @@ ATTRIBUTE_NODES = [
                    node_choices=[
                        Child('ArgumentList', kind='TupleExprElementList'),
                        Child('Token', kind='Token'),
+                       Child('String', kind='StringLiteralExpr'),
                        Child('Availability', kind='AvailabilitySpecList'),
                        Child('SpecializeArguments',
                              kind='SpecializeAttributeSpecList'),
@@ -413,7 +414,7 @@ ATTRIBUTE_NODES = [
          The arguments for the '@_opaqueReturnTypeOf()'.
          ''',
          children=[
-             Child('MangledName', kind='StringLiteralToken',
+             Child('MangledName', kind='StringLiteralExpr',
                    description='The mangled name of a declaration.'),
              Child('Comma', kind='CommaToken'),
              Child('Ordinal', kind='IntegerLiteralToken',
@@ -435,7 +436,7 @@ ATTRIBUTE_NODES = [
              Child('CTypeLabel', kind='IdentifierToken',
                    text_choices=['cType'], is_optional=True),
              Child('Colon', kind='ColonToken', is_optional=True),
-             Child('CTypeString', kind='StringLiteralToken', is_optional=True),
+             Child('CTypeString', kind='StringLiteralExpr', is_optional=True),
         ]),
 
     # convention-attribute-arguments -> 'witness_method' ':' identifier
@@ -459,7 +460,7 @@ ATTRIBUTE_NODES = [
          children=[
            Child('Language', kind='Token'),
            Child('Comma', kind='CommaToken', is_optional=True),
-           Child('CxxName', kind='StringLiteralToken', is_optional=True)
+           Child('CxxName', kind='StringLiteralExpr', is_optional=True)
          ]),
 
     Node('OriginallyDefinedInArguments', name_for_diagnostics='@_originallyDefinedIn arguments',
@@ -470,7 +471,7 @@ ATTRIBUTE_NODES = [
          children=[
            Child('ModuleLabel', kind='IdentifierToken', text_choices=['module']),
            Child('Colon', kind='ColonToken'),
-           Child('ModuleName', kind='StringLiteralToken'),
+           Child('ModuleName', kind='StringLiteralExpr'),
            Child('Comma', kind='CommaToken'),
            Child('Platforms', kind='AvailabilityVersionRestrictionList', collection_element_name='Platform')
          ]),
@@ -483,7 +484,7 @@ ATTRIBUTE_NODES = [
          children=[
            Child('SourceFileLabel', kind='IdentifierToken', text_choices=['sourceFile']),
            Child('Colon', kind='ColonToken'),
-           Child('Filename', kind='StringLiteralToken'),
+           Child('Filename', kind='StringLiteralExpr'),
          ]),
 
     Node('DynamicReplacementArguments', name_for_diagnostics='@_dynamicReplacement argument',
@@ -505,7 +506,7 @@ ATTRIBUTE_NODES = [
          children=[
            Child('MessageLabel', kind='IdentifierToken', text_choices=['message']),
            Child('Colon', kind='ColonToken'),
-           Child('Message', kind='StringLiteralToken'),
+           Child('Message', kind='StringLiteralExpr'),
          ]),
 
     Node('EffectsArguments', name_for_diagnostics='@_effects arguments', kind='SyntaxCollection',
@@ -519,7 +520,10 @@ ATTRIBUTE_NODES = [
          children=[
             Child('Label', kind='IdentifierToken', text_choices=['visibility', 'metadata'], name_for_diagnostics='label'),
             Child('Colon', kind='ColonToken'),
-            Child('Value', kind='Token', token_choices=['IdentifierToken', 'KeywordToken', 'StringLiteralToken'], name_for_diagnostics='value'), # Keywords can be: public, internal, private, fileprivate, open
+            Child('Value', kind='Syntax', node_choices=[
+                  Child('Token', kind='Token', token_choices=['IdentifierToken', 'KeywordToken']), # Keywords can be: public, internal, private, fileprivate, open
+                  Child('String', kind='StringLiteralExpr')
+                  ]),
             Child('TrailingComma', kind='CommaToken',
                    is_optional=True, description='''
                    A trailing comma if this argument is followed by another one

--- a/gyb_syntax_support/AvailabilityNodes.py
+++ b/gyb_syntax_support/AvailabilityNodes.py
@@ -50,7 +50,7 @@ AVAILABILITY_NODES = [
                    description='The colon separating label and value'),
              Child('Value', kind='Syntax', name_for_diagnostics='value',
                    node_choices=[
-                       Child('String', 'StringLiteralToken'),
+                       Child('String', 'StringLiteralExpr'),
                        Child('Version', 'VersionTuple'),
                    ], description='The value of this labeled argument',),
          ]),

--- a/gyb_syntax_support/DeclNodes.py
+++ b/gyb_syntax_support/DeclNodes.py
@@ -156,7 +156,7 @@ DECL_NODES = [
              Child('FileArgLabel', kind='IdentifierToken',
                    text_choices=['file']),
              Child('FileArgColon', kind='ColonToken'),
-             Child('FileName', kind='StringLiteralToken', name_for_diagnostics='file name'),
+             Child('FileName', kind='StringLiteralExpr', name_for_diagnostics='file name'),
              Child('Comma', kind='CommaToken'),
              Child('LineArgLabel', kind='IdentifierToken',
                    text_choices=['line']),

--- a/gyb_syntax_support/StmtNodes.py
+++ b/gyb_syntax_support/StmtNodes.py
@@ -338,7 +338,7 @@ STMT_NODES = [
                    description='The assertion condition.'),
              Child('Comma', kind='CommaToken', is_optional=True,
                    description='The comma after the assertion condition.'),
-             Child('Message', kind='StringLiteralToken', name_for_diagnostics='message', is_optional=True,
+             Child('Message', kind='StringLiteralExpr', name_for_diagnostics='message', is_optional=True,
                    description='The assertion message.'),
              Child('RightParen', kind='RightParenToken'),
          ]),

--- a/gyb_syntax_support/Token.py
+++ b/gyb_syntax_support/Token.py
@@ -274,7 +274,7 @@ SYNTAX_TOKENS = [
             classification='IntegerLiteral'),
     Literal('FloatingLiteral', 'floating_literal',
             name_for_diagnostics='floating literal', classification='FloatingLiteral'),
-    Literal('StringLiteral', 'string_literal', name_for_diagnostics='string literal',
+    Literal('StringLiteralContents', 'string_literal', name_for_diagnostics='string literal',
             classification='StringLiteral'),
     Literal('RegexLiteral', 'regex_literal', name_for_diagnostics='regex literal'),
 


### PR DESCRIPTION
The eventual goal of this change is that we no longer need to re-lex string literals from the parser to separate them into their components. Instead, the lexer should just produce the lexemes that will later be put into the syntax tree as tokens.

The downside of this is that the lexer now needs to carry state and know whether it is lexing a string literal. On the upside, the string literal parser could be significantly simplified and the diagnostics got better without any further changes.