### PR TITLE
In SwiftSyntaxBuilder change String parameters to a custom string interpolation protocol

### DIFF
--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -140,7 +140,7 @@ extension SyntaxStringInterpolation: StringInterpolationProtocol {
 /// Syntax nodes that can be formed by a string interpolation involve source
 /// code and interpolated syntax nodes.
 public protocol SyntaxExpressibleByStringInterpolation:
-  ExpressibleByStringInterpolation, SyntaxProtocol
+  ExpressibleByStringInterpolation
 where Self.StringInterpolation == SyntaxStringInterpolation {
   init(stringInterpolationOrThrow stringInterpolation: SyntaxStringInterpolation) throws
 }


### PR DESCRIPTION
The current mixed String + result builder initializers in SwiftSyntaxBuilder allow people to construct string using all sorts of dynamic features (like concatenation) and then pass them into the initializer. That’s not an API paradigm we want to support.

Instead, these initializers should take a custom type that is expressible by string literal, similar to how expressibility by string literals is implemented for syntax nodes. This stops people from doing string transformations on the strings and only allows string interpolation.

rdar://104090423