### PR TITLE
Refactor the lexer to make it easier to understand, maintain and more swifty

### DIFF
--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -13,7 +13,6 @@ add_swift_host_library(SwiftParser
   Declarations.swift
   Directives.swift
   Expressions.swift
-  Lexer.swift
   Lookahead.swift
   LoopProgressCondition.swift
   Modifiers.swift
@@ -34,7 +33,14 @@ add_swift_host_library(SwiftParser
 
   generated/DeclarationModifier.swift
   generated/Parser+Entry.swift
-  generated/TypeAttribute.swift)
+  generated/TypeAttribute.swift
+
+  Lexer/Cursor.swift
+  Lexer/Lexeme.swift
+  Lexer/LexemeSequence.swift
+  Lexer/Lexer.swift
+  Lexer/UnicodeScalarExtensions.swift
+)
 
 target_link_libraries(SwiftParser PUBLIC
   SwiftSyntax

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1253,7 +1253,7 @@ extension Parser {
       (buffer: UnsafeBufferPointer<UInt8>) -> Bool in
       var cursor = Lexer.Cursor(input: buffer, previous: 0, state: .normal)
       guard buffer[0] == UInt8(ascii: "/") else { return false }
-      switch cursor.lexOperatorIdentifier(tokenStart: cursor, sourceBufferStart: cursor).tokenKind {
+      switch cursor.lexOperatorIdentifier(sourceBufferStart: cursor).tokenKind {
       case .unknown:
         return false
 

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1253,7 +1253,7 @@ extension Parser {
       (buffer: UnsafeBufferPointer<UInt8>) -> Bool in
       var cursor = Lexer.Cursor(input: buffer, previous: 0, state: .normal)
       guard buffer[0] == UInt8(ascii: "/") else { return false }
-      switch cursor.lexOperatorIdentifier(cursor, cursor).tokenKind {
+      switch cursor.lexOperatorIdentifier(tokenStart: cursor, contentStart: cursor).tokenKind {
       case .unknown:
         return false
 

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1253,7 +1253,7 @@ extension Parser {
       (buffer: UnsafeBufferPointer<UInt8>) -> Bool in
       var cursor = Lexer.Cursor(input: buffer, previous: 0, state: .normal)
       guard buffer[0] == UInt8(ascii: "/") else { return false }
-      switch cursor.lexOperatorIdentifier(tokenStart: cursor, contentStart: cursor).tokenKind {
+      switch cursor.lexOperatorIdentifier(tokenStart: cursor, sourceBufferStart: cursor).tokenKind {
       case .unknown:
         return false
 

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -790,7 +790,8 @@ extension Lexer.Cursor {
         return result
       }
 
-      let unknownClassification = self.lexUnknown(tokenStart: start)
+      let unknownClassification = start.lexUnknown()
+      self = start
       assert(unknownClassification == .lexemeContents, "Invalid UTF-8 sequence should be eaten by lexTrivia as LeadingTrivia")
       return Lexer.Result(.unknown)
     }
@@ -919,7 +920,9 @@ extension Lexer.Cursor {
           break
         }
 
-        if self.lexUnknown(tokenStart: start) == .trivia {
+        // `lexUnknown` expects that the first character has not been consumed yet.
+        self = start
+        if self.lexUnknown() == .trivia {
           continue
         } else {
           break
@@ -2010,9 +2013,9 @@ extension Lexer.Cursor {
   /// Assuming the cursor is positioned at neighter a valid identifier nor a
   /// valid operator start, advance the cursor by what can be considered a
   /// lexeme.
-  mutating func lexUnknown(tokenStart: Lexer.Cursor) -> UnknownCharactersClassification {
-    assert(tokenStart.peekScalar()?.isValidIdentifierStartCodePoint == false && tokenStart.peekScalar()?.isOperatorStartCodePoint == false)
-    var tmp = tokenStart
+  mutating func lexUnknown() -> UnknownCharactersClassification {
+    assert(self.peekScalar()?.isValidIdentifierStartCodePoint == false && self.peekScalar()?.isOperatorStartCodePoint == false)
+    var tmp = self
     if tmp.advance(if: { Unicode.Scalar($0).isValidIdentifierContinuationCodePoint }) {
       // If this is a valid identifier continuation, but not a valid identifier
       // start, attempt to recover by eating more continuation characters.

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -1188,16 +1188,13 @@ extension Lexer.Cursor {
 
 extension Lexer.Cursor {
   mutating func lexMagicPoundLiteral() -> Lexer.Result {
-    let start = self
-    var clone = self
+    var tmp = self
     // Scan for [a-zA-Z]+ to see what we match.
-    if let peeked = clone.peek(), Unicode.Scalar(peeked).isAsciiIdentifierStart {
-      repeat {
-        _ = clone.advance()
-      } while clone.peek().map { Unicode.Scalar($0) }?.isAsciiIdentifierContinue == true
+    while let peeked = tmp.peek(), Unicode.Scalar(peeked).isAsciiIdentifierStart {
+      _ = tmp.advance()
     }
 
-    let literal = start.text(upTo: clone)
+    let literal = self.text(upTo: tmp)
 
     let kind: RawTokenKind
     switch literal {
@@ -1220,7 +1217,7 @@ extension Lexer.Cursor {
     }
 
     // If we found something specific, return it.
-    self = clone
+    self = tmp
     return Lexer.Result(kind)
   }
 }

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -32,7 +32,7 @@ extension SyntaxText {
   }
 }
 
-public enum StringLiteralKind {
+enum StringLiteralKind: Equatable {
   /// A normal single-line string literal started by `"`.
   case singleLine
   /// A multi-line string literal started by `"""`.
@@ -41,7 +41,7 @@ public enum StringLiteralKind {
   case singleQuote
 }
 
-public enum LexerCursorState {
+enum LexerCursorState: Equatable {
   /// Normal top-level lexing mode
   case normal
 
@@ -85,20 +85,19 @@ extension Lexer {
   /// cursor and updated when the cursor advances. A cursor is a safe interface
   /// to reading bytes from an input buffer: all accesses to its input are
   /// bounds-checked.
-  public struct Cursor: Equatable {
+  struct Cursor: Equatable {
     var input: UnsafeBufferPointer<UInt8>
     var previous: UInt8
     var state: LexerCursorState
 
-    @_spi(LexerDiagnostics)
-    public init(input: UnsafeBufferPointer<UInt8>, previous: UInt8, state: LexerCursorState) {
+    init(input: UnsafeBufferPointer<UInt8>, previous: UInt8, state: LexerCursorState) {
       self.input = input
       self.previous = previous
       self.state = state
     }
 
     public static func == (lhs: Cursor, rhs: Cursor) -> Bool {
-      return lhs.input.baseAddress == rhs.input.baseAddress
+      return lhs.input.baseAddress == rhs.input.baseAddress && lhs.previous == rhs.previous && lhs.state == rhs.state
     }
 
     public func starts<PossiblePrefix>(with possiblePrefix: PossiblePrefix) -> Bool
@@ -792,8 +791,7 @@ extension Lexer {
 }
 
 extension Lexer.Cursor {
-  @_spi(LexerDiagnostics)
-  public mutating func nextToken(_ ContentStart: Lexer.Cursor) -> Lexer.Lexeme {
+  mutating func nextToken(_ ContentStart: Lexer.Cursor) -> Lexer.Lexeme {
     // Leading trivia.
     let leadingTriviaStart = self
     let newlineInLeadingTrivia: NewlinePresence

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -764,13 +764,13 @@ extension Lexer.Cursor {
       case nil:
         break
       case UInt8(ascii: "\n"):
-        if case .trailing = position {
+        if position == .trailing {
           break
         }
         hasNewline = true
         continue
       case UInt8(ascii: "\r"):
-        if case .trailing = position {
+        if position == .trailing {
           break
         }
         hasNewline = true
@@ -860,11 +860,10 @@ extension Lexer.Cursor {
 
         fallthrough
       default:
-        var tmp = start
-        if tmp.advance(if: { Unicode.Scalar($0).isValidIdentifierStartCodePoint }) {
+        if let peekedScalar = start.peekScalar(), peekedScalar.isValidIdentifierStartCodePoint {
           break
         }
-        if tmp.advance(if: { Unicode.Scalar($0).isOperatorStartCodePoint }) {
+        if let peekedScalar = start.peekScalar(), peekedScalar.isOperatorStartCodePoint {
           break
         }
 

--- a/Sources/SwiftParser/Lexer/Lexeme.swift
+++ b/Sources/SwiftParser/Lexer/Lexeme.swift
@@ -1,0 +1,116 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RawSyntax) import SwiftSyntax
+
+extension Lexer {
+  /// A trivia-delimited region of source text.
+  ///
+  /// A lexeme is the fundamental output unit of lexical analysis. Each lexeme
+  /// represents a fully identified, meaningful part of the input text that
+  /// will can be consumed by a ``Parser``.
+  public struct Lexeme: CustomDebugStringConvertible {
+    public struct Flags: OptionSet, CustomDebugStringConvertible {
+      public var rawValue: UInt8
+
+      public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+      }
+
+      public static let isAtStartOfLine = Flags(rawValue: 1 << 0)
+
+      public var debugDescription: String {
+        var descriptionComponents: [String] = []
+        if self.contains(.isAtStartOfLine) {
+          descriptionComponents.append("isAtStartOfLine")
+        }
+        return "[\(descriptionComponents.joined(separator: ", "))]"
+      }
+    }
+
+    @_spi(RawSyntax)
+    public var rawTokenKind: RawTokenKind
+    public var flags: Lexeme.Flags
+    public var error: LexerError?
+    var start: UnsafePointer<UInt8>
+    public var leadingTriviaByteLength: Int
+    public var textByteLength: Int
+    public var trailingTriviaByteLength: Int
+
+    var isAtStartOfLine: Bool {
+      return self.flags.contains(.isAtStartOfLine)
+    }
+
+    var isEditorPlaceholder: Bool {
+      return self.rawTokenKind == .identifier && self.tokenText.isEditorPlaceholder
+    }
+
+    @_spi(RawSyntax)
+    public init(
+      tokenKind: RawTokenKind,
+      flags: Flags,
+      error: LexerError?,
+      start: UnsafePointer<UInt8>,
+      leadingTriviaLength: Int,
+      textLength: Int,
+      trailingTriviaLength: Int
+    ) {
+      self.rawTokenKind = tokenKind
+      self.flags = flags
+      self.error = error
+      self.start = start
+      self.leadingTriviaByteLength = leadingTriviaLength
+      self.textByteLength = textLength
+      self.trailingTriviaByteLength = trailingTriviaLength
+    }
+
+    public var byteLength: Int {
+      leadingTriviaByteLength + textByteLength + trailingTriviaByteLength
+    }
+
+    @_spi(RawSyntax)
+    public var wholeText: SyntaxText {
+      SyntaxText(baseAddress: start, count: byteLength)
+    }
+
+    @_spi(RawSyntax)
+    public var textRange: Range<SyntaxText.Index> {
+      leadingTriviaByteLength..<leadingTriviaByteLength + textByteLength
+    }
+
+    @_spi(RawSyntax)
+    public var tokenText: SyntaxText {
+      SyntaxText(
+        baseAddress: start.advanced(by: leadingTriviaByteLength),
+        count: textByteLength
+      )
+    }
+    @_spi(RawSyntax)
+    public var leadingTriviaText: SyntaxText {
+      SyntaxText(
+        baseAddress: start,
+        count: leadingTriviaByteLength
+      )
+    }
+    @_spi(RawSyntax)
+    public var trailingTriviaText: SyntaxText {
+      SyntaxText(
+        baseAddress: start.advanced(by: leadingTriviaByteLength + textByteLength),
+        count: trailingTriviaByteLength
+      )
+    }
+
+    public var debugDescription: String {
+      return String(syntaxText: SyntaxText(baseAddress: start, count: byteLength))
+    }
+  }
+}

--- a/Sources/SwiftParser/Lexer/LexemeSequence.swift
+++ b/Sources/SwiftParser/Lexer/LexemeSequence.swift
@@ -16,14 +16,14 @@ extension Lexer {
   /// A sequence of ``Lexer/Lexeme`` tokens starting from a ``Lexer/Cursor``
   /// that points into an input buffer.
   public struct LexemeSequence: IteratorProtocol, Sequence, CustomDebugStringConvertible {
-    fileprivate let start: Lexer.Cursor
+    fileprivate let sourceBufferStart: Lexer.Cursor
     fileprivate var cursor: Lexer.Cursor
     fileprivate var nextToken: Lexer.Lexeme
 
-    fileprivate init(start: Lexer.Cursor, cursor: Lexer.Cursor) {
-      self.start = start
+    fileprivate init(sourceBufferStart: Lexer.Cursor, cursor: Lexer.Cursor) {
+      self.sourceBufferStart = sourceBufferStart
       self.cursor = cursor
-      self.nextToken = self.cursor.nextToken(contentStart: self.start)
+      self.nextToken = self.cursor.nextToken(sourceBufferStart: self.sourceBufferStart)
     }
 
     public mutating func next() -> Lexer.Lexeme? {
@@ -43,7 +43,7 @@ extension Lexer {
             trailingTriviaLength: 0
           )
         } else {
-          self.nextToken = self.cursor.nextToken(contentStart: self.start)
+          self.nextToken = self.cursor.nextToken(sourceBufferStart: self.sourceBufferStart)
         }
       }
       return self.nextToken
@@ -61,7 +61,7 @@ extension Lexer {
       // again in the lexer.
       let backUpLength = self.nextToken.byteLength + bytes
       self.cursor.backUp(by: backUpLength)
-      self.nextToken = self.cursor.nextToken(contentStart: self.start)
+      self.nextToken = self.cursor.nextToken(sourceBufferStart: self.sourceBufferStart)
       return self.advance()
     }
 
@@ -88,6 +88,6 @@ extension Lexer {
     let startChar = startIndex == input.startIndex ? UInt8(ascii: "\0") : input[startIndex - 1]
     let start = Cursor(input: input, previous: UInt8(ascii: "\0"), state: .normal)
     let cursor = Cursor(input: UnsafeBufferPointer(rebasing: input[startIndex...]), previous: startChar, state: .normal)
-    return LexemeSequence(start: start, cursor: cursor)
+    return LexemeSequence(sourceBufferStart: start, cursor: cursor)
   }
 }

--- a/Sources/SwiftParser/Lexer/LexemeSequence.swift
+++ b/Sources/SwiftParser/Lexer/LexemeSequence.swift
@@ -23,7 +23,7 @@ extension Lexer {
     fileprivate init(start: Lexer.Cursor, cursor: Lexer.Cursor) {
       self.start = start
       self.cursor = cursor
-      self.nextToken = self.cursor.nextToken(self.start)
+      self.nextToken = self.cursor.nextToken(contentStart: self.start)
     }
 
     public mutating func next() -> Lexer.Lexeme? {
@@ -43,7 +43,7 @@ extension Lexer {
             trailingTriviaLength: 0
           )
         } else {
-          self.nextToken = self.cursor.nextToken(self.start)
+          self.nextToken = self.cursor.nextToken(contentStart: self.start)
         }
       }
       return self.nextToken
@@ -61,7 +61,7 @@ extension Lexer {
       // again in the lexer.
       let backUpLength = self.nextToken.byteLength + bytes
       self.cursor.backUp(by: backUpLength)
-      self.nextToken = self.cursor.nextToken(self.start)
+      self.nextToken = self.cursor.nextToken(contentStart: self.start)
       return self.advance()
     }
 

--- a/Sources/SwiftParser/Lexer/LexemeSequence.swift
+++ b/Sources/SwiftParser/Lexer/LexemeSequence.swift
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RawSyntax) import SwiftSyntax
+
+extension Lexer {
+  /// A sequence of ``Lexer/Lexeme`` tokens starting from a ``Lexer/Cursor``
+  /// that points into an input buffer.
+  public struct LexemeSequence: IteratorProtocol, Sequence, CustomDebugStringConvertible {
+    fileprivate let start: Lexer.Cursor
+    fileprivate var cursor: Lexer.Cursor
+    fileprivate var nextToken: Lexer.Lexeme
+
+    fileprivate init(start: Lexer.Cursor, cursor: Lexer.Cursor) {
+      self.start = start
+      self.cursor = cursor
+      self.nextToken = self.cursor.nextToken(self.start)
+    }
+
+    public mutating func next() -> Lexer.Lexeme? {
+      return self.advance()
+    }
+
+    mutating func advance() -> Lexer.Lexeme {
+      defer {
+        if self.cursor.isAtEndOfFile {
+          self.nextToken = Lexeme(
+            tokenKind: .eof,
+            flags: [],
+            error: nil,
+            start: self.cursor.pointer,
+            leadingTriviaLength: 0,
+            textLength: 0,
+            trailingTriviaLength: 0
+          )
+        } else {
+          self.nextToken = self.cursor.nextToken(self.start)
+        }
+      }
+      return self.nextToken
+    }
+
+    /// - Warning: Do not add more usages of this function.
+    mutating func resetForSplit(of bytes: Int) -> Lexer.Lexeme {
+      guard bytes > 0 else {
+        return self.advance()
+      }
+
+      // FIXME: This is kind of ridiculous. We shouldn't have to look backwards
+      // in the token stream. We should be fusing together runs of operator and
+      // identifier characters in the parser, not splitting and backing up
+      // again in the lexer.
+      let backUpLength = self.nextToken.byteLength + bytes
+      self.cursor.backUp(by: backUpLength)
+      self.nextToken = self.cursor.nextToken(self.start)
+      return self.advance()
+    }
+
+    func peek() -> Lexer.Lexeme {
+      return self.nextToken
+    }
+
+    public var debugDescription: String {
+      let remainingText = self.nextToken.debugDescription + String(syntaxText: SyntaxText(baseAddress: self.cursor.input.baseAddress, count: self.cursor.input.count))
+      if remainingText.count > 100 {
+        return remainingText.prefix(100) + "..."
+      } else {
+        return remainingText
+      }
+    }
+  }
+
+  @_spi(RawSyntax)
+  public static func tokenize(
+    _ input: UnsafeBufferPointer<UInt8>,
+    from startIndex: Int = 0
+  ) -> LexemeSequence {
+    assert(input.isEmpty || startIndex < input.endIndex)
+    let startChar = startIndex == input.startIndex ? UInt8(ascii: "\0") : input[startIndex - 1]
+    let start = Cursor(input: input, previous: UInt8(ascii: "\0"), state: .normal)
+    let cursor = Cursor(input: UnsafeBufferPointer(rebasing: input[startIndex...]), previous: startChar, state: .normal)
+    return LexemeSequence(start: start, cursor: cursor)
+  }
+}

--- a/Sources/SwiftParser/Lexer/Lexer.swift
+++ b/Sources/SwiftParser/Lexer/Lexer.swift
@@ -17,9 +17,9 @@
 /// - Seealso: ``Lexer/Lexeme``
 /// - Seealso: ``Lexer/Cursor``
 public enum Lexer {
-  public static func lexToEndOfInterpolatedExpression(_ input: UnsafeBufferPointer<UInt8>, _ IsMultilineString: Bool) -> Int {
+  public static func lexToEndOfInterpolatedExpression(_ input: UnsafeBufferPointer<UInt8>, _ isMultilineString: Bool) -> Int {
     let cursor = Lexer.Cursor(input: input, previous: 0, state: .normal)
-    let advancedCursor = Lexer.Cursor.skipToEndOfInterpolatedExpression(cursor, IsMultilineString)
+    let advancedCursor = Lexer.Cursor.skipToEndOfInterpolatedExpression(cursor, isMultilineString)
     return advancedCursor.input.baseAddress! - cursor.input.baseAddress!
   }
 }

--- a/Sources/SwiftParser/Lexer/Lexer.swift
+++ b/Sources/SwiftParser/Lexer/Lexer.swift
@@ -19,7 +19,7 @@
 public enum Lexer {
   public static func lexToEndOfInterpolatedExpression(_ input: UnsafeBufferPointer<UInt8>, _ isMultilineString: Bool) -> Int {
     let cursor = Lexer.Cursor(input: input, previous: 0, state: .normal)
-    let advancedCursor = Lexer.Cursor.skipToEndOfInterpolatedExpression(cursor, isMultilineString)
+    let advancedCursor = Lexer.Cursor.skipToEndOfInterpolatedExpression(cursor, isMultilineString: isMultilineString)
     return advancedCursor.input.baseAddress! - cursor.input.baseAddress!
   }
 }

--- a/Sources/SwiftParser/Lexer/Lexer.swift
+++ b/Sources/SwiftParser/Lexer/Lexer.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RawSyntax) import SwiftSyntax
+
+/// A lexical analyzer for the Swift programming language.
+///
+/// - Seealso: ``Lexer/Lexeme``
+/// - Seealso: ``Lexer/Cursor``
+public enum Lexer {
+  public static func lexToEndOfInterpolatedExpression(_ input: UnsafeBufferPointer<UInt8>, _ IsMultilineString: Bool) -> Int {
+    let cursor = Lexer.Cursor(input: input, previous: 0, state: .normal)
+    let advancedCursor = Lexer.Cursor.skipToEndOfInterpolatedExpression(cursor, IsMultilineString)
+    return advancedCursor.input.baseAddress! - cursor.input.baseAddress!
+  }
+}

--- a/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
+++ b/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
@@ -1,0 +1,153 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension Unicode.Scalar {
+  var isValidIdentifierContinuationCodePoint: Bool {
+    if self.isASCII {
+      return self.isAsciiIdentifierContinue
+    }
+
+    // N1518: Recommendations for extended identifier characters for C and C++
+    // Proposed Annex X.1: Ranges of characters allowed
+    let c = self.value
+    return c == 0x00A8 || c == 0x00AA || c == 0x00AD || c == 0x00AF
+      || (c >= 0x00B2 && c <= 0x00B5) || (c >= 0x00B7 && c <= 0x00BA)
+      || (c >= 0x00BC && c <= 0x00BE) || (c >= 0x00C0 && c <= 0x00D6)
+      || (c >= 0x00D8 && c <= 0x00F6) || (c >= 0x00F8 && c <= 0x00FF)
+
+      || (c >= 0x0100 && c <= 0x167F)
+      || (c >= 0x1681 && c <= 0x180D)
+      || (c >= 0x180F && c <= 0x1FFF)
+
+      || (c >= 0x200B && c <= 0x200D)
+      || (c >= 0x202A && c <= 0x202E)
+      || (c >= 0x203F && c <= 0x2040)
+      || c == 0x2054
+      || (c >= 0x2060 && c <= 0x206F)
+
+      || (c >= 0x2070 && c <= 0x218F)
+      || (c >= 0x2460 && c <= 0x24FF)
+      || (c >= 0x2776 && c <= 0x2793)
+      || (c >= 0x2C00 && c <= 0x2DFF)
+      || (c >= 0x2E80 && c <= 0x2FFF)
+
+      || (c >= 0x3004 && c <= 0x3007)
+      || (c >= 0x3021 && c <= 0x302F)
+      || (c >= 0x3031 && c <= 0x303F)
+
+      || (c >= 0x3040 && c <= 0xD7FF)
+
+      || (c >= 0xF900 && c <= 0xFD3D)
+      || (c >= 0xFD40 && c <= 0xFDCF)
+      || (c >= 0xFDF0 && c <= 0xFE44)
+      || (c >= 0xFE47 && c <= 0xFFF8)
+
+      || (c >= 0x10000 && c <= 0x1FFFD)
+      || (c >= 0x20000 && c <= 0x2FFFD)
+      || (c >= 0x30000 && c <= 0x3FFFD)
+      || (c >= 0x40000 && c <= 0x4FFFD)
+      || (c >= 0x50000 && c <= 0x5FFFD)
+      || (c >= 0x60000 && c <= 0x6FFFD)
+      || (c >= 0x70000 && c <= 0x7FFFD)
+      || (c >= 0x80000 && c <= 0x8FFFD)
+      || (c >= 0x90000 && c <= 0x9FFFD)
+      || (c >= 0xA0000 && c <= 0xAFFFD)
+      || (c >= 0xB0000 && c <= 0xBFFFD)
+      || (c >= 0xC0000 && c <= 0xCFFFD)
+      || (c >= 0xD0000 && c <= 0xDFFFD)
+      || (c >= 0xE0000 && c <= 0xEFFFD)
+  }
+
+  var isValidIdentifierStartCodePoint: Bool {
+    if (self.isASCII) {
+      return self.isAsciiIdentifierStart
+    }
+    guard self.isValidIdentifierContinuationCodePoint else {
+      return false
+    }
+
+    // N1518: Recommendations for extended identifier characters for C and C++
+    // Proposed Annex X.2: Ranges of characters disallowed initially
+    let c = self.value
+    if ((c >= 0x0300 && c <= 0x036F) || (c >= 0x1DC0 && c <= 0x1DFF) || (c >= 0x20D0 && c <= 0x20FF) || (c >= 0xFE20 && c <= 0xFE2F)) {
+      return false
+    }
+
+    return true
+  }
+
+  /// isOperatorStartCodePoint - Return true if the specified code point is a
+  /// valid start of an operator.
+  var isOperatorStartCodePoint: Bool {
+    // ASCII operator chars.
+    if self.value < 0x80 {
+      switch UInt8(self.value) {
+      case UInt8(ascii: "/"),
+        UInt8(ascii: "="),
+        UInt8(ascii: "-"),
+        UInt8(ascii: "+"),
+        UInt8(ascii: "*"),
+        UInt8(ascii: "%"),
+        UInt8(ascii: "<"),
+        UInt8(ascii: ">"),
+        UInt8(ascii: "!"),
+        UInt8(ascii: "&"),
+        UInt8(ascii: "|"),
+        UInt8(ascii: "^"),
+        UInt8(ascii: "~"),
+        UInt8(ascii: "."),
+        UInt8(ascii: "?"):
+        return true
+      default:
+        return false
+      }
+    }
+
+    // Unicode math, symbol, arrow, dingbat, and line/box drawing chars.
+    let C = self.value
+    return (C >= 0x00A1 && C <= 0x00A7)
+      || C == 0x00A9 || C == 0x00AB || C == 0x00AC || C == 0x00AE
+      || C == 0x00B0 || C == 0x00B1 || C == 0x00B6 || C == 0x00BB
+      || C == 0x00BF || C == 0x00D7 || C == 0x00F7
+      || C == 0x2016 || C == 0x2017 || (C >= 0x2020 && C <= 0x2027)
+      || (C >= 0x2030 && C <= 0x203E) || (C >= 0x2041 && C <= 0x2053)
+      || (C >= 0x2055 && C <= 0x205E) || (C >= 0x2190 && C <= 0x23FF)
+      || (C >= 0x2500 && C <= 0x2775) || (C >= 0x2794 && C <= 0x2BFF)
+      || (C >= 0x2E00 && C <= 0x2E7F) || (C >= 0x3001 && C <= 0x3003)
+      || (C >= 0x3008 && C <= 0x3030)
+  }
+
+  /// isOperatorContinuationCodePoint - Return true if the specified code point
+  /// is a valid operator code point.
+  var isOperatorContinuationCodePoint: Bool {
+    if self.isOperatorStartCodePoint {
+      return true
+    }
+
+    // Unicode combining characters and variation selectors.
+    let C = self.value
+    return (C >= 0x0300 && C <= 0x036F)
+      || (C >= 0x1DC0 && C <= 0x1DFF)
+      || (C >= 0x20D0 && C <= 0x20FF)
+      || (C >= 0xFE00 && C <= 0xFE0F)
+      || (C >= 0xFE20 && C <= 0xFE2F)
+      || (C >= 0xE0100 && C <= 0xE01EF)
+  }
+
+  /// Whether this character represents a printable ASCII character,
+  /// for the purposes of pattern parsing.
+  public var isPrintableASCII: Bool {
+    // Exclude non-printables before the space character U+20, and anything
+    // including and above the DEL character U+7F.
+    return self.value >= 0x20 && self.value < 0x7F
+  }
+}

--- a/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
+++ b/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
@@ -150,4 +150,10 @@ extension Unicode.Scalar {
     // including and above the DEL character U+7F.
     return self.value >= 0x20 && self.value < 0x7F
   }
+
+  var isStartOfUTF8Character: Bool {
+    // RFC 2279: The octet values FE and FF never appear.
+    // RFC 3629: The octet values C0, C1, F5 to FF never appear.
+    return self.value <= 0x80 || (self.value >= 0xC2 && self.value < 0xF5)
+  }
 }

--- a/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
+++ b/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
@@ -113,17 +113,17 @@ extension Unicode.Scalar {
     }
 
     // Unicode math, symbol, arrow, dingbat, and line/box drawing chars.
-    let C = self.value
-    return (C >= 0x00A1 && C <= 0x00A7)
-      || C == 0x00A9 || C == 0x00AB || C == 0x00AC || C == 0x00AE
-      || C == 0x00B0 || C == 0x00B1 || C == 0x00B6 || C == 0x00BB
-      || C == 0x00BF || C == 0x00D7 || C == 0x00F7
-      || C == 0x2016 || C == 0x2017 || (C >= 0x2020 && C <= 0x2027)
-      || (C >= 0x2030 && C <= 0x203E) || (C >= 0x2041 && C <= 0x2053)
-      || (C >= 0x2055 && C <= 0x205E) || (C >= 0x2190 && C <= 0x23FF)
-      || (C >= 0x2500 && C <= 0x2775) || (C >= 0x2794 && C <= 0x2BFF)
-      || (C >= 0x2E00 && C <= 0x2E7F) || (C >= 0x3001 && C <= 0x3003)
-      || (C >= 0x3008 && C <= 0x3030)
+    let c = self.value
+    return (c >= 0x00A1 && c <= 0x00A7)
+      || c == 0x00A9 || c == 0x00AB || c == 0x00AC || c == 0x00AE
+      || c == 0x00B0 || c == 0x00B1 || c == 0x00B6 || c == 0x00BB
+      || c == 0x00BF || c == 0x00D7 || c == 0x00F7
+      || c == 0x2016 || c == 0x2017 || (c >= 0x2020 && c <= 0x2027)
+      || (c >= 0x2030 && c <= 0x203E) || (c >= 0x2041 && c <= 0x2053)
+      || (c >= 0x2055 && c <= 0x205E) || (c >= 0x2190 && c <= 0x23FF)
+      || (c >= 0x2500 && c <= 0x2775) || (c >= 0x2794 && c <= 0x2BFF)
+      || (c >= 0x2E00 && c <= 0x2E7F) || (c >= 0x3001 && c <= 0x3003)
+      || (c >= 0x3008 && c <= 0x3030)
   }
 
   /// isOperatorContinuationCodePoint - Return true if the specified code point
@@ -134,13 +134,13 @@ extension Unicode.Scalar {
     }
 
     // Unicode combining characters and variation selectors.
-    let C = self.value
-    return (C >= 0x0300 && C <= 0x036F)
-      || (C >= 0x1DC0 && C <= 0x1DFF)
-      || (C >= 0x20D0 && C <= 0x20FF)
-      || (C >= 0xFE00 && C <= 0xFE0F)
-      || (C >= 0xFE20 && C <= 0xFE2F)
-      || (C >= 0xE0100 && C <= 0xE01EF)
+    let c = self.value
+    return (c >= 0x0300 && c <= 0x036F)
+      || (c >= 0x1DC0 && c <= 0x1DFF)
+      || (c >= 0x20D0 && c <= 0x20FF)
+      || (c >= 0xFE00 && c <= 0xFE0F)
+      || (c >= 0xFE20 && c <= 0xFE2F)
+      || (c >= 0xE0100 && c <= 0xE01EF)
   }
 
   /// Whether this character represents a printable ASCII character,

--- a/Sources/SwiftParser/TriviaParser.swift
+++ b/Sources/SwiftParser/TriviaParser.swift
@@ -86,7 +86,7 @@ public struct TriviaParser {
         // file. We don't know if this trivia is at the start of the file, but
         // we believe that the lexer lexed it accordingly.
         if position == .leading && pieces.isEmpty && cursor.advance(if: { $0 == "!" }) {
-          _ = cursor.advanceToEndOfLine()
+          cursor.advanceToEndOfLine()
           pieces.append(.shebang(start.textUpTo(cursor)))
           continue
         }
@@ -173,7 +173,7 @@ extension Lexer.Cursor {
     // "//...": .lineComment.
     assert(self.previous == UInt8(ascii: "/") && self.peek(matches: "/"))
     let isDocComment = self.input.count > 1 && self.peek(at: 1, matches: "/")
-    _ = self.advanceToEndOfLine()
+    self.advanceToEndOfLine()
     let contents = start.textUpTo(self)
     return isDocComment ? .docLineComment(contents) : .lineComment(contents)
   }

--- a/Sources/SwiftParser/TriviaParser.swift
+++ b/Sources/SwiftParser/TriviaParser.swift
@@ -69,17 +69,15 @@ public struct TriviaParser {
         continue
 
       case UInt8(ascii: "/"):
-        if !cursor.isAtEndOfFile {
-          switch cursor.peek() {
-          case UInt8(ascii: "/"):
-            pieces.append(cursor.lexLineComment(start: start))
-            continue
-          case UInt8(ascii: "*"):
-            pieces.append(cursor.lexBlockComment(start: start))
-            continue
-          default:
-            break
-          }
+        switch cursor.peek() {
+        case UInt8(ascii: "/"):
+          pieces.append(cursor.lexLineComment(start: start))
+          continue
+        case UInt8(ascii: "*"):
+          pieces.append(cursor.lexBlockComment(start: start))
+          continue
+        default:
+          break
         }
 
       case UInt8(ascii: "#"):
@@ -173,8 +171,8 @@ extension Lexer.Cursor {
   fileprivate mutating func lexLineComment(start: Lexer.Cursor) -> RawTriviaPiece {
     // "///...": .docLineComment.
     // "//...": .lineComment.
-    assert(self.previous == UInt8(ascii: "/") && self.peek() == UInt8(ascii: "/"))
-    let isDocComment = self.input.count > 1 && self.peek(at: 1) == UInt8(ascii: "/")
+    assert(self.previous == UInt8(ascii: "/") && self.peek(matches: "/"))
+    let isDocComment = self.input.count > 1 && self.peek(at: 1, matches: "/")
     _ = self.advanceToEndOfLine()
     let contents = start.textUpTo(self)
     return isDocComment ? .docLineComment(contents) : .lineComment(contents)
@@ -184,8 +182,8 @@ extension Lexer.Cursor {
     // "/**...*/": .docBlockComment.
     // "/*...*/": .blockComment.
     // "/**/": .blockComment.
-    assert(self.previous == UInt8(ascii: "/") && self.peek() == UInt8(ascii: "*"))
-    let isDocComment = self.input.count > 2 && self.peek(at: 1) == UInt8(ascii: "*") && self.peek(at: 2) != UInt8(ascii: "/")
+    assert(self.previous == UInt8(ascii: "/") && self.peek(matches: "*"))
+    let isDocComment = self.input.count > 2 && self.peek(at: 1, matches: "*") && self.peek(at: 2, doesntMatch: "/")
     _ = self.advanceToEndOfSlashStarComment()
     let contents = start.textUpTo(self)
     return isDocComment ? .docBlockComment(contents) : .blockComment(contents)

--- a/Sources/SwiftParser/TriviaParser.swift
+++ b/Sources/SwiftParser/TriviaParser.swift
@@ -171,8 +171,8 @@ extension Lexer.Cursor {
   fileprivate mutating func lexLineComment(start: Lexer.Cursor) -> RawTriviaPiece {
     // "///...": .docLineComment.
     // "//...": .lineComment.
-    assert(self.previous == UInt8(ascii: "/") && self.peek(matches: "/"))
-    let isDocComment = self.input.count > 1 && self.peek(at: 1, matches: "/")
+    assert(self.previous == UInt8(ascii: "/") && self.is(at: "/"))
+    let isDocComment = self.input.count > 1 && self.is(offset: 1, at: "/")
     self.advanceToEndOfLine()
     let contents = start.text(upTo: self)
     return isDocComment ? .docLineComment(contents) : .lineComment(contents)
@@ -182,8 +182,8 @@ extension Lexer.Cursor {
     // "/**...*/": .docBlockComment.
     // "/*...*/": .blockComment.
     // "/**/": .blockComment.
-    assert(self.previous == UInt8(ascii: "/") && self.peek(matches: "*"))
-    let isDocComment = self.input.count > 2 && self.peek(at: 1, matches: "*") && self.peek(at: 2, doesntMatch: "/")
+    assert(self.previous == UInt8(ascii: "/") && self.is(at: "*"))
+    let isDocComment = self.input.count > 2 && self.is(offset: 1, at: "*") && self.is(offset: 2, notAt: "/")
     _ = self.advanceToEndOfSlashStarComment()
     let contents = start.text(upTo: self)
     return isDocComment ? .docBlockComment(contents) : .blockComment(contents)

--- a/Sources/SwiftParser/TriviaParser.swift
+++ b/Sources/SwiftParser/TriviaParser.swift
@@ -87,14 +87,14 @@ public struct TriviaParser {
         // we believe that the lexer lexed it accordingly.
         if position == .leading && pieces.isEmpty && cursor.advance(if: { $0 == "!" }) {
           cursor.advanceToEndOfLine()
-          pieces.append(.shebang(start.textUpTo(cursor)))
+          pieces.append(.shebang(start.text(upTo: cursor)))
           continue
         }
 
       case UInt8(ascii: "<"), UInt8(ascii: ">"):
         // SCM conflict markers.
         if cursor.tryLexConflictMarker(start: start) {
-          pieces.append(.unexpectedText(start.textUpTo(cursor)))
+          pieces.append(.unexpectedText(start.text(upTo: cursor)))
           continue
         }
 
@@ -127,7 +127,7 @@ public struct TriviaParser {
         )
         pieces[pieces.count - 1] = .unexpectedText(mergedText)
       } else {
-        pieces.append(.unexpectedText(start.textUpTo(cursor)))
+        pieces.append(.unexpectedText(start.text(upTo: cursor)))
       }
     }
 
@@ -174,7 +174,7 @@ extension Lexer.Cursor {
     assert(self.previous == UInt8(ascii: "/") && self.peek(matches: "/"))
     let isDocComment = self.input.count > 1 && self.peek(at: 1, matches: "/")
     self.advanceToEndOfLine()
-    let contents = start.textUpTo(self)
+    let contents = start.text(upTo: self)
     return isDocComment ? .docLineComment(contents) : .lineComment(contents)
   }
 
@@ -185,7 +185,7 @@ extension Lexer.Cursor {
     assert(self.previous == UInt8(ascii: "/") && self.peek(matches: "*"))
     let isDocComment = self.input.count > 2 && self.peek(at: 1, matches: "*") && self.peek(at: 2, doesntMatch: "/")
     _ = self.advanceToEndOfSlashStarComment()
-    let contents = start.textUpTo(self)
+    let contents = start.text(upTo: self)
     return isDocComment ? .docBlockComment(contents) : .blockComment(contents)
   }
 }

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftDiagnostics
-@_spi(LexerDiagnostics) import SwiftParser
+import SwiftParser
 @_spi(RawSyntax) import SwiftSyntax
 
 fileprivate extension TokenSyntax {

--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -37,6 +37,10 @@
 public struct SyntaxText {
   var buffer: UnsafeBufferPointer<UInt8>
 
+  public init(buffer: UnsafeBufferPointer<UInt8>) {
+    self.buffer = buffer
+  }
+
   public init(baseAddress: UnsafePointer<UInt8>?, count: Int) {
     assert(
       count == 0 || baseAddress != nil,

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -630,6 +630,13 @@ public class LexerTests: XCTestCase {
         LexemeSpec(.identifier, text: "<#b2#>"),
       ]
     )
+
+    AssertLexemes(
+      "<##>",
+      lexemes: [
+        LexemeSpec(.identifier, text: "<##>", trailing: "")
+      ]
+    )
   }
 
   func testCommentAttribution() {

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -746,4 +746,78 @@ public class LexerTests: XCTestCase {
       ]
     )
   }
+
+  func testBOMAtStartOfFile() throws {
+    let sourceBytes: [UInt8] = [0xef, 0xbb, 0xbf]
+    let lexemes = sourceBytes.withUnsafeBufferPointer { buf in
+      var lexemes = [Lexer.Lexeme]()
+      for token in Lexer.tokenize(buf, from: 0) {
+        lexemes.append(token)
+
+        if token.rawTokenKind == .eof {
+          break
+        }
+      }
+      return lexemes
+    }
+
+    XCTAssertEqual(lexemes.count, 1)
+    let lexeme = try XCTUnwrap(lexemes.first)
+    XCTAssertEqual(lexeme.rawTokenKind, .eof)
+
+    let bomBytes: [UInt8] = [0xef, 0xbb, 0xbf]
+    bomBytes.withUnsafeBufferPointer { bomBytes in
+      XCTAssertEqual(lexeme.leadingTriviaText, SyntaxText(buffer: bomBytes))
+    }
+  }
+
+  func testBOMInTheMiddleOfIdentifier() throws {
+    let sourceBytes: [UInt8] = [UInt8(ascii: "a"), 0xef, 0xbb, 0xbf, UInt8(ascii: "b")]
+    let lexemes = sourceBytes.withUnsafeBufferPointer { buf in
+      var lexemes = [Lexer.Lexeme]()
+      for token in Lexer.tokenize(buf, from: 0) {
+        lexemes.append(token)
+
+        if token.rawTokenKind == .eof {
+          break
+        }
+      }
+      return lexemes
+    }
+
+    XCTAssertEqual(lexemes.count, 2)
+    let lexeme = try XCTUnwrap(lexemes.first)
+    XCTAssertEqual(lexeme.rawTokenKind, .identifier)
+
+    sourceBytes.withUnsafeBufferPointer { sourceBytes in
+      XCTAssertEqual(lexeme.tokenText, SyntaxText(buffer: sourceBytes))
+    }
+  }
+
+  func testBOMAsLeadingTriviaInSourceFile() throws {
+    let sourceBytes: [UInt8] = [UInt8(ascii: "1"), UInt8(ascii: " "), UInt8(ascii: "+"), UInt8(ascii: " "), 0xef, 0xbb, 0xbf, UInt8(ascii: "2")]
+    let lexemes = sourceBytes.withUnsafeBufferPointer { buf in
+      var lexemes = [Lexer.Lexeme]()
+      for token in Lexer.tokenize(buf, from: 0) {
+        lexemes.append(token)
+
+        if token.rawTokenKind == .eof {
+          break
+        }
+      }
+      return lexemes
+    }
+
+    guard lexemes.count == 4 else {
+      return XCTFail("Expected 4 lexemes")
+    }
+    let lexeme = lexemes[1]
+    XCTAssertEqual(lexeme.rawTokenKind, .binaryOperator)
+
+    let expectedTrailingTrivia: [UInt8] = [UInt8(ascii: " "), 0xef, 0xbb, 0xbf]
+    expectedTrailingTrivia.withUnsafeBufferPointer { expectedTrailingTrivia in
+      XCTAssertEqual(lexeme.trailingTriviaText, SyntaxText(buffer: expectedTrailingTrivia))
+      XCTAssertEqual(lexeme.tokenText, "+")
+    }
+  }
 }


### PR DESCRIPTION
Honestly, I don’t know how best to review this. Essentially, I’ve gone through the entire lexer (without string lexing because I want to refactor that anyway) and made the following changes 
- `peek` is now safe by default and returns `nil` if we reached the end of the file. There is `peek(matches:)` and `peek(doesntMatch:)` to check if the current token is one of the expected
- Split the lexer into multiple files
- Re-arranges some methods to be grouped more logically 
- All the `lex*` methods now expect to be placed at the first character they are lexing (previously they expected the first character to already be lexed). This means we could get rid of the `tokStart` parameter. Also I think it’s more natural this way
- Added a few more assertions
- Made all variables lowercase
- Added some documentation
- Enabled argument labels
- Plus probably a few miscellaneous more that I forgot

There should be no functionality change in this PR.