### PR TITLE
[Macros] Introduce (Freestanding)DeclarationMacro and implement expansion

### DIFF
--- a/Sources/_SwiftSyntaxMacros/CMakeLists.txt
+++ b/Sources/_SwiftSyntaxMacros/CMakeLists.txt
@@ -7,7 +7,9 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_swift_host_library(_SwiftSyntaxMacros
+  DeclarationMacro.swift
   ExpressionMacro.swift
+  FreestandingDeclarationMacro.swift
   Macro.swift
   MacroExpansionContext.swift
   MacroSystem.swift

--- a/Sources/_SwiftSyntaxMacros/DeclarationMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/DeclarationMacro.swift
@@ -1,0 +1,16 @@
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftParser
+import SwiftDiagnostics
+
+/// Describes a macro that forms declarations.
+public protocol DeclarationMacro: Macro {
+}

--- a/Sources/_SwiftSyntaxMacros/FreestandingDeclarationMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/FreestandingDeclarationMacro.swift
@@ -1,0 +1,21 @@
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftParser
+import SwiftDiagnostics
+
+/// Describes a macro that forms declarations.
+public protocol FreestandingDeclarationMacro: DeclarationMacro {
+  /// Expand a macro described by the given freestanding macro expansion
+  /// declaration within the given context to produce a set of declarations.
+  static func expansion(
+    of node: MacroExpansionDeclSyntax, in context: inout MacroExpansionContext
+  ) throws -> [DeclSyntax]
+}

--- a/Sources/_SwiftSyntaxMacros/FreestandingDeclarationMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/FreestandingDeclarationMacro.swift
@@ -16,6 +16,7 @@ public protocol FreestandingDeclarationMacro: DeclarationMacro {
   /// Expand a macro described by the given freestanding macro expansion
   /// declaration within the given context to produce a set of declarations.
   static func expansion(
-    of node: MacroExpansionDeclSyntax, in context: inout MacroExpansionContext
+    of node: MacroExpansionDeclSyntax,
+    in context: inout MacroExpansionContext
   ) throws -> [DeclSyntax]
 }

--- a/Sources/_SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem.swift
@@ -89,17 +89,21 @@ class MacroApplication: SyntaxRewriter {
       // Expand declaration macros that were parsed as macro expansion
       // expressions in this context.
       if case let .expr(exprItem) = item.item,
-         let exprExpansion = exprItem.as(MacroExpansionExprSyntax.self),
-         let macro = macroSystem.macros[exprExpansion.macro.text],
-         let freestandingMacro = macro as? FreestandingDeclarationMacro.Type {
+        let exprExpansion = exprItem.as(MacroExpansionExprSyntax.self),
+        let macro = macroSystem.macros[exprExpansion.macro.text],
+        let freestandingMacro = macro as? FreestandingDeclarationMacro.Type
+      {
         do {
           let expandedDecls = try freestandingMacro.expansion(
-            of: exprExpansion.asMacroExpansionDecl(), in: &context
+            of: exprExpansion.asMacroExpansionDecl(),
+            in: &context
           )
 
-          newItems.append(contentsOf: expandedDecls.map { decl in
-            CodeBlockItemSyntax(item: .decl(decl))
-          })
+          newItems.append(
+            contentsOf: expandedDecls.map { decl in
+              CodeBlockItemSyntax(item: .decl(decl))
+            }
+          )
         } catch {
           // Record the error
           context.diagnose(
@@ -124,20 +128,24 @@ class MacroApplication: SyntaxRewriter {
   override func visit(_ node: MemberDeclListSyntax) -> MemberDeclListSyntax {
     var newItems: [MemberDeclListItemSyntax] = []
     for item in node {
-        // Expand declaration macros, which produce zero or more declarations.
+      // Expand declaration macros, which produce zero or more declarations.
       if let declExpansion = item.decl.as(MacroExpansionDeclSyntax.self),
-         let macro = macroSystem.macros[declExpansion.macro.text],
-         let freestandingMacro = macro as? FreestandingDeclarationMacro.Type {
+        let macro = macroSystem.macros[declExpansion.macro.text],
+        let freestandingMacro = macro as? FreestandingDeclarationMacro.Type
+      {
         do {
           let expandedDecls = try freestandingMacro.expansion(
-            of: declExpansion, in: &context
+            of: declExpansion,
+            in: &context
           )
 
-          newItems.append(contentsOf: expandedDecls.map { decl in
-            MemberDeclListItemSyntax(decl: decl)
-          })
+          newItems.append(
+            contentsOf: expandedDecls.map { decl in
+              MemberDeclListItemSyntax(decl: decl)
+            }
+          )
         } catch {
-            // Record the error
+          // Record the error
           context.diagnose(
             Diagnostic(
               node: Syntax(node),

--- a/Sources/_SwiftSyntaxMacros/Syntax+MacroEvaluation.swift
+++ b/Sources/_SwiftSyntaxMacros/Syntax+MacroEvaluation.swift
@@ -25,6 +25,29 @@ struct ThrownErrorDiagnostic: DiagnosticMessage {
 }
 
 extension MacroExpansionExprSyntax {
+  /// Macro expansion declarations are parsed in some positions where an
+  /// expression is also warranted, so
+  func asMacroExpansionDecl() -> MacroExpansionDeclSyntax {
+    MacroExpansionDeclSyntax(
+      unexpectedBeforePoundToken,
+      poundToken: poundToken,
+      unexpectedBetweenPoundTokenAndMacro,
+      macro: macro,
+      genericArguments: genericArguments,
+      unexpectedBetweenGenericArgumentsAndLeftParen,
+      leftParen: leftParen,
+      unexpectedBetweenLeftParenAndArgumentList,
+      argumentList: argumentList,
+      unexpectedBetweenArgumentListAndRightParen,
+      rightParen: rightParen,
+      unexpectedBetweenRightParenAndTrailingClosure,
+      trailingClosure: trailingClosure,
+      unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures,
+      additionalTrailingClosures: additionalTrailingClosures,
+      unexpectedAfterAdditionalTrailingClosures
+    )
+  }
+
   /// Evaluate the given macro for this syntax node, producing the expanded
   /// result and (possibly) some diagnostics.
   func evaluateMacro(
@@ -53,29 +76,6 @@ extension MacroExpansionExprSyntax {
 }
 
 extension MacroExpansionDeclSyntax {
-  /// Macro expansion declarations are parsed in some positions where an
-  /// expression is also warranted, so
-  private func asMacroExpansionExpr() -> MacroExpansionExprSyntax {
-    MacroExpansionExprSyntax(
-      unexpectedBeforePoundToken,
-      poundToken: poundToken,
-      unexpectedBetweenPoundTokenAndMacro,
-      macro: macro,
-      genericArguments: genericArguments,
-      unexpectedBetweenGenericArgumentsAndLeftParen,
-      leftParen: leftParen,
-      unexpectedBetweenLeftParenAndArgumentList,
-      argumentList: argumentList,
-      unexpectedBetweenArgumentListAndRightParen,
-      rightParen: rightParen,
-      unexpectedBetweenRightParenAndTrailingClosure,
-      trailingClosure: trailingClosure,
-      unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures,
-      additionalTrailingClosures: additionalTrailingClosures,
-      unexpectedAfterAdditionalTrailingClosures
-    )
-  }
-
   /// Evaluate the given macro for this syntax node, producing the expanded
   /// result and (possibly) some diagnostics.
   func evaluateMacro(
@@ -84,10 +84,7 @@ extension MacroExpansionDeclSyntax {
   ) -> Syntax {
     // TODO: declaration/statement macros
 
-    // Fall back to evaluating as an expression macro.
-    return Syntax(
-      asMacroExpansionExpr().evaluateMacro(macro, in: &context)
-    )
+    return Syntax(self)
   }
 }
 

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -195,7 +195,8 @@ struct DefineBitwidthNumberedStructsMacro: FreestandingDeclarationMacro {
       case let .stringSegment(prefix) = stringLiteral.segments[0]
     else {
       throw CustomError.message(
-        "#bitwidthNumberedStructs macro requires a string literal")
+        "#bitwidthNumberedStructs macro requires a string literal"
+      )
     }
 
     return [8, 16, 32, 64].map { bitwidth in


### PR DESCRIPTION
Freestanding declaration macros are spelled in the same manner as expression macros, with a leading `#`. Introduce a protocol with their expansion operation and implement expansion semantics in the macro system for testing purposes.

Rework the `myError` macro used for testing to be a freestanding declaration macro, which better matches the actual semantics of `#error`.