### PR TITLE
[Macros] Introduce member declaration macros.

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
@@ -1237,6 +1237,7 @@ public let DECL_NODES: [Node] = [
        description: "A Swift `enum` declaration.",
        kind: "Decl",
        traits: [
+         "DeclGroup",
          "IdentifiedDecl",
          "Attributed"
        ],

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -286,7 +286,7 @@ extension EnumCaseDeclSyntax: AttributedSyntax {
 extension EnumCaseElementSyntax: WithTrailingCommaSyntax {
 }
 
-extension EnumDeclSyntax: IdentifiedDeclSyntax, AttributedSyntax {
+extension EnumDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, AttributedSyntax {
 }
 
 extension ExpressionSegmentSyntax: ParenthesizedSyntax {

--- a/Sources/_SwiftSyntaxMacros/CMakeLists.txt
+++ b/Sources/_SwiftSyntaxMacros/CMakeLists.txt
@@ -13,6 +13,7 @@ add_swift_host_library(_SwiftSyntaxMacros
   Macro.swift
   MacroExpansionContext.swift
   MacroSystem.swift
+  MemberDeclarationMacro.swift
   PeerDeclarationMacro.swift
   Syntax+MacroEvaluation.swift
 )

--- a/Sources/_SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem.swift
@@ -258,19 +258,20 @@ class MacroApplication: SyntaxRewriter {
 }
 
 extension MacroApplication {
+  private func getAttributes(attachedTo decl: DeclSyntax) -> AttributeListSyntax? {
+    // Dig out the attribute list.
+    // FIXME: We should have a better way to get the attributes from any
+    // declaration.
+    return (decl.children(viewMode: .sourceAccurate).compactMap {
+      $0.as(AttributeListSyntax.self)
+    }).first
+  }
+
   // If any of the custom attributes associated with the given declaration
   // refer to "peer" declaration macros, expand them and return the resulting
   // set of peer declarations.
   private func expandPeers(of decl: DeclSyntax) -> [DeclSyntax] {
-    // Dig out the attribute list.
-    // FIXME: We should have a better way to get the attributes from any
-    // declaration.
-    guard
-      let attributes =
-        (decl.children(viewMode: .sourceAccurate).compactMap {
-          $0.as(AttributeListSyntax.self)
-        }).first
-    else {
+    guard let attributes = getAttributes(attachedTo: decl) else {
       return []
     }
 
@@ -304,12 +305,7 @@ extension MacroApplication {
   /// Expands any attached custom attributes that refer to member declaration macros,
   /// and returns result of adding those members to the given declaration.
   private func expandMembers<Decl: DeclGroupSyntax & DeclSyntaxProtocol>(of decl: Decl) -> Decl {
-    guard
-      let attributes =
-        (decl.children(viewMode: .sourceAccurate).compactMap {
-          $0.as(AttributeListSyntax.self)
-        }).first
-    else {
+    guard let attributes = getAttributes(attachedTo: DeclSyntax(decl)) else {
       return decl
     }
 

--- a/Sources/_SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem.swift
@@ -334,8 +334,8 @@ extension MacroApplication {
     }
 
     // FIXME: Is there a better way to add N members to a decl?
-    return decl.withMembers(newMembers.reduce(decl.members) { partialMembers, memberListItem in
-      partialMembers.addMember(memberListItem)
+    return decl.withMembers(newMembers.reduce(decl.members) { partialMembers, newMember in
+      partialMembers.addMember(.init(decl: newMember))
     })
   }
 }

--- a/Sources/_SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem.swift
@@ -240,6 +240,10 @@ class MacroApplication: SyntaxRewriter {
     return visit(declGroup: node)
   }
 
+  override func visit(_ node: EnumDeclSyntax) -> DeclSyntax {
+    return visit(declGroup: node)
+  }
+
   override func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
     return visit(declGroup: node)
   }

--- a/Sources/_SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem.swift
@@ -106,8 +106,7 @@ class MacroApplication: SyntaxRewriter {
           return true
         }
 
-        return !(macro is PeerDeclarationMacro.Type ||
-                 macro is MemberDeclarationMacro.Type)
+        return !(macro is PeerDeclarationMacro.Type || macro is MemberDeclarationMacro.Type)
       }
 
       if newAttributes.isEmpty {
@@ -259,18 +258,20 @@ class MacroApplication: SyntaxRewriter {
 
 extension MacroApplication {
   private func getMacroAttributes<MacroType>(
-    attachedTo decl: DeclSyntax, ofType: MacroType.Type
+    attachedTo decl: DeclSyntax,
+    ofType: MacroType.Type
   ) -> [(CustomAttributeSyntax, MacroType)] {
     guard let attributedNode = decl.asProtocol(AttributedSyntax.self),
-          let attributes = attributedNode.attributes else {
+      let attributes = attributedNode.attributes
+    else {
       return []
     }
 
     return attributes.compactMap {
       guard case let .customAttribute(customAttr) = $0,
-            let attributeName = customAttr.attributeName.as(SimpleTypeIdentifierSyntax.self)?.name.text,
-            let macro = macroSystem.macros[attributeName],
-            let macroType = macro as? MacroType
+        let attributeName = customAttr.attributeName.as(SimpleTypeIdentifierSyntax.self)?.name.text,
+        let macro = macroSystem.macros[attributeName],
+        let macroType = macro as? MacroType
       else {
         return nil
       }
@@ -312,9 +313,13 @@ extension MacroApplication {
     let macroAttributes = getMacroAttributes(attachedTo: DeclSyntax(decl), ofType: MemberDeclarationMacro.Type.self)
     for (attribute, memberMacro) in macroAttributes {
       do {
-        try newMembers.append(contentsOf: memberMacro.expansion(of: attribute,
-                                                                attachedTo: DeclSyntax(decl),
-                                                                in: &context))
+        try newMembers.append(
+          contentsOf: memberMacro.expansion(
+            of: attribute,
+            attachedTo: DeclSyntax(decl),
+            in: &context
+          )
+        )
       } catch {
         // Record the error
         context.diagnose(
@@ -327,9 +332,11 @@ extension MacroApplication {
     }
 
     // FIXME: Is there a better way to add N members to a decl?
-    return decl.withMembers(newMembers.reduce(decl.members) { partialMembers, newMember in
-      partialMembers.addMember(.init(decl: newMember))
-    })
+    return decl.withMembers(
+      newMembers.reduce(decl.members) { partialMembers, newMember in
+        partialMembers.addMember(.init(decl: newMember))
+      }
+    )
   }
 }
 

--- a/Sources/_SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem.swift
@@ -220,24 +220,36 @@ class MacroApplication: SyntaxRewriter {
     return .init(newItems)
   }
 
+  func visit<DeclType: DeclGroupSyntax & DeclSyntaxProtocol>(
+    declGroup: DeclType
+  ) -> DeclSyntax {
+    // Expand any attached member macros.
+    let expandedDeclGroup = expandMembers(of: declGroup)
+
+    // Recurse into member decls.
+    let newMembers = visit(expandedDeclGroup.members)
+
+    return DeclSyntax(expandedDeclGroup.withMembers(newMembers))
+  }
+
   override func visit(_ node: ActorDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(expandMembers(of: node))
+    return visit(declGroup: node)
   }
 
   override func visit(_ node: StructDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(expandMembers(of: node))
+    return visit(declGroup: node)
   }
 
   override func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(expandMembers(of: node))
+    return visit(declGroup: node)
   }
 
   override func visit(_ node: ProtocolDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(expandMembers(of: node))
+    return visit(declGroup: node)
   }
 
   override func visit(_ node: ExtensionDeclSyntax) -> DeclSyntax {
-    return DeclSyntax(expandMembers(of: node))
+    return visit(declGroup: node)
   }
 }
 

--- a/Sources/_SwiftSyntaxMacros/MemberDeclarationMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/MemberDeclarationMacro.swift
@@ -27,5 +27,5 @@ public protocol MemberDeclarationMacro: DeclarationMacro {
     of node: CustomAttributeSyntax,
     attachedTo declaration: DeclSyntax,
     in context: inout MacroExpansionContext
-  ) throws -> [MemberDeclListItemSyntax]
+  ) throws -> [DeclSyntax]
 }

--- a/Sources/_SwiftSyntaxMacros/MemberDeclarationMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/MemberDeclarationMacro.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// Describes a macro that can add members to the declaration it's attached to.
+public protocol MemberDeclarationMacro: DeclarationMacro {
+  /// Expand an attached declaration macro to produce a set of members.
+  ///
+  /// - Parameters:
+  ///   - node: The custom attribute describing the attached macro.
+  ///   - declaration: The declaration the macro attribute is attached to.
+  ///   - context: The context in which to perform the macro expansion.
+  ///
+  /// - Returns: the set of member declarations introduced by this macro, which
+  /// are nested inside the `attachedTo` declaration.
+  static func expansion(
+    of node: CustomAttributeSyntax,
+    attachedTo declaration: DeclSyntax,
+    in context: inout MacroExpansionContext
+  ) throws -> [MemberDeclListItemSyntax]
+}

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -323,9 +323,10 @@ public struct AddBackingStorage: MemberDeclarationMacro {
   public static func expansion(
     of node: CustomAttributeSyntax,
     attachedTo decl: DeclSyntax,
-    in context: inout
-    MacroExpansionContext)
-  throws -> [DeclSyntax] {
+    in context: inout MacroExpansionContext
+  )
+    throws -> [DeclSyntax]
+  {
     let storage: DeclSyntax = "var _storage: Storage<Self>"
     return [
       storage.withLeadingTrivia([.newlines(1), .spaces(2)])

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -325,25 +325,10 @@ public struct AddBackingStorage: MemberDeclarationMacro {
     attachedTo decl: DeclSyntax,
     in context: inout
     MacroExpansionContext)
-  throws -> [MemberDeclListItemSyntax] {
-    let identifierPattern = IdentifierPatternSyntax(
-      identifier: .identifier("_storage")
-    )
-      .withLeadingTrivia(.space)
-
-    let pattern = PatternBindingSyntax(
-      pattern: identifierPattern,
-      typeAnnotation: TypeAnnotationSyntax(
-        colon: .colonToken(trailingTrivia: .space),
-        type: SimpleTypeIdentifierSyntax(name: .identifier("Storage<Self>"))
-      )
-    )
-    return [.init(
-        decl: VariableDeclSyntax(
-        letOrVarKeyword: TokenSyntax(.varKeyword, presence: .present),
-        bindings: PatternBindingListSyntax([pattern])
-      ))
-      .withLeadingTrivia([.newlines(1), .spaces(2)])
+  throws -> [DeclSyntax] {
+    let storage: DeclSyntax = "var _storage: Storage<Self>"
+    return [
+      storage.withLeadingTrivia([.newlines(1), .spaces(2)])
     ]
   }
 }

--- a/gyb_syntax_support/DeclNodes.py
+++ b/gyb_syntax_support/DeclNodes.py
@@ -676,7 +676,7 @@ DECL_NODES = [
          ]),
 
     Node('EnumDecl', name_for_diagnostics='enum', kind='Decl',
-         traits=['IdentifiedDecl', 'Attributed'],
+         traits=['DeclGroup', 'IdentifiedDecl', 'Attributed'],
          description='A Swift `enum` declaration.',
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',


### PR DESCRIPTION
An initial implementation for member declaration macros. 

Member declaration macros are represented as custom attributes, and expanding a member macro for a given declaration can produce a set of new members to add to that declaration. For example:

```swift
@addBackingStorage
struct S {
  var value: Int
}
```

Expanding `@addBackingStorage` adds `var _storage` to `S`:

```swift
struct S {
  var value: Int
  var _storage: Storage<Self>
}
```