### PR TITLE
[Macros] Introduce member attribute macros.

### DIFF
--- a/Sources/_SwiftSyntaxMacros/CMakeLists.txt
+++ b/Sources/_SwiftSyntaxMacros/CMakeLists.txt
@@ -14,6 +14,7 @@ add_swift_host_library(_SwiftSyntaxMacros
   Macro.swift
   MacroExpansionContext.swift
   MacroSystem.swift
+  MemberAttributeMacro.swift
   MemberDeclarationMacro.swift
   PeerDeclarationMacro.swift
   Syntax+MacroEvaluation.swift

--- a/Sources/_SwiftSyntaxMacros/MemberAttributeMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/MemberAttributeMacro.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// Describes a macro that can add attributes to the members inside the
+/// declaration it's attached to.
+public protocol MemberAttributeMacro: DeclarationMacro {
+  /// Expand an attached declaration macro to produce an attribute list for
+  /// a given member.
+  ///
+  /// - Parameters:
+  ///   - node: The custom attribute describing the attached macro.
+  ///   - declaration: The declaration the macro attribute is attached to.
+  ///   - member: The member delcaration to attach the resulting attributes to.
+  ///   - context: The context in which to perform the macro expansion.
+  ///
+  /// - Returns: the set of attributes to apply to the given member.
+  static func expansion(
+    of node: CustomAttributeSyntax,
+    attachedTo declaration: DeclSyntax,
+    annotating member: DeclSyntax,
+    in context: inout MacroExpansionContext
+  ) throws -> [CustomAttributeSyntax]
+}


### PR DESCRIPTION
For each member of the declaration the macro attribute is attached to, the macro can produce a set of attributes to attach to that member. For example:

```swift
@declaration(memberAttribute)
macro wrapStoredProperties: Void

@wrapStoredProperties
struct Point {
  var x: Int
  var y: Int

  var description: String { "" }
}

// Expanded to

struct Point {
  @Wrapper var x: Int
  @Wrapper var y: Int

  var description: String { "" }
}
```

The member attribute macro expansion is given the declaration it's attached to along with a member declaration, and it returns a set of attributes to attach to the member. The expansion method is called for each member in the `attachedTo` declaration.