### PR TITLE
Remap identifiers to keywords in `consume(ifAny:)`

### DIFF
--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -181,8 +181,17 @@ extension TokenConsumer {
     ifAny kinds: [RawTokenKind],
     allowTokenAtStartOfLine: Bool = true
   ) -> Token? {
-    if self.at(any: kinds, allowTokenAtStartOfLine: allowTokenAtStartOfLine) {
-      return self.consumeAnyToken()
+    if !allowTokenAtStartOfLine && self.currentToken.isAtStartOfLine {
+      return nil
+    }
+    for kind in kinds {
+      if case RawTokenKindMatch(kind) = self.currentToken {
+        if case .keyword = kind {
+          return self.consumeAnyToken(remapping: kind)
+        } else {
+          return self.consumeAnyToken()
+        }
+      }
     }
     return nil
   }


### PR DESCRIPTION
I don’t have an example that exercises this at the moment but if we are expecting a contextual keyword, we should be remapping it to a keyword in `consume(ifAny:)`

Also fix `debugInitCall` producing invalid code for keyword tokens that now have an associated value.