### PR TITLE
Return `nil` as text in `decomposeToRaw` for keywords

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
@@ -409,7 +409,7 @@ let tokenKindFile = SourceFileSyntax {
         for token in SYNTAX_TOKENS {
           if token.associatedValueClass != nil {
             SwitchCaseSyntax("case .\(raw: token.swiftKind)(let assoc):") {
-              ReturnStmtSyntax("return (.\(raw: token.swiftKind)(assoc), String(syntaxText: assoc.defaultText))")
+              ReturnStmtSyntax("return (.\(raw: token.swiftKind)(assoc), nil)")
             }
           } else if token.text != nil {
             SwitchCaseSyntax("case .\(raw: token.swiftKind):") {

--- a/Sources/SwiftSyntax/generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/generated/TokenKind.swift
@@ -1925,7 +1925,7 @@ extension TokenKind {
     case .dollarIdentifier(let str): 
       return (.dollarIdentifier, str)
     case .keyword(let assoc): 
-      return (.keyword(assoc), String(syntaxText: assoc.defaultText))
+      return (.keyword(assoc), nil)
     case .rawStringDelimiter(let str): 
       return (.rawStringDelimiter, str)
     case .stringSegment(let str): 


### PR DESCRIPTION
This should have always returned `nil`, like for the other keywords but was missed when initially implemented.