### PR TITLE
Generalize macro expansion for macros written as attributes

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/CommonNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/CommonNodes.swift
@@ -45,6 +45,9 @@ public let COMMON_NODES: [Node] = [
   Node(name: "MissingDecl",
        nameForDiagnostics: "declaration",
        kind: "Decl",
+       traits: [
+         "Attributed"
+       ],
        children: [
          Child(name: "Attributes",
                kind: "AttributeList",

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
@@ -30,7 +30,8 @@ public let DECL_NODES: [Node] = [
        nameForDiagnostics: "typealias declaration",
        kind: "Decl",
        traits: [
-         "IdentifiedDecl"
+         "IdentifiedDecl",
+         "Attributed"
        ],
        children: [
          Child(name: "Attributes",
@@ -65,7 +66,8 @@ public let DECL_NODES: [Node] = [
        nameForDiagnostics: "associatedtype declaration",
        kind: "Decl",
        traits: [
-         "IdentifiedDecl"
+         "IdentifiedDecl",
+         "Attributed"
        ],
        children: [
          Child(name: "Attributes",
@@ -454,7 +456,8 @@ public let DECL_NODES: [Node] = [
        kind: "Decl",
        traits: [
          "DeclGroup",
-         "IdentifiedDecl"
+         "IdentifiedDecl",
+         "Attributed"
        ],
        children: [
          Child(name: "Attributes",
@@ -493,7 +496,8 @@ public let DECL_NODES: [Node] = [
        kind: "Decl",
        traits: [
          "DeclGroup",
-         "IdentifiedDecl"
+         "IdentifiedDecl",
+         "Attributed"
        ],
        children: [
          Child(name: "Attributes",
@@ -535,7 +539,8 @@ public let DECL_NODES: [Node] = [
        kind: "Decl",
        traits: [
          "DeclGroup",
-         "IdentifiedDecl"
+         "IdentifiedDecl",
+         "Attributed"
        ],
        children: [
          Child(name: "Attributes",
@@ -574,7 +579,8 @@ public let DECL_NODES: [Node] = [
        kind: "Decl",
        traits: [
          "DeclGroup",
-         "IdentifiedDecl"
+         "IdentifiedDecl",
+         "Attributed"
        ],
        children: [
          Child(name: "Attributes",
@@ -612,7 +618,8 @@ public let DECL_NODES: [Node] = [
        nameForDiagnostics: "extension",
        kind: "Decl",
        traits: [
-         "DeclGroup"
+         "DeclGroup",
+         "Attributed"
        ],
        children: [
          Child(name: "Attributes",
@@ -721,7 +728,8 @@ public let DECL_NODES: [Node] = [
        nameForDiagnostics: "parameter",
        kind: "Syntax",
        traits: [
-         "WithTrailingComma"
+         "WithTrailingComma",
+         "Attributed"
        ],
        children: [
          Child(name: "Attributes",
@@ -783,7 +791,8 @@ public let DECL_NODES: [Node] = [
        nameForDiagnostics: "function",
        kind: "Decl",
        traits: [
-         "IdentifiedDecl"
+         "IdentifiedDecl",
+         "Attributed"
        ],
        children: [
          Child(name: "Attributes",
@@ -824,6 +833,9 @@ public let DECL_NODES: [Node] = [
   Node(name: "InitializerDecl",
        nameForDiagnostics: "initializer",
        kind: "Decl",
+       traits: [
+         "Attributed"
+       ],
        children: [
          Child(name: "Attributes",
                kind: "AttributeList",
@@ -862,6 +874,9 @@ public let DECL_NODES: [Node] = [
   Node(name: "DeinitializerDecl",
        nameForDiagnostics: "deinitializer",
        kind: "Decl",
+       traits: [
+         "Attributed"
+       ],
        children: [
          Child(name: "Attributes",
                kind: "AttributeList",
@@ -884,6 +899,9 @@ public let DECL_NODES: [Node] = [
   Node(name: "SubscriptDecl",
        nameForDiagnostics: "subscript",
        kind: "Decl",
+       traits: [
+         "Attributed"
+       ],
        children: [
          Child(name: "Attributes",
                kind: "AttributeList",
@@ -958,6 +976,9 @@ public let DECL_NODES: [Node] = [
   Node(name: "ImportDecl",
        nameForDiagnostics: "import",
        kind: "Decl",
+       traits: [
+         "Attributed"
+       ],
        children: [
          Child(name: "Attributes",
                kind: "AttributeList",
@@ -1017,6 +1038,9 @@ public let DECL_NODES: [Node] = [
   Node(name: "AccessorDecl",
        nameForDiagnostics: "accessor",
        kind: "Decl",
+       traits: [
+         "Attributed"
+       ],
        children: [
          Child(name: "Attributes",
                kind: "AttributeList",
@@ -1132,6 +1156,9 @@ public let DECL_NODES: [Node] = [
   Node(name: "VariableDecl",
        nameForDiagnostics: "variable",
        kind: "Decl",
+       traits: [
+         "Attributed"
+       ],
        children: [
          Child(name: "Attributes",
                kind: "AttributeList",
@@ -1193,6 +1220,9 @@ public let DECL_NODES: [Node] = [
        nameForDiagnostics: "enum case",
        description: "A `case` declaration of a Swift `enum`. It can have 1 or more`EnumCaseElement`s inside, each declaring a different case of theenum.",
        kind: "Decl",
+       traits: [
+         "Attributed"
+       ],
        children: [
          Child(name: "Attributes",
                kind: "AttributeList",
@@ -1221,7 +1251,8 @@ public let DECL_NODES: [Node] = [
        description: "A Swift `enum` declaration.",
        kind: "Decl",
        traits: [
-         "IdentifiedDecl"
+         "IdentifiedDecl",
+         "Attributed"
        ],
        children: [
          Child(name: "Attributes",
@@ -1268,7 +1299,8 @@ public let DECL_NODES: [Node] = [
        description: "A Swift `operator` declaration.",
        kind: "Decl",
        traits: [
-         "IdentifiedDecl"
+         "IdentifiedDecl",
+         "Attributed"
        ],
        children: [
          Child(name: "Attributes",
@@ -1350,7 +1382,8 @@ public let DECL_NODES: [Node] = [
        description: "A Swift `precedencegroup` declaration.",
        kind: "Decl",
        traits: [
-         "IdentifiedDecl"
+         "IdentifiedDecl",
+         "Attributed"
        ],
        children: [
          Child(name: "Attributes",
@@ -1509,7 +1542,8 @@ public let DECL_NODES: [Node] = [
        nameForDiagnostics: "macro",
        kind: "Decl",
        traits: [
-         "IdentifiedDecl"
+         "IdentifiedDecl",
+         "Attributed"
        ],
        children: [
          Child(name: "Attributes",

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
@@ -745,6 +745,9 @@ public let EXPR_NODES: [Node] = [
   Node(name: "ClosureSignature",
        nameForDiagnostics: "closure signature",
        kind: "Syntax",
+       traits: [
+         "Attributed"
+       ],
        children: [
          Child(name: "Attributes",
                kind: "AttributeList",

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/GenericNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/GenericNodes.swift
@@ -133,7 +133,8 @@ public let GENERIC_NODES: [Node] = [
        nameForDiagnostics: "generic parameter",
        kind: "Syntax",
        traits: [
-         "WithTrailingComma"
+         "WithTrailingComma",
+         "Attributed"
        ],
        children: [
          Child(name: "Attributes",

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/Traits.swift
@@ -25,6 +25,11 @@ public class Trait {
 }
 
 public let TRAITS: [Trait] = [
+  Trait(traitName: "Attributed",
+        children: [
+          Child(name: "Attributes", kind: "AttributeList", isOptional: true),
+        ]
+  ),
   Trait(traitName: "DeclGroup",
         children: [
           Child(name: "Attributes", kind: "AttributeList", isOptional: true),

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/TypeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/TypeNodes.swift
@@ -355,6 +355,9 @@ public let TYPE_NODES: [Node] = [
   Node(name: "AttributedType",
        nameForDiagnostics: "type",
        kind: "Type",
+       traits: [
+         "Attributed"
+       ],
        children: [
          Child(name: "Specifier",
                kind: "Token",

--- a/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
@@ -429,6 +429,7 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 
 ### Traits
 
+- <doc:SwiftSyntax/AttributedSyntax>
 - <doc:SwiftSyntax/DeclGroupSyntax>
 - <doc:SwiftSyntax/BracedSyntax>
 - <doc:SwiftSyntax/IdentifiedDeclSyntax>

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -1,5 +1,29 @@
 
 
+// MARK: - AttributedSyntax
+
+public protocol AttributedSyntax: SyntaxProtocol {
+  var attributes: AttributeListSyntax? { get }
+  
+  func withAttributes(_ newChild: AttributeListSyntax?) -> Self
+}
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to
+  /// `AttributedSyntax`.
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_ : AttributedSyntax.Protocol) -> Bool {
+    return self.asProtocol(AttributedSyntax.self) != nil
+  }
+  
+  /// Return the non-type erased version of this syntax node if it conforms to
+  /// `AttributedSyntax`. Otherwise return `nil`.
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_ : AttributedSyntax.Protocol) -> AttributedSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? AttributedSyntax
+  }
+}
+
 // MARK: - DeclGroupSyntax
 
 public protocol DeclGroupSyntax: SyntaxProtocol {
@@ -187,16 +211,22 @@ public extension SyntaxProtocol {
 extension AccessorBlockSyntax: BracedSyntax {
 }
 
+extension AccessorDeclSyntax: AttributedSyntax {
+}
+
 extension AccessorParameterSyntax: ParenthesizedSyntax {
 }
 
-extension ActorDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax {
+extension ActorDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, AttributedSyntax {
 }
 
 extension ArrayElementSyntax: WithTrailingCommaSyntax {
 }
 
-extension AssociatedtypeDeclSyntax: IdentifiedDeclSyntax {
+extension AssociatedtypeDeclSyntax: IdentifiedDeclSyntax, AttributedSyntax {
+}
+
+extension AttributedTypeSyntax: AttributedSyntax {
 }
 
 extension CaseItemSyntax: WithTrailingCommaSyntax {
@@ -208,7 +238,7 @@ extension CatchClauseSyntax: WithCodeBlockSyntax {
 extension CatchItemSyntax: WithTrailingCommaSyntax {
 }
 
-extension ClassDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax {
+extension ClassDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, AttributedSyntax {
 }
 
 extension ClosureCaptureItemSyntax: WithTrailingCommaSyntax {
@@ -218,6 +248,9 @@ extension ClosureExprSyntax: BracedSyntax, WithStatementsSyntax {
 }
 
 extension ClosureParamSyntax: WithTrailingCommaSyntax {
+}
+
+extension ClosureSignatureSyntax: AttributedSyntax {
 }
 
 extension CodeBlockSyntax: BracedSyntax, WithStatementsSyntax {
@@ -235,6 +268,9 @@ extension DeclNameArgumentsSyntax: ParenthesizedSyntax {
 extension DeferStmtSyntax: WithCodeBlockSyntax {
 }
 
+extension DeinitializerDeclSyntax: AttributedSyntax {
+}
+
 extension DictionaryElementSyntax: WithTrailingCommaSyntax {
 }
 
@@ -244,25 +280,28 @@ extension DifferentiabilityParamSyntax: WithTrailingCommaSyntax {
 extension DoStmtSyntax: WithCodeBlockSyntax {
 }
 
+extension EnumCaseDeclSyntax: AttributedSyntax {
+}
+
 extension EnumCaseElementSyntax: WithTrailingCommaSyntax {
 }
 
-extension EnumDeclSyntax: IdentifiedDeclSyntax {
+extension EnumDeclSyntax: IdentifiedDeclSyntax, AttributedSyntax {
 }
 
 extension ExpressionSegmentSyntax: ParenthesizedSyntax {
 }
 
-extension ExtensionDeclSyntax: DeclGroupSyntax {
+extension ExtensionDeclSyntax: DeclGroupSyntax, AttributedSyntax {
 }
 
 extension ForInStmtSyntax: WithCodeBlockSyntax {
 }
 
-extension FunctionDeclSyntax: IdentifiedDeclSyntax {
+extension FunctionDeclSyntax: IdentifiedDeclSyntax, AttributedSyntax {
 }
 
-extension FunctionParameterSyntax: WithTrailingCommaSyntax {
+extension FunctionParameterSyntax: WithTrailingCommaSyntax, AttributedSyntax {
 }
 
 extension FunctionTypeSyntax: ParenthesizedSyntax {
@@ -271,7 +310,7 @@ extension FunctionTypeSyntax: ParenthesizedSyntax {
 extension GenericArgumentSyntax: WithTrailingCommaSyntax {
 }
 
-extension GenericParameterSyntax: WithTrailingCommaSyntax {
+extension GenericParameterSyntax: WithTrailingCommaSyntax, AttributedSyntax {
 }
 
 extension GenericRequirementSyntax: WithTrailingCommaSyntax {
@@ -283,19 +322,28 @@ extension GuardStmtSyntax: WithCodeBlockSyntax {
 extension IfStmtSyntax: WithCodeBlockSyntax {
 }
 
+extension ImportDeclSyntax: AttributedSyntax {
+}
+
 extension InheritedTypeSyntax: WithTrailingCommaSyntax {
+}
+
+extension InitializerDeclSyntax: AttributedSyntax {
 }
 
 extension LabeledSpecializeEntrySyntax: WithTrailingCommaSyntax {
 }
 
-extension MacroDeclSyntax: IdentifiedDeclSyntax {
+extension MacroDeclSyntax: IdentifiedDeclSyntax, AttributedSyntax {
 }
 
 extension MemberDeclBlockSyntax: BracedSyntax {
 }
 
-extension OperatorDeclSyntax: IdentifiedDeclSyntax {
+extension MissingDeclSyntax: AttributedSyntax {
+}
+
+extension OperatorDeclSyntax: IdentifiedDeclSyntax, AttributedSyntax {
 }
 
 extension ParameterClauseSyntax: ParenthesizedSyntax {
@@ -313,13 +361,13 @@ extension PoundSourceLocationSyntax: ParenthesizedSyntax {
 extension PoundWarningDeclSyntax: ParenthesizedSyntax {
 }
 
-extension PrecedenceGroupDeclSyntax: IdentifiedDeclSyntax {
+extension PrecedenceGroupDeclSyntax: IdentifiedDeclSyntax, AttributedSyntax {
 }
 
 extension PrimaryAssociatedTypeSyntax: WithTrailingCommaSyntax {
 }
 
-extension ProtocolDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax {
+extension ProtocolDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, AttributedSyntax {
 }
 
 extension RepeatWhileStmtSyntax: WithCodeBlockSyntax {
@@ -328,7 +376,10 @@ extension RepeatWhileStmtSyntax: WithCodeBlockSyntax {
 extension SourceFileSyntax: WithStatementsSyntax {
 }
 
-extension StructDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax {
+extension StructDeclSyntax: DeclGroupSyntax, IdentifiedDeclSyntax, AttributedSyntax {
+}
+
+extension SubscriptDeclSyntax: AttributedSyntax {
 }
 
 extension SwitchCaseSyntax: WithStatementsSyntax {
@@ -358,7 +409,10 @@ extension TupleTypeElementSyntax: WithTrailingCommaSyntax {
 extension TupleTypeSyntax: ParenthesizedSyntax {
 }
 
-extension TypealiasDeclSyntax: IdentifiedDeclSyntax {
+extension TypealiasDeclSyntax: IdentifiedDeclSyntax, AttributedSyntax {
+}
+
+extension VariableDeclSyntax: AttributedSyntax {
 }
 
 extension WhileStmtSyntax: WithCodeBlockSyntax {

--- a/Sources/_SwiftSyntaxMacros/DeclarationMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/DeclarationMacro.swift
@@ -7,10 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
-import SwiftParser
-import SwiftDiagnostics
-
 /// Describes a macro that forms declarations.
 public protocol DeclarationMacro: Macro {
 }

--- a/Sources/_SwiftSyntaxMacros/ExpressionMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/ExpressionMacro.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
-import SwiftParser
 
 /// Describes a macro that is explicitly expanded as an expression.
 public protocol ExpressionMacro: Macro {

--- a/Sources/_SwiftSyntaxMacros/FreestandingDeclarationMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/FreestandingDeclarationMacro.swift
@@ -8,7 +8,6 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
-import SwiftParser
 
 /// Describes a macro that forms declarations.
 public protocol FreestandingDeclarationMacro: DeclarationMacro {

--- a/Sources/_SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem.swift
@@ -110,10 +110,10 @@ class MacroApplication: SyntaxRewriter {
       }
 
       if newAttributes.isEmpty {
-        return Syntax(visitedNode.withAttributes(nil))
+        return Syntax(fromProtocol: visitedNode.withAttributes(nil))
       }
 
-      return Syntax(visitedNode.withAttributes(AttributeListSyntax(newAttributes)))
+      return Syntax(fromProtocol: visitedNode.withAttributes(AttributeListSyntax(newAttributes)))
     }
 
     return nil

--- a/Sources/_SwiftSyntaxMacros/PeerDeclarationMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/PeerDeclarationMacro.swift
@@ -8,7 +8,6 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
-import SwiftParser
 
 public protocol PeerDeclarationMacro: DeclarationMacro {
   /// Expand a macro described by the given custom attribute and

--- a/gyb_syntax_support/CommonNodes.py
+++ b/gyb_syntax_support/CommonNodes.py
@@ -13,7 +13,9 @@ COMMON_NODES = [
     Node('Pattern', name_for_diagnostics='pattern', kind='Syntax',
          parser_function='parsePattern'),
     Node('Missing', name_for_diagnostics=None, kind='Syntax'),
-    Node('MissingDecl', name_for_diagnostics='declaration', kind='Decl', children=[
+    Node('MissingDecl', name_for_diagnostics='declaration', kind='Decl',
+         traits=['Attributed'],
+         children=[
         Child('Attributes', kind='AttributeList',
               collection_element_name='Attribute', is_optional=True),
         Child('Modifiers', kind='ModifierList',

--- a/gyb_syntax_support/DeclNodes.py
+++ b/gyb_syntax_support/DeclNodes.py
@@ -16,7 +16,7 @@ DECL_NODES = [
     #                            type-assignment
     # typealias-name -> identifier
     Node('TypealiasDecl', name_for_diagnostics='typealias declaration', kind='Decl',
-         traits=['IdentifiedDecl'],
+         traits=['IdentifiedDecl', 'Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
@@ -37,7 +37,7 @@ DECL_NODES = [
     #                                 generic-where-clause?
     # associatedtype-name -> identifier
     Node('AssociatedtypeDecl', name_for_diagnostics='associatedtype declaration',
-         kind='Decl', traits=['IdentifiedDecl'],
+         kind='Decl', traits=['IdentifiedDecl', 'Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
@@ -217,7 +217,7 @@ DECL_NODES = [
     #                     '{' class-members '}'
     # class-name -> identifier
     Node('ClassDecl', name_for_diagnostics='class', kind='Decl',
-         traits=['DeclGroup', 'IdentifiedDecl'],
+         traits=['DeclGroup', 'IdentifiedDecl', 'Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
@@ -242,7 +242,7 @@ DECL_NODES = [
     #                     '{' actor-members '}'
     # actor-name -> identifier
     Node('ActorDecl', name_for_diagnostics='actor', kind='Decl',
-         traits=['DeclGroup', 'IdentifiedDecl'],
+         traits=['DeclGroup', 'IdentifiedDecl', 'Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
@@ -267,7 +267,7 @@ DECL_NODES = [
     #                         '{' struct-members '}'
     # struct-name -> identifier
     Node('StructDecl', name_for_diagnostics='struct', kind='Decl',
-         traits=['DeclGroup', 'IdentifiedDecl'],
+         traits=['DeclGroup', 'IdentifiedDecl', 'Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
@@ -285,7 +285,7 @@ DECL_NODES = [
          ]),
 
     Node('ProtocolDecl', name_for_diagnostics='protocol', kind='Decl',
-         traits=['DeclGroup', 'IdentifiedDecl'],
+         traits=['DeclGroup', 'IdentifiedDecl', 'Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
@@ -311,7 +311,7 @@ DECL_NODES = [
     #                            '{' extension-members '}'
     # extension-name -> identifier
     Node('ExtensionDecl', name_for_diagnostics='extension', kind='Decl',
-         traits=['DeclGroup'],
+         traits=['DeclGroup', 'Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
@@ -376,7 +376,7 @@ DECL_NODES = [
     # external-parameter-name? local-parameter-name ':'
     #   type '...'? '='? expression? ','?
     Node('FunctionParameter', name_for_diagnostics='parameter', kind='Syntax',
-         traits=['WithTrailingComma'],
+         traits=['WithTrailingComma', 'Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
@@ -436,7 +436,7 @@ DECL_NODES = [
          element_name='Modifier'),
 
     Node('FunctionDecl', name_for_diagnostics='function', kind='Decl',
-         traits=['IdentifiedDecl'],
+         traits=['IdentifiedDecl', 'Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
@@ -461,6 +461,7 @@ DECL_NODES = [
          ]),
 
     Node('InitializerDecl', name_for_diagnostics='initializer', kind='Decl',
+         traits=['Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
@@ -484,6 +485,7 @@ DECL_NODES = [
          ]),
 
     Node('DeinitializerDecl', name_for_diagnostics='deinitializer', kind='Decl',
+         traits=['Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
@@ -494,6 +496,7 @@ DECL_NODES = [
          ]),
 
     Node('SubscriptDecl', name_for_diagnostics='subscript', kind='Decl',
+         traits=['Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
@@ -538,6 +541,7 @@ DECL_NODES = [
          element='AccessPathComponent'),
 
     Node('ImportDecl', name_for_diagnostics='import', kind='Decl',
+         traits=['Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
@@ -564,6 +568,7 @@ DECL_NODES = [
          ]),
 
     Node('AccessorDecl', name_for_diagnostics='accessor', kind='Decl',
+         traits=['Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
@@ -618,6 +623,7 @@ DECL_NODES = [
          element='PatternBinding'),
 
     Node('VariableDecl', name_for_diagnostics='variable', kind='Decl',
+         traits=['Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
@@ -663,6 +669,7 @@ DECL_NODES = [
          `EnumCaseElement`s inside, each declaring a different case of the
          enum.
          ''',
+         traits=['Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True,
@@ -682,7 +689,7 @@ DECL_NODES = [
          ]),
 
     Node('EnumDecl', name_for_diagnostics='enum', kind='Decl',
-         traits=['IdentifiedDecl'],
+         traits=['IdentifiedDecl', 'Attributed'],
          description='A Swift `enum` declaration.',
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
@@ -728,7 +735,7 @@ DECL_NODES = [
 
     # operator-decl -> attribute? modifiers? 'operator' operator
     Node('OperatorDecl', name_for_diagnostics='operator declaration', kind='Decl',
-         traits=['IdentifiedDecl'],
+         traits=['IdentifiedDecl', 'Attributed'],
          description='A Swift `operator` declaration.',
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
@@ -790,7 +797,7 @@ DECL_NODES = [
     #                            identifier '{' precedence-group-attribute-list
     #                            '}'
     Node('PrecedenceGroupDecl', name_for_diagnostics='precedencegroup', kind='Decl',
-         traits=['IdentifiedDecl'],
+         traits=['IdentifiedDecl', 'Attributed'],
          description='A Swift `precedencegroup` declaration.',
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
@@ -917,7 +924,7 @@ DECL_NODES = [
          ]),
 
     Node('MacroDecl', name_for_diagnostics='macro', kind='Decl',
-         traits=['IdentifiedDecl'],
+         traits=['IdentifiedDecl', 'Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),

--- a/gyb_syntax_support/ExprNodes.py
+++ b/gyb_syntax_support/ExprNodes.py
@@ -434,6 +434,7 @@ EXPR_NODES = [
          element='ClosureParam'),
 
     Node('ClosureSignature', name_for_diagnostics='closure signature', kind='Syntax',
+         traits=['Attributed'],
          children=[
              Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),

--- a/gyb_syntax_support/GenericNodes.py
+++ b/gyb_syntax_support/GenericNodes.py
@@ -71,7 +71,7 @@ GENERIC_NODES = [
     #                    | type-name : type-identifier
     #                    | type-name : protocol-composition-type
     Node('GenericParameter', name_for_diagnostics='generic parameter', kind='Syntax',
-         traits=['WithTrailingComma'],
+         traits=['WithTrailingComma', 'Attributed'],
          children=[
              Child('Attributes', kind='AttributeList',
                    collection_element_name='Attribute', is_optional=True),

--- a/gyb_syntax_support/Traits.py
+++ b/gyb_syntax_support/Traits.py
@@ -9,6 +9,11 @@ class Trait(object):
 
 
 TRAITS = [
+    Trait('Attributed',
+          children=[
+              Child('Attributes', kind='AttributeList', is_optional=True),
+          ]),
+
     Trait('DeclGroup',
           children=[
               Child('Attributes', kind='AttributeList', is_optional=True),

--- a/gyb_syntax_support/TypeNodes.py
+++ b/gyb_syntax_support/TypeNodes.py
@@ -196,6 +196,7 @@ TYPE_NODES = [
     # attributed-type -> type-specifier? attribute-list? type
     # type-specifier -> 'inout' | '__owned' | '__unowned'
     Node('AttributedType', name_for_diagnostics='type', kind='Type',
+         traits=['Attributed'],
          children=[
              Child('Specifier', kind='Token',
                    text_choices=['inout', '__shared', '__owned'],


### PR DESCRIPTION
Add 'attributed' trait for nodes that can have attributes, and use it to generalize macro expansion for macros written as attributes.