### PR TITLE
Fix order of of entries in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,13 +7,13 @@
 # Each line is a file pattern followed by one or more owners.
 # Order is important. The last matching pattern has the most precedence.
 
-# Macros
-Sources/_SwiftSyntaxMacros @DougGregor
-Tests/SwiftSyntaxMacrosTest @DougGregor
-
-# SwiftOperators
-Sources/SwiftOperators @DougGregor
-Tests/SwiftOperatorsTest @DougGregor
-
 # Owner of anything in SwiftSyntax not owned by anyone else.
 * @ahoppen
+
+# Macros
+/Sources/_SwiftSyntaxMacros @DougGregor
+/Tests/SwiftSyntaxMacrosTest @DougGregor
+
+# SwiftOperators
+/Sources/SwiftOperators @DougGregor
+/Tests/SwiftOperatorsTest @DougGregor


### PR DESCRIPTION
The last item has *most* precedence not *least*. Entries should be ordered the other way.