### PR TITLE
[Macros] Add accessor declaration macros, to add accessors to a stored property

### DIFF
--- a/Sources/_SwiftSyntaxMacros/AccessorDeclarationMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/AccessorDeclarationMacro.swift
@@ -1,0 +1,22 @@
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// Describes a macro that adds accessors to a given declaration.
+public protocol AccessorDeclarationMacro: DeclarationMacro {
+  /// Expand a macro that's expressed as a custom attribute attached to
+  /// the given declaration. The result is a set of accessors for the
+  /// declaration.
+  static func expansion(
+    of node: CustomAttributeSyntax,
+    attachedTo declaration: DeclSyntax,
+    in context: inout MacroExpansionContext
+  ) throws -> [AccessorDeclSyntax]
+}

--- a/Sources/_SwiftSyntaxMacros/CMakeLists.txt
+++ b/Sources/_SwiftSyntaxMacros/CMakeLists.txt
@@ -7,6 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_swift_host_library(_SwiftSyntaxMacros
+  AccessorDeclarationMacro.swift
   DeclarationMacro.swift
   ExpressionMacro.swift
   FreestandingDeclarationMacro.swift

--- a/Sources/_SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem.swift
@@ -106,9 +106,7 @@ class MacroApplication: SyntaxRewriter {
           return true
         }
 
-        return !(macro is PeerDeclarationMacro.Type ||
-                 macro is MemberDeclarationMacro.Type ||
-                 macro is AccessorDeclarationMacro.Type)
+        return !(macro is PeerDeclarationMacro.Type || macro is MemberDeclarationMacro.Type || macro is AccessorDeclarationMacro.Type)
       }
 
       if newAttributes.isEmpty {
@@ -265,7 +263,8 @@ class MacroApplication: SyntaxRewriter {
     }
 
     guard let binding = visitedVarDecl.bindings.first,
-          visitedVarDecl.bindings.count == 1 else {
+      visitedVarDecl.bindings.count == 1
+    else {
       return DeclSyntax(node)
     }
 
@@ -292,12 +291,19 @@ class MacroApplication: SyntaxRewriter {
 
     return DeclSyntax(
       visitedVarDecl.withBindings(
-      visitedVarDecl.bindings.replacing(childAt: 0, with: binding.withAccessor(.accessors(
-        .init(
-          leftBrace: .leftBraceToken(leadingTrivia: .space),
-          accessors: .init(accessors),
-          rightBrace: .rightBraceToken(leadingTrivia: .newline))
-      ))))
+        visitedVarDecl.bindings.replacing(
+          childAt: 0,
+          with: binding.withAccessor(
+            .accessors(
+              .init(
+                leftBrace: .leftBraceToken(leadingTrivia: .space),
+                accessors: .init(accessors),
+                rightBrace: .rightBraceToken(leadingTrivia: .newline)
+              )
+            )
+          )
+        )
+      )
     )
   }
 

--- a/Sources/_SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem.swift
@@ -106,7 +106,9 @@ class MacroApplication: SyntaxRewriter {
           return true
         }
 
-        return !(macro is PeerDeclarationMacro.Type || macro is MemberDeclarationMacro.Type)
+        return !(macro is PeerDeclarationMacro.Type ||
+                 macro is MemberDeclarationMacro.Type ||
+                 macro is AccessorDeclarationMacro.Type)
       }
 
       if newAttributes.isEmpty {
@@ -254,6 +256,52 @@ class MacroApplication: SyntaxRewriter {
   override func visit(_ node: ExtensionDeclSyntax) -> DeclSyntax {
     return visit(declGroup: node)
   }
+
+  // Properties
+  override func visit(_ node: VariableDeclSyntax) -> DeclSyntax {
+    let visitedNode = super.visit(node)
+    guard let visitedVarDecl = visitedNode.as(VariableDeclSyntax.self) else {
+      return visitedNode
+    }
+
+    guard let binding = visitedVarDecl.bindings.first,
+          visitedVarDecl.bindings.count == 1 else {
+      return DeclSyntax(node)
+    }
+
+    var accessors: [AccessorDeclSyntax] = []
+
+    let accessorMacroAttributes = getMacroAttributes(attachedTo: DeclSyntax(node), ofType: AccessorDeclarationMacro.Type.self)
+    for (accessorAttr, accessorMacro) in accessorMacroAttributes {
+      do {
+        let newAccessors = try accessorMacro.expansion(
+          of: accessorAttr,
+          attachedTo: DeclSyntax(visitedNode),
+          in: &context
+        )
+
+        accessors.append(contentsOf: newAccessors)
+      } catch {
+        // FIXME: record the error
+      }
+    }
+
+    if accessors.isEmpty {
+      return visitedNode
+    }
+
+    return DeclSyntax(
+      visitedVarDecl.withBindings(
+      visitedVarDecl.bindings.replacing(childAt: 0, with: binding.withAccessor(.accessors(
+        .init(
+          leftBrace: .leftBraceToken(leadingTrivia: .space),
+          accessors: .init(accessors),
+          rightBrace: .rightBraceToken(leadingTrivia: .newline))
+      ))))
+    )
+  }
+
+  // Subscripts
 }
 
 extension MacroApplication {

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -208,7 +208,7 @@ struct DefineBitwidthNumberedStructsMacro: FreestandingDeclarationMacro {
   }
 }
 
-public struct PropertyWrapper { }
+public struct PropertyWrapper {}
 
 extension PropertyWrapper: AccessorDeclarationMacro {
   public static func expansion(
@@ -217,9 +217,10 @@ extension PropertyWrapper: AccessorDeclarationMacro {
     in context: inout MacroExpansionContext
   ) throws -> [AccessorDeclSyntax] {
     guard let varDecl = declaration.as(VariableDeclSyntax.self),
-       let binding = varDecl.bindings.first,
-       let identifier =     binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
-       binding.accessor == nil else {
+      let binding = varDecl.bindings.first,
+      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
+      binding.accessor == nil
+    else {
       return []
     }
 
@@ -235,7 +236,7 @@ extension PropertyWrapper: AccessorDeclarationMacro {
         set {
           _\(identifier).wrappedValue = newValue
         }
-      """
+      """,
     ]
   }
 }
@@ -247,17 +248,19 @@ extension PropertyWrapper: PeerDeclarationMacro {
     in context: inout MacroExpansionContext
   ) throws -> [SwiftSyntax.DeclSyntax] {
     guard let varDecl = declaration.as(VariableDeclSyntax.self),
-       let binding = varDecl.bindings.first,
-       let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
-       let type = binding.typeAnnotation?.type,
-       binding.accessor == nil else {
+      let binding = varDecl.bindings.first,
+      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
+      let type = binding.typeAnnotation?.type,
+      binding.accessor == nil
+    else {
       return []
     }
 
     guard let wrapperTypeNameExpr = node.argumentList?.first?.expression,
-       let stringLiteral = wrapperTypeNameExpr.as(StringLiteralExprSyntax.self),
-       stringLiteral.segments.count == 1,
-       case let .stringSegment(wrapperTypeNameSegment)? = stringLiteral.segments.first else {
+      let stringLiteral = wrapperTypeNameExpr.as(StringLiteralExprSyntax.self),
+      stringLiteral.segments.count == 1,
+      case let .stringSegment(wrapperTypeNameSegment)? = stringLiteral.segments.first
+    else {
       return []
     }
 
@@ -461,7 +464,7 @@ public let testMacros: [String: Macro.Type] = [
   "stringify": StringifyMacro.self,
   "myError": ErrorMacro.self,
   "bitwidthNumberedStructs": DefineBitwidthNumberedStructsMacro.self,
-  "wrapProperty" : PropertyWrapper.self,
+  "wrapProperty": PropertyWrapper.self,
   "addCompletionHandler": AddCompletionHandler.self,
   "addBackingStorage": AddBackingStorage.self,
 ]
@@ -600,7 +603,8 @@ final class MacroSystemTests: XCTestCase {
         }
       }
       private var _x: MyWrapperType<Int>
-      """)
+      """
+    )
   }
 
   func testAddCompletionHandler() {


### PR DESCRIPTION
This allows something like this:

    @wrapProperty("MyWrapperType")
    var x: Int

to turn into

    var x: Int {
      get {
        _x.wrappedValue
      }
      set {
        _x.wrappedValue = newValue
      }
    }