### PR TITLE
[Macros] Implement peer declaration macros with expansion

### DIFF
--- a/Sources/_SwiftSyntaxMacros/CMakeLists.txt
+++ b/Sources/_SwiftSyntaxMacros/CMakeLists.txt
@@ -13,6 +13,7 @@ add_swift_host_library(_SwiftSyntaxMacros
   Macro.swift
   MacroExpansionContext.swift
   MacroSystem.swift
+  PeerDeclarationMacro.swift
   Syntax+MacroEvaluation.swift
 )
 

--- a/Sources/_SwiftSyntaxMacros/ExpressionMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/ExpressionMacro.swift
@@ -12,7 +12,6 @@
 
 import SwiftSyntax
 import SwiftParser
-import SwiftDiagnostics
 
 /// Describes a macro that is explicitly expanded as an expression.
 public protocol ExpressionMacro: Macro {

--- a/Sources/_SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem.swift
@@ -120,6 +120,16 @@ class MacroApplication: SyntaxRewriter {
       // Recurse on the child node.
       let newItem = visit(item.item)
       newItems.append(item.withItem(newItem))
+
+      // Expand any peer declarations triggered by macros used as attributes.
+      if case let .decl(decl) = item.item {
+        let peers = expandPeers(of: decl)
+        newItems.append(
+          contentsOf: peers.map {
+            newDecl in CodeBlockItemSyntax(item: .decl(newDecl))
+          }
+        )
+      }
     }
 
     return CodeBlockItemListSyntax(newItems)
@@ -160,9 +170,62 @@ class MacroApplication: SyntaxRewriter {
       // Recurse on the child node.
       let newDecl = visit(item.decl)
       newItems.append(item.withDecl(newDecl))
+
+      // Expand any peer declarations triggered by macros used as attributes.
+      let peers = expandPeers(of: item.decl)
+      newItems.append(
+        contentsOf: peers.map {
+          newDecl in MemberDeclListItemSyntax(decl: newDecl)
+        }
+      )
     }
 
     return .init(newItems)
+  }
+}
+
+extension MacroApplication {
+  // If any of the custom attributes associated with the given declaration
+  // refer to "peer" declaration macros, expand them and return the resulting
+  // set of peer declarations.
+  private func expandPeers(of decl: DeclSyntax) -> [DeclSyntax] {
+    // Dig out the attribute list.
+    // FIXME: We should have a better way to get the attributes from any
+    // declaration.
+    guard
+      let attributes =
+        (decl.children(viewMode: .sourceAccurate).compactMap {
+          $0.as(AttributeListSyntax.self)
+        }).first
+    else {
+      return []
+    }
+
+    var peers: [DeclSyntax] = []
+    for attribute in attributes {
+      guard case let .customAttribute(customAttribute) = attribute,
+        let attributeName = customAttribute.attributeName.as(SimpleTypeIdentifierSyntax.self)?.name.text,
+        let macro = macroSystem.macros[attributeName],
+        let peerMacro = macro as? PeerDeclarationMacro.Type
+      else {
+        continue
+      }
+
+      do {
+        let newPeers = try peerMacro.expansion(of: customAttribute, attachedTo: decl, in: &context)
+        peers.append(contentsOf: newPeers)
+      } catch {
+        // Record the error
+        context.diagnose(
+          Diagnostic(
+            node: Syntax(attribute),
+            message: ThrownErrorDiagnostic(message: String(describing: error))
+          )
+        )
+      }
+    }
+
+    return peers
   }
 }
 

--- a/Sources/_SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem.swift
@@ -190,7 +190,8 @@ class MacroApplication: SyntaxRewriter {
     // Visit the node first.
 
     guard let visitedFunc = visitedNode.as(FunctionDeclSyntax.self),
-          let attributes = visitedFunc.attributes else {
+      let attributes = visitedFunc.attributes
+    else {
       return visitedNode
     }
 
@@ -201,7 +202,8 @@ class MacroApplication: SyntaxRewriter {
       }
 
       guard let attributeName = customAttr.attributeName.as(SimpleTypeIdentifierSyntax.self)?.name.text,
-            let macro = macroSystem.macros[attributeName] else {
+        let macro = macroSystem.macros[attributeName]
+      else {
         return true
       }
 

--- a/Sources/_SwiftSyntaxMacros/PeerDeclarationMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/PeerDeclarationMacro.swift
@@ -10,12 +10,16 @@
 import SwiftSyntax
 import SwiftParser
 
-/// Describes a macro that forms declarations.
-public protocol FreestandingDeclarationMacro: DeclarationMacro {
-  /// Expand a macro described by the given freestanding macro expansion
-  /// declaration within the given context to produce a set of declarations.
+public protocol PeerDeclarationMacro: DeclarationMacro {
+  /// Expand a macro described by the given custom attribute and
+  /// attached to the given declaration and evaluated within a
+  /// particular expansion context.
+  ///
+  /// The macro expansion can introduce "peer" declarations that sit alongside
+  /// the
   static func expansion(
-    of node: MacroExpansionDeclSyntax,
+    of node: CustomAttributeSyntax,
+    attachedTo declaration: DeclSyntax,
     in context: inout MacroExpansionContext
   ) throws -> [DeclSyntax]
 }

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -507,7 +507,7 @@ final class MacroSystemTests: XCTestCase {
       func f(a: Int, for b: String, _ value: Double) async -> String { }
       """,
       """
-      @addCompletionHandler
+
       func f(a: Int, for b: String, _ value: Double) async -> String { }
 
       func f(a: Int, for b: String, _ value: Double, completionHandler: (String) -> Void) {


### PR DESCRIPTION
Peer declaration macros are applied to a declaration via an attribute,
but are responsible for generating "peer" declarations that go
alongside the declaration to which the attribute is attached.
Implement the `addCompletionHandler` example, which takes:

    @addCompletionHandler
    func f(a: Int, for b: String, _ value: Double) async -> String { }

and adds the following peer declaration:

    func f(a: Int, for b: String, _ value: Double, completionHandler: (String) -> Void) {
      Task {
        completionHandler(await f(a: a, for: b, value))
      }
    }