### PR TITLE
Remove the with<childName> functions on syntax nodes

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -291,69 +291,6 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: [.blockComment(gener
         """)
       
       FunctionDeclSyntax("""
-        /// Returns a new `\(raw: node.name)` with its leading trivia replaced
-        /// by the provided trivia.
-        public func withLeadingTrivia(_ leadingTrivia: Trivia) -> \(raw: node.name) {
-          return \(raw: node.name)(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-        }
-        """)
-      
-      FunctionDeclSyntax("""
-        /// Returns a new `\(raw: node.name)` with its trailing trivia replaced
-        /// by the provided trivia.
-        public func withTrailingTrivia(_ trailingTrivia: Trivia) -> \(raw: node.name) {
-          return \(raw: node.name)(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-        }
-        """)
-      
-      FunctionDeclSyntax("""
-        /// Returns a new `\(raw: node.name)` with its leading trivia removed.
-        public func withoutLeadingTrivia() -> \(raw: node.name) {
-          return withLeadingTrivia([])
-        }
-        """)
-      
-      
-      FunctionDeclSyntax("""
-        /// Returns a new `\(raw: node.name)` with its trailing trivia removed.
-        public func withoutTrailingTrivia() -> \(raw: node.name) {
-          return withTrailingTrivia([])
-        }
-        """)
-      
-      
-      FunctionDeclSyntax("""
-        /// Returns a new `\(raw: node.name)` with all trivia removed.
-        public func withoutTrivia() -> \(raw: node.name) {
-          return withoutLeadingTrivia().withoutTrailingTrivia()
-        }
-        """)
-      
-      VariableDeclSyntax("""
-        /// The leading trivia (spaces, newlines, etc.) associated with this `\(raw: node.name)`.
-        public var leadingTrivia: Trivia? {
-          get {
-            return raw.formLeadingTrivia()
-          }
-          set {
-            self = withLeadingTrivia(newValue ?? [])
-          }
-        }
-        """)
-      
-      VariableDeclSyntax("""
-        /// The trailing trivia (spaces, newlines, etc.) associated with this `\(raw: node.name)`.
-        public var trailingTrivia: Trivia? {
-          get {
-            return raw.formTrailingTrivia()
-          }
-          set {
-            self = withTrailingTrivia(newValue ?? [])
-          }
-        }
-        """)
-      
-      FunctionDeclSyntax("""
         public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
           return nil
         }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTraitsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTraitsFile.swift
@@ -24,9 +24,21 @@ let syntaxTraitsFile = SourceFileSyntax {
       """) {
       
       for child in trait.children {
-        VariableDeclSyntax("var \(raw: child.swiftName): \(raw: child.typeName)\(raw: child.isOptional ? "?" : "") { get }")
-        FunctionDeclSyntax("func with\(raw: child.name)(_ newChild: \(raw: child.typeName)\(raw: child.isOptional ? "?" : "")) -> Self")
+        VariableDeclSyntax("var \(raw: child.swiftName): \(raw: child.typeName)\(raw: child.isOptional ? "?" : "") { get set }")
       }
+    }
+
+    ExtensionDeclSyntax("public extension \(trait.traitName)Syntax") {
+      FunctionDeclSyntax("""
+      /// Without this function, the `with` function defined on `SyntaxProtocol`
+      /// does not work on existentials of this protocol type.
+      @_disfavoredOverload
+      func with<T>(_ keyPath: WritableKeyPath<\(raw: trait.traitName)Syntax, T>, _ newChild: T) -> \(raw: trait.traitName)Syntax {
+        var copy: \(raw: trait.traitName)Syntax = self
+        copy[keyPath: keyPath] = newChild
+        return copy
+      }
+      """)
     }
     
     ExtensionDeclSyntax("public extension SyntaxProtocol") {

--- a/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
@@ -77,10 +77,10 @@ extension FixIt.Changes {
   ) -> Self {
     var presentNode = PresentMaker().visit(Syntax(node))
     if let leadingTrivia = leadingTrivia {
-      presentNode = presentNode.withLeadingTrivia(leadingTrivia)
+      presentNode = presentNode.with(\.leadingTrivia, leadingTrivia)
     }
     if let trailingTrivia = trailingTrivia {
-      presentNode = presentNode.withTrailingTrivia(trailingTrivia)
+      presentNode = presentNode.with(\.trailingTrivia, trailingTrivia)
     }
     if node.shouldBeInsertedAfterNextTokenTrivia,
       let nextToken = node.nextToken(viewMode: .sourceAccurate),
@@ -89,7 +89,7 @@ extension FixIt.Changes {
       return [
         .replace(
           oldNode: Syntax(node),
-          newNode: Syntax(presentNode).withLeadingTrivia(nextToken.leadingTrivia)
+          newNode: Syntax(presentNode).with(\.leadingTrivia, nextToken.leadingTrivia)
         ),
         .replaceLeadingTrivia(token: nextToken, newTrivia: []),
       ]
@@ -105,7 +105,7 @@ extension FixIt.Changes {
       return [
         .replace(
           oldNode: Syntax(node),
-          newNode: Syntax(presentNode).withLeadingTrivia(.space)
+          newNode: Syntax(presentNode).with(\.leadingTrivia, .space)
         )
       ]
     } else {
@@ -123,7 +123,7 @@ extension FixIt.Changes {
     if let previousToken = token.previousToken(viewMode: .sourceAccurate) {
       var presentToken = PresentMaker().visit(token)
       if !previousToken.trailingTrivia.isEmpty {
-        presentToken = presentToken.withTrailingTrivia(previousToken.trailingTrivia)
+        presentToken = presentToken.with(\.trailingTrivia, previousToken.trailingTrivia)
       }
       return [
         .replaceTrailingTrivia(token: previousToken, newTrivia: []),

--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -33,8 +33,8 @@ fileprivate enum NodesDescriptionPart {
         tokens = tokens.map({ BasicFormat().visit($0) })
       }
       if !tokens.isEmpty {
-        tokens[0] = tokens[0].withLeadingTrivia([])
-        tokens[tokens.count - 1] = tokens[tokens.count - 1].withTrailingTrivia([])
+        tokens[0] = tokens[0].with(\.leadingTrivia, [])
+        tokens[tokens.count - 1] = tokens[tokens.count - 1].with(\.trailingTrivia, [])
       }
       let tokenContents = tokens.map(\.description).joined()
       return "'\(tokenContents)'"

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -615,7 +615,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
 
           let negatedAvailabilityKeyword = availability.availabilityKeyword.negatedAvailabilityKeyword
           let negatedCoditionElement = ConditionElementSyntax(
-            condition: .availability(availability.withAvailabilityKeyword(negatedAvailabilityKeyword)),
+            condition: .availability(availability.with(\.availabilityKeyword, negatedAvailabilityKeyword)),
             trailingComma: conditionElement.trailingComma
           )
           addDiagnostic(

--- a/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/SyntaxExtensions.swift
@@ -71,7 +71,7 @@ extension SyntaxProtocol {
   /// diagnostic message), return that.
   /// Otherwise, return a generic message that describes the tokens in this node.
   var shortSingleLineContentDescription: String {
-    let contentWithoutTrivia = self.withoutLeadingTrivia().withoutTrailingTrivia().description
+    let contentWithoutTrivia = self.trimmedDescription
     if self.children(viewMode: .sourceAccurate).allSatisfy({ $0.as(TokenSyntax.self)?.tokenKind == .rightBrace }) {
       if self.children(viewMode: .sourceAccurate).count == 1 {
         return "brace"

--- a/Sources/SwiftRefactor/AddSeparatorsToIntegerLiteral.swift
+++ b/Sources/SwiftRefactor/AddSeparatorsToIntegerLiteral.swift
@@ -51,7 +51,7 @@ public struct AddSeparatorsToIntegerLiteral: RefactoringProvider {
     formattedText += value.byAddingGroupSeparators(at: lit.idealGroupSize)
     return
       lit
-      .withDigits(lit.digits.withKind(.integerLiteral(formattedText)))
+      .with(\.digits, lit.digits.withKind(.integerLiteral(formattedText)))
   }
 }
 

--- a/Sources/SwiftRefactor/FormatRawStringLiteral.swift
+++ b/Sources/SwiftRefactor/FormatRawStringLiteral.swift
@@ -49,15 +49,15 @@ public struct FormatRawStringLiteral: RefactoringProvider {
     guard maximumHashes > 0 else {
       return
         lit
-        .withOpenDelimiter(lit.openDelimiter?.withKind(.rawStringDelimiter("")))
-        .withCloseDelimiter(lit.closeDelimiter?.withKind(.rawStringDelimiter("")))
+        .with(\.openDelimiter, lit.openDelimiter?.withKind(.rawStringDelimiter("")))
+        .with(\.closeDelimiter, lit.closeDelimiter?.withKind(.rawStringDelimiter("")))
     }
 
     let delimiters = String(repeating: "#", count: maximumHashes + 1)
     return
       lit
-      .withOpenDelimiter(lit.openDelimiter?.withKind(.rawStringDelimiter(delimiters)))
-      .withCloseDelimiter(lit.closeDelimiter?.withKind(.rawStringDelimiter(delimiters)))
+      .with(\.openDelimiter, lit.openDelimiter?.withKind(.rawStringDelimiter(delimiters)))
+      .with(\.closeDelimiter, lit.closeDelimiter?.withKind(.rawStringDelimiter(delimiters)))
   }
 }
 

--- a/Sources/SwiftRefactor/MigrateToNewIfLetSyntax.swift
+++ b/Sources/SwiftRefactor/MigrateToNewIfLetSyntax.swift
@@ -51,12 +51,12 @@ public struct MigrateToNewIfLetSyntax: RefactoringProvider {
         binding.initializer = nil
         // ... and remove whitespace before the comma (in `if` statements with multiple conditions).
         if index != node.conditions.count - 1 {
-          binding.pattern = binding.pattern.withoutTrailingTrivia()
+          binding.pattern = binding.pattern.with(\.trailingTrivia, [])
         }
         conditionCopy.condition = .optionalBinding(binding)
       }
       return conditionCopy
     }
-    return StmtSyntax(node.withConditions(ConditionElementListSyntax(newConditions)))
+    return StmtSyntax(node.with(\.conditions, ConditionElementListSyntax(newConditions)))
   }
 }

--- a/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
+++ b/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
@@ -48,7 +48,7 @@ fileprivate class SomeParameterRewriter: SyntaxRewriter {
     let colon: TokenSyntax?
     if node.baseType.description != "Any" {
       colon = .colonToken()
-      inheritedType = node.baseType.withLeadingTrivia(.space)
+      inheritedType = node.baseType.with(\.leadingTrivia, .space)
     } else {
       colon = nil
       inheritedType = nil
@@ -143,8 +143,8 @@ public struct OpaqueParameterToGeneric: RefactoringProvider {
       // Add a trailing comma to the prior generic parameter, if there is one.
       if let lastNewGenericParam = newGenericParams.last {
         newGenericParams[newGenericParams.count - 1] =
-          lastNewGenericParam.withTrailingComma(.commaToken())
-        newGenericParams.append(newGenericParam.withLeadingTrivia(.space))
+          lastNewGenericParam.with(\.trailingComma, .commaToken())
+        newGenericParams.append(newGenericParam.with(\.leadingTrivia, .space))
       } else {
         newGenericParams.append(newGenericParam)
       }
@@ -153,7 +153,8 @@ public struct OpaqueParameterToGeneric: RefactoringProvider {
     let newGenericParamSyntax = GenericParameterListSyntax(newGenericParams)
     let newGenericParamClause: GenericParameterClauseSyntax
     if let genericParams = genericParams {
-      newGenericParamClause = genericParams.withGenericParameterList(
+      newGenericParamClause = genericParams.with(
+        \.genericParameterList,
         newGenericParamSyntax
       )
     } else {
@@ -166,7 +167,7 @@ public struct OpaqueParameterToGeneric: RefactoringProvider {
     }
 
     return (
-      params.withParameterList(rewrittenParams),
+      params.with(\.parameterList, rewrittenParams),
       newGenericParamClause
     )
   }
@@ -188,8 +189,8 @@ public struct OpaqueParameterToGeneric: RefactoringProvider {
 
       return DeclSyntax(
         funcSyntax
-          .withSignature(funcSyntax.signature.withInput(newInput))
-          .withGenericParameterClause(newGenericParams)
+          .with(\.signature, funcSyntax.signature.with(\.input, newInput))
+          .with(\.genericParameterClause, newGenericParams)
       )
     }
 
@@ -206,8 +207,8 @@ public struct OpaqueParameterToGeneric: RefactoringProvider {
 
       return DeclSyntax(
         initSyntax
-          .withSignature(initSyntax.signature.withInput(newInput))
-          .withGenericParameterClause(newGenericParams)
+          .with(\.signature, initSyntax.signature.with(\.input, newInput))
+          .with(\.genericParameterClause, newGenericParams)
       )
     }
 
@@ -224,8 +225,8 @@ public struct OpaqueParameterToGeneric: RefactoringProvider {
 
       return DeclSyntax(
         subscriptSyntax
-          .withIndices(newIndices)
-          .withGenericParameterClause(newGenericParams)
+          .with(\.indices, newIndices)
+          .with(\.genericParameterClause, newGenericParams)
       )
     }
 

--- a/Sources/SwiftRefactor/RefactoringProvider.swift
+++ b/Sources/SwiftRefactor/RefactoringProvider.swift
@@ -32,7 +32,7 @@ import SwiftSyntax
 /// syntax trees. The SwiftSyntax API provides a natural, easy-to-use,
 /// and compositional set of updates to the syntax tree. For example, a
 /// refactoring action that wishes to exchange the leading trivia of a node
-/// would call `withLeadingTrivia(_:)` against its input syntax and return
+/// would call `with(\.leadingTrivia, _:)` against its input syntax and return
 /// the resulting syntax node. For compound syntax nodes, entire sub-trees
 /// can be added, exchanged, or removed by calling the corresponding `with`
 /// API.

--- a/Sources/SwiftRefactor/RemoveSeparatorsFromIntegerLiteral.swift
+++ b/Sources/SwiftRefactor/RemoveSeparatorsFromIntegerLiteral.swift
@@ -32,8 +32,6 @@ public struct RemoveSeparatorsFromIntegerLiteral: RefactoringProvider {
       return lit
     }
     let formattedText = lit.digits.text.filter({ $0 != "_" })
-    return
-      lit
-      .withDigits(lit.digits.withKind(.integerLiteral(formattedText)))
+    return lit.with(\.digits, lit.digits.withKind(.integerLiteral(formattedText)))
   }
 }

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step11.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step11.swift
@@ -50,8 +50,8 @@ import Foundation
       case .import(_, let statement):
         return
           statement
-          .withLeadingTrivia(offset == 0 ? [] : .newline)
-          .withTrailingTrivia([])
+          .with(\.leadingTrivia, offset == 0 ? [] : .newline)
+          .with(\.trailingTrivia, [])
       case .other(let statement):
         return statement
       }

--- a/Sources/SwiftSyntax/Documentation.docc/Tutorials/SwiftSyntax By Example.tutorial
+++ b/Sources/SwiftSyntax/Documentation.docc/Tutorials/SwiftSyntax By Example.tutorial
@@ -212,14 +212,14 @@
       
       @Step {
         Normalize the whitespace of all the imports by calling the trivia 
-        manipulation functions `withLeadingTrivia(_:)` and 
-        `withTrailingTrivia(_:)` on import items.
+        manipulation functions `with(\.leadingTrivia, _:)` and 
+        `with(\.trailingTrivia, _:)` on import items.
         
         SwiftSyntax does not automatically format whitespace and trivia when
         items are moved around. SwiftSyntax provides a convenient way of 
         manipulating whitespace by calling the 
-        `withLeadingTrivia(_:)` and 
-        `withTrailingTrivia(_:)` methods. By normalizing all
+        `with(\.leadingTrivia, _:)` and 
+        `with(\.trailingTrivia, _:)` methods. By normalizing all
         of the whitespace to a single leading newline we can fix bug #1. And
         by removing all trailing whitespace we can fix bug #2.
         

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
@@ -194,7 +194,14 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
       return ${child_type}(childData!)
     }
     set(value) {
-      self = with${child.name}(value)
+      let arena = SyntaxArena()
+  %       if child.is_optional:
+      let raw = value?.raw
+  %       else:
+      let raw = value.raw
+  %       end
+      let newData = data.replacingChild(at: ${idx}, with: raw, arena: arena)
+      self = ${node.name}(newData)
     }
   }
 %
@@ -229,23 +236,6 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
     return ${node.name}(newData)
   }
 %       end
-
-%       # ===================
-%       # Replacing children
-%       # ===================
-  /// Returns a copy of the receiver with its `${child.swift_name}` replaced.
-  /// - param newChild: The new `${child.swift_name}` to replace the node's
-  ///                   current `${child.swift_name}`, if present.
-  public func with${child.name}(_ newChild: ${child_type}${'?' if child.is_optional else ''}) -> ${node.name} {
-    let arena = SyntaxArena()
-%       if child.is_optional:
-    let raw = newChild?.raw
-%       else:
-    let raw = newChild.raw
-%       end
-    let newData = data.replacingChild(at: ${idx}, with: raw, arena: arena)
-    return ${node.name}(newData)
-  }
 %     end
 
   public static var structure: SyntaxNodeStructure {

--- a/Sources/SwiftSyntax/SyntaxOtherNodes.swift
+++ b/Sources/SwiftSyntax/SyntaxOtherNodes.swift
@@ -57,7 +57,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
     return tokenView.presence
   }
 
-  /// The text of the token as written in the source code.
+  /// The text of the token as written in the source code, without any trivia.
   public var text: String {
     return tokenKind.text
   }
@@ -78,46 +78,13 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
     return TokenSyntax(newData)
   }
 
-  /// Returns a new TokenSyntax with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> TokenSyntax {
-    guard raw.kind == .token else {
-      fatalError("TokenSyntax must have token as its raw")
-    }
-    return TokenSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-
-  /// Returns a new TokenSyntax with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> TokenSyntax {
-    guard raw.kind == .token else {
-      fatalError("TokenSyntax must have token as its raw")
-    }
-    return TokenSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-
-  /// Returns a new TokenSyntax with its leading trivia removed.
-  public func withoutLeadingTrivia() -> TokenSyntax {
-    return withLeadingTrivia([])
-  }
-
-  /// Returns a new TokenSyntax with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> TokenSyntax {
-    return withTrailingTrivia([])
-  }
-
-  /// Returns a new TokenSyntax with all trivia removed.
-  public func withoutTrivia() -> TokenSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-
   /// The leading trivia (spaces, newlines, etc.) associated with this token.
   public var leadingTrivia: Trivia {
     get {
       return tokenView.formLeadingTrivia()
     }
     set {
-      self = withLeadingTrivia(newValue)
+      self = TokenSyntax(data.withLeadingTrivia(newValue, arena: SyntaxArena()))
     }
   }
 
@@ -127,7 +94,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
       return tokenView.formTrailingTrivia()
     }
     set {
-      self = withTrailingTrivia(newValue)
+      self = TokenSyntax(data.withTrailingTrivia(newValue, arena: SyntaxArena()))
     }
   }
 

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -171,53 +171,6 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `AccessPathSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> AccessPathSyntax {
-    return AccessPathSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `AccessPathSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> AccessPathSyntax {
-    return AccessPathSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `AccessPathSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> AccessPathSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `AccessPathSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> AccessPathSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `AccessPathSyntax` with all trivia removed.
-  public func withoutTrivia() -> AccessPathSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `AccessPathSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `AccessPathSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -433,53 +386,6 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `AccessorListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> AccessorListSyntax {
-    return AccessorListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `AccessorListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> AccessorListSyntax {
-    return AccessorListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `AccessorListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> AccessorListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `AccessorListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> AccessorListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `AccessorListSyntax` with all trivia removed.
-  public func withoutTrivia() -> AccessorListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `AccessorListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `AccessorListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -693,53 +599,6 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `ArrayElementListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ArrayElementListSyntax {
-    return ArrayElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `ArrayElementListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ArrayElementListSyntax {
-    return ArrayElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `ArrayElementListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> ArrayElementListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `ArrayElementListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> ArrayElementListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `ArrayElementListSyntax` with all trivia removed.
-  public func withoutTrivia() -> ArrayElementListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `ArrayElementListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `ArrayElementListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -1001,53 +860,6 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `AttributeListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> AttributeListSyntax {
-    return AttributeListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `AttributeListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> AttributeListSyntax {
-    return AttributeListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `AttributeListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> AttributeListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `AttributeListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> AttributeListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `AttributeListSyntax` with all trivia removed.
-  public func withoutTrivia() -> AttributeListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `AttributeListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `AttributeListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -1261,53 +1073,6 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `AvailabilitySpecListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> AvailabilitySpecListSyntax {
-    return AvailabilitySpecListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `AvailabilitySpecListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> AvailabilitySpecListSyntax {
-    return AvailabilitySpecListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `AvailabilitySpecListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> AvailabilitySpecListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `AvailabilitySpecListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> AvailabilitySpecListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `AvailabilitySpecListSyntax` with all trivia removed.
-  public func withoutTrivia() -> AvailabilitySpecListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `AvailabilitySpecListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `AvailabilitySpecListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -1525,53 +1290,6 @@ public struct AvailabilityVersionRestrictionListSyntax: SyntaxCollection, Syntax
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `AvailabilityVersionRestrictionListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> AvailabilityVersionRestrictionListSyntax {
-    return AvailabilityVersionRestrictionListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `AvailabilityVersionRestrictionListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> AvailabilityVersionRestrictionListSyntax {
-    return AvailabilityVersionRestrictionListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `AvailabilityVersionRestrictionListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> AvailabilityVersionRestrictionListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `AvailabilityVersionRestrictionListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> AvailabilityVersionRestrictionListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `AvailabilityVersionRestrictionListSyntax` with all trivia removed.
-  public func withoutTrivia() -> AvailabilityVersionRestrictionListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `AvailabilityVersionRestrictionListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `AvailabilityVersionRestrictionListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -1785,53 +1503,6 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `CaseItemListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> CaseItemListSyntax {
-    return CaseItemListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `CaseItemListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> CaseItemListSyntax {
-    return CaseItemListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `CaseItemListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> CaseItemListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `CaseItemListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> CaseItemListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `CaseItemListSyntax` with all trivia removed.
-  public func withoutTrivia() -> CaseItemListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `CaseItemListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `CaseItemListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -2049,53 +1720,6 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `CatchClauseListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> CatchClauseListSyntax {
-    return CatchClauseListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `CatchClauseListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> CatchClauseListSyntax {
-    return CatchClauseListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `CatchClauseListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> CatchClauseListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `CatchClauseListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> CatchClauseListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `CatchClauseListSyntax` with all trivia removed.
-  public func withoutTrivia() -> CatchClauseListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `CatchClauseListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `CatchClauseListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -2309,53 +1933,6 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `CatchItemListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> CatchItemListSyntax {
-    return CatchItemListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `CatchItemListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> CatchItemListSyntax {
-    return CatchItemListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `CatchItemListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> CatchItemListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `CatchItemListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> CatchItemListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `CatchItemListSyntax` with all trivia removed.
-  public func withoutTrivia() -> CatchItemListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `CatchItemListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `CatchItemListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -2573,53 +2150,6 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `ClosureCaptureItemListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ClosureCaptureItemListSyntax {
-    return ClosureCaptureItemListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `ClosureCaptureItemListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ClosureCaptureItemListSyntax {
-    return ClosureCaptureItemListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `ClosureCaptureItemListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> ClosureCaptureItemListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `ClosureCaptureItemListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> ClosureCaptureItemListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `ClosureCaptureItemListSyntax` with all trivia removed.
-  public func withoutTrivia() -> ClosureCaptureItemListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `ClosureCaptureItemListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `ClosureCaptureItemListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -2833,53 +2363,6 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `ClosureParamListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ClosureParamListSyntax {
-    return ClosureParamListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `ClosureParamListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ClosureParamListSyntax {
-    return ClosureParamListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `ClosureParamListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> ClosureParamListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `ClosureParamListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> ClosureParamListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `ClosureParamListSyntax` with all trivia removed.
-  public func withoutTrivia() -> ClosureParamListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `ClosureParamListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `ClosureParamListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -3097,53 +2580,6 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `CodeBlockItemListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> CodeBlockItemListSyntax {
-    return CodeBlockItemListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `CodeBlockItemListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> CodeBlockItemListSyntax {
-    return CodeBlockItemListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `CodeBlockItemListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> CodeBlockItemListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `CodeBlockItemListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> CodeBlockItemListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `CodeBlockItemListSyntax` with all trivia removed.
-  public func withoutTrivia() -> CodeBlockItemListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `CodeBlockItemListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `CodeBlockItemListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -3357,53 +2793,6 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `CompositionTypeElementListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> CompositionTypeElementListSyntax {
-    return CompositionTypeElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `CompositionTypeElementListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> CompositionTypeElementListSyntax {
-    return CompositionTypeElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `CompositionTypeElementListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> CompositionTypeElementListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `CompositionTypeElementListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> CompositionTypeElementListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `CompositionTypeElementListSyntax` with all trivia removed.
-  public func withoutTrivia() -> CompositionTypeElementListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `CompositionTypeElementListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `CompositionTypeElementListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -3621,53 +3010,6 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `ConditionElementListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ConditionElementListSyntax {
-    return ConditionElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `ConditionElementListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ConditionElementListSyntax {
-    return ConditionElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `ConditionElementListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> ConditionElementListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `ConditionElementListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> ConditionElementListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `ConditionElementListSyntax` with all trivia removed.
-  public func withoutTrivia() -> ConditionElementListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `ConditionElementListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `ConditionElementListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -3881,53 +3223,6 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `DeclNameArgumentListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> DeclNameArgumentListSyntax {
-    return DeclNameArgumentListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `DeclNameArgumentListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> DeclNameArgumentListSyntax {
-    return DeclNameArgumentListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `DeclNameArgumentListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> DeclNameArgumentListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `DeclNameArgumentListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> DeclNameArgumentListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `DeclNameArgumentListSyntax` with all trivia removed.
-  public func withoutTrivia() -> DeclNameArgumentListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `DeclNameArgumentListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `DeclNameArgumentListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -4145,53 +3440,6 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `DesignatedTypeListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> DesignatedTypeListSyntax {
-    return DesignatedTypeListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `DesignatedTypeListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> DesignatedTypeListSyntax {
-    return DesignatedTypeListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `DesignatedTypeListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> DesignatedTypeListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `DesignatedTypeListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> DesignatedTypeListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `DesignatedTypeListSyntax` with all trivia removed.
-  public func withoutTrivia() -> DesignatedTypeListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `DesignatedTypeListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `DesignatedTypeListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -4405,53 +3653,6 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `DictionaryElementListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> DictionaryElementListSyntax {
-    return DictionaryElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `DictionaryElementListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> DictionaryElementListSyntax {
-    return DictionaryElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `DictionaryElementListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> DictionaryElementListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `DictionaryElementListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> DictionaryElementListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `DictionaryElementListSyntax` with all trivia removed.
-  public func withoutTrivia() -> DictionaryElementListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `DictionaryElementListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `DictionaryElementListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -4669,53 +3870,6 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `DifferentiabilityParamListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> DifferentiabilityParamListSyntax {
-    return DifferentiabilityParamListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `DifferentiabilityParamListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> DifferentiabilityParamListSyntax {
-    return DifferentiabilityParamListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `DifferentiabilityParamListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> DifferentiabilityParamListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `DifferentiabilityParamListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> DifferentiabilityParamListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `DifferentiabilityParamListSyntax` with all trivia removed.
-  public func withoutTrivia() -> DifferentiabilityParamListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `DifferentiabilityParamListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `DifferentiabilityParamListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -4926,53 +4080,6 @@ public struct DocumentationAttributeArgumentsSyntax: SyntaxCollection, SyntaxHas
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `DocumentationAttributeArgumentsSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> DocumentationAttributeArgumentsSyntax {
-    return DocumentationAttributeArgumentsSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `DocumentationAttributeArgumentsSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> DocumentationAttributeArgumentsSyntax {
-    return DocumentationAttributeArgumentsSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `DocumentationAttributeArgumentsSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> DocumentationAttributeArgumentsSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `DocumentationAttributeArgumentsSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> DocumentationAttributeArgumentsSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `DocumentationAttributeArgumentsSyntax` with all trivia removed.
-  public func withoutTrivia() -> DocumentationAttributeArgumentsSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `DocumentationAttributeArgumentsSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `DocumentationAttributeArgumentsSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -5187,53 +4294,6 @@ public struct EffectsArgumentsSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `EffectsArgumentsSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> EffectsArgumentsSyntax {
-    return EffectsArgumentsSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `EffectsArgumentsSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> EffectsArgumentsSyntax {
-    return EffectsArgumentsSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `EffectsArgumentsSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> EffectsArgumentsSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `EffectsArgumentsSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> EffectsArgumentsSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `EffectsArgumentsSyntax` with all trivia removed.
-  public func withoutTrivia() -> EffectsArgumentsSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `EffectsArgumentsSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `EffectsArgumentsSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -5446,53 +4506,6 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `EnumCaseElementListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> EnumCaseElementListSyntax {
-    return EnumCaseElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `EnumCaseElementListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> EnumCaseElementListSyntax {
-    return EnumCaseElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `EnumCaseElementListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> EnumCaseElementListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `EnumCaseElementListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> EnumCaseElementListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `EnumCaseElementListSyntax` with all trivia removed.
-  public func withoutTrivia() -> EnumCaseElementListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `EnumCaseElementListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `EnumCaseElementListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -5703,53 +4716,6 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `ExprListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ExprListSyntax {
-    return ExprListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `ExprListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ExprListSyntax {
-    return ExprListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `ExprListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> ExprListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `ExprListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> ExprListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `ExprListSyntax` with all trivia removed.
-  public func withoutTrivia() -> ExprListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `ExprListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `ExprListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -5967,53 +4933,6 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `FunctionParameterListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> FunctionParameterListSyntax {
-    return FunctionParameterListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `FunctionParameterListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> FunctionParameterListSyntax {
-    return FunctionParameterListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `FunctionParameterListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> FunctionParameterListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `FunctionParameterListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> FunctionParameterListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `FunctionParameterListSyntax` with all trivia removed.
-  public func withoutTrivia() -> FunctionParameterListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `FunctionParameterListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `FunctionParameterListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -6227,53 +5146,6 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `GenericArgumentListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> GenericArgumentListSyntax {
-    return GenericArgumentListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `GenericArgumentListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> GenericArgumentListSyntax {
-    return GenericArgumentListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `GenericArgumentListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> GenericArgumentListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `GenericArgumentListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> GenericArgumentListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `GenericArgumentListSyntax` with all trivia removed.
-  public func withoutTrivia() -> GenericArgumentListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `GenericArgumentListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `GenericArgumentListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -6491,53 +5363,6 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `GenericParameterListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> GenericParameterListSyntax {
-    return GenericParameterListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `GenericParameterListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> GenericParameterListSyntax {
-    return GenericParameterListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `GenericParameterListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> GenericParameterListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `GenericParameterListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> GenericParameterListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `GenericParameterListSyntax` with all trivia removed.
-  public func withoutTrivia() -> GenericParameterListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `GenericParameterListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `GenericParameterListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -6751,53 +5576,6 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `GenericRequirementListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> GenericRequirementListSyntax {
-    return GenericRequirementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `GenericRequirementListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> GenericRequirementListSyntax {
-    return GenericRequirementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `GenericRequirementListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> GenericRequirementListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `GenericRequirementListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> GenericRequirementListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `GenericRequirementListSyntax` with all trivia removed.
-  public func withoutTrivia() -> GenericRequirementListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `GenericRequirementListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `GenericRequirementListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -7015,53 +5793,6 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `IfConfigClauseListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> IfConfigClauseListSyntax {
-    return IfConfigClauseListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `IfConfigClauseListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> IfConfigClauseListSyntax {
-    return IfConfigClauseListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `IfConfigClauseListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> IfConfigClauseListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `IfConfigClauseListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> IfConfigClauseListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `IfConfigClauseListSyntax` with all trivia removed.
-  public func withoutTrivia() -> IfConfigClauseListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `IfConfigClauseListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `IfConfigClauseListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -7275,53 +6006,6 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `InheritedTypeListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> InheritedTypeListSyntax {
-    return InheritedTypeListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `InheritedTypeListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> InheritedTypeListSyntax {
-    return InheritedTypeListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `InheritedTypeListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> InheritedTypeListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `InheritedTypeListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> InheritedTypeListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `InheritedTypeListSyntax` with all trivia removed.
-  public func withoutTrivia() -> InheritedTypeListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `InheritedTypeListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `InheritedTypeListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -7539,53 +6223,6 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `KeyPathComponentListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> KeyPathComponentListSyntax {
-    return KeyPathComponentListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `KeyPathComponentListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> KeyPathComponentListSyntax {
-    return KeyPathComponentListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `KeyPathComponentListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> KeyPathComponentListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `KeyPathComponentListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> KeyPathComponentListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `KeyPathComponentListSyntax` with all trivia removed.
-  public func withoutTrivia() -> KeyPathComponentListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `KeyPathComponentListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `KeyPathComponentListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -7799,53 +6436,6 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `MemberDeclListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> MemberDeclListSyntax {
-    return MemberDeclListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `MemberDeclListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> MemberDeclListSyntax {
-    return MemberDeclListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `MemberDeclListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> MemberDeclListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `MemberDeclListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> MemberDeclListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `MemberDeclListSyntax` with all trivia removed.
-  public func withoutTrivia() -> MemberDeclListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `MemberDeclListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `MemberDeclListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -8063,53 +6653,6 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `ModifierListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ModifierListSyntax {
-    return ModifierListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `ModifierListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ModifierListSyntax {
-    return ModifierListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `ModifierListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> ModifierListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `ModifierListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> ModifierListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `ModifierListSyntax` with all trivia removed.
-  public func withoutTrivia() -> ModifierListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `ModifierListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `ModifierListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -8323,53 +6866,6 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `MultipleTrailingClosureElementListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> MultipleTrailingClosureElementListSyntax {
-    return MultipleTrailingClosureElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `MultipleTrailingClosureElementListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> MultipleTrailingClosureElementListSyntax {
-    return MultipleTrailingClosureElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `MultipleTrailingClosureElementListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> MultipleTrailingClosureElementListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `MultipleTrailingClosureElementListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> MultipleTrailingClosureElementListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `MultipleTrailingClosureElementListSyntax` with all trivia removed.
-  public func withoutTrivia() -> MultipleTrailingClosureElementListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `MultipleTrailingClosureElementListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `MultipleTrailingClosureElementListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -8587,53 +7083,6 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `ObjCSelectorSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ObjCSelectorSyntax {
-    return ObjCSelectorSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `ObjCSelectorSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ObjCSelectorSyntax {
-    return ObjCSelectorSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `ObjCSelectorSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> ObjCSelectorSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `ObjCSelectorSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> ObjCSelectorSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `ObjCSelectorSyntax` with all trivia removed.
-  public func withoutTrivia() -> ObjCSelectorSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `ObjCSelectorSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `ObjCSelectorSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -8847,53 +7296,6 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `PatternBindingListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> PatternBindingListSyntax {
-    return PatternBindingListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `PatternBindingListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> PatternBindingListSyntax {
-    return PatternBindingListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `PatternBindingListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> PatternBindingListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `PatternBindingListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> PatternBindingListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `PatternBindingListSyntax` with all trivia removed.
-  public func withoutTrivia() -> PatternBindingListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `PatternBindingListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `PatternBindingListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -9168,53 +7570,6 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `PrecedenceGroupAttributeListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> PrecedenceGroupAttributeListSyntax {
-    return PrecedenceGroupAttributeListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `PrecedenceGroupAttributeListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> PrecedenceGroupAttributeListSyntax {
-    return PrecedenceGroupAttributeListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `PrecedenceGroupAttributeListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> PrecedenceGroupAttributeListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `PrecedenceGroupAttributeListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> PrecedenceGroupAttributeListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `PrecedenceGroupAttributeListSyntax` with all trivia removed.
-  public func withoutTrivia() -> PrecedenceGroupAttributeListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `PrecedenceGroupAttributeListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `PrecedenceGroupAttributeListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -9430,53 +7785,6 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `PrecedenceGroupNameListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> PrecedenceGroupNameListSyntax {
-    return PrecedenceGroupNameListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `PrecedenceGroupNameListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> PrecedenceGroupNameListSyntax {
-    return PrecedenceGroupNameListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `PrecedenceGroupNameListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> PrecedenceGroupNameListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `PrecedenceGroupNameListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> PrecedenceGroupNameListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `PrecedenceGroupNameListSyntax` with all trivia removed.
-  public func withoutTrivia() -> PrecedenceGroupNameListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `PrecedenceGroupNameListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `PrecedenceGroupNameListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -9690,53 +7998,6 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `PrimaryAssociatedTypeListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> PrimaryAssociatedTypeListSyntax {
-    return PrimaryAssociatedTypeListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `PrimaryAssociatedTypeListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> PrimaryAssociatedTypeListSyntax {
-    return PrimaryAssociatedTypeListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `PrimaryAssociatedTypeListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> PrimaryAssociatedTypeListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `PrimaryAssociatedTypeListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> PrimaryAssociatedTypeListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `PrimaryAssociatedTypeListSyntax` with all trivia removed.
-  public func withoutTrivia() -> PrimaryAssociatedTypeListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `PrimaryAssociatedTypeListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `PrimaryAssociatedTypeListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -10021,53 +8282,6 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `SpecializeAttributeSpecListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> SpecializeAttributeSpecListSyntax {
-    return SpecializeAttributeSpecListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `SpecializeAttributeSpecListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> SpecializeAttributeSpecListSyntax {
-    return SpecializeAttributeSpecListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `SpecializeAttributeSpecListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> SpecializeAttributeSpecListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `SpecializeAttributeSpecListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> SpecializeAttributeSpecListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `SpecializeAttributeSpecListSyntax` with all trivia removed.
-  public func withoutTrivia() -> SpecializeAttributeSpecListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `SpecializeAttributeSpecListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `SpecializeAttributeSpecListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -10325,53 +8539,6 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `StringLiteralSegmentsSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> StringLiteralSegmentsSyntax {
-    return StringLiteralSegmentsSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `StringLiteralSegmentsSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> StringLiteralSegmentsSyntax {
-    return StringLiteralSegmentsSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `StringLiteralSegmentsSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> StringLiteralSegmentsSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `StringLiteralSegmentsSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> StringLiteralSegmentsSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `StringLiteralSegmentsSyntax` with all trivia removed.
-  public func withoutTrivia() -> StringLiteralSegmentsSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `StringLiteralSegmentsSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `StringLiteralSegmentsSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -10633,53 +8800,6 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `SwitchCaseListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> SwitchCaseListSyntax {
-    return SwitchCaseListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `SwitchCaseListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> SwitchCaseListSyntax {
-    return SwitchCaseListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `SwitchCaseListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> SwitchCaseListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `SwitchCaseListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> SwitchCaseListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `SwitchCaseListSyntax` with all trivia removed.
-  public func withoutTrivia() -> SwitchCaseListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `SwitchCaseListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `SwitchCaseListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -10893,53 +9013,6 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `TupleExprElementListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> TupleExprElementListSyntax {
-    return TupleExprElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `TupleExprElementListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> TupleExprElementListSyntax {
-    return TupleExprElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `TupleExprElementListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> TupleExprElementListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `TupleExprElementListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> TupleExprElementListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `TupleExprElementListSyntax` with all trivia removed.
-  public func withoutTrivia() -> TupleExprElementListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `TupleExprElementListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `TupleExprElementListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -11157,53 +9230,6 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `TuplePatternElementListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> TuplePatternElementListSyntax {
-    return TuplePatternElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `TuplePatternElementListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> TuplePatternElementListSyntax {
-    return TuplePatternElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `TuplePatternElementListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> TuplePatternElementListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `TuplePatternElementListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> TuplePatternElementListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `TuplePatternElementListSyntax` with all trivia removed.
-  public func withoutTrivia() -> TuplePatternElementListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `TuplePatternElementListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `TuplePatternElementListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -11419,53 +9445,6 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
   
-  /// Returns a new `TupleTypeElementListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> TupleTypeElementListSyntax {
-    return TupleTypeElementListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `TupleTypeElementListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> TupleTypeElementListSyntax {
-    return TupleTypeElementListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `TupleTypeElementListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> TupleTypeElementListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `TupleTypeElementListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> TupleTypeElementListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `TupleTypeElementListSyntax` with all trivia removed.
-  public func withoutTrivia() -> TupleTypeElementListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `TupleTypeElementListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `TupleTypeElementListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
-  }
-  
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     return nil
   }
@@ -11676,53 +9655,6 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `UnexpectedNodesSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> UnexpectedNodesSyntax {
-    return UnexpectedNodesSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `UnexpectedNodesSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> UnexpectedNodesSyntax {
-    return UnexpectedNodesSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `UnexpectedNodesSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> UnexpectedNodesSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `UnexpectedNodesSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> UnexpectedNodesSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `UnexpectedNodesSyntax` with all trivia removed.
-  public func withoutTrivia() -> UnexpectedNodesSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `UnexpectedNodesSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `UnexpectedNodesSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
@@ -11938,53 +9870,6 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
-  }
-  
-  /// Returns a new `YieldExprListSyntax` with its leading trivia replaced
-  /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> YieldExprListSyntax {
-    return YieldExprListSyntax(data.withLeadingTrivia(leadingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `YieldExprListSyntax` with its trailing trivia replaced
-  /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> YieldExprListSyntax {
-    return YieldExprListSyntax(data.withTrailingTrivia(trailingTrivia, arena: SyntaxArena()))
-  }
-  
-  /// Returns a new `YieldExprListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> YieldExprListSyntax {
-    return withLeadingTrivia([])
-  }
-  
-  /// Returns a new `YieldExprListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> YieldExprListSyntax {
-    return withTrailingTrivia([])
-  }
-  
-  /// Returns a new `YieldExprListSyntax` with all trivia removed.
-  public func withoutTrivia() -> YieldExprListSyntax {
-    return withoutLeadingTrivia().withoutTrailingTrivia()
-  }
-  
-  /// The leading trivia (spaces, newlines, etc.) associated with this `YieldExprListSyntax`.
-  public var leadingTrivia: Trivia? {
-    get {
-      return raw.formLeadingTrivia()
-    }
-    set {
-      self = withLeadingTrivia(newValue ?? [])
-    }
-  }
-  
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `YieldExprListSyntax`.
-  public var trailingTrivia: Trivia? {
-    get {
-      return raw.formTrailingTrivia()
-    }
-    set {
-      self = withTrailingTrivia(newValue ?? [])
-    }
   }
   
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -5,9 +5,19 @@
 public protocol AttributedSyntax: SyntaxProtocol {
   var attributes: AttributeListSyntax? { 
     get 
+    set 
   }
-  
-  func withAttributes(_ newChild: AttributeListSyntax?) -> Self
+}
+
+public extension AttributedSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<AttributedSyntax, T>, _ newChild: T) -> AttributedSyntax {
+    var copy: AttributedSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
 }
 
 public extension SyntaxProtocol {
@@ -31,21 +41,29 @@ public extension SyntaxProtocol {
 public protocol DeclGroupSyntax: SyntaxProtocol {
   var attributes: AttributeListSyntax? { 
     get 
+    set 
   }
-  
-  func withAttributes(_ newChild: AttributeListSyntax?) -> Self
   
   var modifiers: ModifierListSyntax? { 
     get 
+    set 
   }
-  
-  func withModifiers(_ newChild: ModifierListSyntax?) -> Self
   
   var members: MemberDeclBlockSyntax { 
     get 
+    set 
   }
-  
-  func withMembers(_ newChild: MemberDeclBlockSyntax) -> Self
+}
+
+public extension DeclGroupSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<DeclGroupSyntax, T>, _ newChild: T) -> DeclGroupSyntax {
+    var copy: DeclGroupSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
 }
 
 public extension SyntaxProtocol {
@@ -69,15 +87,24 @@ public extension SyntaxProtocol {
 public protocol BracedSyntax: SyntaxProtocol {
   var leftBrace: TokenSyntax { 
     get 
+    set 
   }
-  
-  func withLeftBrace(_ newChild: TokenSyntax) -> Self
   
   var rightBrace: TokenSyntax { 
     get 
+    set 
   }
-  
-  func withRightBrace(_ newChild: TokenSyntax) -> Self
+}
+
+public extension BracedSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<BracedSyntax, T>, _ newChild: T) -> BracedSyntax {
+    var copy: BracedSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
 }
 
 public extension SyntaxProtocol {
@@ -101,9 +128,19 @@ public extension SyntaxProtocol {
 public protocol IdentifiedDeclSyntax: SyntaxProtocol {
   var identifier: TokenSyntax { 
     get 
+    set 
   }
-  
-  func withIdentifier(_ newChild: TokenSyntax) -> Self
+}
+
+public extension IdentifiedDeclSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<IdentifiedDeclSyntax, T>, _ newChild: T) -> IdentifiedDeclSyntax {
+    var copy: IdentifiedDeclSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
 }
 
 public extension SyntaxProtocol {
@@ -127,9 +164,19 @@ public extension SyntaxProtocol {
 public protocol WithCodeBlockSyntax: SyntaxProtocol {
   var body: CodeBlockSyntax { 
     get 
+    set 
   }
-  
-  func withBody(_ newChild: CodeBlockSyntax) -> Self
+}
+
+public extension WithCodeBlockSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<WithCodeBlockSyntax, T>, _ newChild: T) -> WithCodeBlockSyntax {
+    var copy: WithCodeBlockSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
 }
 
 public extension SyntaxProtocol {
@@ -153,15 +200,24 @@ public extension SyntaxProtocol {
 public protocol ParenthesizedSyntax: SyntaxProtocol {
   var leftParen: TokenSyntax { 
     get 
+    set 
   }
-  
-  func withLeftParen(_ newChild: TokenSyntax) -> Self
   
   var rightParen: TokenSyntax { 
     get 
+    set 
   }
-  
-  func withRightParen(_ newChild: TokenSyntax) -> Self
+}
+
+public extension ParenthesizedSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<ParenthesizedSyntax, T>, _ newChild: T) -> ParenthesizedSyntax {
+    var copy: ParenthesizedSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
 }
 
 public extension SyntaxProtocol {
@@ -185,51 +241,54 @@ public extension SyntaxProtocol {
 public protocol FreestandingMacroExpansionSyntax: SyntaxProtocol {
   var poundToken: TokenSyntax { 
     get 
+    set 
   }
-  
-  func withPoundToken(_ newChild: TokenSyntax) -> Self
   
   var macro: TokenSyntax { 
     get 
+    set 
   }
-  
-  func withMacro(_ newChild: TokenSyntax) -> Self
   
   var genericArguments: GenericArgumentClauseSyntax? { 
     get 
+    set 
   }
-  
-  func withGenericArguments(_ newChild: GenericArgumentClauseSyntax?) -> Self
   
   var leftParen: TokenSyntax? { 
     get 
+    set 
   }
-  
-  func withLeftParen(_ newChild: TokenSyntax?) -> Self
   
   var argumentList: TupleExprElementListSyntax { 
     get 
+    set 
   }
-  
-  func withArgumentList(_ newChild: TupleExprElementListSyntax) -> Self
   
   var rightParen: TokenSyntax? { 
     get 
+    set 
   }
-  
-  func withRightParen(_ newChild: TokenSyntax?) -> Self
   
   var trailingClosure: ClosureExprSyntax? { 
     get 
+    set 
   }
-  
-  func withTrailingClosure(_ newChild: ClosureExprSyntax?) -> Self
   
   var additionalTrailingClosures: MultipleTrailingClosureElementListSyntax? { 
     get 
+    set 
   }
-  
-  func withAdditionalTrailingClosures(_ newChild: MultipleTrailingClosureElementListSyntax?) -> Self
+}
+
+public extension FreestandingMacroExpansionSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<FreestandingMacroExpansionSyntax, T>, _ newChild: T) -> FreestandingMacroExpansionSyntax {
+    var copy: FreestandingMacroExpansionSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
 }
 
 public extension SyntaxProtocol {
@@ -253,9 +312,19 @@ public extension SyntaxProtocol {
 public protocol WithTrailingCommaSyntax: SyntaxProtocol {
   var trailingComma: TokenSyntax? { 
     get 
+    set 
   }
-  
-  func withTrailingComma(_ newChild: TokenSyntax?) -> Self
+}
+
+public extension WithTrailingCommaSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<WithTrailingCommaSyntax, T>, _ newChild: T) -> WithTrailingCommaSyntax {
+    var copy: WithTrailingCommaSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
 }
 
 public extension SyntaxProtocol {
@@ -279,9 +348,19 @@ public extension SyntaxProtocol {
 public protocol WithStatementsSyntax: SyntaxProtocol {
   var statements: CodeBlockItemListSyntax { 
     get 
+    set 
   }
-  
-  func withStatements(_ newChild: CodeBlockItemListSyntax) -> Self
+}
+
+public extension WithStatementsSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<WithStatementsSyntax, T>, _ newChild: T) -> WithStatementsSyntax {
+    var copy: WithStatementsSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
 }
 
 public extension SyntaxProtocol {
@@ -305,33 +384,39 @@ public extension SyntaxProtocol {
 public protocol EffectSpecifiersSyntax: SyntaxProtocol {
   var unexpectedBeforeAsyncSpecifier: UnexpectedNodesSyntax? { 
     get 
+    set 
   }
-  
-  func withUnexpectedBeforeAsyncSpecifier(_ newChild: UnexpectedNodesSyntax?) -> Self
   
   var asyncSpecifier: TokenSyntax? { 
     get 
+    set 
   }
-  
-  func withAsyncSpecifier(_ newChild: TokenSyntax?) -> Self
   
   var unexpectedBetweenAsyncSpecifierAndThrowsSpecifier: UnexpectedNodesSyntax? { 
     get 
+    set 
   }
-  
-  func withUnexpectedBetweenAsyncSpecifierAndThrowsSpecifier(_ newChild: UnexpectedNodesSyntax?) -> Self
   
   var throwsSpecifier: TokenSyntax? { 
     get 
+    set 
   }
-  
-  func withThrowsSpecifier(_ newChild: TokenSyntax?) -> Self
   
   var unexpectedAfterThrowsSpecifier: UnexpectedNodesSyntax? { 
     get 
+    set 
   }
-  
-  func withUnexpectedAfterThrowsSpecifier(_ newChild: UnexpectedNodesSyntax?) -> Self
+}
+
+public extension EffectSpecifiersSyntax {
+  /// Without this function, the `with` function defined on `SyntaxProtocol`
+  /// does not work on existentials of this protocol type.
+  @_disfavoredOverload
+  func with<T>(_ keyPath: WritableKeyPath<EffectSpecifiersSyntax, T>, _ newChild: T) -> EffectSpecifiersSyntax {
+    var copy: EffectSpecifiersSyntax = self
+    copy[keyPath: keyPath] = newChild
+    return copy
+  }
 }
 
 public extension SyntaxProtocol {

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -65,18 +65,11 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = MissingDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> MissingDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return MissingDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -86,7 +79,10 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = MissingDeclSyntax(newData)
     }
   }
 
@@ -109,16 +105,6 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return MissingDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> MissingDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return MissingDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -126,18 +112,11 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = MissingDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> MissingDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return MissingDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -147,7 +126,10 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = MissingDeclSyntax(newData)
     }
   }
 
@@ -170,16 +152,6 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return MissingDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> MissingDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return MissingDeclSyntax(newData)
-  }
-
   public var unexpectedAfterModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -187,18 +159,11 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = MissingDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterModifiers` replaced.
-  /// - param newChild: The new `unexpectedAfterModifiers` to replace the node's
-  ///                   current `unexpectedAfterModifiers`, if present.
-  public func withUnexpectedAfterModifiers(_ newChild: UnexpectedNodesSyntax?) -> MissingDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return MissingDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -313,18 +278,11 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = TypealiasDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return TypealiasDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -334,7 +292,10 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = TypealiasDeclSyntax(newData)
     }
   }
 
@@ -357,16 +318,6 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return TypealiasDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> TypealiasDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return TypealiasDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -374,18 +325,11 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = TypealiasDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return TypealiasDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -395,7 +339,10 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = TypealiasDeclSyntax(newData)
     }
   }
 
@@ -418,16 +365,6 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return TypealiasDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> TypealiasDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return TypealiasDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndTypealiasKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -435,18 +372,11 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndTypealiasKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = TypealiasDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndTypealiasKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndTypealiasKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndTypealiasKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndTypealiasKeyword(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return TypealiasDeclSyntax(newData)
   }
 
   public var typealiasKeyword: TokenSyntax {
@@ -455,18 +385,11 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTypealiasKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = TypealiasDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `typealiasKeyword` replaced.
-  /// - param newChild: The new `typealiasKeyword` to replace the node's
-  ///                   current `typealiasKeyword`, if present.
-  public func withTypealiasKeyword(_ newChild: TokenSyntax) -> TypealiasDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return TypealiasDeclSyntax(newData)
   }
 
   public var unexpectedBetweenTypealiasKeywordAndIdentifier: UnexpectedNodesSyntax? {
@@ -476,18 +399,11 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTypealiasKeywordAndIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = TypealiasDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTypealiasKeywordAndIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenTypealiasKeywordAndIdentifier` to replace the node's
-  ///                   current `unexpectedBetweenTypealiasKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenTypealiasKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return TypealiasDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
@@ -496,18 +412,11 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = TypealiasDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> TypealiasDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return TypealiasDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? {
@@ -517,18 +426,11 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIdentifierAndGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = TypealiasDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndGenericParameterClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenIdentifierAndGenericParameterClause` to replace the node's
-  ///                   current `unexpectedBetweenIdentifierAndGenericParameterClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return TypealiasDeclSyntax(newData)
   }
 
   public var genericParameterClause: GenericParameterClauseSyntax? {
@@ -538,18 +440,11 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericParameterClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = TypealiasDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericParameterClause` replaced.
-  /// - param newChild: The new `genericParameterClause` to replace the node's
-  ///                   current `genericParameterClause`, if present.
-  public func withGenericParameterClause(_ newChild: GenericParameterClauseSyntax?) -> TypealiasDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return TypealiasDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterClauseAndInitializer: UnexpectedNodesSyntax? {
@@ -559,18 +454,11 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericParameterClauseAndInitializer(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = TypealiasDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterClauseAndInitializer` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericParameterClauseAndInitializer` to replace the node's
-  ///                   current `unexpectedBetweenGenericParameterClauseAndInitializer`, if present.
-  public func withUnexpectedBetweenGenericParameterClauseAndInitializer(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return TypealiasDeclSyntax(newData)
   }
 
   public var initializer: TypeInitializerClauseSyntax {
@@ -579,18 +467,11 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TypeInitializerClauseSyntax(childData!)
     }
     set(value) {
-      self = withInitializer(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = TypealiasDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `initializer` replaced.
-  /// - param newChild: The new `initializer` to replace the node's
-  ///                   current `initializer`, if present.
-  public func withInitializer(_ newChild: TypeInitializerClauseSyntax) -> TypealiasDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return TypealiasDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodesSyntax? {
@@ -600,18 +481,11 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInitializerAndGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = TypealiasDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInitializerAndGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenInitializerAndGenericWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenInitializerAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInitializerAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return TypealiasDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
@@ -621,18 +495,11 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericWhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = TypealiasDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericWhereClause` replaced.
-  /// - param newChild: The new `genericWhereClause` to replace the node's
-  ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> TypealiasDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return TypealiasDeclSyntax(newData)
   }
 
   public var unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? {
@@ -642,18 +509,11 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = TypealiasDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedAfterGenericWhereClause` to replace the node's
-  ///                   current `unexpectedAfterGenericWhereClause`, if present.
-  public func withUnexpectedAfterGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return TypealiasDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -808,18 +668,11 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AssociatedtypeDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AssociatedtypeDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -829,7 +682,10 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AssociatedtypeDeclSyntax(newData)
     }
   }
 
@@ -852,16 +708,6 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return AssociatedtypeDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> AssociatedtypeDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AssociatedtypeDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -869,18 +715,11 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AssociatedtypeDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AssociatedtypeDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -890,7 +729,10 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = AssociatedtypeDeclSyntax(newData)
     }
   }
 
@@ -913,16 +755,6 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return AssociatedtypeDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> AssociatedtypeDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return AssociatedtypeDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndAssociatedtypeKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -930,18 +762,11 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndAssociatedtypeKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = AssociatedtypeDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndAssociatedtypeKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndAssociatedtypeKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndAssociatedtypeKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndAssociatedtypeKeyword(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return AssociatedtypeDeclSyntax(newData)
   }
 
   public var associatedtypeKeyword: TokenSyntax {
@@ -950,18 +775,11 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAssociatedtypeKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = AssociatedtypeDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `associatedtypeKeyword` replaced.
-  /// - param newChild: The new `associatedtypeKeyword` to replace the node's
-  ///                   current `associatedtypeKeyword`, if present.
-  public func withAssociatedtypeKeyword(_ newChild: TokenSyntax) -> AssociatedtypeDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return AssociatedtypeDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAssociatedtypeKeywordAndIdentifier: UnexpectedNodesSyntax? {
@@ -971,18 +789,11 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAssociatedtypeKeywordAndIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = AssociatedtypeDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAssociatedtypeKeywordAndIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenAssociatedtypeKeywordAndIdentifier` to replace the node's
-  ///                   current `unexpectedBetweenAssociatedtypeKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenAssociatedtypeKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return AssociatedtypeDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
@@ -991,18 +802,11 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = AssociatedtypeDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> AssociatedtypeDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return AssociatedtypeDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndInheritanceClause: UnexpectedNodesSyntax? {
@@ -1012,18 +816,11 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIdentifierAndInheritanceClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = AssociatedtypeDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndInheritanceClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenIdentifierAndInheritanceClause` to replace the node's
-  ///                   current `unexpectedBetweenIdentifierAndInheritanceClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndInheritanceClause(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return AssociatedtypeDeclSyntax(newData)
   }
 
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
@@ -1033,18 +830,11 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TypeInheritanceClauseSyntax(childData!)
     }
     set(value) {
-      self = withInheritanceClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = AssociatedtypeDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `inheritanceClause` replaced.
-  /// - param newChild: The new `inheritanceClause` to replace the node's
-  ///                   current `inheritanceClause`, if present.
-  public func withInheritanceClause(_ newChild: TypeInheritanceClauseSyntax?) -> AssociatedtypeDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return AssociatedtypeDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInheritanceClauseAndInitializer: UnexpectedNodesSyntax? {
@@ -1054,18 +844,11 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInheritanceClauseAndInitializer(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = AssociatedtypeDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInheritanceClauseAndInitializer` replaced.
-  /// - param newChild: The new `unexpectedBetweenInheritanceClauseAndInitializer` to replace the node's
-  ///                   current `unexpectedBetweenInheritanceClauseAndInitializer`, if present.
-  public func withUnexpectedBetweenInheritanceClauseAndInitializer(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return AssociatedtypeDeclSyntax(newData)
   }
 
   public var initializer: TypeInitializerClauseSyntax? {
@@ -1075,18 +858,11 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TypeInitializerClauseSyntax(childData!)
     }
     set(value) {
-      self = withInitializer(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = AssociatedtypeDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `initializer` replaced.
-  /// - param newChild: The new `initializer` to replace the node's
-  ///                   current `initializer`, if present.
-  public func withInitializer(_ newChild: TypeInitializerClauseSyntax?) -> AssociatedtypeDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return AssociatedtypeDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodesSyntax? {
@@ -1096,18 +872,11 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInitializerAndGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = AssociatedtypeDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInitializerAndGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenInitializerAndGenericWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenInitializerAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInitializerAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return AssociatedtypeDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
@@ -1117,18 +886,11 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericWhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = AssociatedtypeDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericWhereClause` replaced.
-  /// - param newChild: The new `genericWhereClause` to replace the node's
-  ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> AssociatedtypeDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return AssociatedtypeDeclSyntax(newData)
   }
 
   public var unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? {
@@ -1138,18 +900,11 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = AssociatedtypeDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedAfterGenericWhereClause` to replace the node's
-  ///                   current `unexpectedAfterGenericWhereClause`, if present.
-  public func withUnexpectedAfterGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return AssociatedtypeDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1284,18 +1039,11 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeClauses(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = IfConfigDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeClauses` replaced.
-  /// - param newChild: The new `unexpectedBeforeClauses` to replace the node's
-  ///                   current `unexpectedBeforeClauses`, if present.
-  public func withUnexpectedBeforeClauses(_ newChild: UnexpectedNodesSyntax?) -> IfConfigDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return IfConfigDeclSyntax(newData)
   }
 
   public var clauses: IfConfigClauseListSyntax {
@@ -1304,7 +1052,10 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return IfConfigClauseListSyntax(childData!)
     }
     set(value) {
-      self = withClauses(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = IfConfigDeclSyntax(newData)
     }
   }
 
@@ -1327,16 +1078,6 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return IfConfigDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `clauses` replaced.
-  /// - param newChild: The new `clauses` to replace the node's
-  ///                   current `clauses`, if present.
-  public func withClauses(_ newChild: IfConfigClauseListSyntax) -> IfConfigDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return IfConfigDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenClausesAndPoundEndif: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -1344,18 +1085,11 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenClausesAndPoundEndif(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = IfConfigDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenClausesAndPoundEndif` replaced.
-  /// - param newChild: The new `unexpectedBetweenClausesAndPoundEndif` to replace the node's
-  ///                   current `unexpectedBetweenClausesAndPoundEndif`, if present.
-  public func withUnexpectedBetweenClausesAndPoundEndif(_ newChild: UnexpectedNodesSyntax?) -> IfConfigDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return IfConfigDeclSyntax(newData)
   }
 
   public var poundEndif: TokenSyntax {
@@ -1364,18 +1098,11 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPoundEndif(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = IfConfigDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `poundEndif` replaced.
-  /// - param newChild: The new `poundEndif` to replace the node's
-  ///                   current `poundEndif`, if present.
-  public func withPoundEndif(_ newChild: TokenSyntax) -> IfConfigDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return IfConfigDeclSyntax(newData)
   }
 
   public var unexpectedAfterPoundEndif: UnexpectedNodesSyntax? {
@@ -1385,18 +1112,11 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterPoundEndif(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = IfConfigDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterPoundEndif` replaced.
-  /// - param newChild: The new `unexpectedAfterPoundEndif` to replace the node's
-  ///                   current `unexpectedAfterPoundEndif`, if present.
-  public func withUnexpectedAfterPoundEndif(_ newChild: UnexpectedNodesSyntax?) -> IfConfigDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return IfConfigDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1499,18 +1219,11 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforePoundError(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PoundErrorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforePoundError` replaced.
-  /// - param newChild: The new `unexpectedBeforePoundError` to replace the node's
-  ///                   current `unexpectedBeforePoundError`, if present.
-  public func withUnexpectedBeforePoundError(_ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PoundErrorDeclSyntax(newData)
   }
 
   public var poundError: TokenSyntax {
@@ -1519,18 +1232,11 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPoundError(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PoundErrorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `poundError` replaced.
-  /// - param newChild: The new `poundError` to replace the node's
-  ///                   current `poundError`, if present.
-  public func withPoundError(_ newChild: TokenSyntax) -> PoundErrorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PoundErrorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenPoundErrorAndLeftParen: UnexpectedNodesSyntax? {
@@ -1540,18 +1246,11 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPoundErrorAndLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PoundErrorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPoundErrorAndLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenPoundErrorAndLeftParen` to replace the node's
-  ///                   current `unexpectedBetweenPoundErrorAndLeftParen`, if present.
-  public func withUnexpectedBetweenPoundErrorAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PoundErrorDeclSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -1560,18 +1259,11 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PoundErrorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> PoundErrorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PoundErrorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndMessage: UnexpectedNodesSyntax? {
@@ -1581,18 +1273,11 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndMessage(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PoundErrorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndMessage` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndMessage` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndMessage`, if present.
-  public func withUnexpectedBetweenLeftParenAndMessage(_ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PoundErrorDeclSyntax(newData)
   }
 
   public var message: StringLiteralExprSyntax {
@@ -1601,18 +1286,11 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return StringLiteralExprSyntax(childData!)
     }
     set(value) {
-      self = withMessage(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = PoundErrorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `message` replaced.
-  /// - param newChild: The new `message` to replace the node's
-  ///                   current `message`, if present.
-  public func withMessage(_ newChild: StringLiteralExprSyntax) -> PoundErrorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return PoundErrorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? {
@@ -1622,18 +1300,11 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenMessageAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = PoundErrorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenMessageAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenMessageAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenMessageAndRightParen`, if present.
-  public func withUnexpectedBetweenMessageAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return PoundErrorDeclSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -1642,18 +1313,11 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = PoundErrorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> PoundErrorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return PoundErrorDeclSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -1663,18 +1327,11 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = PoundErrorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return PoundErrorDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1793,18 +1450,11 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforePoundWarning(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PoundWarningDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforePoundWarning` replaced.
-  /// - param newChild: The new `unexpectedBeforePoundWarning` to replace the node's
-  ///                   current `unexpectedBeforePoundWarning`, if present.
-  public func withUnexpectedBeforePoundWarning(_ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PoundWarningDeclSyntax(newData)
   }
 
   public var poundWarning: TokenSyntax {
@@ -1813,18 +1463,11 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPoundWarning(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PoundWarningDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `poundWarning` replaced.
-  /// - param newChild: The new `poundWarning` to replace the node's
-  ///                   current `poundWarning`, if present.
-  public func withPoundWarning(_ newChild: TokenSyntax) -> PoundWarningDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PoundWarningDeclSyntax(newData)
   }
 
   public var unexpectedBetweenPoundWarningAndLeftParen: UnexpectedNodesSyntax? {
@@ -1834,18 +1477,11 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPoundWarningAndLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PoundWarningDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPoundWarningAndLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenPoundWarningAndLeftParen` to replace the node's
-  ///                   current `unexpectedBetweenPoundWarningAndLeftParen`, if present.
-  public func withUnexpectedBetweenPoundWarningAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PoundWarningDeclSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -1854,18 +1490,11 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PoundWarningDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> PoundWarningDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PoundWarningDeclSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndMessage: UnexpectedNodesSyntax? {
@@ -1875,18 +1504,11 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndMessage(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PoundWarningDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndMessage` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndMessage` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndMessage`, if present.
-  public func withUnexpectedBetweenLeftParenAndMessage(_ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PoundWarningDeclSyntax(newData)
   }
 
   public var message: StringLiteralExprSyntax {
@@ -1895,18 +1517,11 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return StringLiteralExprSyntax(childData!)
     }
     set(value) {
-      self = withMessage(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = PoundWarningDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `message` replaced.
-  /// - param newChild: The new `message` to replace the node's
-  ///                   current `message`, if present.
-  public func withMessage(_ newChild: StringLiteralExprSyntax) -> PoundWarningDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return PoundWarningDeclSyntax(newData)
   }
 
   public var unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? {
@@ -1916,18 +1531,11 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenMessageAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = PoundWarningDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenMessageAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenMessageAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenMessageAndRightParen`, if present.
-  public func withUnexpectedBetweenMessageAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return PoundWarningDeclSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -1936,18 +1544,11 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = PoundWarningDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> PoundWarningDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return PoundWarningDeclSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -1957,18 +1558,11 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = PoundWarningDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return PoundWarningDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2087,18 +1681,11 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforePoundSourceLocation(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PoundSourceLocationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforePoundSourceLocation` replaced.
-  /// - param newChild: The new `unexpectedBeforePoundSourceLocation` to replace the node's
-  ///                   current `unexpectedBeforePoundSourceLocation`, if present.
-  public func withUnexpectedBeforePoundSourceLocation(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PoundSourceLocationSyntax(newData)
   }
 
   public var poundSourceLocation: TokenSyntax {
@@ -2107,18 +1694,11 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPoundSourceLocation(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PoundSourceLocationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `poundSourceLocation` replaced.
-  /// - param newChild: The new `poundSourceLocation` to replace the node's
-  ///                   current `poundSourceLocation`, if present.
-  public func withPoundSourceLocation(_ newChild: TokenSyntax) -> PoundSourceLocationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PoundSourceLocationSyntax(newData)
   }
 
   public var unexpectedBetweenPoundSourceLocationAndLeftParen: UnexpectedNodesSyntax? {
@@ -2128,18 +1708,11 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPoundSourceLocationAndLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PoundSourceLocationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPoundSourceLocationAndLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenPoundSourceLocationAndLeftParen` to replace the node's
-  ///                   current `unexpectedBetweenPoundSourceLocationAndLeftParen`, if present.
-  public func withUnexpectedBetweenPoundSourceLocationAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PoundSourceLocationSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -2148,18 +1721,11 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PoundSourceLocationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> PoundSourceLocationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PoundSourceLocationSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndArgs: UnexpectedNodesSyntax? {
@@ -2169,18 +1735,11 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndArgs(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PoundSourceLocationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArgs` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndArgs` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndArgs`, if present.
-  public func withUnexpectedBetweenLeftParenAndArgs(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PoundSourceLocationSyntax(newData)
   }
 
   public var args: PoundSourceLocationArgsSyntax? {
@@ -2190,18 +1749,11 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return PoundSourceLocationArgsSyntax(childData!)
     }
     set(value) {
-      self = withArgs(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = PoundSourceLocationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `args` replaced.
-  /// - param newChild: The new `args` to replace the node's
-  ///                   current `args`, if present.
-  public func withArgs(_ newChild: PoundSourceLocationArgsSyntax?) -> PoundSourceLocationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return PoundSourceLocationSyntax(newData)
   }
 
   public var unexpectedBetweenArgsAndRightParen: UnexpectedNodesSyntax? {
@@ -2211,18 +1763,11 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenArgsAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = PoundSourceLocationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenArgsAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenArgsAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenArgsAndRightParen`, if present.
-  public func withUnexpectedBetweenArgsAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return PoundSourceLocationSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -2231,18 +1776,11 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = PoundSourceLocationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> PoundSourceLocationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return PoundSourceLocationSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -2252,18 +1790,11 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = PoundSourceLocationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return PoundSourceLocationSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2398,18 +1929,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -2419,7 +1943,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
   }
 
@@ -2442,16 +1969,6 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ClassDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -2459,18 +1976,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -2480,7 +1990,10 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
   }
 
@@ -2503,16 +2016,6 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ClassDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndClassKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -2520,18 +2023,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndClassKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndClassKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndClassKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndClassKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndClassKeyword(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
   }
 
   public var classKeyword: TokenSyntax {
@@ -2540,18 +2036,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withClassKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `classKeyword` replaced.
-  /// - param newChild: The new `classKeyword` to replace the node's
-  ///                   current `classKeyword`, if present.
-  public func withClassKeyword(_ newChild: TokenSyntax) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
   }
 
   public var unexpectedBetweenClassKeywordAndIdentifier: UnexpectedNodesSyntax? {
@@ -2561,18 +2050,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenClassKeywordAndIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenClassKeywordAndIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenClassKeywordAndIdentifier` to replace the node's
-  ///                   current `unexpectedBetweenClassKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenClassKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
@@ -2581,18 +2063,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? {
@@ -2602,18 +2077,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIdentifierAndGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndGenericParameterClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenIdentifierAndGenericParameterClause` to replace the node's
-  ///                   current `unexpectedBetweenIdentifierAndGenericParameterClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
   }
 
   public var genericParameterClause: GenericParameterClauseSyntax? {
@@ -2623,18 +2091,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericParameterClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericParameterClause` replaced.
-  /// - param newChild: The new `genericParameterClause` to replace the node's
-  ///                   current `genericParameterClause`, if present.
-  public func withGenericParameterClause(_ newChild: GenericParameterClauseSyntax?) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? {
@@ -2644,18 +2105,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericParameterClauseAndInheritanceClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterClauseAndInheritanceClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericParameterClauseAndInheritanceClause` to replace the node's
-  ///                   current `unexpectedBetweenGenericParameterClauseAndInheritanceClause`, if present.
-  public func withUnexpectedBetweenGenericParameterClauseAndInheritanceClause(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
   }
 
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
@@ -2665,18 +2119,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TypeInheritanceClauseSyntax(childData!)
     }
     set(value) {
-      self = withInheritanceClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `inheritanceClause` replaced.
-  /// - param newChild: The new `inheritanceClause` to replace the node's
-  ///                   current `inheritanceClause`, if present.
-  public func withInheritanceClause(_ newChild: TypeInheritanceClauseSyntax?) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? {
@@ -2686,18 +2133,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInheritanceClauseAndGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenInheritanceClauseAndGenericWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenInheritanceClauseAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
@@ -2707,18 +2147,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericWhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericWhereClause` replaced.
-  /// - param newChild: The new `genericWhereClause` to replace the node's
-  ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
@@ -2728,18 +2161,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericWhereClauseAndMembers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndMembers` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndMembers` to replace the node's
-  ///                   current `unexpectedBetweenGenericWhereClauseAndMembers`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndMembers(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
   }
 
   public var members: MemberDeclBlockSyntax {
@@ -2748,18 +2174,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return MemberDeclBlockSyntax(childData!)
     }
     set(value) {
-      self = withMembers(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 15, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `members` replaced.
-  /// - param newChild: The new `members` to replace the node's
-  ///                   current `members`, if present.
-  public func withMembers(_ newChild: MemberDeclBlockSyntax) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 15, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
   }
 
   public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
@@ -2769,18 +2188,11 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterMembers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 16, with: raw, arena: arena)
+      self = ClassDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
-  /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
-  ///                   current `unexpectedAfterMembers`, if present.
-  public func withUnexpectedAfterMembers(_ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 16, with: raw, arena: arena)
-    return ClassDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2947,18 +2359,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -2968,7 +2373,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
   }
 
@@ -2991,16 +2399,6 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ActorDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -3008,18 +2406,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -3029,7 +2420,10 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
   }
 
@@ -3052,16 +2446,6 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ActorDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndActorKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -3069,18 +2453,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndActorKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndActorKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndActorKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndActorKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndActorKeyword(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
   }
 
   public var actorKeyword: TokenSyntax {
@@ -3089,18 +2466,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withActorKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `actorKeyword` replaced.
-  /// - param newChild: The new `actorKeyword` to replace the node's
-  ///                   current `actorKeyword`, if present.
-  public func withActorKeyword(_ newChild: TokenSyntax) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenActorKeywordAndIdentifier: UnexpectedNodesSyntax? {
@@ -3110,18 +2480,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenActorKeywordAndIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenActorKeywordAndIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenActorKeywordAndIdentifier` to replace the node's
-  ///                   current `unexpectedBetweenActorKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenActorKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
@@ -3130,18 +2493,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? {
@@ -3151,18 +2507,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIdentifierAndGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndGenericParameterClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenIdentifierAndGenericParameterClause` to replace the node's
-  ///                   current `unexpectedBetweenIdentifierAndGenericParameterClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
   }
 
   public var genericParameterClause: GenericParameterClauseSyntax? {
@@ -3172,18 +2521,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericParameterClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericParameterClause` replaced.
-  /// - param newChild: The new `genericParameterClause` to replace the node's
-  ///                   current `genericParameterClause`, if present.
-  public func withGenericParameterClause(_ newChild: GenericParameterClauseSyntax?) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? {
@@ -3193,18 +2535,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericParameterClauseAndInheritanceClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterClauseAndInheritanceClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericParameterClauseAndInheritanceClause` to replace the node's
-  ///                   current `unexpectedBetweenGenericParameterClauseAndInheritanceClause`, if present.
-  public func withUnexpectedBetweenGenericParameterClauseAndInheritanceClause(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
   }
 
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
@@ -3214,18 +2549,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TypeInheritanceClauseSyntax(childData!)
     }
     set(value) {
-      self = withInheritanceClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `inheritanceClause` replaced.
-  /// - param newChild: The new `inheritanceClause` to replace the node's
-  ///                   current `inheritanceClause`, if present.
-  public func withInheritanceClause(_ newChild: TypeInheritanceClauseSyntax?) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? {
@@ -3235,18 +2563,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInheritanceClauseAndGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenInheritanceClauseAndGenericWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenInheritanceClauseAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
@@ -3256,18 +2577,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericWhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericWhereClause` replaced.
-  /// - param newChild: The new `genericWhereClause` to replace the node's
-  ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
@@ -3277,18 +2591,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericWhereClauseAndMembers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndMembers` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndMembers` to replace the node's
-  ///                   current `unexpectedBetweenGenericWhereClauseAndMembers`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndMembers(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
   }
 
   public var members: MemberDeclBlockSyntax {
@@ -3297,18 +2604,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return MemberDeclBlockSyntax(childData!)
     }
     set(value) {
-      self = withMembers(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 15, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `members` replaced.
-  /// - param newChild: The new `members` to replace the node's
-  ///                   current `members`, if present.
-  public func withMembers(_ newChild: MemberDeclBlockSyntax) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 15, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
   }
 
   public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
@@ -3318,18 +2618,11 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterMembers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 16, with: raw, arena: arena)
+      self = ActorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
-  /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
-  ///                   current `unexpectedAfterMembers`, if present.
-  public func withUnexpectedAfterMembers(_ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 16, with: raw, arena: arena)
-    return ActorDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -3496,18 +2789,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -3517,7 +2803,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
   }
 
@@ -3540,16 +2829,6 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return StructDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -3557,18 +2836,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -3578,7 +2850,10 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
   }
 
@@ -3601,16 +2876,6 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return StructDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndStructKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -3618,18 +2883,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndStructKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndStructKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndStructKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndStructKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndStructKeyword(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
   }
 
   public var structKeyword: TokenSyntax {
@@ -3638,18 +2896,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withStructKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `structKeyword` replaced.
-  /// - param newChild: The new `structKeyword` to replace the node's
-  ///                   current `structKeyword`, if present.
-  public func withStructKeyword(_ newChild: TokenSyntax) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
   }
 
   public var unexpectedBetweenStructKeywordAndIdentifier: UnexpectedNodesSyntax? {
@@ -3659,18 +2910,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenStructKeywordAndIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenStructKeywordAndIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenStructKeywordAndIdentifier` to replace the node's
-  ///                   current `unexpectedBetweenStructKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenStructKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
@@ -3679,18 +2923,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? {
@@ -3700,18 +2937,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIdentifierAndGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndGenericParameterClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenIdentifierAndGenericParameterClause` to replace the node's
-  ///                   current `unexpectedBetweenIdentifierAndGenericParameterClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
   }
 
   public var genericParameterClause: GenericParameterClauseSyntax? {
@@ -3721,18 +2951,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericParameterClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericParameterClause` replaced.
-  /// - param newChild: The new `genericParameterClause` to replace the node's
-  ///                   current `genericParameterClause`, if present.
-  public func withGenericParameterClause(_ newChild: GenericParameterClauseSyntax?) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? {
@@ -3742,18 +2965,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericParameterClauseAndInheritanceClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterClauseAndInheritanceClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericParameterClauseAndInheritanceClause` to replace the node's
-  ///                   current `unexpectedBetweenGenericParameterClauseAndInheritanceClause`, if present.
-  public func withUnexpectedBetweenGenericParameterClauseAndInheritanceClause(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
   }
 
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
@@ -3763,18 +2979,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TypeInheritanceClauseSyntax(childData!)
     }
     set(value) {
-      self = withInheritanceClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `inheritanceClause` replaced.
-  /// - param newChild: The new `inheritanceClause` to replace the node's
-  ///                   current `inheritanceClause`, if present.
-  public func withInheritanceClause(_ newChild: TypeInheritanceClauseSyntax?) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? {
@@ -3784,18 +2993,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInheritanceClauseAndGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenInheritanceClauseAndGenericWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenInheritanceClauseAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
@@ -3805,18 +3007,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericWhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericWhereClause` replaced.
-  /// - param newChild: The new `genericWhereClause` to replace the node's
-  ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
@@ -3826,18 +3021,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericWhereClauseAndMembers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndMembers` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndMembers` to replace the node's
-  ///                   current `unexpectedBetweenGenericWhereClauseAndMembers`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndMembers(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
   }
 
   public var members: MemberDeclBlockSyntax {
@@ -3846,18 +3034,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return MemberDeclBlockSyntax(childData!)
     }
     set(value) {
-      self = withMembers(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 15, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `members` replaced.
-  /// - param newChild: The new `members` to replace the node's
-  ///                   current `members`, if present.
-  public func withMembers(_ newChild: MemberDeclBlockSyntax) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 15, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
   }
 
   public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
@@ -3867,18 +3048,11 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterMembers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 16, with: raw, arena: arena)
+      self = StructDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
-  /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
-  ///                   current `unexpectedAfterMembers`, if present.
-  public func withUnexpectedAfterMembers(_ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 16, with: raw, arena: arena)
-    return StructDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -4045,18 +3219,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -4066,7 +3233,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
   }
 
@@ -4089,16 +3259,6 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ProtocolDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -4106,18 +3266,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -4127,7 +3280,10 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
   }
 
@@ -4150,16 +3306,6 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ProtocolDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndProtocolKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -4167,18 +3313,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndProtocolKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndProtocolKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndProtocolKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndProtocolKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndProtocolKeyword(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
   }
 
   public var protocolKeyword: TokenSyntax {
@@ -4187,18 +3326,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withProtocolKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `protocolKeyword` replaced.
-  /// - param newChild: The new `protocolKeyword` to replace the node's
-  ///                   current `protocolKeyword`, if present.
-  public func withProtocolKeyword(_ newChild: TokenSyntax) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
   }
 
   public var unexpectedBetweenProtocolKeywordAndIdentifier: UnexpectedNodesSyntax? {
@@ -4208,18 +3340,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenProtocolKeywordAndIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenProtocolKeywordAndIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenProtocolKeywordAndIdentifier` to replace the node's
-  ///                   current `unexpectedBetweenProtocolKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenProtocolKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
@@ -4228,18 +3353,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause: UnexpectedNodesSyntax? {
@@ -4249,18 +3367,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause` to replace the node's
-  ///                   current `unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
   }
 
   public var primaryAssociatedTypeClause: PrimaryAssociatedTypeClauseSyntax? {
@@ -4270,18 +3381,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return PrimaryAssociatedTypeClauseSyntax(childData!)
     }
     set(value) {
-      self = withPrimaryAssociatedTypeClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `primaryAssociatedTypeClause` replaced.
-  /// - param newChild: The new `primaryAssociatedTypeClause` to replace the node's
-  ///                   current `primaryAssociatedTypeClause`, if present.
-  public func withPrimaryAssociatedTypeClause(_ newChild: PrimaryAssociatedTypeClauseSyntax?) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
   }
 
   public var unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause: UnexpectedNodesSyntax? {
@@ -4291,18 +3395,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause` to replace the node's
-  ///                   current `unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause`, if present.
-  public func withUnexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
   }
 
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
@@ -4312,18 +3409,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TypeInheritanceClauseSyntax(childData!)
     }
     set(value) {
-      self = withInheritanceClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `inheritanceClause` replaced.
-  /// - param newChild: The new `inheritanceClause` to replace the node's
-  ///                   current `inheritanceClause`, if present.
-  public func withInheritanceClause(_ newChild: TypeInheritanceClauseSyntax?) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? {
@@ -4333,18 +3423,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInheritanceClauseAndGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenInheritanceClauseAndGenericWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenInheritanceClauseAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
@@ -4354,18 +3437,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericWhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericWhereClause` replaced.
-  /// - param newChild: The new `genericWhereClause` to replace the node's
-  ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
@@ -4375,18 +3451,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericWhereClauseAndMembers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndMembers` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndMembers` to replace the node's
-  ///                   current `unexpectedBetweenGenericWhereClauseAndMembers`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndMembers(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
   }
 
   public var members: MemberDeclBlockSyntax {
@@ -4395,18 +3464,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return MemberDeclBlockSyntax(childData!)
     }
     set(value) {
-      self = withMembers(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 15, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `members` replaced.
-  /// - param newChild: The new `members` to replace the node's
-  ///                   current `members`, if present.
-  public func withMembers(_ newChild: MemberDeclBlockSyntax) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 15, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
   }
 
   public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
@@ -4416,18 +3478,11 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterMembers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 16, with: raw, arena: arena)
+      self = ProtocolDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
-  /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
-  ///                   current `unexpectedAfterMembers`, if present.
-  public func withUnexpectedAfterMembers(_ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 16, with: raw, arena: arena)
-    return ProtocolDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -4590,18 +3645,11 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ExtensionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ExtensionDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -4611,7 +3659,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ExtensionDeclSyntax(newData)
     }
   }
 
@@ -4634,16 +3685,6 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ExtensionDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> ExtensionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ExtensionDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -4651,18 +3692,11 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ExtensionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ExtensionDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -4672,7 +3706,10 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ExtensionDeclSyntax(newData)
     }
   }
 
@@ -4695,16 +3732,6 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ExtensionDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> ExtensionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ExtensionDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndExtensionKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -4712,18 +3739,11 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndExtensionKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ExtensionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndExtensionKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndExtensionKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndExtensionKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndExtensionKeyword(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ExtensionDeclSyntax(newData)
   }
 
   public var extensionKeyword: TokenSyntax {
@@ -4732,18 +3752,11 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withExtensionKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ExtensionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `extensionKeyword` replaced.
-  /// - param newChild: The new `extensionKeyword` to replace the node's
-  ///                   current `extensionKeyword`, if present.
-  public func withExtensionKeyword(_ newChild: TokenSyntax) -> ExtensionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ExtensionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenExtensionKeywordAndExtendedType: UnexpectedNodesSyntax? {
@@ -4753,18 +3766,11 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenExtensionKeywordAndExtendedType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ExtensionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenExtensionKeywordAndExtendedType` replaced.
-  /// - param newChild: The new `unexpectedBetweenExtensionKeywordAndExtendedType` to replace the node's
-  ///                   current `unexpectedBetweenExtensionKeywordAndExtendedType`, if present.
-  public func withUnexpectedBetweenExtensionKeywordAndExtendedType(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ExtensionDeclSyntax(newData)
   }
 
   public var extendedType: TypeSyntax {
@@ -4773,18 +3779,11 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withExtendedType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = ExtensionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `extendedType` replaced.
-  /// - param newChild: The new `extendedType` to replace the node's
-  ///                   current `extendedType`, if present.
-  public func withExtendedType(_ newChild: TypeSyntax) -> ExtensionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return ExtensionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenExtendedTypeAndInheritanceClause: UnexpectedNodesSyntax? {
@@ -4794,18 +3793,11 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenExtendedTypeAndInheritanceClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = ExtensionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenExtendedTypeAndInheritanceClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenExtendedTypeAndInheritanceClause` to replace the node's
-  ///                   current `unexpectedBetweenExtendedTypeAndInheritanceClause`, if present.
-  public func withUnexpectedBetweenExtendedTypeAndInheritanceClause(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return ExtensionDeclSyntax(newData)
   }
 
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
@@ -4815,18 +3807,11 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TypeInheritanceClauseSyntax(childData!)
     }
     set(value) {
-      self = withInheritanceClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = ExtensionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `inheritanceClause` replaced.
-  /// - param newChild: The new `inheritanceClause` to replace the node's
-  ///                   current `inheritanceClause`, if present.
-  public func withInheritanceClause(_ newChild: TypeInheritanceClauseSyntax?) -> ExtensionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return ExtensionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? {
@@ -4836,18 +3821,11 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = ExtensionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInheritanceClauseAndGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenInheritanceClauseAndGenericWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenInheritanceClauseAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return ExtensionDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
@@ -4857,18 +3835,11 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericWhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = ExtensionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericWhereClause` replaced.
-  /// - param newChild: The new `genericWhereClause` to replace the node's
-  ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> ExtensionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return ExtensionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
@@ -4878,18 +3849,11 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericWhereClauseAndMembers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = ExtensionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndMembers` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndMembers` to replace the node's
-  ///                   current `unexpectedBetweenGenericWhereClauseAndMembers`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndMembers(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return ExtensionDeclSyntax(newData)
   }
 
   public var members: MemberDeclBlockSyntax {
@@ -4898,18 +3862,11 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return MemberDeclBlockSyntax(childData!)
     }
     set(value) {
-      self = withMembers(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = ExtensionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `members` replaced.
-  /// - param newChild: The new `members` to replace the node's
-  ///                   current `members`, if present.
-  public func withMembers(_ newChild: MemberDeclBlockSyntax) -> ExtensionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return ExtensionDeclSyntax(newData)
   }
 
   public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
@@ -4919,18 +3876,11 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterMembers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = ExtensionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
-  /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
-  ///                   current `unexpectedAfterMembers`, if present.
-  public func withUnexpectedAfterMembers(_ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return ExtensionDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -5089,18 +4039,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -5110,7 +4053,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
   }
 
@@ -5133,16 +4079,6 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return FunctionDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -5150,18 +4086,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -5171,7 +4100,10 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
   }
 
@@ -5194,16 +4126,6 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return FunctionDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndFuncKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -5211,18 +4133,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndFuncKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndFuncKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndFuncKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndFuncKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndFuncKeyword(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
   }
 
   public var funcKeyword: TokenSyntax {
@@ -5231,18 +4146,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withFuncKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `funcKeyword` replaced.
-  /// - param newChild: The new `funcKeyword` to replace the node's
-  ///                   current `funcKeyword`, if present.
-  public func withFuncKeyword(_ newChild: TokenSyntax) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenFuncKeywordAndIdentifier: UnexpectedNodesSyntax? {
@@ -5252,18 +4160,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenFuncKeywordAndIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenFuncKeywordAndIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenFuncKeywordAndIdentifier` to replace the node's
-  ///                   current `unexpectedBetweenFuncKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenFuncKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
@@ -5272,18 +4173,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? {
@@ -5293,18 +4187,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIdentifierAndGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndGenericParameterClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenIdentifierAndGenericParameterClause` to replace the node's
-  ///                   current `unexpectedBetweenIdentifierAndGenericParameterClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
   }
 
   public var genericParameterClause: GenericParameterClauseSyntax? {
@@ -5314,18 +4201,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericParameterClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericParameterClause` replaced.
-  /// - param newChild: The new `genericParameterClause` to replace the node's
-  ///                   current `genericParameterClause`, if present.
-  public func withGenericParameterClause(_ newChild: GenericParameterClauseSyntax?) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? {
@@ -5335,18 +4215,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericParameterClauseAndSignature(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterClauseAndSignature` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericParameterClauseAndSignature` to replace the node's
-  ///                   current `unexpectedBetweenGenericParameterClauseAndSignature`, if present.
-  public func withUnexpectedBetweenGenericParameterClauseAndSignature(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
   }
 
   public var signature: FunctionSignatureSyntax {
@@ -5355,18 +4228,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return FunctionSignatureSyntax(childData!)
     }
     set(value) {
-      self = withSignature(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `signature` replaced.
-  /// - param newChild: The new `signature` to replace the node's
-  ///                   current `signature`, if present.
-  public func withSignature(_ newChild: FunctionSignatureSyntax) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodesSyntax? {
@@ -5376,18 +4242,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSignatureAndGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSignatureAndGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenSignatureAndGenericWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenSignatureAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenSignatureAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
@@ -5397,18 +4256,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericWhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericWhereClause` replaced.
-  /// - param newChild: The new `genericWhereClause` to replace the node's
-  ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodesSyntax? {
@@ -5418,18 +4270,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericWhereClauseAndBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndBody` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndBody` to replace the node's
-  ///                   current `unexpectedBetweenGenericWhereClauseAndBody`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndBody(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
   }
 
   public var body: CodeBlockSyntax? {
@@ -5439,18 +4284,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return CodeBlockSyntax(childData!)
     }
     set(value) {
-      self = withBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 15, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `body` replaced.
-  /// - param newChild: The new `body` to replace the node's
-  ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax?) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 15, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
   }
 
   public var unexpectedAfterBody: UnexpectedNodesSyntax? {
@@ -5460,18 +4298,11 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 16, with: raw, arena: arena)
+      self = FunctionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
-  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
-  ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 16, with: raw, arena: arena)
-    return FunctionDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -5638,18 +4469,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -5659,7 +4483,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
   }
 
@@ -5682,16 +4509,6 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return InitializerDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -5699,18 +4516,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -5720,7 +4530,10 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
   }
 
@@ -5743,16 +4556,6 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return InitializerDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndInitKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -5760,18 +4563,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndInitKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndInitKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndInitKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndInitKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndInitKeyword(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
   }
 
   public var initKeyword: TokenSyntax {
@@ -5780,18 +4576,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withInitKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `initKeyword` replaced.
-  /// - param newChild: The new `initKeyword` to replace the node's
-  ///                   current `initKeyword`, if present.
-  public func withInitKeyword(_ newChild: TokenSyntax) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInitKeywordAndOptionalMark: UnexpectedNodesSyntax? {
@@ -5801,18 +4590,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInitKeywordAndOptionalMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInitKeywordAndOptionalMark` replaced.
-  /// - param newChild: The new `unexpectedBetweenInitKeywordAndOptionalMark` to replace the node's
-  ///                   current `unexpectedBetweenInitKeywordAndOptionalMark`, if present.
-  public func withUnexpectedBetweenInitKeywordAndOptionalMark(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
   }
 
   public var optionalMark: TokenSyntax? {
@@ -5822,18 +4604,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withOptionalMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `optionalMark` replaced.
-  /// - param newChild: The new `optionalMark` to replace the node's
-  ///                   current `optionalMark`, if present.
-  public func withOptionalMark(_ newChild: TokenSyntax?) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenOptionalMarkAndGenericParameterClause: UnexpectedNodesSyntax? {
@@ -5843,18 +4618,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenOptionalMarkAndGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenOptionalMarkAndGenericParameterClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenOptionalMarkAndGenericParameterClause` to replace the node's
-  ///                   current `unexpectedBetweenOptionalMarkAndGenericParameterClause`, if present.
-  public func withUnexpectedBetweenOptionalMarkAndGenericParameterClause(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
   }
 
   public var genericParameterClause: GenericParameterClauseSyntax? {
@@ -5864,18 +4632,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericParameterClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericParameterClause` replaced.
-  /// - param newChild: The new `genericParameterClause` to replace the node's
-  ///                   current `genericParameterClause`, if present.
-  public func withGenericParameterClause(_ newChild: GenericParameterClauseSyntax?) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? {
@@ -5885,18 +4646,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericParameterClauseAndSignature(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterClauseAndSignature` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericParameterClauseAndSignature` to replace the node's
-  ///                   current `unexpectedBetweenGenericParameterClauseAndSignature`, if present.
-  public func withUnexpectedBetweenGenericParameterClauseAndSignature(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
   }
 
   public var signature: FunctionSignatureSyntax {
@@ -5905,18 +4659,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return FunctionSignatureSyntax(childData!)
     }
     set(value) {
-      self = withSignature(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `signature` replaced.
-  /// - param newChild: The new `signature` to replace the node's
-  ///                   current `signature`, if present.
-  public func withSignature(_ newChild: FunctionSignatureSyntax) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodesSyntax? {
@@ -5926,18 +4673,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSignatureAndGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSignatureAndGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenSignatureAndGenericWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenSignatureAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenSignatureAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
@@ -5947,18 +4687,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericWhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericWhereClause` replaced.
-  /// - param newChild: The new `genericWhereClause` to replace the node's
-  ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodesSyntax? {
@@ -5968,18 +4701,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericWhereClauseAndBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndBody` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndBody` to replace the node's
-  ///                   current `unexpectedBetweenGenericWhereClauseAndBody`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndBody(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
   }
 
   public var body: CodeBlockSyntax? {
@@ -5989,18 +4715,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return CodeBlockSyntax(childData!)
     }
     set(value) {
-      self = withBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 15, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `body` replaced.
-  /// - param newChild: The new `body` to replace the node's
-  ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax?) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 15, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
   }
 
   public var unexpectedAfterBody: UnexpectedNodesSyntax? {
@@ -6010,18 +4729,11 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 16, with: raw, arena: arena)
+      self = InitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
-  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
-  ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 16, with: raw, arena: arena)
-    return InitializerDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -6172,18 +4884,11 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DeinitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DeinitializerDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -6193,7 +4898,10 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DeinitializerDeclSyntax(newData)
     }
   }
 
@@ -6216,16 +4924,6 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return DeinitializerDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> DeinitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DeinitializerDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -6233,18 +4931,11 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DeinitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DeinitializerDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -6254,7 +4945,10 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DeinitializerDeclSyntax(newData)
     }
   }
 
@@ -6277,16 +4971,6 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return DeinitializerDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> DeinitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DeinitializerDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndDeinitKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -6294,18 +4978,11 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndDeinitKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DeinitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndDeinitKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndDeinitKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndDeinitKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndDeinitKeyword(_ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DeinitializerDeclSyntax(newData)
   }
 
   public var deinitKeyword: TokenSyntax {
@@ -6314,18 +4991,11 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withDeinitKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = DeinitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `deinitKeyword` replaced.
-  /// - param newChild: The new `deinitKeyword` to replace the node's
-  ///                   current `deinitKeyword`, if present.
-  public func withDeinitKeyword(_ newChild: TokenSyntax) -> DeinitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return DeinitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenDeinitKeywordAndBody: UnexpectedNodesSyntax? {
@@ -6335,18 +5005,11 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDeinitKeywordAndBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = DeinitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDeinitKeywordAndBody` replaced.
-  /// - param newChild: The new `unexpectedBetweenDeinitKeywordAndBody` to replace the node's
-  ///                   current `unexpectedBetweenDeinitKeywordAndBody`, if present.
-  public func withUnexpectedBetweenDeinitKeywordAndBody(_ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return DeinitializerDeclSyntax(newData)
   }
 
   public var body: CodeBlockSyntax? {
@@ -6356,18 +5019,11 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return CodeBlockSyntax(childData!)
     }
     set(value) {
-      self = withBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = DeinitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `body` replaced.
-  /// - param newChild: The new `body` to replace the node's
-  ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax?) -> DeinitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return DeinitializerDeclSyntax(newData)
   }
 
   public var unexpectedAfterBody: UnexpectedNodesSyntax? {
@@ -6377,18 +5033,11 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = DeinitializerDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
-  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
-  ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return DeinitializerDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -6559,18 +5208,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -6580,7 +5222,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
   }
 
@@ -6603,16 +5248,6 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return SubscriptDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -6620,18 +5255,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -6641,7 +5269,10 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
   }
 
@@ -6664,16 +5295,6 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return SubscriptDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndSubscriptKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -6681,18 +5302,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndSubscriptKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndSubscriptKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndSubscriptKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndSubscriptKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndSubscriptKeyword(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
   }
 
   public var subscriptKeyword: TokenSyntax {
@@ -6701,18 +5315,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withSubscriptKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `subscriptKeyword` replaced.
-  /// - param newChild: The new `subscriptKeyword` to replace the node's
-  ///                   current `subscriptKeyword`, if present.
-  public func withSubscriptKeyword(_ newChild: TokenSyntax) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
   }
 
   public var unexpectedBetweenSubscriptKeywordAndGenericParameterClause: UnexpectedNodesSyntax? {
@@ -6722,18 +5329,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSubscriptKeywordAndGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSubscriptKeywordAndGenericParameterClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenSubscriptKeywordAndGenericParameterClause` to replace the node's
-  ///                   current `unexpectedBetweenSubscriptKeywordAndGenericParameterClause`, if present.
-  public func withUnexpectedBetweenSubscriptKeywordAndGenericParameterClause(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
   }
 
   public var genericParameterClause: GenericParameterClauseSyntax? {
@@ -6743,18 +5343,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericParameterClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericParameterClause` replaced.
-  /// - param newChild: The new `genericParameterClause` to replace the node's
-  ///                   current `genericParameterClause`, if present.
-  public func withGenericParameterClause(_ newChild: GenericParameterClauseSyntax?) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterClauseAndIndices: UnexpectedNodesSyntax? {
@@ -6764,18 +5357,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericParameterClauseAndIndices(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterClauseAndIndices` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericParameterClauseAndIndices` to replace the node's
-  ///                   current `unexpectedBetweenGenericParameterClauseAndIndices`, if present.
-  public func withUnexpectedBetweenGenericParameterClauseAndIndices(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
   }
 
   public var indices: ParameterClauseSyntax {
@@ -6784,18 +5370,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ParameterClauseSyntax(childData!)
     }
     set(value) {
-      self = withIndices(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `indices` replaced.
-  /// - param newChild: The new `indices` to replace the node's
-  ///                   current `indices`, if present.
-  public func withIndices(_ newChild: ParameterClauseSyntax) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIndicesAndResult: UnexpectedNodesSyntax? {
@@ -6805,18 +5384,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIndicesAndResult(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIndicesAndResult` replaced.
-  /// - param newChild: The new `unexpectedBetweenIndicesAndResult` to replace the node's
-  ///                   current `unexpectedBetweenIndicesAndResult`, if present.
-  public func withUnexpectedBetweenIndicesAndResult(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
   }
 
   public var result: ReturnClauseSyntax {
@@ -6825,18 +5397,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ReturnClauseSyntax(childData!)
     }
     set(value) {
-      self = withResult(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `result` replaced.
-  /// - param newChild: The new `result` to replace the node's
-  ///                   current `result`, if present.
-  public func withResult(_ newChild: ReturnClauseSyntax) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
   }
 
   public var unexpectedBetweenResultAndGenericWhereClause: UnexpectedNodesSyntax? {
@@ -6846,18 +5411,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenResultAndGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenResultAndGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenResultAndGenericWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenResultAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenResultAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
@@ -6867,18 +5425,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericWhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericWhereClause` replaced.
-  /// - param newChild: The new `genericWhereClause` to replace the node's
-  ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndAccessor: UnexpectedNodesSyntax? {
@@ -6888,18 +5439,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericWhereClauseAndAccessor(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndAccessor` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndAccessor` to replace the node's
-  ///                   current `unexpectedBetweenGenericWhereClauseAndAccessor`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndAccessor(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
   }
 
   public var accessor: Accessor? {
@@ -6909,18 +5453,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return Accessor(childData!)
     }
     set(value) {
-      self = withAccessor(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 15, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `accessor` replaced.
-  /// - param newChild: The new `accessor` to replace the node's
-  ///                   current `accessor`, if present.
-  public func withAccessor(_ newChild: Accessor?) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 15, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
   }
 
   public var unexpectedAfterAccessor: UnexpectedNodesSyntax? {
@@ -6930,18 +5467,11 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterAccessor(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 16, with: raw, arena: arena)
+      self = SubscriptDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterAccessor` replaced.
-  /// - param newChild: The new `unexpectedAfterAccessor` to replace the node's
-  ///                   current `unexpectedAfterAccessor`, if present.
-  public func withUnexpectedAfterAccessor(_ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 16, with: raw, arena: arena)
-    return SubscriptDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -7096,18 +5626,11 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ImportDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ImportDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -7117,7 +5640,10 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ImportDeclSyntax(newData)
     }
   }
 
@@ -7140,16 +5666,6 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ImportDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> ImportDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ImportDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -7157,18 +5673,11 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ImportDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ImportDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -7178,7 +5687,10 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ImportDeclSyntax(newData)
     }
   }
 
@@ -7201,16 +5713,6 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ImportDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> ImportDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ImportDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndImportTok: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -7218,18 +5720,11 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndImportTok(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ImportDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndImportTok` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndImportTok` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndImportTok`, if present.
-  public func withUnexpectedBetweenModifiersAndImportTok(_ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ImportDeclSyntax(newData)
   }
 
   public var importTok: TokenSyntax {
@@ -7238,18 +5733,11 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withImportTok(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ImportDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `importTok` replaced.
-  /// - param newChild: The new `importTok` to replace the node's
-  ///                   current `importTok`, if present.
-  public func withImportTok(_ newChild: TokenSyntax) -> ImportDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ImportDeclSyntax(newData)
   }
 
   public var unexpectedBetweenImportTokAndImportKind: UnexpectedNodesSyntax? {
@@ -7259,18 +5747,11 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenImportTokAndImportKind(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ImportDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenImportTokAndImportKind` replaced.
-  /// - param newChild: The new `unexpectedBetweenImportTokAndImportKind` to replace the node's
-  ///                   current `unexpectedBetweenImportTokAndImportKind`, if present.
-  public func withUnexpectedBetweenImportTokAndImportKind(_ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ImportDeclSyntax(newData)
   }
 
   public var importKind: TokenSyntax? {
@@ -7280,18 +5761,11 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withImportKind(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = ImportDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `importKind` replaced.
-  /// - param newChild: The new `importKind` to replace the node's
-  ///                   current `importKind`, if present.
-  public func withImportKind(_ newChild: TokenSyntax?) -> ImportDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return ImportDeclSyntax(newData)
   }
 
   public var unexpectedBetweenImportKindAndPath: UnexpectedNodesSyntax? {
@@ -7301,18 +5775,11 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenImportKindAndPath(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = ImportDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenImportKindAndPath` replaced.
-  /// - param newChild: The new `unexpectedBetweenImportKindAndPath` to replace the node's
-  ///                   current `unexpectedBetweenImportKindAndPath`, if present.
-  public func withUnexpectedBetweenImportKindAndPath(_ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return ImportDeclSyntax(newData)
   }
 
   public var path: AccessPathSyntax {
@@ -7321,7 +5788,10 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AccessPathSyntax(childData!)
     }
     set(value) {
-      self = withPath(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = ImportDeclSyntax(newData)
     }
   }
 
@@ -7344,16 +5814,6 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ImportDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `path` replaced.
-  /// - param newChild: The new `path` to replace the node's
-  ///                   current `path`, if present.
-  public func withPath(_ newChild: AccessPathSyntax) -> ImportDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return ImportDeclSyntax(newData)
-  }
-
   public var unexpectedAfterPath: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 10, parent: Syntax(self))
@@ -7361,18 +5821,11 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterPath(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = ImportDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterPath` replaced.
-  /// - param newChild: The new `unexpectedAfterPath` to replace the node's
-  ///                   current `unexpectedAfterPath`, if present.
-  public func withUnexpectedAfterPath(_ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return ImportDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -7507,18 +5960,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AccessorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AccessorDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -7528,7 +5974,10 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AccessorDeclSyntax(newData)
     }
   }
 
@@ -7551,16 +6000,6 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return AccessorDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> AccessorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AccessorDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifier: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -7568,18 +6007,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AccessorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifier` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifier`, if present.
-  public func withUnexpectedBetweenAttributesAndModifier(_ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AccessorDeclSyntax(newData)
   }
 
   public var modifier: DeclModifierSyntax? {
@@ -7589,18 +6021,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return DeclModifierSyntax(childData!)
     }
     set(value) {
-      self = withModifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = AccessorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `modifier` replaced.
-  /// - param newChild: The new `modifier` to replace the node's
-  ///                   current `modifier`, if present.
-  public func withModifier(_ newChild: DeclModifierSyntax?) -> AccessorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return AccessorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifierAndAccessorKind: UnexpectedNodesSyntax? {
@@ -7610,18 +6035,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifierAndAccessorKind(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = AccessorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifierAndAccessorKind` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifierAndAccessorKind` to replace the node's
-  ///                   current `unexpectedBetweenModifierAndAccessorKind`, if present.
-  public func withUnexpectedBetweenModifierAndAccessorKind(_ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return AccessorDeclSyntax(newData)
   }
 
   public var accessorKind: TokenSyntax {
@@ -7630,18 +6048,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAccessorKind(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = AccessorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `accessorKind` replaced.
-  /// - param newChild: The new `accessorKind` to replace the node's
-  ///                   current `accessorKind`, if present.
-  public func withAccessorKind(_ newChild: TokenSyntax) -> AccessorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return AccessorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAccessorKindAndParameter: UnexpectedNodesSyntax? {
@@ -7651,18 +6062,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAccessorKindAndParameter(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = AccessorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAccessorKindAndParameter` replaced.
-  /// - param newChild: The new `unexpectedBetweenAccessorKindAndParameter` to replace the node's
-  ///                   current `unexpectedBetweenAccessorKindAndParameter`, if present.
-  public func withUnexpectedBetweenAccessorKindAndParameter(_ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return AccessorDeclSyntax(newData)
   }
 
   public var parameter: AccessorParameterSyntax? {
@@ -7672,18 +6076,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AccessorParameterSyntax(childData!)
     }
     set(value) {
-      self = withParameter(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = AccessorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `parameter` replaced.
-  /// - param newChild: The new `parameter` to replace the node's
-  ///                   current `parameter`, if present.
-  public func withParameter(_ newChild: AccessorParameterSyntax?) -> AccessorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return AccessorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenParameterAndEffectSpecifiers: UnexpectedNodesSyntax? {
@@ -7693,18 +6090,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenParameterAndEffectSpecifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = AccessorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenParameterAndEffectSpecifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenParameterAndEffectSpecifiers` to replace the node's
-  ///                   current `unexpectedBetweenParameterAndEffectSpecifiers`, if present.
-  public func withUnexpectedBetweenParameterAndEffectSpecifiers(_ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return AccessorDeclSyntax(newData)
   }
 
   public var effectSpecifiers: DeclEffectSpecifiersSyntax? {
@@ -7714,18 +6104,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return DeclEffectSpecifiersSyntax(childData!)
     }
     set(value) {
-      self = withEffectSpecifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = AccessorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `effectSpecifiers` replaced.
-  /// - param newChild: The new `effectSpecifiers` to replace the node's
-  ///                   current `effectSpecifiers`, if present.
-  public func withEffectSpecifiers(_ newChild: DeclEffectSpecifiersSyntax?) -> AccessorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return AccessorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenEffectSpecifiersAndBody: UnexpectedNodesSyntax? {
@@ -7735,18 +6118,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenEffectSpecifiersAndBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = AccessorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenEffectSpecifiersAndBody` replaced.
-  /// - param newChild: The new `unexpectedBetweenEffectSpecifiersAndBody` to replace the node's
-  ///                   current `unexpectedBetweenEffectSpecifiersAndBody`, if present.
-  public func withUnexpectedBetweenEffectSpecifiersAndBody(_ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return AccessorDeclSyntax(newData)
   }
 
   public var body: CodeBlockSyntax? {
@@ -7756,18 +6132,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return CodeBlockSyntax(childData!)
     }
     set(value) {
-      self = withBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = AccessorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `body` replaced.
-  /// - param newChild: The new `body` to replace the node's
-  ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax?) -> AccessorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return AccessorDeclSyntax(newData)
   }
 
   public var unexpectedAfterBody: UnexpectedNodesSyntax? {
@@ -7777,18 +6146,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = AccessorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
-  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
-  ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return AccessorDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -7923,18 +6285,11 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = VariableDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return VariableDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -7944,7 +6299,10 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = VariableDeclSyntax(newData)
     }
   }
 
@@ -7967,16 +6325,6 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return VariableDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> VariableDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return VariableDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -7984,18 +6332,11 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = VariableDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return VariableDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -8005,7 +6346,10 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = VariableDeclSyntax(newData)
     }
   }
 
@@ -8028,16 +6372,6 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return VariableDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> VariableDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return VariableDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndLetOrVarKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -8045,18 +6379,11 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndLetOrVarKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = VariableDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndLetOrVarKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndLetOrVarKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndLetOrVarKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndLetOrVarKeyword(_ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return VariableDeclSyntax(newData)
   }
 
   public var letOrVarKeyword: TokenSyntax {
@@ -8065,18 +6392,11 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLetOrVarKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = VariableDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `letOrVarKeyword` replaced.
-  /// - param newChild: The new `letOrVarKeyword` to replace the node's
-  ///                   current `letOrVarKeyword`, if present.
-  public func withLetOrVarKeyword(_ newChild: TokenSyntax) -> VariableDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return VariableDeclSyntax(newData)
   }
 
   public var unexpectedBetweenLetOrVarKeywordAndBindings: UnexpectedNodesSyntax? {
@@ -8086,18 +6406,11 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLetOrVarKeywordAndBindings(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = VariableDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLetOrVarKeywordAndBindings` replaced.
-  /// - param newChild: The new `unexpectedBetweenLetOrVarKeywordAndBindings` to replace the node's
-  ///                   current `unexpectedBetweenLetOrVarKeywordAndBindings`, if present.
-  public func withUnexpectedBetweenLetOrVarKeywordAndBindings(_ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return VariableDeclSyntax(newData)
   }
 
   public var bindings: PatternBindingListSyntax {
@@ -8106,7 +6419,10 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return PatternBindingListSyntax(childData!)
     }
     set(value) {
-      self = withBindings(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = VariableDeclSyntax(newData)
     }
   }
 
@@ -8129,16 +6445,6 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return VariableDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `bindings` replaced.
-  /// - param newChild: The new `bindings` to replace the node's
-  ///                   current `bindings`, if present.
-  public func withBindings(_ newChild: PatternBindingListSyntax) -> VariableDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return VariableDeclSyntax(newData)
-  }
-
   public var unexpectedAfterBindings: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 8, parent: Syntax(self))
@@ -8146,18 +6452,11 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterBindings(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = VariableDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterBindings` replaced.
-  /// - param newChild: The new `unexpectedAfterBindings` to replace the node's
-  ///                   current `unexpectedAfterBindings`, if present.
-  public func withUnexpectedAfterBindings(_ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return VariableDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -8281,18 +6580,11 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = EnumCaseDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return EnumCaseDeclSyntax(newData)
   }
 
   /// 
@@ -8305,7 +6597,10 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = EnumCaseDeclSyntax(newData)
     }
   }
 
@@ -8328,16 +6623,6 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return EnumCaseDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> EnumCaseDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return EnumCaseDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -8345,18 +6630,11 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = EnumCaseDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return EnumCaseDeclSyntax(newData)
   }
 
   /// 
@@ -8369,7 +6647,10 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = EnumCaseDeclSyntax(newData)
     }
   }
 
@@ -8392,16 +6673,6 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return EnumCaseDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> EnumCaseDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return EnumCaseDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndCaseKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -8409,18 +6680,11 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndCaseKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = EnumCaseDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndCaseKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndCaseKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndCaseKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndCaseKeyword(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return EnumCaseDeclSyntax(newData)
   }
 
   /// The `case` keyword for this case.
@@ -8430,18 +6694,11 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withCaseKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = EnumCaseDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `caseKeyword` replaced.
-  /// - param newChild: The new `caseKeyword` to replace the node's
-  ///                   current `caseKeyword`, if present.
-  public func withCaseKeyword(_ newChild: TokenSyntax) -> EnumCaseDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return EnumCaseDeclSyntax(newData)
   }
 
   public var unexpectedBetweenCaseKeywordAndElements: UnexpectedNodesSyntax? {
@@ -8451,18 +6708,11 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCaseKeywordAndElements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = EnumCaseDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCaseKeywordAndElements` replaced.
-  /// - param newChild: The new `unexpectedBetweenCaseKeywordAndElements` to replace the node's
-  ///                   current `unexpectedBetweenCaseKeywordAndElements`, if present.
-  public func withUnexpectedBetweenCaseKeywordAndElements(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return EnumCaseDeclSyntax(newData)
   }
 
   /// The elements this case declares.
@@ -8472,7 +6722,10 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return EnumCaseElementListSyntax(childData!)
     }
     set(value) {
-      self = withElements(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = EnumCaseDeclSyntax(newData)
     }
   }
 
@@ -8495,16 +6748,6 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return EnumCaseDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `elements` replaced.
-  /// - param newChild: The new `elements` to replace the node's
-  ///                   current `elements`, if present.
-  public func withElements(_ newChild: EnumCaseElementListSyntax) -> EnumCaseDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return EnumCaseDeclSyntax(newData)
-  }
-
   public var unexpectedAfterElements: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 8, parent: Syntax(self))
@@ -8512,18 +6755,11 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterElements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = EnumCaseDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterElements` replaced.
-  /// - param newChild: The new `unexpectedAfterElements` to replace the node's
-  ///                   current `unexpectedAfterElements`, if present.
-  public func withUnexpectedAfterElements(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return EnumCaseDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -8659,18 +6895,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
   }
 
   /// 
@@ -8683,7 +6912,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
   }
 
@@ -8706,16 +6938,6 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return EnumDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -8723,18 +6945,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
   }
 
   /// 
@@ -8747,7 +6962,10 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
   }
 
@@ -8770,16 +6988,6 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return EnumDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndEnumKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -8787,18 +6995,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndEnumKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndEnumKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndEnumKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndEnumKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndEnumKeyword(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
   }
 
   /// 
@@ -8810,18 +7011,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withEnumKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `enumKeyword` replaced.
-  /// - param newChild: The new `enumKeyword` to replace the node's
-  ///                   current `enumKeyword`, if present.
-  public func withEnumKeyword(_ newChild: TokenSyntax) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
   }
 
   public var unexpectedBetweenEnumKeywordAndIdentifier: UnexpectedNodesSyntax? {
@@ -8831,18 +7025,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenEnumKeywordAndIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenEnumKeywordAndIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenEnumKeywordAndIdentifier` to replace the node's
-  ///                   current `unexpectedBetweenEnumKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenEnumKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
   }
 
   /// 
@@ -8854,18 +7041,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndGenericParameters: UnexpectedNodesSyntax? {
@@ -8875,18 +7055,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIdentifierAndGenericParameters(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndGenericParameters` replaced.
-  /// - param newChild: The new `unexpectedBetweenIdentifierAndGenericParameters` to replace the node's
-  ///                   current `unexpectedBetweenIdentifierAndGenericParameters`, if present.
-  public func withUnexpectedBetweenIdentifierAndGenericParameters(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
   }
 
   /// 
@@ -8899,18 +7072,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericParameterClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericParameters(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericParameters` replaced.
-  /// - param newChild: The new `genericParameters` to replace the node's
-  ///                   current `genericParameters`, if present.
-  public func withGenericParameters(_ newChild: GenericParameterClauseSyntax?) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParametersAndInheritanceClause: UnexpectedNodesSyntax? {
@@ -8920,18 +7086,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericParametersAndInheritanceClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericParametersAndInheritanceClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericParametersAndInheritanceClause` to replace the node's
-  ///                   current `unexpectedBetweenGenericParametersAndInheritanceClause`, if present.
-  public func withUnexpectedBetweenGenericParametersAndInheritanceClause(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
   }
 
   /// 
@@ -8945,18 +7104,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TypeInheritanceClauseSyntax(childData!)
     }
     set(value) {
-      self = withInheritanceClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `inheritanceClause` replaced.
-  /// - param newChild: The new `inheritanceClause` to replace the node's
-  ///                   current `inheritanceClause`, if present.
-  public func withInheritanceClause(_ newChild: TypeInheritanceClauseSyntax?) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? {
@@ -8966,18 +7118,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInheritanceClauseAndGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenInheritanceClauseAndGenericWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenInheritanceClauseAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
   }
 
   /// 
@@ -8991,18 +7136,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericWhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericWhereClause` replaced.
-  /// - param newChild: The new `genericWhereClause` to replace the node's
-  ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
@@ -9012,18 +7150,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericWhereClauseAndMembers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndMembers` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndMembers` to replace the node's
-  ///                   current `unexpectedBetweenGenericWhereClauseAndMembers`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndMembers(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
   }
 
   /// 
@@ -9035,18 +7166,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return MemberDeclBlockSyntax(childData!)
     }
     set(value) {
-      self = withMembers(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 15, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `members` replaced.
-  /// - param newChild: The new `members` to replace the node's
-  ///                   current `members`, if present.
-  public func withMembers(_ newChild: MemberDeclBlockSyntax) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 15, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
   }
 
   public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
@@ -9056,18 +7180,11 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterMembers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 16, with: raw, arena: arena)
+      self = EnumDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
-  /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
-  ///                   current `unexpectedAfterMembers`, if present.
-  public func withUnexpectedAfterMembers(_ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 16, with: raw, arena: arena)
-    return EnumDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -9223,18 +7340,11 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = OperatorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return OperatorDeclSyntax(newData)
   }
 
   /// 
@@ -9247,7 +7357,10 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = OperatorDeclSyntax(newData)
     }
   }
 
@@ -9270,16 +7383,6 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return OperatorDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> OperatorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return OperatorDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -9287,18 +7390,11 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = OperatorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return OperatorDeclSyntax(newData)
   }
 
   /// 
@@ -9312,7 +7408,10 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = OperatorDeclSyntax(newData)
     }
   }
 
@@ -9335,16 +7434,6 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return OperatorDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> OperatorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return OperatorDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndOperatorKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -9352,18 +7441,11 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndOperatorKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = OperatorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndOperatorKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndOperatorKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndOperatorKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndOperatorKeyword(_ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return OperatorDeclSyntax(newData)
   }
 
   public var operatorKeyword: TokenSyntax {
@@ -9372,18 +7454,11 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withOperatorKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = OperatorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `operatorKeyword` replaced.
-  /// - param newChild: The new `operatorKeyword` to replace the node's
-  ///                   current `operatorKeyword`, if present.
-  public func withOperatorKeyword(_ newChild: TokenSyntax) -> OperatorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return OperatorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenOperatorKeywordAndIdentifier: UnexpectedNodesSyntax? {
@@ -9393,18 +7468,11 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenOperatorKeywordAndIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = OperatorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenOperatorKeywordAndIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenOperatorKeywordAndIdentifier` to replace the node's
-  ///                   current `unexpectedBetweenOperatorKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenOperatorKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return OperatorDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
@@ -9413,18 +7481,11 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = OperatorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> OperatorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return OperatorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes: UnexpectedNodesSyntax? {
@@ -9434,18 +7495,11 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = OperatorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes` replaced.
-  /// - param newChild: The new `unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes` to replace the node's
-  ///                   current `unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes`, if present.
-  public func withUnexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes(_ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return OperatorDeclSyntax(newData)
   }
 
   /// 
@@ -9458,18 +7512,11 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return OperatorPrecedenceAndTypesSyntax(childData!)
     }
     set(value) {
-      self = withOperatorPrecedenceAndTypes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = OperatorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `operatorPrecedenceAndTypes` replaced.
-  /// - param newChild: The new `operatorPrecedenceAndTypes` to replace the node's
-  ///                   current `operatorPrecedenceAndTypes`, if present.
-  public func withOperatorPrecedenceAndTypes(_ newChild: OperatorPrecedenceAndTypesSyntax?) -> OperatorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return OperatorDeclSyntax(newData)
   }
 
   public var unexpectedAfterOperatorPrecedenceAndTypes: UnexpectedNodesSyntax? {
@@ -9479,18 +7526,11 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterOperatorPrecedenceAndTypes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = OperatorDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterOperatorPrecedenceAndTypes` replaced.
-  /// - param newChild: The new `unexpectedAfterOperatorPrecedenceAndTypes` to replace the node's
-  ///                   current `unexpectedAfterOperatorPrecedenceAndTypes`, if present.
-  public func withUnexpectedAfterOperatorPrecedenceAndTypes(_ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return OperatorDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -9630,18 +7670,11 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PrecedenceGroupDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PrecedenceGroupDeclSyntax(newData)
   }
 
   /// 
@@ -9654,7 +7687,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PrecedenceGroupDeclSyntax(newData)
     }
   }
 
@@ -9677,16 +7713,6 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return PrecedenceGroupDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> PrecedenceGroupDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PrecedenceGroupDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -9694,18 +7720,11 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PrecedenceGroupDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PrecedenceGroupDeclSyntax(newData)
   }
 
   /// 
@@ -9719,7 +7738,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PrecedenceGroupDeclSyntax(newData)
     }
   }
 
@@ -9742,16 +7764,6 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return PrecedenceGroupDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> PrecedenceGroupDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PrecedenceGroupDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndPrecedencegroupKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -9759,18 +7771,11 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndPrecedencegroupKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PrecedenceGroupDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndPrecedencegroupKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndPrecedencegroupKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndPrecedencegroupKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndPrecedencegroupKeyword(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var precedencegroupKeyword: TokenSyntax {
@@ -9779,18 +7784,11 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPrecedencegroupKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = PrecedenceGroupDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `precedencegroupKeyword` replaced.
-  /// - param newChild: The new `precedencegroupKeyword` to replace the node's
-  ///                   current `precedencegroupKeyword`, if present.
-  public func withPrecedencegroupKeyword(_ newChild: TokenSyntax) -> PrecedenceGroupDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var unexpectedBetweenPrecedencegroupKeywordAndIdentifier: UnexpectedNodesSyntax? {
@@ -9800,18 +7798,11 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPrecedencegroupKeywordAndIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = PrecedenceGroupDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPrecedencegroupKeywordAndIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenPrecedencegroupKeywordAndIdentifier` to replace the node's
-  ///                   current `unexpectedBetweenPrecedencegroupKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenPrecedencegroupKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return PrecedenceGroupDeclSyntax(newData)
   }
 
   /// 
@@ -9823,18 +7814,11 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = PrecedenceGroupDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> PrecedenceGroupDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndLeftBrace: UnexpectedNodesSyntax? {
@@ -9844,18 +7828,11 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIdentifierAndLeftBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = PrecedenceGroupDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndLeftBrace` replaced.
-  /// - param newChild: The new `unexpectedBetweenIdentifierAndLeftBrace` to replace the node's
-  ///                   current `unexpectedBetweenIdentifierAndLeftBrace`, if present.
-  public func withUnexpectedBetweenIdentifierAndLeftBrace(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var leftBrace: TokenSyntax {
@@ -9864,18 +7841,11 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftBrace(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = PrecedenceGroupDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftBrace` replaced.
-  /// - param newChild: The new `leftBrace` to replace the node's
-  ///                   current `leftBrace`, if present.
-  public func withLeftBrace(_ newChild: TokenSyntax) -> PrecedenceGroupDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var unexpectedBetweenLeftBraceAndGroupAttributes: UnexpectedNodesSyntax? {
@@ -9885,18 +7855,11 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftBraceAndGroupAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = PrecedenceGroupDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftBraceAndGroupAttributes` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftBraceAndGroupAttributes` to replace the node's
-  ///                   current `unexpectedBetweenLeftBraceAndGroupAttributes`, if present.
-  public func withUnexpectedBetweenLeftBraceAndGroupAttributes(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return PrecedenceGroupDeclSyntax(newData)
   }
 
   /// 
@@ -9908,7 +7871,10 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return PrecedenceGroupAttributeListSyntax(childData!)
     }
     set(value) {
-      self = withGroupAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = PrecedenceGroupDeclSyntax(newData)
     }
   }
 
@@ -9931,16 +7897,6 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return PrecedenceGroupDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `groupAttributes` replaced.
-  /// - param newChild: The new `groupAttributes` to replace the node's
-  ///                   current `groupAttributes`, if present.
-  public func withGroupAttributes(_ newChild: PrecedenceGroupAttributeListSyntax) -> PrecedenceGroupDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return PrecedenceGroupDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenGroupAttributesAndRightBrace: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 12, parent: Syntax(self))
@@ -9948,18 +7904,11 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGroupAttributesAndRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = PrecedenceGroupDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGroupAttributesAndRightBrace` replaced.
-  /// - param newChild: The new `unexpectedBetweenGroupAttributesAndRightBrace` to replace the node's
-  ///                   current `unexpectedBetweenGroupAttributesAndRightBrace`, if present.
-  public func withUnexpectedBetweenGroupAttributesAndRightBrace(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var rightBrace: TokenSyntax {
@@ -9968,18 +7917,11 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = PrecedenceGroupDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightBrace` replaced.
-  /// - param newChild: The new `rightBrace` to replace the node's
-  ///                   current `rightBrace`, if present.
-  public func withRightBrace(_ newChild: TokenSyntax) -> PrecedenceGroupDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var unexpectedAfterRightBrace: UnexpectedNodesSyntax? {
@@ -9989,18 +7931,11 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = PrecedenceGroupDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
-  /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
-  ///                   current `unexpectedAfterRightBrace`, if present.
-  public func withUnexpectedAfterRightBrace(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return PrecedenceGroupDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -10195,18 +8130,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -10216,7 +8144,10 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
   }
 
@@ -10239,16 +8170,6 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return MacroDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -10256,18 +8177,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -10277,7 +8191,10 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
   }
 
@@ -10300,16 +8217,6 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return MacroDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndMacroKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -10317,18 +8224,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndMacroKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndMacroKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndMacroKeyword` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndMacroKeyword`, if present.
-  public func withUnexpectedBetweenModifiersAndMacroKeyword(_ newChild: UnexpectedNodesSyntax?) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
   }
 
   public var macroKeyword: TokenSyntax {
@@ -10337,18 +8237,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withMacroKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `macroKeyword` replaced.
-  /// - param newChild: The new `macroKeyword` to replace the node's
-  ///                   current `macroKeyword`, if present.
-  public func withMacroKeyword(_ newChild: TokenSyntax) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
   }
 
   public var unexpectedBetweenMacroKeywordAndIdentifier: UnexpectedNodesSyntax? {
@@ -10358,18 +8251,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenMacroKeywordAndIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenMacroKeywordAndIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenMacroKeywordAndIdentifier` to replace the node's
-  ///                   current `unexpectedBetweenMacroKeywordAndIdentifier`, if present.
-  public func withUnexpectedBetweenMacroKeywordAndIdentifier(_ newChild: UnexpectedNodesSyntax?) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
@@ -10378,18 +8264,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? {
@@ -10399,18 +8278,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIdentifierAndGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndGenericParameterClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenIdentifierAndGenericParameterClause` to replace the node's
-  ///                   current `unexpectedBetweenIdentifierAndGenericParameterClause`, if present.
-  public func withUnexpectedBetweenIdentifierAndGenericParameterClause(_ newChild: UnexpectedNodesSyntax?) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
   }
 
   public var genericParameterClause: GenericParameterClauseSyntax? {
@@ -10420,18 +8292,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericParameterClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericParameterClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericParameterClause` replaced.
-  /// - param newChild: The new `genericParameterClause` to replace the node's
-  ///                   current `genericParameterClause`, if present.
-  public func withGenericParameterClause(_ newChild: GenericParameterClauseSyntax?) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? {
@@ -10441,18 +8306,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericParameterClauseAndSignature(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterClauseAndSignature` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericParameterClauseAndSignature` to replace the node's
-  ///                   current `unexpectedBetweenGenericParameterClauseAndSignature`, if present.
-  public func withUnexpectedBetweenGenericParameterClauseAndSignature(_ newChild: UnexpectedNodesSyntax?) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
   }
 
   public var signature: Signature {
@@ -10461,18 +8319,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return Signature(childData!)
     }
     set(value) {
-      self = withSignature(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `signature` replaced.
-  /// - param newChild: The new `signature` to replace the node's
-  ///                   current `signature`, if present.
-  public func withSignature(_ newChild: Signature) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
   }
 
   public var unexpectedBetweenSignatureAndDefinition: UnexpectedNodesSyntax? {
@@ -10482,18 +8333,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSignatureAndDefinition(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSignatureAndDefinition` replaced.
-  /// - param newChild: The new `unexpectedBetweenSignatureAndDefinition` to replace the node's
-  ///                   current `unexpectedBetweenSignatureAndDefinition`, if present.
-  public func withUnexpectedBetweenSignatureAndDefinition(_ newChild: UnexpectedNodesSyntax?) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
   }
 
   public var definition: InitializerClauseSyntax? {
@@ -10503,18 +8347,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return InitializerClauseSyntax(childData!)
     }
     set(value) {
-      self = withDefinition(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `definition` replaced.
-  /// - param newChild: The new `definition` to replace the node's
-  ///                   current `definition`, if present.
-  public func withDefinition(_ newChild: InitializerClauseSyntax?) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
   }
 
   public var unexpectedBetweenDefinitionAndGenericWhereClause: UnexpectedNodesSyntax? {
@@ -10524,18 +8361,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDefinitionAndGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDefinitionAndGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenDefinitionAndGenericWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenDefinitionAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenDefinitionAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
@@ -10545,18 +8375,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericWhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 15, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericWhereClause` replaced.
-  /// - param newChild: The new `genericWhereClause` to replace the node's
-  ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 15, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
   }
 
   public var unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? {
@@ -10566,18 +8389,11 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 16, with: raw, arena: arena)
+      self = MacroDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedAfterGenericWhereClause` to replace the node's
-  ///                   current `unexpectedAfterGenericWhereClause`, if present.
-  public func withUnexpectedAfterGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> MacroDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 16, with: raw, arena: arena)
-    return MacroDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -10744,18 +8560,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforePoundToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforePoundToken` replaced.
-  /// - param newChild: The new `unexpectedBeforePoundToken` to replace the node's
-  ///                   current `unexpectedBeforePoundToken`, if present.
-  public func withUnexpectedBeforePoundToken(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
   }
 
   /// The `#` sign.
@@ -10765,18 +8574,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPoundToken(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `poundToken` replaced.
-  /// - param newChild: The new `poundToken` to replace the node's
-  ///                   current `poundToken`, if present.
-  public func withPoundToken(_ newChild: TokenSyntax) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenPoundTokenAndMacro: UnexpectedNodesSyntax? {
@@ -10786,18 +8588,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPoundTokenAndMacro(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPoundTokenAndMacro` replaced.
-  /// - param newChild: The new `unexpectedBetweenPoundTokenAndMacro` to replace the node's
-  ///                   current `unexpectedBetweenPoundTokenAndMacro`, if present.
-  public func withUnexpectedBetweenPoundTokenAndMacro(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
   }
 
   public var macro: TokenSyntax {
@@ -10806,18 +8601,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withMacro(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `macro` replaced.
-  /// - param newChild: The new `macro` to replace the node's
-  ///                   current `macro`, if present.
-  public func withMacro(_ newChild: TokenSyntax) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenMacroAndGenericArguments: UnexpectedNodesSyntax? {
@@ -10827,18 +8615,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenMacroAndGenericArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenMacroAndGenericArguments` replaced.
-  /// - param newChild: The new `unexpectedBetweenMacroAndGenericArguments` to replace the node's
-  ///                   current `unexpectedBetweenMacroAndGenericArguments`, if present.
-  public func withUnexpectedBetweenMacroAndGenericArguments(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
   }
 
   public var genericArguments: GenericArgumentClauseSyntax? {
@@ -10848,18 +8629,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return GenericArgumentClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericArguments` replaced.
-  /// - param newChild: The new `genericArguments` to replace the node's
-  ///                   current `genericArguments`, if present.
-  public func withGenericArguments(_ newChild: GenericArgumentClauseSyntax?) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericArgumentsAndLeftParen: UnexpectedNodesSyntax? {
@@ -10869,18 +8643,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericArgumentsAndLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericArgumentsAndLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericArgumentsAndLeftParen` to replace the node's
-  ///                   current `unexpectedBetweenGenericArgumentsAndLeftParen`, if present.
-  public func withUnexpectedBetweenGenericArgumentsAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
   }
 
   public var leftParen: TokenSyntax? {
@@ -10890,18 +8657,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? {
@@ -10911,18 +8671,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndArgumentList(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArgumentList` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndArgumentList` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndArgumentList`, if present.
-  public func withUnexpectedBetweenLeftParenAndArgumentList(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
   }
 
   public var argumentList: TupleExprElementListSyntax {
@@ -10931,7 +8684,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TupleExprElementListSyntax(childData!)
     }
     set(value) {
-      self = withArgumentList(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
   }
 
@@ -10954,16 +8710,6 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return MacroExpansionDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `argumentList` replaced.
-  /// - param newChild: The new `argumentList` to replace the node's
-  ///                   current `argumentList`, if present.
-  public func withArgumentList(_ newChild: TupleExprElementListSyntax) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
-  }
-
   public var unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 10, parent: Syntax(self))
@@ -10971,18 +8717,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenArgumentListAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenArgumentListAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenArgumentListAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenArgumentListAndRightParen`, if present.
-  public func withUnexpectedBetweenArgumentListAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
   }
 
   public var rightParen: TokenSyntax? {
@@ -10992,18 +8731,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodesSyntax? {
@@ -11013,18 +8745,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenRightParenAndTrailingClosure(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenRightParenAndTrailingClosure` replaced.
-  /// - param newChild: The new `unexpectedBetweenRightParenAndTrailingClosure` to replace the node's
-  ///                   current `unexpectedBetweenRightParenAndTrailingClosure`, if present.
-  public func withUnexpectedBetweenRightParenAndTrailingClosure(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
   }
 
   public var trailingClosure: ClosureExprSyntax? {
@@ -11034,18 +8759,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return ClosureExprSyntax(childData!)
     }
     set(value) {
-      self = withTrailingClosure(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingClosure` replaced.
-  /// - param newChild: The new `trailingClosure` to replace the node's
-  ///                   current `trailingClosure`, if present.
-  public func withTrailingClosure(_ newChild: ClosureExprSyntax?) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? {
@@ -11055,18 +8773,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` replaced.
-  /// - param newChild: The new `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` to replace the node's
-  ///                   current `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures`, if present.
-  public func withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
   }
 
   public var additionalTrailingClosures: MultipleTrailingClosureElementListSyntax? {
@@ -11076,7 +8787,10 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return MultipleTrailingClosureElementListSyntax(childData!)
     }
     set(value) {
-      self = withAdditionalTrailingClosures(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 15, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
   }
 
@@ -11099,16 +8813,6 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return MacroExpansionDeclSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `additionalTrailingClosures` replaced.
-  /// - param newChild: The new `additionalTrailingClosures` to replace the node's
-  ///                   current `additionalTrailingClosures`, if present.
-  public func withAdditionalTrailingClosures(_ newChild: MultipleTrailingClosureElementListSyntax?) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 15, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
-  }
-
   public var unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 16, parent: Syntax(self))
@@ -11116,18 +8820,11 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterAdditionalTrailingClosures(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 16, with: raw, arena: arena)
+      self = MacroExpansionDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterAdditionalTrailingClosures` replaced.
-  /// - param newChild: The new `unexpectedAfterAdditionalTrailingClosures` to replace the node's
-  ///                   current `unexpectedAfterAdditionalTrailingClosures`, if present.
-  public func withUnexpectedAfterAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 16, with: raw, arena: arena)
-    return MacroExpansionDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -11266,18 +8963,11 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = EditorPlaceholderDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBeforeIdentifier` to replace the node's
-  ///                   current `unexpectedBeforeIdentifier`, if present.
-  public func withUnexpectedBeforeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> EditorPlaceholderDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return EditorPlaceholderDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
@@ -11286,18 +8976,11 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = EditorPlaceholderDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> EditorPlaceholderDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return EditorPlaceholderDeclSyntax(newData)
   }
 
   public var unexpectedAfterIdentifier: UnexpectedNodesSyntax? {
@@ -11307,18 +8990,11 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = EditorPlaceholderDeclSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterIdentifier` replaced.
-  /// - param newChild: The new `unexpectedAfterIdentifier` to replace the node's
-  ///                   current `unexpectedAfterIdentifier`, if present.
-  public func withUnexpectedAfterIdentifier(_ newChild: UnexpectedNodesSyntax?) -> EditorPlaceholderDeclSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return EditorPlaceholderDeclSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -113,18 +113,11 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAmpersand(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = InOutExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAmpersand` replaced.
-  /// - param newChild: The new `unexpectedBeforeAmpersand` to replace the node's
-  ///                   current `unexpectedBeforeAmpersand`, if present.
-  public func withUnexpectedBeforeAmpersand(_ newChild: UnexpectedNodesSyntax?) -> InOutExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return InOutExprSyntax(newData)
   }
 
   public var ampersand: TokenSyntax {
@@ -133,18 +126,11 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAmpersand(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = InOutExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `ampersand` replaced.
-  /// - param newChild: The new `ampersand` to replace the node's
-  ///                   current `ampersand`, if present.
-  public func withAmpersand(_ newChild: TokenSyntax) -> InOutExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return InOutExprSyntax(newData)
   }
 
   public var unexpectedBetweenAmpersandAndExpression: UnexpectedNodesSyntax? {
@@ -154,18 +140,11 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAmpersandAndExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = InOutExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAmpersandAndExpression` replaced.
-  /// - param newChild: The new `unexpectedBetweenAmpersandAndExpression` to replace the node's
-  ///                   current `unexpectedBetweenAmpersandAndExpression`, if present.
-  public func withUnexpectedBetweenAmpersandAndExpression(_ newChild: UnexpectedNodesSyntax?) -> InOutExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return InOutExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -174,18 +153,11 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = InOutExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> InOutExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return InOutExprSyntax(newData)
   }
 
   public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
@@ -195,18 +167,11 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = InOutExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
-  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
-  ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> InOutExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return InOutExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -305,18 +270,11 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeTryKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = TryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeTryKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeTryKeyword` to replace the node's
-  ///                   current `unexpectedBeforeTryKeyword`, if present.
-  public func withUnexpectedBeforeTryKeyword(_ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return TryExprSyntax(newData)
   }
 
   public var tryKeyword: TokenSyntax {
@@ -325,18 +283,11 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTryKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = TryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `tryKeyword` replaced.
-  /// - param newChild: The new `tryKeyword` to replace the node's
-  ///                   current `tryKeyword`, if present.
-  public func withTryKeyword(_ newChild: TokenSyntax) -> TryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return TryExprSyntax(newData)
   }
 
   public var unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: UnexpectedNodesSyntax? {
@@ -346,18 +297,11 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTryKeywordAndQuestionOrExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = TryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTryKeywordAndQuestionOrExclamationMark` replaced.
-  /// - param newChild: The new `unexpectedBetweenTryKeywordAndQuestionOrExclamationMark` to replace the node's
-  ///                   current `unexpectedBetweenTryKeywordAndQuestionOrExclamationMark`, if present.
-  public func withUnexpectedBetweenTryKeywordAndQuestionOrExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return TryExprSyntax(newData)
   }
 
   public var questionOrExclamationMark: TokenSyntax? {
@@ -367,18 +311,11 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withQuestionOrExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = TryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `questionOrExclamationMark` replaced.
-  /// - param newChild: The new `questionOrExclamationMark` to replace the node's
-  ///                   current `questionOrExclamationMark`, if present.
-  public func withQuestionOrExclamationMark(_ newChild: TokenSyntax?) -> TryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return TryExprSyntax(newData)
   }
 
   public var unexpectedBetweenQuestionOrExclamationMarkAndExpression: UnexpectedNodesSyntax? {
@@ -388,18 +325,11 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenQuestionOrExclamationMarkAndExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = TryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenQuestionOrExclamationMarkAndExpression` replaced.
-  /// - param newChild: The new `unexpectedBetweenQuestionOrExclamationMarkAndExpression` to replace the node's
-  ///                   current `unexpectedBetweenQuestionOrExclamationMarkAndExpression`, if present.
-  public func withUnexpectedBetweenQuestionOrExclamationMarkAndExpression(_ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return TryExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -408,18 +338,11 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = TryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> TryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return TryExprSyntax(newData)
   }
 
   public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
@@ -429,18 +352,11 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = TryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
-  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
-  ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return TryExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -543,18 +459,11 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAwaitKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AwaitExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAwaitKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeAwaitKeyword` to replace the node's
-  ///                   current `unexpectedBeforeAwaitKeyword`, if present.
-  public func withUnexpectedBeforeAwaitKeyword(_ newChild: UnexpectedNodesSyntax?) -> AwaitExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AwaitExprSyntax(newData)
   }
 
   public var awaitKeyword: TokenSyntax {
@@ -563,18 +472,11 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAwaitKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AwaitExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `awaitKeyword` replaced.
-  /// - param newChild: The new `awaitKeyword` to replace the node's
-  ///                   current `awaitKeyword`, if present.
-  public func withAwaitKeyword(_ newChild: TokenSyntax) -> AwaitExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AwaitExprSyntax(newData)
   }
 
   public var unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodesSyntax? {
@@ -584,18 +486,11 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAwaitKeywordAndExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AwaitExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAwaitKeywordAndExpression` replaced.
-  /// - param newChild: The new `unexpectedBetweenAwaitKeywordAndExpression` to replace the node's
-  ///                   current `unexpectedBetweenAwaitKeywordAndExpression`, if present.
-  public func withUnexpectedBetweenAwaitKeywordAndExpression(_ newChild: UnexpectedNodesSyntax?) -> AwaitExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AwaitExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -604,18 +499,11 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = AwaitExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> AwaitExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return AwaitExprSyntax(newData)
   }
 
   public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
@@ -625,18 +513,11 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = AwaitExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
-  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
-  ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> AwaitExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return AwaitExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -731,18 +612,11 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeMoveKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = MoveExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeMoveKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeMoveKeyword` to replace the node's
-  ///                   current `unexpectedBeforeMoveKeyword`, if present.
-  public func withUnexpectedBeforeMoveKeyword(_ newChild: UnexpectedNodesSyntax?) -> MoveExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return MoveExprSyntax(newData)
   }
 
   public var moveKeyword: TokenSyntax {
@@ -751,18 +625,11 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withMoveKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = MoveExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `moveKeyword` replaced.
-  /// - param newChild: The new `moveKeyword` to replace the node's
-  ///                   current `moveKeyword`, if present.
-  public func withMoveKeyword(_ newChild: TokenSyntax) -> MoveExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return MoveExprSyntax(newData)
   }
 
   public var unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodesSyntax? {
@@ -772,18 +639,11 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenMoveKeywordAndExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = MoveExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenMoveKeywordAndExpression` replaced.
-  /// - param newChild: The new `unexpectedBetweenMoveKeywordAndExpression` to replace the node's
-  ///                   current `unexpectedBetweenMoveKeywordAndExpression`, if present.
-  public func withUnexpectedBetweenMoveKeywordAndExpression(_ newChild: UnexpectedNodesSyntax?) -> MoveExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return MoveExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -792,18 +652,11 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = MoveExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> MoveExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return MoveExprSyntax(newData)
   }
 
   public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
@@ -813,18 +666,11 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = MoveExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
-  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
-  ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> MoveExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return MoveExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -919,18 +765,11 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeBorrowKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = BorrowExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeBorrowKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeBorrowKeyword` to replace the node's
-  ///                   current `unexpectedBeforeBorrowKeyword`, if present.
-  public func withUnexpectedBeforeBorrowKeyword(_ newChild: UnexpectedNodesSyntax?) -> BorrowExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return BorrowExprSyntax(newData)
   }
 
   public var borrowKeyword: TokenSyntax {
@@ -939,18 +778,11 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withBorrowKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = BorrowExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `borrowKeyword` replaced.
-  /// - param newChild: The new `borrowKeyword` to replace the node's
-  ///                   current `borrowKeyword`, if present.
-  public func withBorrowKeyword(_ newChild: TokenSyntax) -> BorrowExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return BorrowExprSyntax(newData)
   }
 
   public var unexpectedBetweenBorrowKeywordAndExpression: UnexpectedNodesSyntax? {
@@ -960,18 +792,11 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenBorrowKeywordAndExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = BorrowExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenBorrowKeywordAndExpression` replaced.
-  /// - param newChild: The new `unexpectedBetweenBorrowKeywordAndExpression` to replace the node's
-  ///                   current `unexpectedBetweenBorrowKeywordAndExpression`, if present.
-  public func withUnexpectedBetweenBorrowKeywordAndExpression(_ newChild: UnexpectedNodesSyntax?) -> BorrowExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return BorrowExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -980,18 +805,11 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = BorrowExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> BorrowExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return BorrowExprSyntax(newData)
   }
 
   public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
@@ -1001,18 +819,11 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = BorrowExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
-  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
-  ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> BorrowExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return BorrowExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1107,18 +918,11 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = IdentifierExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBeforeIdentifier` to replace the node's
-  ///                   current `unexpectedBeforeIdentifier`, if present.
-  public func withUnexpectedBeforeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> IdentifierExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return IdentifierExprSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
@@ -1127,18 +931,11 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = IdentifierExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> IdentifierExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return IdentifierExprSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? {
@@ -1148,18 +945,11 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIdentifierAndDeclNameArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = IdentifierExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndDeclNameArguments` replaced.
-  /// - param newChild: The new `unexpectedBetweenIdentifierAndDeclNameArguments` to replace the node's
-  ///                   current `unexpectedBetweenIdentifierAndDeclNameArguments`, if present.
-  public func withUnexpectedBetweenIdentifierAndDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> IdentifierExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return IdentifierExprSyntax(newData)
   }
 
   public var declNameArguments: DeclNameArgumentsSyntax? {
@@ -1169,18 +959,11 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return DeclNameArgumentsSyntax(childData!)
     }
     set(value) {
-      self = withDeclNameArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = IdentifierExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `declNameArguments` replaced.
-  /// - param newChild: The new `declNameArguments` to replace the node's
-  ///                   current `declNameArguments`, if present.
-  public func withDeclNameArguments(_ newChild: DeclNameArgumentsSyntax?) -> IdentifierExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return IdentifierExprSyntax(newData)
   }
 
   public var unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? {
@@ -1190,18 +973,11 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterDeclNameArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = IdentifierExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterDeclNameArguments` replaced.
-  /// - param newChild: The new `unexpectedAfterDeclNameArguments` to replace the node's
-  ///                   current `unexpectedAfterDeclNameArguments`, if present.
-  public func withUnexpectedAfterDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> IdentifierExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return IdentifierExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1292,18 +1068,11 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeSuperKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = SuperRefExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeSuperKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeSuperKeyword` to replace the node's
-  ///                   current `unexpectedBeforeSuperKeyword`, if present.
-  public func withUnexpectedBeforeSuperKeyword(_ newChild: UnexpectedNodesSyntax?) -> SuperRefExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return SuperRefExprSyntax(newData)
   }
 
   public var superKeyword: TokenSyntax {
@@ -1312,18 +1081,11 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withSuperKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = SuperRefExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `superKeyword` replaced.
-  /// - param newChild: The new `superKeyword` to replace the node's
-  ///                   current `superKeyword`, if present.
-  public func withSuperKeyword(_ newChild: TokenSyntax) -> SuperRefExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return SuperRefExprSyntax(newData)
   }
 
   public var unexpectedAfterSuperKeyword: UnexpectedNodesSyntax? {
@@ -1333,18 +1095,11 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterSuperKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = SuperRefExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterSuperKeyword` replaced.
-  /// - param newChild: The new `unexpectedAfterSuperKeyword` to replace the node's
-  ///                   current `unexpectedAfterSuperKeyword`, if present.
-  public func withUnexpectedAfterSuperKeyword(_ newChild: UnexpectedNodesSyntax?) -> SuperRefExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return SuperRefExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1427,18 +1182,11 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeNilKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = NilLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeNilKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeNilKeyword` to replace the node's
-  ///                   current `unexpectedBeforeNilKeyword`, if present.
-  public func withUnexpectedBeforeNilKeyword(_ newChild: UnexpectedNodesSyntax?) -> NilLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return NilLiteralExprSyntax(newData)
   }
 
   public var nilKeyword: TokenSyntax {
@@ -1447,18 +1195,11 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withNilKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = NilLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `nilKeyword` replaced.
-  /// - param newChild: The new `nilKeyword` to replace the node's
-  ///                   current `nilKeyword`, if present.
-  public func withNilKeyword(_ newChild: TokenSyntax) -> NilLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return NilLiteralExprSyntax(newData)
   }
 
   public var unexpectedAfterNilKeyword: UnexpectedNodesSyntax? {
@@ -1468,18 +1209,11 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterNilKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = NilLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterNilKeyword` replaced.
-  /// - param newChild: The new `unexpectedAfterNilKeyword` to replace the node's
-  ///                   current `unexpectedAfterNilKeyword`, if present.
-  public func withUnexpectedAfterNilKeyword(_ newChild: UnexpectedNodesSyntax?) -> NilLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return NilLiteralExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1562,18 +1296,11 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeWildcard(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DiscardAssignmentExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeWildcard` replaced.
-  /// - param newChild: The new `unexpectedBeforeWildcard` to replace the node's
-  ///                   current `unexpectedBeforeWildcard`, if present.
-  public func withUnexpectedBeforeWildcard(_ newChild: UnexpectedNodesSyntax?) -> DiscardAssignmentExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DiscardAssignmentExprSyntax(newData)
   }
 
   public var wildcard: TokenSyntax {
@@ -1582,18 +1309,11 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withWildcard(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DiscardAssignmentExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `wildcard` replaced.
-  /// - param newChild: The new `wildcard` to replace the node's
-  ///                   current `wildcard`, if present.
-  public func withWildcard(_ newChild: TokenSyntax) -> DiscardAssignmentExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DiscardAssignmentExprSyntax(newData)
   }
 
   public var unexpectedAfterWildcard: UnexpectedNodesSyntax? {
@@ -1603,18 +1323,11 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterWildcard(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DiscardAssignmentExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterWildcard` replaced.
-  /// - param newChild: The new `unexpectedAfterWildcard` to replace the node's
-  ///                   current `unexpectedAfterWildcard`, if present.
-  public func withUnexpectedAfterWildcard(_ newChild: UnexpectedNodesSyntax?) -> DiscardAssignmentExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DiscardAssignmentExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1697,18 +1410,11 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAssignToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AssignmentExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAssignToken` replaced.
-  /// - param newChild: The new `unexpectedBeforeAssignToken` to replace the node's
-  ///                   current `unexpectedBeforeAssignToken`, if present.
-  public func withUnexpectedBeforeAssignToken(_ newChild: UnexpectedNodesSyntax?) -> AssignmentExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AssignmentExprSyntax(newData)
   }
 
   public var assignToken: TokenSyntax {
@@ -1717,18 +1423,11 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAssignToken(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AssignmentExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `assignToken` replaced.
-  /// - param newChild: The new `assignToken` to replace the node's
-  ///                   current `assignToken`, if present.
-  public func withAssignToken(_ newChild: TokenSyntax) -> AssignmentExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AssignmentExprSyntax(newData)
   }
 
   public var unexpectedAfterAssignToken: UnexpectedNodesSyntax? {
@@ -1738,18 +1437,11 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterAssignToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AssignmentExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterAssignToken` replaced.
-  /// - param newChild: The new `unexpectedAfterAssignToken` to replace the node's
-  ///                   current `unexpectedAfterAssignToken`, if present.
-  public func withUnexpectedAfterAssignToken(_ newChild: UnexpectedNodesSyntax?) -> AssignmentExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AssignmentExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1836,18 +1528,11 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeRepeatKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PackExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeRepeatKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeRepeatKeyword` to replace the node's
-  ///                   current `unexpectedBeforeRepeatKeyword`, if present.
-  public func withUnexpectedBeforeRepeatKeyword(_ newChild: UnexpectedNodesSyntax?) -> PackExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PackExpansionExprSyntax(newData)
   }
 
   public var repeatKeyword: TokenSyntax {
@@ -1856,18 +1541,11 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRepeatKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PackExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `repeatKeyword` replaced.
-  /// - param newChild: The new `repeatKeyword` to replace the node's
-  ///                   current `repeatKeyword`, if present.
-  public func withRepeatKeyword(_ newChild: TokenSyntax) -> PackExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PackExpansionExprSyntax(newData)
   }
 
   public var unexpectedBetweenRepeatKeywordAndPatternExpr: UnexpectedNodesSyntax? {
@@ -1877,18 +1555,11 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenRepeatKeywordAndPatternExpr(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PackExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenRepeatKeywordAndPatternExpr` replaced.
-  /// - param newChild: The new `unexpectedBetweenRepeatKeywordAndPatternExpr` to replace the node's
-  ///                   current `unexpectedBetweenRepeatKeywordAndPatternExpr`, if present.
-  public func withUnexpectedBetweenRepeatKeywordAndPatternExpr(_ newChild: UnexpectedNodesSyntax?) -> PackExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PackExpansionExprSyntax(newData)
   }
 
   public var patternExpr: ExprSyntax {
@@ -1897,18 +1568,11 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withPatternExpr(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PackExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `patternExpr` replaced.
-  /// - param newChild: The new `patternExpr` to replace the node's
-  ///                   current `patternExpr`, if present.
-  public func withPatternExpr(_ newChild: ExprSyntax) -> PackExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PackExpansionExprSyntax(newData)
   }
 
   public var unexpectedAfterPatternExpr: UnexpectedNodesSyntax? {
@@ -1918,18 +1582,11 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterPatternExpr(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PackExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterPatternExpr` replaced.
-  /// - param newChild: The new `unexpectedAfterPatternExpr` to replace the node's
-  ///                   current `unexpectedAfterPatternExpr`, if present.
-  public func withUnexpectedAfterPatternExpr(_ newChild: UnexpectedNodesSyntax?) -> PackExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PackExpansionExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2024,18 +1681,11 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeEachKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PackElementExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeEachKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeEachKeyword` to replace the node's
-  ///                   current `unexpectedBeforeEachKeyword`, if present.
-  public func withUnexpectedBeforeEachKeyword(_ newChild: UnexpectedNodesSyntax?) -> PackElementExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PackElementExprSyntax(newData)
   }
 
   public var eachKeyword: TokenSyntax {
@@ -2044,18 +1694,11 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withEachKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PackElementExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `eachKeyword` replaced.
-  /// - param newChild: The new `eachKeyword` to replace the node's
-  ///                   current `eachKeyword`, if present.
-  public func withEachKeyword(_ newChild: TokenSyntax) -> PackElementExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PackElementExprSyntax(newData)
   }
 
   public var unexpectedBetweenEachKeywordAndPackRefExpr: UnexpectedNodesSyntax? {
@@ -2065,18 +1708,11 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenEachKeywordAndPackRefExpr(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PackElementExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenEachKeywordAndPackRefExpr` replaced.
-  /// - param newChild: The new `unexpectedBetweenEachKeywordAndPackRefExpr` to replace the node's
-  ///                   current `unexpectedBetweenEachKeywordAndPackRefExpr`, if present.
-  public func withUnexpectedBetweenEachKeywordAndPackRefExpr(_ newChild: UnexpectedNodesSyntax?) -> PackElementExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PackElementExprSyntax(newData)
   }
 
   public var packRefExpr: ExprSyntax {
@@ -2085,18 +1721,11 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withPackRefExpr(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PackElementExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `packRefExpr` replaced.
-  /// - param newChild: The new `packRefExpr` to replace the node's
-  ///                   current `packRefExpr`, if present.
-  public func withPackRefExpr(_ newChild: ExprSyntax) -> PackElementExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PackElementExprSyntax(newData)
   }
 
   public var unexpectedAfterPackRefExpr: UnexpectedNodesSyntax? {
@@ -2106,18 +1735,11 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterPackRefExpr(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PackElementExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterPackRefExpr` replaced.
-  /// - param newChild: The new `unexpectedAfterPackRefExpr` to replace the node's
-  ///                   current `unexpectedAfterPackRefExpr`, if present.
-  public func withUnexpectedAfterPackRefExpr(_ newChild: UnexpectedNodesSyntax?) -> PackElementExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PackElementExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2208,18 +1830,11 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeElements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = SequenceExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeElements` replaced.
-  /// - param newChild: The new `unexpectedBeforeElements` to replace the node's
-  ///                   current `unexpectedBeforeElements`, if present.
-  public func withUnexpectedBeforeElements(_ newChild: UnexpectedNodesSyntax?) -> SequenceExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return SequenceExprSyntax(newData)
   }
 
   public var elements: ExprListSyntax {
@@ -2228,7 +1843,10 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprListSyntax(childData!)
     }
     set(value) {
-      self = withElements(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = SequenceExprSyntax(newData)
     }
   }
 
@@ -2251,16 +1869,6 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return SequenceExprSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `elements` replaced.
-  /// - param newChild: The new `elements` to replace the node's
-  ///                   current `elements`, if present.
-  public func withElements(_ newChild: ExprListSyntax) -> SequenceExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return SequenceExprSyntax(newData)
-  }
-
   public var unexpectedAfterElements: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -2268,18 +1876,11 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterElements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = SequenceExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterElements` replaced.
-  /// - param newChild: The new `unexpectedAfterElements` to replace the node's
-  ///                   current `unexpectedAfterElements`, if present.
-  public func withUnexpectedAfterElements(_ newChild: UnexpectedNodesSyntax?) -> SequenceExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return SequenceExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2366,18 +1967,11 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeOperatorToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PrefixOperatorExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeOperatorToken` replaced.
-  /// - param newChild: The new `unexpectedBeforeOperatorToken` to replace the node's
-  ///                   current `unexpectedBeforeOperatorToken`, if present.
-  public func withUnexpectedBeforeOperatorToken(_ newChild: UnexpectedNodesSyntax?) -> PrefixOperatorExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PrefixOperatorExprSyntax(newData)
   }
 
   public var operatorToken: TokenSyntax? {
@@ -2387,18 +1981,11 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withOperatorToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PrefixOperatorExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `operatorToken` replaced.
-  /// - param newChild: The new `operatorToken` to replace the node's
-  ///                   current `operatorToken`, if present.
-  public func withOperatorToken(_ newChild: TokenSyntax?) -> PrefixOperatorExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PrefixOperatorExprSyntax(newData)
   }
 
   public var unexpectedBetweenOperatorTokenAndPostfixExpression: UnexpectedNodesSyntax? {
@@ -2408,18 +1995,11 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenOperatorTokenAndPostfixExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PrefixOperatorExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenOperatorTokenAndPostfixExpression` replaced.
-  /// - param newChild: The new `unexpectedBetweenOperatorTokenAndPostfixExpression` to replace the node's
-  ///                   current `unexpectedBetweenOperatorTokenAndPostfixExpression`, if present.
-  public func withUnexpectedBetweenOperatorTokenAndPostfixExpression(_ newChild: UnexpectedNodesSyntax?) -> PrefixOperatorExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PrefixOperatorExprSyntax(newData)
   }
 
   public var postfixExpression: ExprSyntax {
@@ -2428,18 +2008,11 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withPostfixExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PrefixOperatorExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `postfixExpression` replaced.
-  /// - param newChild: The new `postfixExpression` to replace the node's
-  ///                   current `postfixExpression`, if present.
-  public func withPostfixExpression(_ newChild: ExprSyntax) -> PrefixOperatorExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PrefixOperatorExprSyntax(newData)
   }
 
   public var unexpectedAfterPostfixExpression: UnexpectedNodesSyntax? {
@@ -2449,18 +2022,11 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterPostfixExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PrefixOperatorExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterPostfixExpression` replaced.
-  /// - param newChild: The new `unexpectedAfterPostfixExpression` to replace the node's
-  ///                   current `unexpectedAfterPostfixExpression`, if present.
-  public func withUnexpectedAfterPostfixExpression(_ newChild: UnexpectedNodesSyntax?) -> PrefixOperatorExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PrefixOperatorExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2551,18 +2117,11 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeOperatorToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = BinaryOperatorExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeOperatorToken` replaced.
-  /// - param newChild: The new `unexpectedBeforeOperatorToken` to replace the node's
-  ///                   current `unexpectedBeforeOperatorToken`, if present.
-  public func withUnexpectedBeforeOperatorToken(_ newChild: UnexpectedNodesSyntax?) -> BinaryOperatorExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return BinaryOperatorExprSyntax(newData)
   }
 
   public var operatorToken: TokenSyntax {
@@ -2571,18 +2130,11 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withOperatorToken(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = BinaryOperatorExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `operatorToken` replaced.
-  /// - param newChild: The new `operatorToken` to replace the node's
-  ///                   current `operatorToken`, if present.
-  public func withOperatorToken(_ newChild: TokenSyntax) -> BinaryOperatorExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return BinaryOperatorExprSyntax(newData)
   }
 
   public var unexpectedAfterOperatorToken: UnexpectedNodesSyntax? {
@@ -2592,18 +2144,11 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterOperatorToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = BinaryOperatorExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterOperatorToken` replaced.
-  /// - param newChild: The new `unexpectedAfterOperatorToken` to replace the node's
-  ///                   current `unexpectedAfterOperatorToken`, if present.
-  public func withUnexpectedAfterOperatorToken(_ newChild: UnexpectedNodesSyntax?) -> BinaryOperatorExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return BinaryOperatorExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2690,18 +2235,11 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeEffectSpecifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ArrowExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeEffectSpecifiers` replaced.
-  /// - param newChild: The new `unexpectedBeforeEffectSpecifiers` to replace the node's
-  ///                   current `unexpectedBeforeEffectSpecifiers`, if present.
-  public func withUnexpectedBeforeEffectSpecifiers(_ newChild: UnexpectedNodesSyntax?) -> ArrowExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ArrowExprSyntax(newData)
   }
 
   public var effectSpecifiers: TypeEffectSpecifiersSyntax? {
@@ -2711,18 +2249,11 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TypeEffectSpecifiersSyntax(childData!)
     }
     set(value) {
-      self = withEffectSpecifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ArrowExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `effectSpecifiers` replaced.
-  /// - param newChild: The new `effectSpecifiers` to replace the node's
-  ///                   current `effectSpecifiers`, if present.
-  public func withEffectSpecifiers(_ newChild: TypeEffectSpecifiersSyntax?) -> ArrowExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ArrowExprSyntax(newData)
   }
 
   public var unexpectedBetweenEffectSpecifiersAndArrowToken: UnexpectedNodesSyntax? {
@@ -2732,18 +2263,11 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenEffectSpecifiersAndArrowToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ArrowExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenEffectSpecifiersAndArrowToken` replaced.
-  /// - param newChild: The new `unexpectedBetweenEffectSpecifiersAndArrowToken` to replace the node's
-  ///                   current `unexpectedBetweenEffectSpecifiersAndArrowToken`, if present.
-  public func withUnexpectedBetweenEffectSpecifiersAndArrowToken(_ newChild: UnexpectedNodesSyntax?) -> ArrowExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ArrowExprSyntax(newData)
   }
 
   public var arrowToken: TokenSyntax {
@@ -2752,18 +2276,11 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withArrowToken(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ArrowExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `arrowToken` replaced.
-  /// - param newChild: The new `arrowToken` to replace the node's
-  ///                   current `arrowToken`, if present.
-  public func withArrowToken(_ newChild: TokenSyntax) -> ArrowExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ArrowExprSyntax(newData)
   }
 
   public var unexpectedAfterArrowToken: UnexpectedNodesSyntax? {
@@ -2773,18 +2290,11 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterArrowToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ArrowExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterArrowToken` replaced.
-  /// - param newChild: The new `unexpectedAfterArrowToken` to replace the node's
-  ///                   current `unexpectedAfterArrowToken`, if present.
-  public func withUnexpectedAfterArrowToken(_ newChild: UnexpectedNodesSyntax?) -> ArrowExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ArrowExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2883,18 +2393,11 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftOperand(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = InfixOperatorExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftOperand` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftOperand` to replace the node's
-  ///                   current `unexpectedBeforeLeftOperand`, if present.
-  public func withUnexpectedBeforeLeftOperand(_ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return InfixOperatorExprSyntax(newData)
   }
 
   public var leftOperand: ExprSyntax {
@@ -2903,18 +2406,11 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withLeftOperand(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = InfixOperatorExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftOperand` replaced.
-  /// - param newChild: The new `leftOperand` to replace the node's
-  ///                   current `leftOperand`, if present.
-  public func withLeftOperand(_ newChild: ExprSyntax) -> InfixOperatorExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return InfixOperatorExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftOperandAndOperatorOperand: UnexpectedNodesSyntax? {
@@ -2924,18 +2420,11 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftOperandAndOperatorOperand(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = InfixOperatorExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftOperandAndOperatorOperand` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftOperandAndOperatorOperand` to replace the node's
-  ///                   current `unexpectedBetweenLeftOperandAndOperatorOperand`, if present.
-  public func withUnexpectedBetweenLeftOperandAndOperatorOperand(_ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return InfixOperatorExprSyntax(newData)
   }
 
   public var operatorOperand: ExprSyntax {
@@ -2944,18 +2433,11 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withOperatorOperand(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = InfixOperatorExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `operatorOperand` replaced.
-  /// - param newChild: The new `operatorOperand` to replace the node's
-  ///                   current `operatorOperand`, if present.
-  public func withOperatorOperand(_ newChild: ExprSyntax) -> InfixOperatorExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return InfixOperatorExprSyntax(newData)
   }
 
   public var unexpectedBetweenOperatorOperandAndRightOperand: UnexpectedNodesSyntax? {
@@ -2965,18 +2447,11 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenOperatorOperandAndRightOperand(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = InfixOperatorExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenOperatorOperandAndRightOperand` replaced.
-  /// - param newChild: The new `unexpectedBetweenOperatorOperandAndRightOperand` to replace the node's
-  ///                   current `unexpectedBetweenOperatorOperandAndRightOperand`, if present.
-  public func withUnexpectedBetweenOperatorOperandAndRightOperand(_ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return InfixOperatorExprSyntax(newData)
   }
 
   public var rightOperand: ExprSyntax {
@@ -2985,18 +2460,11 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withRightOperand(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = InfixOperatorExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightOperand` replaced.
-  /// - param newChild: The new `rightOperand` to replace the node's
-  ///                   current `rightOperand`, if present.
-  public func withRightOperand(_ newChild: ExprSyntax) -> InfixOperatorExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return InfixOperatorExprSyntax(newData)
   }
 
   public var unexpectedAfterRightOperand: UnexpectedNodesSyntax? {
@@ -3006,18 +2474,11 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightOperand(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = InfixOperatorExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightOperand` replaced.
-  /// - param newChild: The new `unexpectedAfterRightOperand` to replace the node's
-  ///                   current `unexpectedAfterRightOperand`, if present.
-  public func withUnexpectedAfterRightOperand(_ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return InfixOperatorExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -3116,18 +2577,11 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeFloatingDigits(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = FloatLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeFloatingDigits` replaced.
-  /// - param newChild: The new `unexpectedBeforeFloatingDigits` to replace the node's
-  ///                   current `unexpectedBeforeFloatingDigits`, if present.
-  public func withUnexpectedBeforeFloatingDigits(_ newChild: UnexpectedNodesSyntax?) -> FloatLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return FloatLiteralExprSyntax(newData)
   }
 
   public var floatingDigits: TokenSyntax {
@@ -3136,18 +2590,11 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withFloatingDigits(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = FloatLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `floatingDigits` replaced.
-  /// - param newChild: The new `floatingDigits` to replace the node's
-  ///                   current `floatingDigits`, if present.
-  public func withFloatingDigits(_ newChild: TokenSyntax) -> FloatLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return FloatLiteralExprSyntax(newData)
   }
 
   public var unexpectedAfterFloatingDigits: UnexpectedNodesSyntax? {
@@ -3157,18 +2604,11 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterFloatingDigits(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = FloatLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterFloatingDigits` replaced.
-  /// - param newChild: The new `unexpectedAfterFloatingDigits` to replace the node's
-  ///                   current `unexpectedAfterFloatingDigits`, if present.
-  public func withUnexpectedAfterFloatingDigits(_ newChild: UnexpectedNodesSyntax?) -> FloatLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return FloatLiteralExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -3259,18 +2699,11 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = TupleExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
-  ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return TupleExprSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -3279,18 +2712,11 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = TupleExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> TupleExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return TupleExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? {
@@ -3300,18 +2726,11 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndElementList(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = TupleExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndElementList` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndElementList` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndElementList`, if present.
-  public func withUnexpectedBetweenLeftParenAndElementList(_ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return TupleExprSyntax(newData)
   }
 
   public var elementList: TupleExprElementListSyntax {
@@ -3320,7 +2739,10 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TupleExprElementListSyntax(childData!)
     }
     set(value) {
-      self = withElementList(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = TupleExprSyntax(newData)
     }
   }
 
@@ -3343,16 +2765,6 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return TupleExprSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `elementList` replaced.
-  /// - param newChild: The new `elementList` to replace the node's
-  ///                   current `elementList`, if present.
-  public func withElementList(_ newChild: TupleExprElementListSyntax) -> TupleExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return TupleExprSyntax(newData)
-  }
-
   public var unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -3360,18 +2772,11 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenElementListAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = TupleExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenElementListAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenElementListAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenElementListAndRightParen`, if present.
-  public func withUnexpectedBetweenElementListAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return TupleExprSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -3380,18 +2785,11 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = TupleExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> TupleExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return TupleExprSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -3401,18 +2799,11 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = TupleExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return TupleExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -3519,18 +2910,11 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftSquare(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ArrayExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftSquare` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftSquare` to replace the node's
-  ///                   current `unexpectedBeforeLeftSquare`, if present.
-  public func withUnexpectedBeforeLeftSquare(_ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ArrayExprSyntax(newData)
   }
 
   public var leftSquare: TokenSyntax {
@@ -3539,18 +2923,11 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftSquare(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ArrayExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftSquare` replaced.
-  /// - param newChild: The new `leftSquare` to replace the node's
-  ///                   current `leftSquare`, if present.
-  public func withLeftSquare(_ newChild: TokenSyntax) -> ArrayExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ArrayExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftSquareAndElements: UnexpectedNodesSyntax? {
@@ -3560,18 +2937,11 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftSquareAndElements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ArrayExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftSquareAndElements` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftSquareAndElements` to replace the node's
-  ///                   current `unexpectedBetweenLeftSquareAndElements`, if present.
-  public func withUnexpectedBetweenLeftSquareAndElements(_ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ArrayExprSyntax(newData)
   }
 
   public var elements: ArrayElementListSyntax {
@@ -3580,7 +2950,10 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ArrayElementListSyntax(childData!)
     }
     set(value) {
-      self = withElements(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ArrayExprSyntax(newData)
     }
   }
 
@@ -3603,16 +2976,6 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return ArrayExprSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `elements` replaced.
-  /// - param newChild: The new `elements` to replace the node's
-  ///                   current `elements`, if present.
-  public func withElements(_ newChild: ArrayElementListSyntax) -> ArrayExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ArrayExprSyntax(newData)
-  }
-
   public var unexpectedBetweenElementsAndRightSquare: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -3620,18 +2983,11 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenElementsAndRightSquare(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ArrayExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenElementsAndRightSquare` replaced.
-  /// - param newChild: The new `unexpectedBetweenElementsAndRightSquare` to replace the node's
-  ///                   current `unexpectedBetweenElementsAndRightSquare`, if present.
-  public func withUnexpectedBetweenElementsAndRightSquare(_ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ArrayExprSyntax(newData)
   }
 
   public var rightSquare: TokenSyntax {
@@ -3640,18 +2996,11 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightSquare(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ArrayExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightSquare` replaced.
-  /// - param newChild: The new `rightSquare` to replace the node's
-  ///                   current `rightSquare`, if present.
-  public func withRightSquare(_ newChild: TokenSyntax) -> ArrayExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ArrayExprSyntax(newData)
   }
 
   public var unexpectedAfterRightSquare: UnexpectedNodesSyntax? {
@@ -3661,18 +3010,11 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightSquare(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ArrayExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightSquare` replaced.
-  /// - param newChild: The new `unexpectedAfterRightSquare` to replace the node's
-  ///                   current `unexpectedAfterRightSquare`, if present.
-  public func withUnexpectedAfterRightSquare(_ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ArrayExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -3815,18 +3157,11 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftSquare(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DictionaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftSquare` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftSquare` to replace the node's
-  ///                   current `unexpectedBeforeLeftSquare`, if present.
-  public func withUnexpectedBeforeLeftSquare(_ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DictionaryExprSyntax(newData)
   }
 
   public var leftSquare: TokenSyntax {
@@ -3835,18 +3170,11 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftSquare(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DictionaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftSquare` replaced.
-  /// - param newChild: The new `leftSquare` to replace the node's
-  ///                   current `leftSquare`, if present.
-  public func withLeftSquare(_ newChild: TokenSyntax) -> DictionaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DictionaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftSquareAndContent: UnexpectedNodesSyntax? {
@@ -3856,18 +3184,11 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftSquareAndContent(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DictionaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftSquareAndContent` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftSquareAndContent` to replace the node's
-  ///                   current `unexpectedBetweenLeftSquareAndContent`, if present.
-  public func withUnexpectedBetweenLeftSquareAndContent(_ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DictionaryExprSyntax(newData)
   }
 
   public var content: Content {
@@ -3876,18 +3197,11 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return Content(childData!)
     }
     set(value) {
-      self = withContent(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DictionaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `content` replaced.
-  /// - param newChild: The new `content` to replace the node's
-  ///                   current `content`, if present.
-  public func withContent(_ newChild: Content) -> DictionaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DictionaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenContentAndRightSquare: UnexpectedNodesSyntax? {
@@ -3897,18 +3211,11 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenContentAndRightSquare(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DictionaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenContentAndRightSquare` replaced.
-  /// - param newChild: The new `unexpectedBetweenContentAndRightSquare` to replace the node's
-  ///                   current `unexpectedBetweenContentAndRightSquare`, if present.
-  public func withUnexpectedBetweenContentAndRightSquare(_ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DictionaryExprSyntax(newData)
   }
 
   public var rightSquare: TokenSyntax {
@@ -3917,18 +3224,11 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightSquare(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = DictionaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightSquare` replaced.
-  /// - param newChild: The new `rightSquare` to replace the node's
-  ///                   current `rightSquare`, if present.
-  public func withRightSquare(_ newChild: TokenSyntax) -> DictionaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return DictionaryExprSyntax(newData)
   }
 
   public var unexpectedAfterRightSquare: UnexpectedNodesSyntax? {
@@ -3938,18 +3238,11 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightSquare(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = DictionaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightSquare` replaced.
-  /// - param newChild: The new `unexpectedAfterRightSquare` to replace the node's
-  ///                   current `unexpectedAfterRightSquare`, if present.
-  public func withUnexpectedAfterRightSquare(_ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return DictionaryExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -4048,18 +3341,11 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeDigits(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = IntegerLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeDigits` replaced.
-  /// - param newChild: The new `unexpectedBeforeDigits` to replace the node's
-  ///                   current `unexpectedBeforeDigits`, if present.
-  public func withUnexpectedBeforeDigits(_ newChild: UnexpectedNodesSyntax?) -> IntegerLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return IntegerLiteralExprSyntax(newData)
   }
 
   public var digits: TokenSyntax {
@@ -4068,18 +3354,11 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withDigits(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = IntegerLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `digits` replaced.
-  /// - param newChild: The new `digits` to replace the node's
-  ///                   current `digits`, if present.
-  public func withDigits(_ newChild: TokenSyntax) -> IntegerLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return IntegerLiteralExprSyntax(newData)
   }
 
   public var unexpectedAfterDigits: UnexpectedNodesSyntax? {
@@ -4089,18 +3368,11 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterDigits(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = IntegerLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterDigits` replaced.
-  /// - param newChild: The new `unexpectedAfterDigits` to replace the node's
-  ///                   current `unexpectedAfterDigits`, if present.
-  public func withUnexpectedAfterDigits(_ newChild: UnexpectedNodesSyntax?) -> IntegerLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return IntegerLiteralExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -4183,18 +3455,11 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeBooleanLiteral(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = BooleanLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeBooleanLiteral` replaced.
-  /// - param newChild: The new `unexpectedBeforeBooleanLiteral` to replace the node's
-  ///                   current `unexpectedBeforeBooleanLiteral`, if present.
-  public func withUnexpectedBeforeBooleanLiteral(_ newChild: UnexpectedNodesSyntax?) -> BooleanLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return BooleanLiteralExprSyntax(newData)
   }
 
   public var booleanLiteral: TokenSyntax {
@@ -4203,18 +3468,11 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withBooleanLiteral(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = BooleanLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `booleanLiteral` replaced.
-  /// - param newChild: The new `booleanLiteral` to replace the node's
-  ///                   current `booleanLiteral`, if present.
-  public func withBooleanLiteral(_ newChild: TokenSyntax) -> BooleanLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return BooleanLiteralExprSyntax(newData)
   }
 
   public var unexpectedAfterBooleanLiteral: UnexpectedNodesSyntax? {
@@ -4224,18 +3482,11 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterBooleanLiteral(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = BooleanLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterBooleanLiteral` replaced.
-  /// - param newChild: The new `unexpectedAfterBooleanLiteral` to replace the node's
-  ///                   current `unexpectedAfterBooleanLiteral`, if present.
-  public func withUnexpectedAfterBooleanLiteral(_ newChild: UnexpectedNodesSyntax?) -> BooleanLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return BooleanLiteralExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -4326,18 +3577,11 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeQuestionMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = UnresolvedTernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeQuestionMark` replaced.
-  /// - param newChild: The new `unexpectedBeforeQuestionMark` to replace the node's
-  ///                   current `unexpectedBeforeQuestionMark`, if present.
-  public func withUnexpectedBeforeQuestionMark(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return UnresolvedTernaryExprSyntax(newData)
   }
 
   public var questionMark: TokenSyntax {
@@ -4346,18 +3590,11 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withQuestionMark(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = UnresolvedTernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `questionMark` replaced.
-  /// - param newChild: The new `questionMark` to replace the node's
-  ///                   current `questionMark`, if present.
-  public func withQuestionMark(_ newChild: TokenSyntax) -> UnresolvedTernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return UnresolvedTernaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? {
@@ -4367,18 +3604,11 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenQuestionMarkAndFirstChoice(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = UnresolvedTernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenQuestionMarkAndFirstChoice` replaced.
-  /// - param newChild: The new `unexpectedBetweenQuestionMarkAndFirstChoice` to replace the node's
-  ///                   current `unexpectedBetweenQuestionMarkAndFirstChoice`, if present.
-  public func withUnexpectedBetweenQuestionMarkAndFirstChoice(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return UnresolvedTernaryExprSyntax(newData)
   }
 
   public var firstChoice: ExprSyntax {
@@ -4387,18 +3617,11 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withFirstChoice(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = UnresolvedTernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `firstChoice` replaced.
-  /// - param newChild: The new `firstChoice` to replace the node's
-  ///                   current `firstChoice`, if present.
-  public func withFirstChoice(_ newChild: ExprSyntax) -> UnresolvedTernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return UnresolvedTernaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? {
@@ -4408,18 +3631,11 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenFirstChoiceAndColonMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = UnresolvedTernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenFirstChoiceAndColonMark` replaced.
-  /// - param newChild: The new `unexpectedBetweenFirstChoiceAndColonMark` to replace the node's
-  ///                   current `unexpectedBetweenFirstChoiceAndColonMark`, if present.
-  public func withUnexpectedBetweenFirstChoiceAndColonMark(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return UnresolvedTernaryExprSyntax(newData)
   }
 
   public var colonMark: TokenSyntax {
@@ -4428,18 +3644,11 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColonMark(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = UnresolvedTernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colonMark` replaced.
-  /// - param newChild: The new `colonMark` to replace the node's
-  ///                   current `colonMark`, if present.
-  public func withColonMark(_ newChild: TokenSyntax) -> UnresolvedTernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return UnresolvedTernaryExprSyntax(newData)
   }
 
   public var unexpectedAfterColonMark: UnexpectedNodesSyntax? {
@@ -4449,18 +3658,11 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterColonMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = UnresolvedTernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterColonMark` replaced.
-  /// - param newChild: The new `unexpectedAfterColonMark` to replace the node's
-  ///                   current `unexpectedAfterColonMark`, if present.
-  public func withUnexpectedAfterColonMark(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return UnresolvedTernaryExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -4575,18 +3777,11 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeConditionExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = TernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeConditionExpression` replaced.
-  /// - param newChild: The new `unexpectedBeforeConditionExpression` to replace the node's
-  ///                   current `unexpectedBeforeConditionExpression`, if present.
-  public func withUnexpectedBeforeConditionExpression(_ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return TernaryExprSyntax(newData)
   }
 
   public var conditionExpression: ExprSyntax {
@@ -4595,18 +3790,11 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withConditionExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = TernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `conditionExpression` replaced.
-  /// - param newChild: The new `conditionExpression` to replace the node's
-  ///                   current `conditionExpression`, if present.
-  public func withConditionExpression(_ newChild: ExprSyntax) -> TernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return TernaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenConditionExpressionAndQuestionMark: UnexpectedNodesSyntax? {
@@ -4616,18 +3804,11 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenConditionExpressionAndQuestionMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = TernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenConditionExpressionAndQuestionMark` replaced.
-  /// - param newChild: The new `unexpectedBetweenConditionExpressionAndQuestionMark` to replace the node's
-  ///                   current `unexpectedBetweenConditionExpressionAndQuestionMark`, if present.
-  public func withUnexpectedBetweenConditionExpressionAndQuestionMark(_ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return TernaryExprSyntax(newData)
   }
 
   public var questionMark: TokenSyntax {
@@ -4636,18 +3817,11 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withQuestionMark(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = TernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `questionMark` replaced.
-  /// - param newChild: The new `questionMark` to replace the node's
-  ///                   current `questionMark`, if present.
-  public func withQuestionMark(_ newChild: TokenSyntax) -> TernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return TernaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? {
@@ -4657,18 +3831,11 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenQuestionMarkAndFirstChoice(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = TernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenQuestionMarkAndFirstChoice` replaced.
-  /// - param newChild: The new `unexpectedBetweenQuestionMarkAndFirstChoice` to replace the node's
-  ///                   current `unexpectedBetweenQuestionMarkAndFirstChoice`, if present.
-  public func withUnexpectedBetweenQuestionMarkAndFirstChoice(_ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return TernaryExprSyntax(newData)
   }
 
   public var firstChoice: ExprSyntax {
@@ -4677,18 +3844,11 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withFirstChoice(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = TernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `firstChoice` replaced.
-  /// - param newChild: The new `firstChoice` to replace the node's
-  ///                   current `firstChoice`, if present.
-  public func withFirstChoice(_ newChild: ExprSyntax) -> TernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return TernaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? {
@@ -4698,18 +3858,11 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenFirstChoiceAndColonMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = TernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenFirstChoiceAndColonMark` replaced.
-  /// - param newChild: The new `unexpectedBetweenFirstChoiceAndColonMark` to replace the node's
-  ///                   current `unexpectedBetweenFirstChoiceAndColonMark`, if present.
-  public func withUnexpectedBetweenFirstChoiceAndColonMark(_ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return TernaryExprSyntax(newData)
   }
 
   public var colonMark: TokenSyntax {
@@ -4718,18 +3871,11 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColonMark(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = TernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colonMark` replaced.
-  /// - param newChild: The new `colonMark` to replace the node's
-  ///                   current `colonMark`, if present.
-  public func withColonMark(_ newChild: TokenSyntax) -> TernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return TernaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenColonMarkAndSecondChoice: UnexpectedNodesSyntax? {
@@ -4739,18 +3885,11 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonMarkAndSecondChoice(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = TernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonMarkAndSecondChoice` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonMarkAndSecondChoice` to replace the node's
-  ///                   current `unexpectedBetweenColonMarkAndSecondChoice`, if present.
-  public func withUnexpectedBetweenColonMarkAndSecondChoice(_ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return TernaryExprSyntax(newData)
   }
 
   public var secondChoice: ExprSyntax {
@@ -4759,18 +3898,11 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withSecondChoice(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = TernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `secondChoice` replaced.
-  /// - param newChild: The new `secondChoice` to replace the node's
-  ///                   current `secondChoice`, if present.
-  public func withSecondChoice(_ newChild: ExprSyntax) -> TernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return TernaryExprSyntax(newData)
   }
 
   public var unexpectedAfterSecondChoice: UnexpectedNodesSyntax? {
@@ -4780,18 +3912,11 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterSecondChoice(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = TernaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterSecondChoice` replaced.
-  /// - param newChild: The new `unexpectedAfterSecondChoice` to replace the node's
-  ///                   current `unexpectedAfterSecondChoice`, if present.
-  public func withUnexpectedAfterSecondChoice(_ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return TernaryExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -4956,18 +4081,11 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeBase(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = MemberAccessExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeBase` replaced.
-  /// - param newChild: The new `unexpectedBeforeBase` to replace the node's
-  ///                   current `unexpectedBeforeBase`, if present.
-  public func withUnexpectedBeforeBase(_ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return MemberAccessExprSyntax(newData)
   }
 
   public var base: ExprSyntax? {
@@ -4977,18 +4095,11 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withBase(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = MemberAccessExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `base` replaced.
-  /// - param newChild: The new `base` to replace the node's
-  ///                   current `base`, if present.
-  public func withBase(_ newChild: ExprSyntax?) -> MemberAccessExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return MemberAccessExprSyntax(newData)
   }
 
   public var unexpectedBetweenBaseAndDot: UnexpectedNodesSyntax? {
@@ -4998,18 +4109,11 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenBaseAndDot(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = MemberAccessExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenBaseAndDot` replaced.
-  /// - param newChild: The new `unexpectedBetweenBaseAndDot` to replace the node's
-  ///                   current `unexpectedBetweenBaseAndDot`, if present.
-  public func withUnexpectedBetweenBaseAndDot(_ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return MemberAccessExprSyntax(newData)
   }
 
   public var dot: TokenSyntax {
@@ -5018,18 +4122,11 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withDot(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = MemberAccessExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `dot` replaced.
-  /// - param newChild: The new `dot` to replace the node's
-  ///                   current `dot`, if present.
-  public func withDot(_ newChild: TokenSyntax) -> MemberAccessExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return MemberAccessExprSyntax(newData)
   }
 
   public var unexpectedBetweenDotAndName: UnexpectedNodesSyntax? {
@@ -5039,18 +4136,11 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDotAndName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = MemberAccessExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDotAndName` replaced.
-  /// - param newChild: The new `unexpectedBetweenDotAndName` to replace the node's
-  ///                   current `unexpectedBetweenDotAndName`, if present.
-  public func withUnexpectedBetweenDotAndName(_ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return MemberAccessExprSyntax(newData)
   }
 
   public var name: TokenSyntax {
@@ -5059,18 +4149,11 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = MemberAccessExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax) -> MemberAccessExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return MemberAccessExprSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndDeclNameArguments: UnexpectedNodesSyntax? {
@@ -5080,18 +4163,11 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenNameAndDeclNameArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = MemberAccessExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenNameAndDeclNameArguments` replaced.
-  /// - param newChild: The new `unexpectedBetweenNameAndDeclNameArguments` to replace the node's
-  ///                   current `unexpectedBetweenNameAndDeclNameArguments`, if present.
-  public func withUnexpectedBetweenNameAndDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return MemberAccessExprSyntax(newData)
   }
 
   public var declNameArguments: DeclNameArgumentsSyntax? {
@@ -5101,18 +4177,11 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return DeclNameArgumentsSyntax(childData!)
     }
     set(value) {
-      self = withDeclNameArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = MemberAccessExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `declNameArguments` replaced.
-  /// - param newChild: The new `declNameArguments` to replace the node's
-  ///                   current `declNameArguments`, if present.
-  public func withDeclNameArguments(_ newChild: DeclNameArgumentsSyntax?) -> MemberAccessExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return MemberAccessExprSyntax(newData)
   }
 
   public var unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? {
@@ -5122,18 +4191,11 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterDeclNameArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = MemberAccessExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterDeclNameArguments` replaced.
-  /// - param newChild: The new `unexpectedAfterDeclNameArguments` to replace the node's
-  ///                   current `unexpectedAfterDeclNameArguments`, if present.
-  public func withUnexpectedAfterDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return MemberAccessExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -5240,18 +4302,11 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeIsTok(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = UnresolvedIsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeIsTok` replaced.
-  /// - param newChild: The new `unexpectedBeforeIsTok` to replace the node's
-  ///                   current `unexpectedBeforeIsTok`, if present.
-  public func withUnexpectedBeforeIsTok(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedIsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return UnresolvedIsExprSyntax(newData)
   }
 
   public var isTok: TokenSyntax {
@@ -5260,18 +4315,11 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIsTok(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = UnresolvedIsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `isTok` replaced.
-  /// - param newChild: The new `isTok` to replace the node's
-  ///                   current `isTok`, if present.
-  public func withIsTok(_ newChild: TokenSyntax) -> UnresolvedIsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return UnresolvedIsExprSyntax(newData)
   }
 
   public var unexpectedAfterIsTok: UnexpectedNodesSyntax? {
@@ -5281,18 +4329,11 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterIsTok(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = UnresolvedIsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterIsTok` replaced.
-  /// - param newChild: The new `unexpectedAfterIsTok` to replace the node's
-  ///                   current `unexpectedAfterIsTok`, if present.
-  public func withUnexpectedAfterIsTok(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedIsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return UnresolvedIsExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -5383,18 +4424,11 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = IsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
-  /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
-  ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> IsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return IsExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -5403,18 +4437,11 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = IsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> IsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return IsExprSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndIsTok: UnexpectedNodesSyntax? {
@@ -5424,18 +4451,11 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenExpressionAndIsTok(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = IsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndIsTok` replaced.
-  /// - param newChild: The new `unexpectedBetweenExpressionAndIsTok` to replace the node's
-  ///                   current `unexpectedBetweenExpressionAndIsTok`, if present.
-  public func withUnexpectedBetweenExpressionAndIsTok(_ newChild: UnexpectedNodesSyntax?) -> IsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return IsExprSyntax(newData)
   }
 
   public var isTok: TokenSyntax {
@@ -5444,18 +4464,11 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIsTok(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = IsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `isTok` replaced.
-  /// - param newChild: The new `isTok` to replace the node's
-  ///                   current `isTok`, if present.
-  public func withIsTok(_ newChild: TokenSyntax) -> IsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return IsExprSyntax(newData)
   }
 
   public var unexpectedBetweenIsTokAndTypeName: UnexpectedNodesSyntax? {
@@ -5465,18 +4478,11 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIsTokAndTypeName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = IsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIsTokAndTypeName` replaced.
-  /// - param newChild: The new `unexpectedBetweenIsTokAndTypeName` to replace the node's
-  ///                   current `unexpectedBetweenIsTokAndTypeName`, if present.
-  public func withUnexpectedBetweenIsTokAndTypeName(_ newChild: UnexpectedNodesSyntax?) -> IsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return IsExprSyntax(newData)
   }
 
   public var typeName: TypeSyntax {
@@ -5485,18 +4491,11 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withTypeName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = IsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `typeName` replaced.
-  /// - param newChild: The new `typeName` to replace the node's
-  ///                   current `typeName`, if present.
-  public func withTypeName(_ newChild: TypeSyntax) -> IsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return IsExprSyntax(newData)
   }
 
   public var unexpectedAfterTypeName: UnexpectedNodesSyntax? {
@@ -5506,18 +4505,11 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTypeName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = IsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTypeName` replaced.
-  /// - param newChild: The new `unexpectedAfterTypeName` to replace the node's
-  ///                   current `unexpectedAfterTypeName`, if present.
-  public func withUnexpectedAfterTypeName(_ newChild: UnexpectedNodesSyntax?) -> IsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return IsExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -5620,18 +4612,11 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAsTok(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = UnresolvedAsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAsTok` replaced.
-  /// - param newChild: The new `unexpectedBeforeAsTok` to replace the node's
-  ///                   current `unexpectedBeforeAsTok`, if present.
-  public func withUnexpectedBeforeAsTok(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedAsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return UnresolvedAsExprSyntax(newData)
   }
 
   public var asTok: TokenSyntax {
@@ -5640,18 +4625,11 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAsTok(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = UnresolvedAsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `asTok` replaced.
-  /// - param newChild: The new `asTok` to replace the node's
-  ///                   current `asTok`, if present.
-  public func withAsTok(_ newChild: TokenSyntax) -> UnresolvedAsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return UnresolvedAsExprSyntax(newData)
   }
 
   public var unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodesSyntax? {
@@ -5661,18 +4639,11 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAsTokAndQuestionOrExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = UnresolvedAsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAsTokAndQuestionOrExclamationMark` replaced.
-  /// - param newChild: The new `unexpectedBetweenAsTokAndQuestionOrExclamationMark` to replace the node's
-  ///                   current `unexpectedBetweenAsTokAndQuestionOrExclamationMark`, if present.
-  public func withUnexpectedBetweenAsTokAndQuestionOrExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedAsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return UnresolvedAsExprSyntax(newData)
   }
 
   public var questionOrExclamationMark: TokenSyntax? {
@@ -5682,18 +4653,11 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withQuestionOrExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = UnresolvedAsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `questionOrExclamationMark` replaced.
-  /// - param newChild: The new `questionOrExclamationMark` to replace the node's
-  ///                   current `questionOrExclamationMark`, if present.
-  public func withQuestionOrExclamationMark(_ newChild: TokenSyntax?) -> UnresolvedAsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return UnresolvedAsExprSyntax(newData)
   }
 
   public var unexpectedAfterQuestionOrExclamationMark: UnexpectedNodesSyntax? {
@@ -5703,18 +4667,11 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterQuestionOrExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = UnresolvedAsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterQuestionOrExclamationMark` replaced.
-  /// - param newChild: The new `unexpectedAfterQuestionOrExclamationMark` to replace the node's
-  ///                   current `unexpectedAfterQuestionOrExclamationMark`, if present.
-  public func withUnexpectedAfterQuestionOrExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedAsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return UnresolvedAsExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -5817,18 +4774,11 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
-  /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
-  ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AsExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -5837,18 +4787,11 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> AsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AsExprSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndAsTok: UnexpectedNodesSyntax? {
@@ -5858,18 +4801,11 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenExpressionAndAsTok(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndAsTok` replaced.
-  /// - param newChild: The new `unexpectedBetweenExpressionAndAsTok` to replace the node's
-  ///                   current `unexpectedBetweenExpressionAndAsTok`, if present.
-  public func withUnexpectedBetweenExpressionAndAsTok(_ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AsExprSyntax(newData)
   }
 
   public var asTok: TokenSyntax {
@@ -5878,18 +4814,11 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAsTok(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = AsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `asTok` replaced.
-  /// - param newChild: The new `asTok` to replace the node's
-  ///                   current `asTok`, if present.
-  public func withAsTok(_ newChild: TokenSyntax) -> AsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return AsExprSyntax(newData)
   }
 
   public var unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodesSyntax? {
@@ -5899,18 +4828,11 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAsTokAndQuestionOrExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = AsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAsTokAndQuestionOrExclamationMark` replaced.
-  /// - param newChild: The new `unexpectedBetweenAsTokAndQuestionOrExclamationMark` to replace the node's
-  ///                   current `unexpectedBetweenAsTokAndQuestionOrExclamationMark`, if present.
-  public func withUnexpectedBetweenAsTokAndQuestionOrExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return AsExprSyntax(newData)
   }
 
   public var questionOrExclamationMark: TokenSyntax? {
@@ -5920,18 +4842,11 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withQuestionOrExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = AsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `questionOrExclamationMark` replaced.
-  /// - param newChild: The new `questionOrExclamationMark` to replace the node's
-  ///                   current `questionOrExclamationMark`, if present.
-  public func withQuestionOrExclamationMark(_ newChild: TokenSyntax?) -> AsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return AsExprSyntax(newData)
   }
 
   public var unexpectedBetweenQuestionOrExclamationMarkAndTypeName: UnexpectedNodesSyntax? {
@@ -5941,18 +4856,11 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenQuestionOrExclamationMarkAndTypeName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = AsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenQuestionOrExclamationMarkAndTypeName` replaced.
-  /// - param newChild: The new `unexpectedBetweenQuestionOrExclamationMarkAndTypeName` to replace the node's
-  ///                   current `unexpectedBetweenQuestionOrExclamationMarkAndTypeName`, if present.
-  public func withUnexpectedBetweenQuestionOrExclamationMarkAndTypeName(_ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return AsExprSyntax(newData)
   }
 
   public var typeName: TypeSyntax {
@@ -5961,18 +4869,11 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withTypeName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = AsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `typeName` replaced.
-  /// - param newChild: The new `typeName` to replace the node's
-  ///                   current `typeName`, if present.
-  public func withTypeName(_ newChild: TypeSyntax) -> AsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return AsExprSyntax(newData)
   }
 
   public var unexpectedAfterTypeName: UnexpectedNodesSyntax? {
@@ -5982,18 +4883,11 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTypeName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = AsExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTypeName` replaced.
-  /// - param newChild: The new `unexpectedAfterTypeName` to replace the node's
-  ///                   current `unexpectedAfterTypeName`, if present.
-  public func withUnexpectedAfterTypeName(_ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return AsExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -6100,18 +4994,11 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = TypeExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeType` replaced.
-  /// - param newChild: The new `unexpectedBeforeType` to replace the node's
-  ///                   current `unexpectedBeforeType`, if present.
-  public func withUnexpectedBeforeType(_ newChild: UnexpectedNodesSyntax?) -> TypeExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return TypeExprSyntax(newData)
   }
 
   public var type: TypeSyntax {
@@ -6120,18 +5007,11 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = TypeExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `type` replaced.
-  /// - param newChild: The new `type` to replace the node's
-  ///                   current `type`, if present.
-  public func withType(_ newChild: TypeSyntax) -> TypeExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return TypeExprSyntax(newData)
   }
 
   public var unexpectedAfterType: UnexpectedNodesSyntax? {
@@ -6141,18 +5021,11 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = TypeExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterType` replaced.
-  /// - param newChild: The new `unexpectedAfterType` to replace the node's
-  ///                   current `unexpectedAfterType`, if present.
-  public func withUnexpectedAfterType(_ newChild: UnexpectedNodesSyntax?) -> TypeExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return TypeExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -6247,18 +5120,11 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ClosureExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftBrace` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftBrace` to replace the node's
-  ///                   current `unexpectedBeforeLeftBrace`, if present.
-  public func withUnexpectedBeforeLeftBrace(_ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ClosureExprSyntax(newData)
   }
 
   public var leftBrace: TokenSyntax {
@@ -6267,18 +5133,11 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftBrace(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ClosureExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftBrace` replaced.
-  /// - param newChild: The new `leftBrace` to replace the node's
-  ///                   current `leftBrace`, if present.
-  public func withLeftBrace(_ newChild: TokenSyntax) -> ClosureExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ClosureExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftBraceAndSignature: UnexpectedNodesSyntax? {
@@ -6288,18 +5147,11 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftBraceAndSignature(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ClosureExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftBraceAndSignature` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftBraceAndSignature` to replace the node's
-  ///                   current `unexpectedBetweenLeftBraceAndSignature`, if present.
-  public func withUnexpectedBetweenLeftBraceAndSignature(_ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ClosureExprSyntax(newData)
   }
 
   public var signature: ClosureSignatureSyntax? {
@@ -6309,18 +5161,11 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ClosureSignatureSyntax(childData!)
     }
     set(value) {
-      self = withSignature(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ClosureExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `signature` replaced.
-  /// - param newChild: The new `signature` to replace the node's
-  ///                   current `signature`, if present.
-  public func withSignature(_ newChild: ClosureSignatureSyntax?) -> ClosureExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ClosureExprSyntax(newData)
   }
 
   public var unexpectedBetweenSignatureAndStatements: UnexpectedNodesSyntax? {
@@ -6330,18 +5175,11 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSignatureAndStatements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ClosureExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSignatureAndStatements` replaced.
-  /// - param newChild: The new `unexpectedBetweenSignatureAndStatements` to replace the node's
-  ///                   current `unexpectedBetweenSignatureAndStatements`, if present.
-  public func withUnexpectedBetweenSignatureAndStatements(_ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ClosureExprSyntax(newData)
   }
 
   public var statements: CodeBlockItemListSyntax {
@@ -6350,7 +5188,10 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return CodeBlockItemListSyntax(childData!)
     }
     set(value) {
-      self = withStatements(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ClosureExprSyntax(newData)
     }
   }
 
@@ -6373,16 +5214,6 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return ClosureExprSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `statements` replaced.
-  /// - param newChild: The new `statements` to replace the node's
-  ///                   current `statements`, if present.
-  public func withStatements(_ newChild: CodeBlockItemListSyntax) -> ClosureExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ClosureExprSyntax(newData)
-  }
-
   public var unexpectedBetweenStatementsAndRightBrace: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 6, parent: Syntax(self))
@@ -6390,18 +5221,11 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenStatementsAndRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ClosureExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenStatementsAndRightBrace` replaced.
-  /// - param newChild: The new `unexpectedBetweenStatementsAndRightBrace` to replace the node's
-  ///                   current `unexpectedBetweenStatementsAndRightBrace`, if present.
-  public func withUnexpectedBetweenStatementsAndRightBrace(_ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ClosureExprSyntax(newData)
   }
 
   public var rightBrace: TokenSyntax {
@@ -6410,18 +5234,11 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = ClosureExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightBrace` replaced.
-  /// - param newChild: The new `rightBrace` to replace the node's
-  ///                   current `rightBrace`, if present.
-  public func withRightBrace(_ newChild: TokenSyntax) -> ClosureExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return ClosureExprSyntax(newData)
   }
 
   public var unexpectedAfterRightBrace: UnexpectedNodesSyntax? {
@@ -6431,18 +5248,11 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = ClosureExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
-  /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
-  ///                   current `unexpectedAfterRightBrace`, if present.
-  public func withUnexpectedAfterRightBrace(_ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return ClosureExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -6549,18 +5359,11 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforePattern(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = UnresolvedPatternExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforePattern` replaced.
-  /// - param newChild: The new `unexpectedBeforePattern` to replace the node's
-  ///                   current `unexpectedBeforePattern`, if present.
-  public func withUnexpectedBeforePattern(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedPatternExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return UnresolvedPatternExprSyntax(newData)
   }
 
   public var pattern: PatternSyntax {
@@ -6569,18 +5372,11 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return PatternSyntax(childData!)
     }
     set(value) {
-      self = withPattern(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = UnresolvedPatternExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `pattern` replaced.
-  /// - param newChild: The new `pattern` to replace the node's
-  ///                   current `pattern`, if present.
-  public func withPattern(_ newChild: PatternSyntax) -> UnresolvedPatternExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return UnresolvedPatternExprSyntax(newData)
   }
 
   public var unexpectedAfterPattern: UnexpectedNodesSyntax? {
@@ -6590,18 +5386,11 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterPattern(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = UnresolvedPatternExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterPattern` replaced.
-  /// - param newChild: The new `unexpectedAfterPattern` to replace the node's
-  ///                   current `unexpectedAfterPattern`, if present.
-  public func withUnexpectedAfterPattern(_ newChild: UnexpectedNodesSyntax?) -> UnresolvedPatternExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return UnresolvedPatternExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -6704,18 +5493,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeCalledExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = FunctionCallExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeCalledExpression` replaced.
-  /// - param newChild: The new `unexpectedBeforeCalledExpression` to replace the node's
-  ///                   current `unexpectedBeforeCalledExpression`, if present.
-  public func withUnexpectedBeforeCalledExpression(_ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return FunctionCallExprSyntax(newData)
   }
 
   public var calledExpression: ExprSyntax {
@@ -6724,18 +5506,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withCalledExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = FunctionCallExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `calledExpression` replaced.
-  /// - param newChild: The new `calledExpression` to replace the node's
-  ///                   current `calledExpression`, if present.
-  public func withCalledExpression(_ newChild: ExprSyntax) -> FunctionCallExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return FunctionCallExprSyntax(newData)
   }
 
   public var unexpectedBetweenCalledExpressionAndLeftParen: UnexpectedNodesSyntax? {
@@ -6745,18 +5520,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCalledExpressionAndLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = FunctionCallExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCalledExpressionAndLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenCalledExpressionAndLeftParen` to replace the node's
-  ///                   current `unexpectedBetweenCalledExpressionAndLeftParen`, if present.
-  public func withUnexpectedBetweenCalledExpressionAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return FunctionCallExprSyntax(newData)
   }
 
   public var leftParen: TokenSyntax? {
@@ -6766,18 +5534,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = FunctionCallExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> FunctionCallExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return FunctionCallExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? {
@@ -6787,18 +5548,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndArgumentList(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = FunctionCallExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArgumentList` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndArgumentList` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndArgumentList`, if present.
-  public func withUnexpectedBetweenLeftParenAndArgumentList(_ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return FunctionCallExprSyntax(newData)
   }
 
   public var argumentList: TupleExprElementListSyntax {
@@ -6807,7 +5561,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TupleExprElementListSyntax(childData!)
     }
     set(value) {
-      self = withArgumentList(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = FunctionCallExprSyntax(newData)
     }
   }
 
@@ -6830,16 +5587,6 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return FunctionCallExprSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `argumentList` replaced.
-  /// - param newChild: The new `argumentList` to replace the node's
-  ///                   current `argumentList`, if present.
-  public func withArgumentList(_ newChild: TupleExprElementListSyntax) -> FunctionCallExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return FunctionCallExprSyntax(newData)
-  }
-
   public var unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 6, parent: Syntax(self))
@@ -6847,18 +5594,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenArgumentListAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = FunctionCallExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenArgumentListAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenArgumentListAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenArgumentListAndRightParen`, if present.
-  public func withUnexpectedBetweenArgumentListAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return FunctionCallExprSyntax(newData)
   }
 
   public var rightParen: TokenSyntax? {
@@ -6868,18 +5608,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = FunctionCallExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> FunctionCallExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return FunctionCallExprSyntax(newData)
   }
 
   public var unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodesSyntax? {
@@ -6889,18 +5622,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenRightParenAndTrailingClosure(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = FunctionCallExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenRightParenAndTrailingClosure` replaced.
-  /// - param newChild: The new `unexpectedBetweenRightParenAndTrailingClosure` to replace the node's
-  ///                   current `unexpectedBetweenRightParenAndTrailingClosure`, if present.
-  public func withUnexpectedBetweenRightParenAndTrailingClosure(_ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return FunctionCallExprSyntax(newData)
   }
 
   public var trailingClosure: ClosureExprSyntax? {
@@ -6910,18 +5636,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ClosureExprSyntax(childData!)
     }
     set(value) {
-      self = withTrailingClosure(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = FunctionCallExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingClosure` replaced.
-  /// - param newChild: The new `trailingClosure` to replace the node's
-  ///                   current `trailingClosure`, if present.
-  public func withTrailingClosure(_ newChild: ClosureExprSyntax?) -> FunctionCallExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return FunctionCallExprSyntax(newData)
   }
 
   public var unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? {
@@ -6931,18 +5650,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = FunctionCallExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` replaced.
-  /// - param newChild: The new `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` to replace the node's
-  ///                   current `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures`, if present.
-  public func withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return FunctionCallExprSyntax(newData)
   }
 
   public var additionalTrailingClosures: MultipleTrailingClosureElementListSyntax? {
@@ -6952,7 +5664,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return MultipleTrailingClosureElementListSyntax(childData!)
     }
     set(value) {
-      self = withAdditionalTrailingClosures(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = FunctionCallExprSyntax(newData)
     }
   }
 
@@ -6975,16 +5690,6 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return FunctionCallExprSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `additionalTrailingClosures` replaced.
-  /// - param newChild: The new `additionalTrailingClosures` to replace the node's
-  ///                   current `additionalTrailingClosures`, if present.
-  public func withAdditionalTrailingClosures(_ newChild: MultipleTrailingClosureElementListSyntax?) -> FunctionCallExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return FunctionCallExprSyntax(newData)
-  }
-
   public var unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 12, parent: Syntax(self))
@@ -6992,18 +5697,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterAdditionalTrailingClosures(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = FunctionCallExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterAdditionalTrailingClosures` replaced.
-  /// - param newChild: The new `unexpectedAfterAdditionalTrailingClosures` to replace the node's
-  ///                   current `unexpectedAfterAdditionalTrailingClosures`, if present.
-  public func withUnexpectedAfterAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return FunctionCallExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -7146,18 +5844,11 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeCalledExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = SubscriptExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeCalledExpression` replaced.
-  /// - param newChild: The new `unexpectedBeforeCalledExpression` to replace the node's
-  ///                   current `unexpectedBeforeCalledExpression`, if present.
-  public func withUnexpectedBeforeCalledExpression(_ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return SubscriptExprSyntax(newData)
   }
 
   public var calledExpression: ExprSyntax {
@@ -7166,18 +5857,11 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withCalledExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = SubscriptExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `calledExpression` replaced.
-  /// - param newChild: The new `calledExpression` to replace the node's
-  ///                   current `calledExpression`, if present.
-  public func withCalledExpression(_ newChild: ExprSyntax) -> SubscriptExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return SubscriptExprSyntax(newData)
   }
 
   public var unexpectedBetweenCalledExpressionAndLeftBracket: UnexpectedNodesSyntax? {
@@ -7187,18 +5871,11 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCalledExpressionAndLeftBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = SubscriptExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCalledExpressionAndLeftBracket` replaced.
-  /// - param newChild: The new `unexpectedBetweenCalledExpressionAndLeftBracket` to replace the node's
-  ///                   current `unexpectedBetweenCalledExpressionAndLeftBracket`, if present.
-  public func withUnexpectedBetweenCalledExpressionAndLeftBracket(_ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return SubscriptExprSyntax(newData)
   }
 
   public var leftBracket: TokenSyntax {
@@ -7207,18 +5884,11 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftBracket(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = SubscriptExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftBracket` replaced.
-  /// - param newChild: The new `leftBracket` to replace the node's
-  ///                   current `leftBracket`, if present.
-  public func withLeftBracket(_ newChild: TokenSyntax) -> SubscriptExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return SubscriptExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodesSyntax? {
@@ -7228,18 +5898,11 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftBracketAndArgumentList(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = SubscriptExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftBracketAndArgumentList` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftBracketAndArgumentList` to replace the node's
-  ///                   current `unexpectedBetweenLeftBracketAndArgumentList`, if present.
-  public func withUnexpectedBetweenLeftBracketAndArgumentList(_ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return SubscriptExprSyntax(newData)
   }
 
   public var argumentList: TupleExprElementListSyntax {
@@ -7248,7 +5911,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TupleExprElementListSyntax(childData!)
     }
     set(value) {
-      self = withArgumentList(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = SubscriptExprSyntax(newData)
     }
   }
 
@@ -7271,16 +5937,6 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return SubscriptExprSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `argumentList` replaced.
-  /// - param newChild: The new `argumentList` to replace the node's
-  ///                   current `argumentList`, if present.
-  public func withArgumentList(_ newChild: TupleExprElementListSyntax) -> SubscriptExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return SubscriptExprSyntax(newData)
-  }
-
   public var unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 6, parent: Syntax(self))
@@ -7288,18 +5944,11 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenArgumentListAndRightBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = SubscriptExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenArgumentListAndRightBracket` replaced.
-  /// - param newChild: The new `unexpectedBetweenArgumentListAndRightBracket` to replace the node's
-  ///                   current `unexpectedBetweenArgumentListAndRightBracket`, if present.
-  public func withUnexpectedBetweenArgumentListAndRightBracket(_ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return SubscriptExprSyntax(newData)
   }
 
   public var rightBracket: TokenSyntax {
@@ -7308,18 +5957,11 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightBracket(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = SubscriptExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightBracket` replaced.
-  /// - param newChild: The new `rightBracket` to replace the node's
-  ///                   current `rightBracket`, if present.
-  public func withRightBracket(_ newChild: TokenSyntax) -> SubscriptExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return SubscriptExprSyntax(newData)
   }
 
   public var unexpectedBetweenRightBracketAndTrailingClosure: UnexpectedNodesSyntax? {
@@ -7329,18 +5971,11 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenRightBracketAndTrailingClosure(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = SubscriptExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenRightBracketAndTrailingClosure` replaced.
-  /// - param newChild: The new `unexpectedBetweenRightBracketAndTrailingClosure` to replace the node's
-  ///                   current `unexpectedBetweenRightBracketAndTrailingClosure`, if present.
-  public func withUnexpectedBetweenRightBracketAndTrailingClosure(_ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return SubscriptExprSyntax(newData)
   }
 
   public var trailingClosure: ClosureExprSyntax? {
@@ -7350,18 +5985,11 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ClosureExprSyntax(childData!)
     }
     set(value) {
-      self = withTrailingClosure(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = SubscriptExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingClosure` replaced.
-  /// - param newChild: The new `trailingClosure` to replace the node's
-  ///                   current `trailingClosure`, if present.
-  public func withTrailingClosure(_ newChild: ClosureExprSyntax?) -> SubscriptExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return SubscriptExprSyntax(newData)
   }
 
   public var unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? {
@@ -7371,18 +5999,11 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = SubscriptExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` replaced.
-  /// - param newChild: The new `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` to replace the node's
-  ///                   current `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures`, if present.
-  public func withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return SubscriptExprSyntax(newData)
   }
 
   public var additionalTrailingClosures: MultipleTrailingClosureElementListSyntax? {
@@ -7392,7 +6013,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return MultipleTrailingClosureElementListSyntax(childData!)
     }
     set(value) {
-      self = withAdditionalTrailingClosures(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = SubscriptExprSyntax(newData)
     }
   }
 
@@ -7415,16 +6039,6 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return SubscriptExprSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `additionalTrailingClosures` replaced.
-  /// - param newChild: The new `additionalTrailingClosures` to replace the node's
-  ///                   current `additionalTrailingClosures`, if present.
-  public func withAdditionalTrailingClosures(_ newChild: MultipleTrailingClosureElementListSyntax?) -> SubscriptExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return SubscriptExprSyntax(newData)
-  }
-
   public var unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 12, parent: Syntax(self))
@@ -7432,18 +6046,11 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterAdditionalTrailingClosures(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = SubscriptExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterAdditionalTrailingClosures` replaced.
-  /// - param newChild: The new `unexpectedAfterAdditionalTrailingClosures` to replace the node's
-  ///                   current `unexpectedAfterAdditionalTrailingClosures`, if present.
-  public func withUnexpectedAfterAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return SubscriptExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -7570,18 +6177,11 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = OptionalChainingExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
-  /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
-  ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> OptionalChainingExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return OptionalChainingExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -7590,18 +6190,11 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = OptionalChainingExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> OptionalChainingExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return OptionalChainingExprSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndQuestionMark: UnexpectedNodesSyntax? {
@@ -7611,18 +6204,11 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenExpressionAndQuestionMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = OptionalChainingExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndQuestionMark` replaced.
-  /// - param newChild: The new `unexpectedBetweenExpressionAndQuestionMark` to replace the node's
-  ///                   current `unexpectedBetweenExpressionAndQuestionMark`, if present.
-  public func withUnexpectedBetweenExpressionAndQuestionMark(_ newChild: UnexpectedNodesSyntax?) -> OptionalChainingExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return OptionalChainingExprSyntax(newData)
   }
 
   public var questionMark: TokenSyntax {
@@ -7631,18 +6217,11 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withQuestionMark(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = OptionalChainingExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `questionMark` replaced.
-  /// - param newChild: The new `questionMark` to replace the node's
-  ///                   current `questionMark`, if present.
-  public func withQuestionMark(_ newChild: TokenSyntax) -> OptionalChainingExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return OptionalChainingExprSyntax(newData)
   }
 
   public var unexpectedAfterQuestionMark: UnexpectedNodesSyntax? {
@@ -7652,18 +6231,11 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterQuestionMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = OptionalChainingExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterQuestionMark` replaced.
-  /// - param newChild: The new `unexpectedAfterQuestionMark` to replace the node's
-  ///                   current `unexpectedAfterQuestionMark`, if present.
-  public func withUnexpectedAfterQuestionMark(_ newChild: UnexpectedNodesSyntax?) -> OptionalChainingExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return OptionalChainingExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -7758,18 +6330,11 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ForcedValueExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
-  /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
-  ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> ForcedValueExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ForcedValueExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -7778,18 +6343,11 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ForcedValueExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> ForcedValueExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ForcedValueExprSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndExclamationMark: UnexpectedNodesSyntax? {
@@ -7799,18 +6357,11 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenExpressionAndExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ForcedValueExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndExclamationMark` replaced.
-  /// - param newChild: The new `unexpectedBetweenExpressionAndExclamationMark` to replace the node's
-  ///                   current `unexpectedBetweenExpressionAndExclamationMark`, if present.
-  public func withUnexpectedBetweenExpressionAndExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> ForcedValueExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ForcedValueExprSyntax(newData)
   }
 
   public var exclamationMark: TokenSyntax {
@@ -7819,18 +6370,11 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ForcedValueExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `exclamationMark` replaced.
-  /// - param newChild: The new `exclamationMark` to replace the node's
-  ///                   current `exclamationMark`, if present.
-  public func withExclamationMark(_ newChild: TokenSyntax) -> ForcedValueExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ForcedValueExprSyntax(newData)
   }
 
   public var unexpectedAfterExclamationMark: UnexpectedNodesSyntax? {
@@ -7840,18 +6384,11 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ForcedValueExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterExclamationMark` replaced.
-  /// - param newChild: The new `unexpectedAfterExclamationMark` to replace the node's
-  ///                   current `unexpectedAfterExclamationMark`, if present.
-  public func withUnexpectedAfterExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> ForcedValueExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ForcedValueExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -7946,18 +6483,11 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PostfixUnaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
-  /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
-  ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> PostfixUnaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PostfixUnaryExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -7966,18 +6496,11 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PostfixUnaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> PostfixUnaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PostfixUnaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndOperatorToken: UnexpectedNodesSyntax? {
@@ -7987,18 +6510,11 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenExpressionAndOperatorToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PostfixUnaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndOperatorToken` replaced.
-  /// - param newChild: The new `unexpectedBetweenExpressionAndOperatorToken` to replace the node's
-  ///                   current `unexpectedBetweenExpressionAndOperatorToken`, if present.
-  public func withUnexpectedBetweenExpressionAndOperatorToken(_ newChild: UnexpectedNodesSyntax?) -> PostfixUnaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PostfixUnaryExprSyntax(newData)
   }
 
   public var operatorToken: TokenSyntax {
@@ -8007,18 +6523,11 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withOperatorToken(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PostfixUnaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `operatorToken` replaced.
-  /// - param newChild: The new `operatorToken` to replace the node's
-  ///                   current `operatorToken`, if present.
-  public func withOperatorToken(_ newChild: TokenSyntax) -> PostfixUnaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PostfixUnaryExprSyntax(newData)
   }
 
   public var unexpectedAfterOperatorToken: UnexpectedNodesSyntax? {
@@ -8028,18 +6537,11 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterOperatorToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PostfixUnaryExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterOperatorToken` replaced.
-  /// - param newChild: The new `unexpectedAfterOperatorToken` to replace the node's
-  ///                   current `unexpectedAfterOperatorToken`, if present.
-  public func withUnexpectedAfterOperatorToken(_ newChild: UnexpectedNodesSyntax?) -> PostfixUnaryExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PostfixUnaryExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -8134,18 +6636,11 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = SpecializeExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
-  /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
-  ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> SpecializeExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return SpecializeExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -8154,18 +6649,11 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = SpecializeExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> SpecializeExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return SpecializeExprSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndGenericArgumentClause: UnexpectedNodesSyntax? {
@@ -8175,18 +6663,11 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenExpressionAndGenericArgumentClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = SpecializeExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndGenericArgumentClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenExpressionAndGenericArgumentClause` to replace the node's
-  ///                   current `unexpectedBetweenExpressionAndGenericArgumentClause`, if present.
-  public func withUnexpectedBetweenExpressionAndGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> SpecializeExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return SpecializeExprSyntax(newData)
   }
 
   public var genericArgumentClause: GenericArgumentClauseSyntax {
@@ -8195,18 +6676,11 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return GenericArgumentClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericArgumentClause(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = SpecializeExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericArgumentClause` replaced.
-  /// - param newChild: The new `genericArgumentClause` to replace the node's
-  ///                   current `genericArgumentClause`, if present.
-  public func withGenericArgumentClause(_ newChild: GenericArgumentClauseSyntax) -> SpecializeExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return SpecializeExprSyntax(newData)
   }
 
   public var unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? {
@@ -8216,18 +6690,11 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterGenericArgumentClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = SpecializeExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterGenericArgumentClause` replaced.
-  /// - param newChild: The new `unexpectedAfterGenericArgumentClause` to replace the node's
-  ///                   current `unexpectedAfterGenericArgumentClause`, if present.
-  public func withUnexpectedAfterGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> SpecializeExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return SpecializeExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -8334,18 +6801,11 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeOpenDelimiter(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = StringLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeOpenDelimiter` replaced.
-  /// - param newChild: The new `unexpectedBeforeOpenDelimiter` to replace the node's
-  ///                   current `unexpectedBeforeOpenDelimiter`, if present.
-  public func withUnexpectedBeforeOpenDelimiter(_ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return StringLiteralExprSyntax(newData)
   }
 
   public var openDelimiter: TokenSyntax? {
@@ -8355,18 +6815,11 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withOpenDelimiter(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = StringLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `openDelimiter` replaced.
-  /// - param newChild: The new `openDelimiter` to replace the node's
-  ///                   current `openDelimiter`, if present.
-  public func withOpenDelimiter(_ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return StringLiteralExprSyntax(newData)
   }
 
   public var unexpectedBetweenOpenDelimiterAndOpenQuote: UnexpectedNodesSyntax? {
@@ -8376,18 +6829,11 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenOpenDelimiterAndOpenQuote(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = StringLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenOpenDelimiterAndOpenQuote` replaced.
-  /// - param newChild: The new `unexpectedBetweenOpenDelimiterAndOpenQuote` to replace the node's
-  ///                   current `unexpectedBetweenOpenDelimiterAndOpenQuote`, if present.
-  public func withUnexpectedBetweenOpenDelimiterAndOpenQuote(_ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return StringLiteralExprSyntax(newData)
   }
 
   public var openQuote: TokenSyntax {
@@ -8396,18 +6842,11 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withOpenQuote(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = StringLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `openQuote` replaced.
-  /// - param newChild: The new `openQuote` to replace the node's
-  ///                   current `openQuote`, if present.
-  public func withOpenQuote(_ newChild: TokenSyntax) -> StringLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return StringLiteralExprSyntax(newData)
   }
 
   public var unexpectedBetweenOpenQuoteAndSegments: UnexpectedNodesSyntax? {
@@ -8417,18 +6856,11 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenOpenQuoteAndSegments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = StringLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenOpenQuoteAndSegments` replaced.
-  /// - param newChild: The new `unexpectedBetweenOpenQuoteAndSegments` to replace the node's
-  ///                   current `unexpectedBetweenOpenQuoteAndSegments`, if present.
-  public func withUnexpectedBetweenOpenQuoteAndSegments(_ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return StringLiteralExprSyntax(newData)
   }
 
   public var segments: StringLiteralSegmentsSyntax {
@@ -8437,7 +6869,10 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return StringLiteralSegmentsSyntax(childData!)
     }
     set(value) {
-      self = withSegments(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = StringLiteralExprSyntax(newData)
     }
   }
 
@@ -8460,16 +6895,6 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return StringLiteralExprSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `segments` replaced.
-  /// - param newChild: The new `segments` to replace the node's
-  ///                   current `segments`, if present.
-  public func withSegments(_ newChild: StringLiteralSegmentsSyntax) -> StringLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return StringLiteralExprSyntax(newData)
-  }
-
   public var unexpectedBetweenSegmentsAndCloseQuote: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 6, parent: Syntax(self))
@@ -8477,18 +6902,11 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSegmentsAndCloseQuote(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = StringLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSegmentsAndCloseQuote` replaced.
-  /// - param newChild: The new `unexpectedBetweenSegmentsAndCloseQuote` to replace the node's
-  ///                   current `unexpectedBetweenSegmentsAndCloseQuote`, if present.
-  public func withUnexpectedBetweenSegmentsAndCloseQuote(_ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return StringLiteralExprSyntax(newData)
   }
 
   public var closeQuote: TokenSyntax {
@@ -8497,18 +6915,11 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withCloseQuote(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = StringLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `closeQuote` replaced.
-  /// - param newChild: The new `closeQuote` to replace the node's
-  ///                   current `closeQuote`, if present.
-  public func withCloseQuote(_ newChild: TokenSyntax) -> StringLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return StringLiteralExprSyntax(newData)
   }
 
   public var unexpectedBetweenCloseQuoteAndCloseDelimiter: UnexpectedNodesSyntax? {
@@ -8518,18 +6929,11 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCloseQuoteAndCloseDelimiter(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = StringLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCloseQuoteAndCloseDelimiter` replaced.
-  /// - param newChild: The new `unexpectedBetweenCloseQuoteAndCloseDelimiter` to replace the node's
-  ///                   current `unexpectedBetweenCloseQuoteAndCloseDelimiter`, if present.
-  public func withUnexpectedBetweenCloseQuoteAndCloseDelimiter(_ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return StringLiteralExprSyntax(newData)
   }
 
   public var closeDelimiter: TokenSyntax? {
@@ -8539,18 +6943,11 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withCloseDelimiter(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = StringLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `closeDelimiter` replaced.
-  /// - param newChild: The new `closeDelimiter` to replace the node's
-  ///                   current `closeDelimiter`, if present.
-  public func withCloseDelimiter(_ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return StringLiteralExprSyntax(newData)
   }
 
   public var unexpectedAfterCloseDelimiter: UnexpectedNodesSyntax? {
@@ -8560,18 +6957,11 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterCloseDelimiter(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = StringLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterCloseDelimiter` replaced.
-  /// - param newChild: The new `unexpectedAfterCloseDelimiter` to replace the node's
-  ///                   current `unexpectedAfterCloseDelimiter`, if present.
-  public func withUnexpectedAfterCloseDelimiter(_ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return StringLiteralExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -8686,18 +7076,11 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeRegex(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = RegexLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeRegex` replaced.
-  /// - param newChild: The new `unexpectedBeforeRegex` to replace the node's
-  ///                   current `unexpectedBeforeRegex`, if present.
-  public func withUnexpectedBeforeRegex(_ newChild: UnexpectedNodesSyntax?) -> RegexLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return RegexLiteralExprSyntax(newData)
   }
 
   public var regex: TokenSyntax {
@@ -8706,18 +7089,11 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRegex(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = RegexLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `regex` replaced.
-  /// - param newChild: The new `regex` to replace the node's
-  ///                   current `regex`, if present.
-  public func withRegex(_ newChild: TokenSyntax) -> RegexLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return RegexLiteralExprSyntax(newData)
   }
 
   public var unexpectedAfterRegex: UnexpectedNodesSyntax? {
@@ -8727,18 +7103,11 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRegex(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = RegexLiteralExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRegex` replaced.
-  /// - param newChild: The new `unexpectedAfterRegex` to replace the node's
-  ///                   current `unexpectedAfterRegex`, if present.
-  public func withUnexpectedAfterRegex(_ newChild: UnexpectedNodesSyntax?) -> RegexLiteralExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return RegexLiteralExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -8863,18 +7232,11 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeBackslash(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = KeyPathExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeBackslash` replaced.
-  /// - param newChild: The new `unexpectedBeforeBackslash` to replace the node's
-  ///                   current `unexpectedBeforeBackslash`, if present.
-  public func withUnexpectedBeforeBackslash(_ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return KeyPathExprSyntax(newData)
   }
 
   public var backslash: TokenSyntax {
@@ -8883,18 +7245,11 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withBackslash(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = KeyPathExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `backslash` replaced.
-  /// - param newChild: The new `backslash` to replace the node's
-  ///                   current `backslash`, if present.
-  public func withBackslash(_ newChild: TokenSyntax) -> KeyPathExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return KeyPathExprSyntax(newData)
   }
 
   public var unexpectedBetweenBackslashAndRoot: UnexpectedNodesSyntax? {
@@ -8904,18 +7259,11 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenBackslashAndRoot(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = KeyPathExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenBackslashAndRoot` replaced.
-  /// - param newChild: The new `unexpectedBetweenBackslashAndRoot` to replace the node's
-  ///                   current `unexpectedBetweenBackslashAndRoot`, if present.
-  public func withUnexpectedBetweenBackslashAndRoot(_ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return KeyPathExprSyntax(newData)
   }
 
   public var root: TypeSyntax? {
@@ -8925,18 +7273,11 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withRoot(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = KeyPathExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `root` replaced.
-  /// - param newChild: The new `root` to replace the node's
-  ///                   current `root`, if present.
-  public func withRoot(_ newChild: TypeSyntax?) -> KeyPathExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return KeyPathExprSyntax(newData)
   }
 
   public var unexpectedBetweenRootAndComponents: UnexpectedNodesSyntax? {
@@ -8946,18 +7287,11 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenRootAndComponents(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = KeyPathExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenRootAndComponents` replaced.
-  /// - param newChild: The new `unexpectedBetweenRootAndComponents` to replace the node's
-  ///                   current `unexpectedBetweenRootAndComponents`, if present.
-  public func withUnexpectedBetweenRootAndComponents(_ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return KeyPathExprSyntax(newData)
   }
 
   public var components: KeyPathComponentListSyntax {
@@ -8966,7 +7300,10 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return KeyPathComponentListSyntax(childData!)
     }
     set(value) {
-      self = withComponents(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = KeyPathExprSyntax(newData)
     }
   }
 
@@ -8989,16 +7326,6 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return KeyPathExprSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `components` replaced.
-  /// - param newChild: The new `components` to replace the node's
-  ///                   current `components`, if present.
-  public func withComponents(_ newChild: KeyPathComponentListSyntax) -> KeyPathExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return KeyPathExprSyntax(newData)
-  }
-
   public var unexpectedAfterComponents: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 6, parent: Syntax(self))
@@ -9006,18 +7333,11 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterComponents(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = KeyPathExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterComponents` replaced.
-  /// - param newChild: The new `unexpectedAfterComponents` to replace the node's
-  ///                   current `unexpectedAfterComponents`, if present.
-  public func withUnexpectedAfterComponents(_ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return KeyPathExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -9144,18 +7464,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforePoundToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforePoundToken` replaced.
-  /// - param newChild: The new `unexpectedBeforePoundToken` to replace the node's
-  ///                   current `unexpectedBeforePoundToken`, if present.
-  public func withUnexpectedBeforePoundToken(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
   }
 
   /// The `#` sign.
@@ -9165,18 +7478,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPoundToken(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `poundToken` replaced.
-  /// - param newChild: The new `poundToken` to replace the node's
-  ///                   current `poundToken`, if present.
-  public func withPoundToken(_ newChild: TokenSyntax) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
   }
 
   public var unexpectedBetweenPoundTokenAndMacro: UnexpectedNodesSyntax? {
@@ -9186,18 +7492,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPoundTokenAndMacro(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPoundTokenAndMacro` replaced.
-  /// - param newChild: The new `unexpectedBetweenPoundTokenAndMacro` to replace the node's
-  ///                   current `unexpectedBetweenPoundTokenAndMacro`, if present.
-  public func withUnexpectedBetweenPoundTokenAndMacro(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
   }
 
   public var macro: TokenSyntax {
@@ -9206,18 +7505,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withMacro(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `macro` replaced.
-  /// - param newChild: The new `macro` to replace the node's
-  ///                   current `macro`, if present.
-  public func withMacro(_ newChild: TokenSyntax) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
   }
 
   public var unexpectedBetweenMacroAndGenericArguments: UnexpectedNodesSyntax? {
@@ -9227,18 +7519,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenMacroAndGenericArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenMacroAndGenericArguments` replaced.
-  /// - param newChild: The new `unexpectedBetweenMacroAndGenericArguments` to replace the node's
-  ///                   current `unexpectedBetweenMacroAndGenericArguments`, if present.
-  public func withUnexpectedBetweenMacroAndGenericArguments(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
   }
 
   public var genericArguments: GenericArgumentClauseSyntax? {
@@ -9248,18 +7533,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return GenericArgumentClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericArguments` replaced.
-  /// - param newChild: The new `genericArguments` to replace the node's
-  ///                   current `genericArguments`, if present.
-  public func withGenericArguments(_ newChild: GenericArgumentClauseSyntax?) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
   }
 
   public var unexpectedBetweenGenericArgumentsAndLeftParen: UnexpectedNodesSyntax? {
@@ -9269,18 +7547,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericArgumentsAndLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericArgumentsAndLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericArgumentsAndLeftParen` to replace the node's
-  ///                   current `unexpectedBetweenGenericArgumentsAndLeftParen`, if present.
-  public func withUnexpectedBetweenGenericArgumentsAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
   }
 
   public var leftParen: TokenSyntax? {
@@ -9290,18 +7561,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? {
@@ -9311,18 +7575,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndArgumentList(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArgumentList` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndArgumentList` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndArgumentList`, if present.
-  public func withUnexpectedBetweenLeftParenAndArgumentList(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
   }
 
   public var argumentList: TupleExprElementListSyntax {
@@ -9331,7 +7588,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TupleExprElementListSyntax(childData!)
     }
     set(value) {
-      self = withArgumentList(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
   }
 
@@ -9354,16 +7614,6 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return MacroExpansionExprSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `argumentList` replaced.
-  /// - param newChild: The new `argumentList` to replace the node's
-  ///                   current `argumentList`, if present.
-  public func withArgumentList(_ newChild: TupleExprElementListSyntax) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
-  }
-
   public var unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 10, parent: Syntax(self))
@@ -9371,18 +7621,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenArgumentListAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenArgumentListAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenArgumentListAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenArgumentListAndRightParen`, if present.
-  public func withUnexpectedBetweenArgumentListAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
   }
 
   public var rightParen: TokenSyntax? {
@@ -9392,18 +7635,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
   }
 
   public var unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodesSyntax? {
@@ -9413,18 +7649,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenRightParenAndTrailingClosure(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenRightParenAndTrailingClosure` replaced.
-  /// - param newChild: The new `unexpectedBetweenRightParenAndTrailingClosure` to replace the node's
-  ///                   current `unexpectedBetweenRightParenAndTrailingClosure`, if present.
-  public func withUnexpectedBetweenRightParenAndTrailingClosure(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
   }
 
   public var trailingClosure: ClosureExprSyntax? {
@@ -9434,18 +7663,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ClosureExprSyntax(childData!)
     }
     set(value) {
-      self = withTrailingClosure(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingClosure` replaced.
-  /// - param newChild: The new `trailingClosure` to replace the node's
-  ///                   current `trailingClosure`, if present.
-  public func withTrailingClosure(_ newChild: ClosureExprSyntax?) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
   }
 
   public var unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? {
@@ -9455,18 +7677,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` replaced.
-  /// - param newChild: The new `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures` to replace the node's
-  ///                   current `unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures`, if present.
-  public func withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
   }
 
   public var additionalTrailingClosures: MultipleTrailingClosureElementListSyntax? {
@@ -9476,7 +7691,10 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return MultipleTrailingClosureElementListSyntax(childData!)
     }
     set(value) {
-      self = withAdditionalTrailingClosures(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 15, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
   }
 
@@ -9499,16 +7717,6 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return MacroExpansionExprSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `additionalTrailingClosures` replaced.
-  /// - param newChild: The new `additionalTrailingClosures` to replace the node's
-  ///                   current `additionalTrailingClosures`, if present.
-  public func withAdditionalTrailingClosures(_ newChild: MultipleTrailingClosureElementListSyntax?) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 15, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
-  }
-
   public var unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 16, parent: Syntax(self))
@@ -9516,18 +7724,11 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterAdditionalTrailingClosures(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 16, with: raw, arena: arena)
+      self = MacroExpansionExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterAdditionalTrailingClosures` replaced.
-  /// - param newChild: The new `unexpectedAfterAdditionalTrailingClosures` to replace the node's
-  ///                   current `unexpectedAfterAdditionalTrailingClosures`, if present.
-  public func withUnexpectedAfterAdditionalTrailingClosures(_ newChild: UnexpectedNodesSyntax?) -> MacroExpansionExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 16, with: raw, arena: arena)
-    return MacroExpansionExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -9700,18 +7901,11 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeBase(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PostfixIfConfigExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeBase` replaced.
-  /// - param newChild: The new `unexpectedBeforeBase` to replace the node's
-  ///                   current `unexpectedBeforeBase`, if present.
-  public func withUnexpectedBeforeBase(_ newChild: UnexpectedNodesSyntax?) -> PostfixIfConfigExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PostfixIfConfigExprSyntax(newData)
   }
 
   public var base: ExprSyntax? {
@@ -9721,18 +7915,11 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withBase(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PostfixIfConfigExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `base` replaced.
-  /// - param newChild: The new `base` to replace the node's
-  ///                   current `base`, if present.
-  public func withBase(_ newChild: ExprSyntax?) -> PostfixIfConfigExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PostfixIfConfigExprSyntax(newData)
   }
 
   public var unexpectedBetweenBaseAndConfig: UnexpectedNodesSyntax? {
@@ -9742,18 +7929,11 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenBaseAndConfig(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PostfixIfConfigExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenBaseAndConfig` replaced.
-  /// - param newChild: The new `unexpectedBetweenBaseAndConfig` to replace the node's
-  ///                   current `unexpectedBetweenBaseAndConfig`, if present.
-  public func withUnexpectedBetweenBaseAndConfig(_ newChild: UnexpectedNodesSyntax?) -> PostfixIfConfigExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PostfixIfConfigExprSyntax(newData)
   }
 
   public var config: IfConfigDeclSyntax {
@@ -9762,18 +7942,11 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return IfConfigDeclSyntax(childData!)
     }
     set(value) {
-      self = withConfig(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PostfixIfConfigExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `config` replaced.
-  /// - param newChild: The new `config` to replace the node's
-  ///                   current `config`, if present.
-  public func withConfig(_ newChild: IfConfigDeclSyntax) -> PostfixIfConfigExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PostfixIfConfigExprSyntax(newData)
   }
 
   public var unexpectedAfterConfig: UnexpectedNodesSyntax? {
@@ -9783,18 +7956,11 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterConfig(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PostfixIfConfigExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterConfig` replaced.
-  /// - param newChild: The new `unexpectedAfterConfig` to replace the node's
-  ///                   current `unexpectedAfterConfig`, if present.
-  public func withUnexpectedAfterConfig(_ newChild: UnexpectedNodesSyntax?) -> PostfixIfConfigExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PostfixIfConfigExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -9885,18 +8051,11 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = EditorPlaceholderExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBeforeIdentifier` to replace the node's
-  ///                   current `unexpectedBeforeIdentifier`, if present.
-  public func withUnexpectedBeforeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> EditorPlaceholderExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return EditorPlaceholderExprSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
@@ -9905,18 +8064,11 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = EditorPlaceholderExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> EditorPlaceholderExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return EditorPlaceholderExprSyntax(newData)
   }
 
   public var unexpectedAfterIdentifier: UnexpectedNodesSyntax? {
@@ -9926,18 +8078,11 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = EditorPlaceholderExprSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterIdentifier` replaced.
-  /// - param newChild: The new `unexpectedAfterIdentifier` to replace the node's
-  ///                   current `unexpectedAfterIdentifier`, if present.
-  public func withUnexpectedAfterIdentifier(_ newChild: UnexpectedNodesSyntax?) -> EditorPlaceholderExprSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return EditorPlaceholderExprSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -163,18 +163,11 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeItem(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = CodeBlockItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeItem` replaced.
-  /// - param newChild: The new `unexpectedBeforeItem` to replace the node's
-  ///                   current `unexpectedBeforeItem`, if present.
-  public func withUnexpectedBeforeItem(_ newChild: UnexpectedNodesSyntax?) -> CodeBlockItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return CodeBlockItemSyntax(newData)
   }
 
   /// The underlying node inside the code block.
@@ -184,18 +177,11 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
       return Item(childData!)
     }
     set(value) {
-      self = withItem(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = CodeBlockItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `item` replaced.
-  /// - param newChild: The new `item` to replace the node's
-  ///                   current `item`, if present.
-  public func withItem(_ newChild: Item) -> CodeBlockItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return CodeBlockItemSyntax(newData)
   }
 
   public var unexpectedBetweenItemAndSemicolon: UnexpectedNodesSyntax? {
@@ -205,18 +191,11 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenItemAndSemicolon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = CodeBlockItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenItemAndSemicolon` replaced.
-  /// - param newChild: The new `unexpectedBetweenItemAndSemicolon` to replace the node's
-  ///                   current `unexpectedBetweenItemAndSemicolon`, if present.
-  public func withUnexpectedBetweenItemAndSemicolon(_ newChild: UnexpectedNodesSyntax?) -> CodeBlockItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return CodeBlockItemSyntax(newData)
   }
 
   /// 
@@ -229,18 +208,11 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withSemicolon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = CodeBlockItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `semicolon` replaced.
-  /// - param newChild: The new `semicolon` to replace the node's
-  ///                   current `semicolon`, if present.
-  public func withSemicolon(_ newChild: TokenSyntax?) -> CodeBlockItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return CodeBlockItemSyntax(newData)
   }
 
   public var unexpectedAfterSemicolon: UnexpectedNodesSyntax? {
@@ -250,18 +222,11 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterSemicolon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = CodeBlockItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterSemicolon` replaced.
-  /// - param newChild: The new `unexpectedAfterSemicolon` to replace the node's
-  ///                   current `unexpectedAfterSemicolon`, if present.
-  public func withUnexpectedAfterSemicolon(_ newChild: UnexpectedNodesSyntax?) -> CodeBlockItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return CodeBlockItemSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -360,18 +325,11 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = CodeBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftBrace` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftBrace` to replace the node's
-  ///                   current `unexpectedBeforeLeftBrace`, if present.
-  public func withUnexpectedBeforeLeftBrace(_ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return CodeBlockSyntax(newData)
   }
 
   public var leftBrace: TokenSyntax {
@@ -380,18 +338,11 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftBrace(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = CodeBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftBrace` replaced.
-  /// - param newChild: The new `leftBrace` to replace the node's
-  ///                   current `leftBrace`, if present.
-  public func withLeftBrace(_ newChild: TokenSyntax) -> CodeBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return CodeBlockSyntax(newData)
   }
 
   public var unexpectedBetweenLeftBraceAndStatements: UnexpectedNodesSyntax? {
@@ -401,18 +352,11 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftBraceAndStatements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = CodeBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftBraceAndStatements` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftBraceAndStatements` to replace the node's
-  ///                   current `unexpectedBetweenLeftBraceAndStatements`, if present.
-  public func withUnexpectedBetweenLeftBraceAndStatements(_ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return CodeBlockSyntax(newData)
   }
 
   public var statements: CodeBlockItemListSyntax {
@@ -421,7 +365,10 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return CodeBlockItemListSyntax(childData!)
     }
     set(value) {
-      self = withStatements(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = CodeBlockSyntax(newData)
     }
   }
 
@@ -444,16 +391,6 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
     return CodeBlockSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `statements` replaced.
-  /// - param newChild: The new `statements` to replace the node's
-  ///                   current `statements`, if present.
-  public func withStatements(_ newChild: CodeBlockItemListSyntax) -> CodeBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return CodeBlockSyntax(newData)
-  }
-
   public var unexpectedBetweenStatementsAndRightBrace: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -461,18 +398,11 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenStatementsAndRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = CodeBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenStatementsAndRightBrace` replaced.
-  /// - param newChild: The new `unexpectedBetweenStatementsAndRightBrace` to replace the node's
-  ///                   current `unexpectedBetweenStatementsAndRightBrace`, if present.
-  public func withUnexpectedBetweenStatementsAndRightBrace(_ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return CodeBlockSyntax(newData)
   }
 
   public var rightBrace: TokenSyntax {
@@ -481,18 +411,11 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = CodeBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightBrace` replaced.
-  /// - param newChild: The new `rightBrace` to replace the node's
-  ///                   current `rightBrace`, if present.
-  public func withRightBrace(_ newChild: TokenSyntax) -> CodeBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return CodeBlockSyntax(newData)
   }
 
   public var unexpectedAfterRightBrace: UnexpectedNodesSyntax? {
@@ -502,18 +425,11 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = CodeBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
-  /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
-  ///                   current `unexpectedAfterRightBrace`, if present.
-  public func withUnexpectedAfterRightBrace(_ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return CodeBlockSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -616,18 +532,11 @@ public struct DeclEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAsyncSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DeclEffectSpecifiersSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAsyncSpecifier` replaced.
-  /// - param newChild: The new `unexpectedBeforeAsyncSpecifier` to replace the node's
-  ///                   current `unexpectedBeforeAsyncSpecifier`, if present.
-  public func withUnexpectedBeforeAsyncSpecifier(_ newChild: UnexpectedNodesSyntax?) -> DeclEffectSpecifiersSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DeclEffectSpecifiersSyntax(newData)
   }
 
   public var asyncSpecifier: TokenSyntax? {
@@ -637,18 +546,11 @@ public struct DeclEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAsyncSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DeclEffectSpecifiersSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `asyncSpecifier` replaced.
-  /// - param newChild: The new `asyncSpecifier` to replace the node's
-  ///                   current `asyncSpecifier`, if present.
-  public func withAsyncSpecifier(_ newChild: TokenSyntax?) -> DeclEffectSpecifiersSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DeclEffectSpecifiersSyntax(newData)
   }
 
   public var unexpectedBetweenAsyncSpecifierAndThrowsSpecifier: UnexpectedNodesSyntax? {
@@ -658,18 +560,11 @@ public struct DeclEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAsyncSpecifierAndThrowsSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DeclEffectSpecifiersSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAsyncSpecifierAndThrowsSpecifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenAsyncSpecifierAndThrowsSpecifier` to replace the node's
-  ///                   current `unexpectedBetweenAsyncSpecifierAndThrowsSpecifier`, if present.
-  public func withUnexpectedBetweenAsyncSpecifierAndThrowsSpecifier(_ newChild: UnexpectedNodesSyntax?) -> DeclEffectSpecifiersSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DeclEffectSpecifiersSyntax(newData)
   }
 
   public var throwsSpecifier: TokenSyntax? {
@@ -679,18 +574,11 @@ public struct DeclEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withThrowsSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DeclEffectSpecifiersSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `throwsSpecifier` replaced.
-  /// - param newChild: The new `throwsSpecifier` to replace the node's
-  ///                   current `throwsSpecifier`, if present.
-  public func withThrowsSpecifier(_ newChild: TokenSyntax?) -> DeclEffectSpecifiersSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DeclEffectSpecifiersSyntax(newData)
   }
 
   public var unexpectedAfterThrowsSpecifier: UnexpectedNodesSyntax? {
@@ -700,18 +588,11 @@ public struct DeclEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterThrowsSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DeclEffectSpecifiersSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterThrowsSpecifier` replaced.
-  /// - param newChild: The new `unexpectedAfterThrowsSpecifier` to replace the node's
-  ///                   current `unexpectedAfterThrowsSpecifier`, if present.
-  public func withUnexpectedAfterThrowsSpecifier(_ newChild: UnexpectedNodesSyntax?) -> DeclEffectSpecifiersSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DeclEffectSpecifiersSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -806,18 +687,11 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAsyncSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = TypeEffectSpecifiersSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAsyncSpecifier` replaced.
-  /// - param newChild: The new `unexpectedBeforeAsyncSpecifier` to replace the node's
-  ///                   current `unexpectedBeforeAsyncSpecifier`, if present.
-  public func withUnexpectedBeforeAsyncSpecifier(_ newChild: UnexpectedNodesSyntax?) -> TypeEffectSpecifiersSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return TypeEffectSpecifiersSyntax(newData)
   }
 
   public var asyncSpecifier: TokenSyntax? {
@@ -827,18 +701,11 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAsyncSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = TypeEffectSpecifiersSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `asyncSpecifier` replaced.
-  /// - param newChild: The new `asyncSpecifier` to replace the node's
-  ///                   current `asyncSpecifier`, if present.
-  public func withAsyncSpecifier(_ newChild: TokenSyntax?) -> TypeEffectSpecifiersSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return TypeEffectSpecifiersSyntax(newData)
   }
 
   public var unexpectedBetweenAsyncSpecifierAndThrowsSpecifier: UnexpectedNodesSyntax? {
@@ -848,18 +715,11 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAsyncSpecifierAndThrowsSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = TypeEffectSpecifiersSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAsyncSpecifierAndThrowsSpecifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenAsyncSpecifierAndThrowsSpecifier` to replace the node's
-  ///                   current `unexpectedBetweenAsyncSpecifierAndThrowsSpecifier`, if present.
-  public func withUnexpectedBetweenAsyncSpecifierAndThrowsSpecifier(_ newChild: UnexpectedNodesSyntax?) -> TypeEffectSpecifiersSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return TypeEffectSpecifiersSyntax(newData)
   }
 
   public var throwsSpecifier: TokenSyntax? {
@@ -869,18 +729,11 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withThrowsSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = TypeEffectSpecifiersSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `throwsSpecifier` replaced.
-  /// - param newChild: The new `throwsSpecifier` to replace the node's
-  ///                   current `throwsSpecifier`, if present.
-  public func withThrowsSpecifier(_ newChild: TokenSyntax?) -> TypeEffectSpecifiersSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return TypeEffectSpecifiersSyntax(newData)
   }
 
   public var unexpectedAfterThrowsSpecifier: UnexpectedNodesSyntax? {
@@ -890,18 +743,11 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterThrowsSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = TypeEffectSpecifiersSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterThrowsSpecifier` replaced.
-  /// - param newChild: The new `unexpectedAfterThrowsSpecifier` to replace the node's
-  ///                   current `unexpectedAfterThrowsSpecifier`, if present.
-  public func withUnexpectedAfterThrowsSpecifier(_ newChild: UnexpectedNodesSyntax?) -> TypeEffectSpecifiersSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return TypeEffectSpecifiersSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -996,18 +842,11 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DeclNameArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
-  /// - param newChild: The new `unexpectedBeforeName` to replace the node's
-  ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DeclNameArgumentSyntax(newData)
   }
 
   public var name: TokenSyntax {
@@ -1016,18 +855,11 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DeclNameArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax) -> DeclNameArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DeclNameArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? {
@@ -1037,18 +869,11 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenNameAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DeclNameArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenNameAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenNameAndColon` to replace the node's
-  ///                   current `unexpectedBetweenNameAndColon`, if present.
-  public func withUnexpectedBetweenNameAndColon(_ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DeclNameArgumentSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -1057,18 +882,11 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DeclNameArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> DeclNameArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DeclNameArgumentSyntax(newData)
   }
 
   public var unexpectedAfterColon: UnexpectedNodesSyntax? {
@@ -1078,18 +896,11 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DeclNameArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterColon` replaced.
-  /// - param newChild: The new `unexpectedAfterColon` to replace the node's
-  ///                   current `unexpectedAfterColon`, if present.
-  public func withUnexpectedAfterColon(_ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DeclNameArgumentSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1188,18 +999,11 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DeclNameArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
-  ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DeclNameArgumentsSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -1208,18 +1012,11 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DeclNameArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> DeclNameArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DeclNameArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? {
@@ -1229,18 +1026,11 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DeclNameArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArguments` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndArguments` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndArguments`, if present.
-  public func withUnexpectedBetweenLeftParenAndArguments(_ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DeclNameArgumentsSyntax(newData)
   }
 
   public var arguments: DeclNameArgumentListSyntax {
@@ -1249,7 +1039,10 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       return DeclNameArgumentListSyntax(childData!)
     }
     set(value) {
-      self = withArguments(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DeclNameArgumentsSyntax(newData)
     }
   }
 
@@ -1272,16 +1065,6 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
     return DeclNameArgumentsSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `arguments` replaced.
-  /// - param newChild: The new `arguments` to replace the node's
-  ///                   current `arguments`, if present.
-  public func withArguments(_ newChild: DeclNameArgumentListSyntax) -> DeclNameArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DeclNameArgumentsSyntax(newData)
-  }
-
   public var unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -1289,18 +1072,11 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenArgumentsAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DeclNameArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenArgumentsAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenArgumentsAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenArgumentsAndRightParen`, if present.
-  public func withUnexpectedBetweenArgumentsAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DeclNameArgumentsSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -1309,18 +1085,11 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = DeclNameArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> DeclNameArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return DeclNameArgumentsSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -1330,18 +1099,11 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = DeclNameArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return DeclNameArgumentsSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1452,18 +1214,11 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = TupleExprElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeLabel` to replace the node's
-  ///                   current `unexpectedBeforeLabel`, if present.
-  public func withUnexpectedBeforeLabel(_ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return TupleExprElementSyntax(newData)
   }
 
   public var label: TokenSyntax? {
@@ -1473,18 +1228,11 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = TupleExprElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `label` replaced.
-  /// - param newChild: The new `label` to replace the node's
-  ///                   current `label`, if present.
-  public func withLabel(_ newChild: TokenSyntax?) -> TupleExprElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return TupleExprElementSyntax(newData)
   }
 
   public var unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? {
@@ -1494,18 +1242,11 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = TupleExprElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenLabelAndColon`, if present.
-  public func withUnexpectedBetweenLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return TupleExprElementSyntax(newData)
   }
 
   public var colon: TokenSyntax? {
@@ -1515,18 +1256,11 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = TupleExprElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> TupleExprElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return TupleExprElementSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndExpression: UnexpectedNodesSyntax? {
@@ -1536,18 +1270,11 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = TupleExprElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndExpression` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndExpression` to replace the node's
-  ///                   current `unexpectedBetweenColonAndExpression`, if present.
-  public func withUnexpectedBetweenColonAndExpression(_ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return TupleExprElementSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -1556,18 +1283,11 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = TupleExprElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> TupleExprElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return TupleExprElementSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? {
@@ -1577,18 +1297,11 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenExpressionAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = TupleExprElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenExpressionAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenExpressionAndTrailingComma`, if present.
-  public func withUnexpectedBetweenExpressionAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return TupleExprElementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -1598,18 +1311,11 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = TupleExprElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> TupleExprElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return TupleExprElementSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -1619,18 +1325,11 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = TupleExprElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return TupleExprElementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1741,18 +1440,11 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ArrayElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
-  /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
-  ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> ArrayElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ArrayElementSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -1761,18 +1453,11 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ArrayElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> ArrayElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ArrayElementSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? {
@@ -1782,18 +1467,11 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenExpressionAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ArrayElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenExpressionAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenExpressionAndTrailingComma`, if present.
-  public func withUnexpectedBetweenExpressionAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ArrayElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ArrayElementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -1803,18 +1481,11 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ArrayElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> ArrayElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ArrayElementSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -1824,18 +1495,11 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ArrayElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ArrayElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ArrayElementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1938,18 +1602,11 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeKeyExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DictionaryElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeKeyExpression` replaced.
-  /// - param newChild: The new `unexpectedBeforeKeyExpression` to replace the node's
-  ///                   current `unexpectedBeforeKeyExpression`, if present.
-  public func withUnexpectedBeforeKeyExpression(_ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DictionaryElementSyntax(newData)
   }
 
   public var keyExpression: ExprSyntax {
@@ -1958,18 +1615,11 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withKeyExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DictionaryElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `keyExpression` replaced.
-  /// - param newChild: The new `keyExpression` to replace the node's
-  ///                   current `keyExpression`, if present.
-  public func withKeyExpression(_ newChild: ExprSyntax) -> DictionaryElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DictionaryElementSyntax(newData)
   }
 
   public var unexpectedBetweenKeyExpressionAndColon: UnexpectedNodesSyntax? {
@@ -1979,18 +1629,11 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenKeyExpressionAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DictionaryElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenKeyExpressionAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenKeyExpressionAndColon` to replace the node's
-  ///                   current `unexpectedBetweenKeyExpressionAndColon`, if present.
-  public func withUnexpectedBetweenKeyExpressionAndColon(_ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DictionaryElementSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -1999,18 +1642,11 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DictionaryElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> DictionaryElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DictionaryElementSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndValueExpression: UnexpectedNodesSyntax? {
@@ -2020,18 +1656,11 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndValueExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DictionaryElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndValueExpression` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndValueExpression` to replace the node's
-  ///                   current `unexpectedBetweenColonAndValueExpression`, if present.
-  public func withUnexpectedBetweenColonAndValueExpression(_ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DictionaryElementSyntax(newData)
   }
 
   public var valueExpression: ExprSyntax {
@@ -2040,18 +1669,11 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withValueExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = DictionaryElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `valueExpression` replaced.
-  /// - param newChild: The new `valueExpression` to replace the node's
-  ///                   current `valueExpression`, if present.
-  public func withValueExpression(_ newChild: ExprSyntax) -> DictionaryElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return DictionaryElementSyntax(newData)
   }
 
   public var unexpectedBetweenValueExpressionAndTrailingComma: UnexpectedNodesSyntax? {
@@ -2061,18 +1683,11 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenValueExpressionAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = DictionaryElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenValueExpressionAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenValueExpressionAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenValueExpressionAndTrailingComma`, if present.
-  public func withUnexpectedBetweenValueExpressionAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return DictionaryElementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -2082,18 +1697,11 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = DictionaryElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> DictionaryElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return DictionaryElementSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -2103,18 +1711,11 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = DictionaryElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return DictionaryElementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2233,18 +1834,11 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ClosureCaptureItemSpecifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeSpecifier` replaced.
-  /// - param newChild: The new `unexpectedBeforeSpecifier` to replace the node's
-  ///                   current `unexpectedBeforeSpecifier`, if present.
-  public func withUnexpectedBeforeSpecifier(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSpecifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ClosureCaptureItemSpecifierSyntax(newData)
   }
 
   public var specifier: TokenSyntax {
@@ -2253,18 +1847,11 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ClosureCaptureItemSpecifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `specifier` replaced.
-  /// - param newChild: The new `specifier` to replace the node's
-  ///                   current `specifier`, if present.
-  public func withSpecifier(_ newChild: TokenSyntax) -> ClosureCaptureItemSpecifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ClosureCaptureItemSpecifierSyntax(newData)
   }
 
   public var unexpectedBetweenSpecifierAndLeftParen: UnexpectedNodesSyntax? {
@@ -2274,18 +1861,11 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSpecifierAndLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ClosureCaptureItemSpecifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSpecifierAndLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenSpecifierAndLeftParen` to replace the node's
-  ///                   current `unexpectedBetweenSpecifierAndLeftParen`, if present.
-  public func withUnexpectedBetweenSpecifierAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSpecifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ClosureCaptureItemSpecifierSyntax(newData)
   }
 
   public var leftParen: TokenSyntax? {
@@ -2295,18 +1875,11 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ClosureCaptureItemSpecifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> ClosureCaptureItemSpecifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ClosureCaptureItemSpecifierSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndDetail: UnexpectedNodesSyntax? {
@@ -2316,18 +1889,11 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndDetail(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ClosureCaptureItemSpecifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndDetail` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndDetail` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndDetail`, if present.
-  public func withUnexpectedBetweenLeftParenAndDetail(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSpecifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ClosureCaptureItemSpecifierSyntax(newData)
   }
 
   public var detail: TokenSyntax? {
@@ -2337,18 +1903,11 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withDetail(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ClosureCaptureItemSpecifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `detail` replaced.
-  /// - param newChild: The new `detail` to replace the node's
-  ///                   current `detail`, if present.
-  public func withDetail(_ newChild: TokenSyntax?) -> ClosureCaptureItemSpecifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ClosureCaptureItemSpecifierSyntax(newData)
   }
 
   public var unexpectedBetweenDetailAndRightParen: UnexpectedNodesSyntax? {
@@ -2358,18 +1917,11 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDetailAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ClosureCaptureItemSpecifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDetailAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenDetailAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenDetailAndRightParen`, if present.
-  public func withUnexpectedBetweenDetailAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSpecifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ClosureCaptureItemSpecifierSyntax(newData)
   }
 
   public var rightParen: TokenSyntax? {
@@ -2379,18 +1931,11 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = ClosureCaptureItemSpecifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> ClosureCaptureItemSpecifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return ClosureCaptureItemSpecifierSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -2400,18 +1945,11 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = ClosureCaptureItemSpecifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSpecifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return ClosureCaptureItemSpecifierSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2534,18 +2072,11 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ClosureCaptureItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeSpecifier` replaced.
-  /// - param newChild: The new `unexpectedBeforeSpecifier` to replace the node's
-  ///                   current `unexpectedBeforeSpecifier`, if present.
-  public func withUnexpectedBeforeSpecifier(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ClosureCaptureItemSyntax(newData)
   }
 
   public var specifier: ClosureCaptureItemSpecifierSyntax? {
@@ -2555,18 +2086,11 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       return ClosureCaptureItemSpecifierSyntax(childData!)
     }
     set(value) {
-      self = withSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ClosureCaptureItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `specifier` replaced.
-  /// - param newChild: The new `specifier` to replace the node's
-  ///                   current `specifier`, if present.
-  public func withSpecifier(_ newChild: ClosureCaptureItemSpecifierSyntax?) -> ClosureCaptureItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ClosureCaptureItemSyntax(newData)
   }
 
   public var unexpectedBetweenSpecifierAndName: UnexpectedNodesSyntax? {
@@ -2576,18 +2100,11 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSpecifierAndName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ClosureCaptureItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSpecifierAndName` replaced.
-  /// - param newChild: The new `unexpectedBetweenSpecifierAndName` to replace the node's
-  ///                   current `unexpectedBetweenSpecifierAndName`, if present.
-  public func withUnexpectedBetweenSpecifierAndName(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ClosureCaptureItemSyntax(newData)
   }
 
   public var name: TokenSyntax? {
@@ -2597,18 +2114,11 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ClosureCaptureItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> ClosureCaptureItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ClosureCaptureItemSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndAssignToken: UnexpectedNodesSyntax? {
@@ -2618,18 +2128,11 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenNameAndAssignToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ClosureCaptureItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenNameAndAssignToken` replaced.
-  /// - param newChild: The new `unexpectedBetweenNameAndAssignToken` to replace the node's
-  ///                   current `unexpectedBetweenNameAndAssignToken`, if present.
-  public func withUnexpectedBetweenNameAndAssignToken(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ClosureCaptureItemSyntax(newData)
   }
 
   public var assignToken: TokenSyntax? {
@@ -2639,18 +2142,11 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAssignToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ClosureCaptureItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `assignToken` replaced.
-  /// - param newChild: The new `assignToken` to replace the node's
-  ///                   current `assignToken`, if present.
-  public func withAssignToken(_ newChild: TokenSyntax?) -> ClosureCaptureItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ClosureCaptureItemSyntax(newData)
   }
 
   public var unexpectedBetweenAssignTokenAndExpression: UnexpectedNodesSyntax? {
@@ -2660,18 +2156,11 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAssignTokenAndExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ClosureCaptureItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAssignTokenAndExpression` replaced.
-  /// - param newChild: The new `unexpectedBetweenAssignTokenAndExpression` to replace the node's
-  ///                   current `unexpectedBetweenAssignTokenAndExpression`, if present.
-  public func withUnexpectedBetweenAssignTokenAndExpression(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ClosureCaptureItemSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -2680,18 +2169,11 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = ClosureCaptureItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> ClosureCaptureItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return ClosureCaptureItemSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? {
@@ -2701,18 +2183,11 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenExpressionAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = ClosureCaptureItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenExpressionAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenExpressionAndTrailingComma`, if present.
-  public func withUnexpectedBetweenExpressionAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return ClosureCaptureItemSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -2722,18 +2197,11 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = ClosureCaptureItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> ClosureCaptureItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return ClosureCaptureItemSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -2743,18 +2211,11 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = ClosureCaptureItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return ClosureCaptureItemSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2877,18 +2338,11 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftSquare(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ClosureCaptureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftSquare` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftSquare` to replace the node's
-  ///                   current `unexpectedBeforeLeftSquare`, if present.
-  public func withUnexpectedBeforeLeftSquare(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ClosureCaptureSignatureSyntax(newData)
   }
 
   public var leftSquare: TokenSyntax {
@@ -2897,18 +2351,11 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftSquare(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ClosureCaptureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftSquare` replaced.
-  /// - param newChild: The new `leftSquare` to replace the node's
-  ///                   current `leftSquare`, if present.
-  public func withLeftSquare(_ newChild: TokenSyntax) -> ClosureCaptureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ClosureCaptureSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenLeftSquareAndItems: UnexpectedNodesSyntax? {
@@ -2918,18 +2365,11 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftSquareAndItems(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ClosureCaptureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftSquareAndItems` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftSquareAndItems` to replace the node's
-  ///                   current `unexpectedBetweenLeftSquareAndItems`, if present.
-  public func withUnexpectedBetweenLeftSquareAndItems(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ClosureCaptureSignatureSyntax(newData)
   }
 
   public var items: ClosureCaptureItemListSyntax? {
@@ -2939,7 +2379,10 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return ClosureCaptureItemListSyntax(childData!)
     }
     set(value) {
-      self = withItems(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ClosureCaptureSignatureSyntax(newData)
     }
   }
 
@@ -2962,16 +2405,6 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     return ClosureCaptureSignatureSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `items` replaced.
-  /// - param newChild: The new `items` to replace the node's
-  ///                   current `items`, if present.
-  public func withItems(_ newChild: ClosureCaptureItemListSyntax?) -> ClosureCaptureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ClosureCaptureSignatureSyntax(newData)
-  }
-
   public var unexpectedBetweenItemsAndRightSquare: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -2979,18 +2412,11 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenItemsAndRightSquare(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ClosureCaptureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenItemsAndRightSquare` replaced.
-  /// - param newChild: The new `unexpectedBetweenItemsAndRightSquare` to replace the node's
-  ///                   current `unexpectedBetweenItemsAndRightSquare`, if present.
-  public func withUnexpectedBetweenItemsAndRightSquare(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ClosureCaptureSignatureSyntax(newData)
   }
 
   public var rightSquare: TokenSyntax {
@@ -2999,18 +2425,11 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightSquare(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ClosureCaptureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightSquare` replaced.
-  /// - param newChild: The new `rightSquare` to replace the node's
-  ///                   current `rightSquare`, if present.
-  public func withRightSquare(_ newChild: TokenSyntax) -> ClosureCaptureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ClosureCaptureSignatureSyntax(newData)
   }
 
   public var unexpectedAfterRightSquare: UnexpectedNodesSyntax? {
@@ -3020,18 +2439,11 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightSquare(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ClosureCaptureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightSquare` replaced.
-  /// - param newChild: The new `unexpectedAfterRightSquare` to replace the node's
-  ///                   current `unexpectedAfterRightSquare`, if present.
-  public func withUnexpectedAfterRightSquare(_ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ClosureCaptureSignatureSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -3134,18 +2546,11 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ClosureParamSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
-  /// - param newChild: The new `unexpectedBeforeName` to replace the node's
-  ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> ClosureParamSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ClosureParamSyntax(newData)
   }
 
   public var name: TokenSyntax {
@@ -3154,18 +2559,11 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ClosureParamSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax) -> ClosureParamSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ClosureParamSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? {
@@ -3175,18 +2573,11 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenNameAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ClosureParamSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenNameAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenNameAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenNameAndTrailingComma`, if present.
-  public func withUnexpectedBetweenNameAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ClosureParamSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ClosureParamSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -3196,18 +2587,11 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ClosureParamSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> ClosureParamSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ClosureParamSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -3217,18 +2601,11 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ClosureParamSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ClosureParamSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ClosureParamSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -3375,18 +2752,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ClosureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ClosureSignatureSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -3396,7 +2766,10 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ClosureSignatureSyntax(newData)
     }
   }
 
@@ -3419,16 +2792,6 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     return ClosureSignatureSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> ClosureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ClosureSignatureSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndCapture: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -3436,18 +2799,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndCapture(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ClosureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndCapture` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndCapture` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndCapture`, if present.
-  public func withUnexpectedBetweenAttributesAndCapture(_ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ClosureSignatureSyntax(newData)
   }
 
   public var capture: ClosureCaptureSignatureSyntax? {
@@ -3457,18 +2813,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return ClosureCaptureSignatureSyntax(childData!)
     }
     set(value) {
-      self = withCapture(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ClosureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `capture` replaced.
-  /// - param newChild: The new `capture` to replace the node's
-  ///                   current `capture`, if present.
-  public func withCapture(_ newChild: ClosureCaptureSignatureSyntax?) -> ClosureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ClosureSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenCaptureAndInput: UnexpectedNodesSyntax? {
@@ -3478,18 +2827,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCaptureAndInput(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ClosureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCaptureAndInput` replaced.
-  /// - param newChild: The new `unexpectedBetweenCaptureAndInput` to replace the node's
-  ///                   current `unexpectedBetweenCaptureAndInput`, if present.
-  public func withUnexpectedBetweenCaptureAndInput(_ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ClosureSignatureSyntax(newData)
   }
 
   public var input: Input? {
@@ -3499,18 +2841,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return Input(childData!)
     }
     set(value) {
-      self = withInput(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ClosureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `input` replaced.
-  /// - param newChild: The new `input` to replace the node's
-  ///                   current `input`, if present.
-  public func withInput(_ newChild: Input?) -> ClosureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ClosureSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenInputAndEffectSpecifiers: UnexpectedNodesSyntax? {
@@ -3520,18 +2855,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInputAndEffectSpecifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ClosureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInputAndEffectSpecifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenInputAndEffectSpecifiers` to replace the node's
-  ///                   current `unexpectedBetweenInputAndEffectSpecifiers`, if present.
-  public func withUnexpectedBetweenInputAndEffectSpecifiers(_ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ClosureSignatureSyntax(newData)
   }
 
   public var effectSpecifiers: TypeEffectSpecifiersSyntax? {
@@ -3541,18 +2869,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeEffectSpecifiersSyntax(childData!)
     }
     set(value) {
-      self = withEffectSpecifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = ClosureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `effectSpecifiers` replaced.
-  /// - param newChild: The new `effectSpecifiers` to replace the node's
-  ///                   current `effectSpecifiers`, if present.
-  public func withEffectSpecifiers(_ newChild: TypeEffectSpecifiersSyntax?) -> ClosureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return ClosureSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenEffectSpecifiersAndOutput: UnexpectedNodesSyntax? {
@@ -3562,18 +2883,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenEffectSpecifiersAndOutput(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = ClosureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenEffectSpecifiersAndOutput` replaced.
-  /// - param newChild: The new `unexpectedBetweenEffectSpecifiersAndOutput` to replace the node's
-  ///                   current `unexpectedBetweenEffectSpecifiersAndOutput`, if present.
-  public func withUnexpectedBetweenEffectSpecifiersAndOutput(_ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return ClosureSignatureSyntax(newData)
   }
 
   public var output: ReturnClauseSyntax? {
@@ -3583,18 +2897,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return ReturnClauseSyntax(childData!)
     }
     set(value) {
-      self = withOutput(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = ClosureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `output` replaced.
-  /// - param newChild: The new `output` to replace the node's
-  ///                   current `output`, if present.
-  public func withOutput(_ newChild: ReturnClauseSyntax?) -> ClosureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return ClosureSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenOutputAndInTok: UnexpectedNodesSyntax? {
@@ -3604,18 +2911,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenOutputAndInTok(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = ClosureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenOutputAndInTok` replaced.
-  /// - param newChild: The new `unexpectedBetweenOutputAndInTok` to replace the node's
-  ///                   current `unexpectedBetweenOutputAndInTok`, if present.
-  public func withUnexpectedBetweenOutputAndInTok(_ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return ClosureSignatureSyntax(newData)
   }
 
   public var inTok: TokenSyntax {
@@ -3624,18 +2924,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withInTok(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = ClosureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `inTok` replaced.
-  /// - param newChild: The new `inTok` to replace the node's
-  ///                   current `inTok`, if present.
-  public func withInTok(_ newChild: TokenSyntax) -> ClosureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return ClosureSignatureSyntax(newData)
   }
 
   public var unexpectedAfterInTok: UnexpectedNodesSyntax? {
@@ -3645,18 +2938,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterInTok(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = ClosureSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterInTok` replaced.
-  /// - param newChild: The new `unexpectedAfterInTok` to replace the node's
-  ///                   current `unexpectedAfterInTok`, if present.
-  public func withUnexpectedAfterInTok(_ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return ClosureSignatureSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -3787,18 +3073,11 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = MultipleTrailingClosureElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeLabel` to replace the node's
-  ///                   current `unexpectedBeforeLabel`, if present.
-  public func withUnexpectedBeforeLabel(_ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return MultipleTrailingClosureElementSyntax(newData)
   }
 
   public var label: TokenSyntax {
@@ -3807,18 +3086,11 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = MultipleTrailingClosureElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `label` replaced.
-  /// - param newChild: The new `label` to replace the node's
-  ///                   current `label`, if present.
-  public func withLabel(_ newChild: TokenSyntax) -> MultipleTrailingClosureElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return MultipleTrailingClosureElementSyntax(newData)
   }
 
   public var unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? {
@@ -3828,18 +3100,11 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = MultipleTrailingClosureElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenLabelAndColon`, if present.
-  public func withUnexpectedBetweenLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return MultipleTrailingClosureElementSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -3848,18 +3113,11 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = MultipleTrailingClosureElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> MultipleTrailingClosureElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return MultipleTrailingClosureElementSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndClosure: UnexpectedNodesSyntax? {
@@ -3869,18 +3127,11 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndClosure(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = MultipleTrailingClosureElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndClosure` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndClosure` to replace the node's
-  ///                   current `unexpectedBetweenColonAndClosure`, if present.
-  public func withUnexpectedBetweenColonAndClosure(_ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return MultipleTrailingClosureElementSyntax(newData)
   }
 
   public var closure: ClosureExprSyntax {
@@ -3889,18 +3140,11 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
       return ClosureExprSyntax(childData!)
     }
     set(value) {
-      self = withClosure(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = MultipleTrailingClosureElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `closure` replaced.
-  /// - param newChild: The new `closure` to replace the node's
-  ///                   current `closure`, if present.
-  public func withClosure(_ newChild: ClosureExprSyntax) -> MultipleTrailingClosureElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return MultipleTrailingClosureElementSyntax(newData)
   }
 
   public var unexpectedAfterClosure: UnexpectedNodesSyntax? {
@@ -3910,18 +3154,11 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterClosure(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = MultipleTrailingClosureElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterClosure` replaced.
-  /// - param newChild: The new `unexpectedAfterClosure` to replace the node's
-  ///                   current `unexpectedAfterClosure`, if present.
-  public func withUnexpectedAfterClosure(_ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return MultipleTrailingClosureElementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -4020,18 +3257,11 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeContent(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = StringSegmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeContent` replaced.
-  /// - param newChild: The new `unexpectedBeforeContent` to replace the node's
-  ///                   current `unexpectedBeforeContent`, if present.
-  public func withUnexpectedBeforeContent(_ newChild: UnexpectedNodesSyntax?) -> StringSegmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return StringSegmentSyntax(newData)
   }
 
   public var content: TokenSyntax {
@@ -4040,18 +3270,11 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withContent(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = StringSegmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `content` replaced.
-  /// - param newChild: The new `content` to replace the node's
-  ///                   current `content`, if present.
-  public func withContent(_ newChild: TokenSyntax) -> StringSegmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return StringSegmentSyntax(newData)
   }
 
   public var unexpectedAfterContent: UnexpectedNodesSyntax? {
@@ -4061,18 +3284,11 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterContent(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = StringSegmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterContent` replaced.
-  /// - param newChild: The new `unexpectedAfterContent` to replace the node's
-  ///                   current `unexpectedAfterContent`, if present.
-  public func withUnexpectedAfterContent(_ newChild: UnexpectedNodesSyntax?) -> StringSegmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return StringSegmentSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -4171,18 +3387,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeBackslash(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ExpressionSegmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeBackslash` replaced.
-  /// - param newChild: The new `unexpectedBeforeBackslash` to replace the node's
-  ///                   current `unexpectedBeforeBackslash`, if present.
-  public func withUnexpectedBeforeBackslash(_ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ExpressionSegmentSyntax(newData)
   }
 
   public var backslash: TokenSyntax {
@@ -4191,18 +3400,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withBackslash(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ExpressionSegmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `backslash` replaced.
-  /// - param newChild: The new `backslash` to replace the node's
-  ///                   current `backslash`, if present.
-  public func withBackslash(_ newChild: TokenSyntax) -> ExpressionSegmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ExpressionSegmentSyntax(newData)
   }
 
   public var unexpectedBetweenBackslashAndDelimiter: UnexpectedNodesSyntax? {
@@ -4212,18 +3414,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenBackslashAndDelimiter(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ExpressionSegmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenBackslashAndDelimiter` replaced.
-  /// - param newChild: The new `unexpectedBetweenBackslashAndDelimiter` to replace the node's
-  ///                   current `unexpectedBetweenBackslashAndDelimiter`, if present.
-  public func withUnexpectedBetweenBackslashAndDelimiter(_ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ExpressionSegmentSyntax(newData)
   }
 
   public var delimiter: TokenSyntax? {
@@ -4233,18 +3428,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withDelimiter(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ExpressionSegmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `delimiter` replaced.
-  /// - param newChild: The new `delimiter` to replace the node's
-  ///                   current `delimiter`, if present.
-  public func withDelimiter(_ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ExpressionSegmentSyntax(newData)
   }
 
   public var unexpectedBetweenDelimiterAndLeftParen: UnexpectedNodesSyntax? {
@@ -4254,18 +3442,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDelimiterAndLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ExpressionSegmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDelimiterAndLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenDelimiterAndLeftParen` to replace the node's
-  ///                   current `unexpectedBetweenDelimiterAndLeftParen`, if present.
-  public func withUnexpectedBetweenDelimiterAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ExpressionSegmentSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -4274,18 +3455,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ExpressionSegmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> ExpressionSegmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ExpressionSegmentSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndExpressions: UnexpectedNodesSyntax? {
@@ -4295,18 +3469,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndExpressions(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ExpressionSegmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndExpressions` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndExpressions` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndExpressions`, if present.
-  public func withUnexpectedBetweenLeftParenAndExpressions(_ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ExpressionSegmentSyntax(newData)
   }
 
   public var expressions: TupleExprElementListSyntax {
@@ -4315,7 +3482,10 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       return TupleExprElementListSyntax(childData!)
     }
     set(value) {
-      self = withExpressions(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = ExpressionSegmentSyntax(newData)
     }
   }
 
@@ -4338,16 +3508,6 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
     return ExpressionSegmentSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `expressions` replaced.
-  /// - param newChild: The new `expressions` to replace the node's
-  ///                   current `expressions`, if present.
-  public func withExpressions(_ newChild: TupleExprElementListSyntax) -> ExpressionSegmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return ExpressionSegmentSyntax(newData)
-  }
-
   public var unexpectedBetweenExpressionsAndRightParen: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 8, parent: Syntax(self))
@@ -4355,18 +3515,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenExpressionsAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = ExpressionSegmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenExpressionsAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenExpressionsAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenExpressionsAndRightParen`, if present.
-  public func withUnexpectedBetweenExpressionsAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return ExpressionSegmentSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -4375,18 +3528,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = ExpressionSegmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> ExpressionSegmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return ExpressionSegmentSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -4396,18 +3542,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = ExpressionSegmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return ExpressionSegmentSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -4572,18 +3711,11 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforePeriod(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = KeyPathComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforePeriod` replaced.
-  /// - param newChild: The new `unexpectedBeforePeriod` to replace the node's
-  ///                   current `unexpectedBeforePeriod`, if present.
-  public func withUnexpectedBeforePeriod(_ newChild: UnexpectedNodesSyntax?) -> KeyPathComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return KeyPathComponentSyntax(newData)
   }
 
   public var period: TokenSyntax? {
@@ -4593,18 +3725,11 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPeriod(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = KeyPathComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `period` replaced.
-  /// - param newChild: The new `period` to replace the node's
-  ///                   current `period`, if present.
-  public func withPeriod(_ newChild: TokenSyntax?) -> KeyPathComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return KeyPathComponentSyntax(newData)
   }
 
   public var unexpectedBetweenPeriodAndComponent: UnexpectedNodesSyntax? {
@@ -4614,18 +3739,11 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPeriodAndComponent(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = KeyPathComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPeriodAndComponent` replaced.
-  /// - param newChild: The new `unexpectedBetweenPeriodAndComponent` to replace the node's
-  ///                   current `unexpectedBetweenPeriodAndComponent`, if present.
-  public func withUnexpectedBetweenPeriodAndComponent(_ newChild: UnexpectedNodesSyntax?) -> KeyPathComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return KeyPathComponentSyntax(newData)
   }
 
   public var component: Component {
@@ -4634,18 +3752,11 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return Component(childData!)
     }
     set(value) {
-      self = withComponent(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = KeyPathComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `component` replaced.
-  /// - param newChild: The new `component` to replace the node's
-  ///                   current `component`, if present.
-  public func withComponent(_ newChild: Component) -> KeyPathComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return KeyPathComponentSyntax(newData)
   }
 
   public var unexpectedAfterComponent: UnexpectedNodesSyntax? {
@@ -4655,18 +3766,11 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterComponent(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = KeyPathComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterComponent` replaced.
-  /// - param newChild: The new `unexpectedAfterComponent` to replace the node's
-  ///                   current `unexpectedAfterComponent`, if present.
-  public func withUnexpectedAfterComponent(_ newChild: UnexpectedNodesSyntax?) -> KeyPathComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return KeyPathComponentSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -4765,18 +3869,11 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = KeyPathPropertyComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBeforeIdentifier` to replace the node's
-  ///                   current `unexpectedBeforeIdentifier`, if present.
-  public func withUnexpectedBeforeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> KeyPathPropertyComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return KeyPathPropertyComponentSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
@@ -4785,18 +3882,11 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = KeyPathPropertyComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> KeyPathPropertyComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return KeyPathPropertyComponentSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? {
@@ -4806,18 +3896,11 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIdentifierAndDeclNameArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = KeyPathPropertyComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndDeclNameArguments` replaced.
-  /// - param newChild: The new `unexpectedBetweenIdentifierAndDeclNameArguments` to replace the node's
-  ///                   current `unexpectedBetweenIdentifierAndDeclNameArguments`, if present.
-  public func withUnexpectedBetweenIdentifierAndDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> KeyPathPropertyComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return KeyPathPropertyComponentSyntax(newData)
   }
 
   public var declNameArguments: DeclNameArgumentsSyntax? {
@@ -4827,18 +3910,11 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return DeclNameArgumentsSyntax(childData!)
     }
     set(value) {
-      self = withDeclNameArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = KeyPathPropertyComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `declNameArguments` replaced.
-  /// - param newChild: The new `declNameArguments` to replace the node's
-  ///                   current `declNameArguments`, if present.
-  public func withDeclNameArguments(_ newChild: DeclNameArgumentsSyntax?) -> KeyPathPropertyComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return KeyPathPropertyComponentSyntax(newData)
   }
 
   public var unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause: UnexpectedNodesSyntax? {
@@ -4848,18 +3924,11 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDeclNameArgumentsAndGenericArgumentClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = KeyPathPropertyComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause` to replace the node's
-  ///                   current `unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause`, if present.
-  public func withUnexpectedBetweenDeclNameArgumentsAndGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> KeyPathPropertyComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return KeyPathPropertyComponentSyntax(newData)
   }
 
   public var genericArgumentClause: GenericArgumentClauseSyntax? {
@@ -4869,18 +3938,11 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return GenericArgumentClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericArgumentClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = KeyPathPropertyComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericArgumentClause` replaced.
-  /// - param newChild: The new `genericArgumentClause` to replace the node's
-  ///                   current `genericArgumentClause`, if present.
-  public func withGenericArgumentClause(_ newChild: GenericArgumentClauseSyntax?) -> KeyPathPropertyComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return KeyPathPropertyComponentSyntax(newData)
   }
 
   public var unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? {
@@ -4890,18 +3952,11 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterGenericArgumentClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = KeyPathPropertyComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterGenericArgumentClause` replaced.
-  /// - param newChild: The new `unexpectedAfterGenericArgumentClause` to replace the node's
-  ///                   current `unexpectedAfterGenericArgumentClause`, if present.
-  public func withUnexpectedAfterGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> KeyPathPropertyComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return KeyPathPropertyComponentSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -5008,18 +4063,11 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = KeyPathSubscriptComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftBracket` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftBracket` to replace the node's
-  ///                   current `unexpectedBeforeLeftBracket`, if present.
-  public func withUnexpectedBeforeLeftBracket(_ newChild: UnexpectedNodesSyntax?) -> KeyPathSubscriptComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return KeyPathSubscriptComponentSyntax(newData)
   }
 
   public var leftBracket: TokenSyntax {
@@ -5028,18 +4076,11 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftBracket(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = KeyPathSubscriptComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftBracket` replaced.
-  /// - param newChild: The new `leftBracket` to replace the node's
-  ///                   current `leftBracket`, if present.
-  public func withLeftBracket(_ newChild: TokenSyntax) -> KeyPathSubscriptComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return KeyPathSubscriptComponentSyntax(newData)
   }
 
   public var unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodesSyntax? {
@@ -5049,18 +4090,11 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftBracketAndArgumentList(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = KeyPathSubscriptComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftBracketAndArgumentList` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftBracketAndArgumentList` to replace the node's
-  ///                   current `unexpectedBetweenLeftBracketAndArgumentList`, if present.
-  public func withUnexpectedBetweenLeftBracketAndArgumentList(_ newChild: UnexpectedNodesSyntax?) -> KeyPathSubscriptComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return KeyPathSubscriptComponentSyntax(newData)
   }
 
   public var argumentList: TupleExprElementListSyntax {
@@ -5069,7 +4103,10 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return TupleExprElementListSyntax(childData!)
     }
     set(value) {
-      self = withArgumentList(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = KeyPathSubscriptComponentSyntax(newData)
     }
   }
 
@@ -5092,16 +4129,6 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
     return KeyPathSubscriptComponentSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `argumentList` replaced.
-  /// - param newChild: The new `argumentList` to replace the node's
-  ///                   current `argumentList`, if present.
-  public func withArgumentList(_ newChild: TupleExprElementListSyntax) -> KeyPathSubscriptComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return KeyPathSubscriptComponentSyntax(newData)
-  }
-
   public var unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -5109,18 +4136,11 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenArgumentListAndRightBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = KeyPathSubscriptComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenArgumentListAndRightBracket` replaced.
-  /// - param newChild: The new `unexpectedBetweenArgumentListAndRightBracket` to replace the node's
-  ///                   current `unexpectedBetweenArgumentListAndRightBracket`, if present.
-  public func withUnexpectedBetweenArgumentListAndRightBracket(_ newChild: UnexpectedNodesSyntax?) -> KeyPathSubscriptComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return KeyPathSubscriptComponentSyntax(newData)
   }
 
   public var rightBracket: TokenSyntax {
@@ -5129,18 +4149,11 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightBracket(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = KeyPathSubscriptComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightBracket` replaced.
-  /// - param newChild: The new `rightBracket` to replace the node's
-  ///                   current `rightBracket`, if present.
-  public func withRightBracket(_ newChild: TokenSyntax) -> KeyPathSubscriptComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return KeyPathSubscriptComponentSyntax(newData)
   }
 
   public var unexpectedAfterRightBracket: UnexpectedNodesSyntax? {
@@ -5150,18 +4163,11 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = KeyPathSubscriptComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightBracket` replaced.
-  /// - param newChild: The new `unexpectedAfterRightBracket` to replace the node's
-  ///                   current `unexpectedAfterRightBracket`, if present.
-  public func withUnexpectedAfterRightBracket(_ newChild: UnexpectedNodesSyntax?) -> KeyPathSubscriptComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return KeyPathSubscriptComponentSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -5260,18 +4266,11 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeQuestionOrExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = KeyPathOptionalComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeQuestionOrExclamationMark` replaced.
-  /// - param newChild: The new `unexpectedBeforeQuestionOrExclamationMark` to replace the node's
-  ///                   current `unexpectedBeforeQuestionOrExclamationMark`, if present.
-  public func withUnexpectedBeforeQuestionOrExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> KeyPathOptionalComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return KeyPathOptionalComponentSyntax(newData)
   }
 
   public var questionOrExclamationMark: TokenSyntax {
@@ -5280,18 +4279,11 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withQuestionOrExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = KeyPathOptionalComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `questionOrExclamationMark` replaced.
-  /// - param newChild: The new `questionOrExclamationMark` to replace the node's
-  ///                   current `questionOrExclamationMark`, if present.
-  public func withQuestionOrExclamationMark(_ newChild: TokenSyntax) -> KeyPathOptionalComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return KeyPathOptionalComponentSyntax(newData)
   }
 
   public var unexpectedAfterQuestionOrExclamationMark: UnexpectedNodesSyntax? {
@@ -5301,18 +4293,11 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterQuestionOrExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = KeyPathOptionalComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterQuestionOrExclamationMark` replaced.
-  /// - param newChild: The new `unexpectedAfterQuestionOrExclamationMark` to replace the node's
-  ///                   current `unexpectedAfterQuestionOrExclamationMark`, if present.
-  public func withUnexpectedAfterQuestionOrExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> KeyPathOptionalComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return KeyPathOptionalComponentSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -5399,18 +4384,11 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = YieldExprListElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
-  /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
-  ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> YieldExprListElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return YieldExprListElementSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -5419,18 +4397,11 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = YieldExprListElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> YieldExprListElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return YieldExprListElementSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndComma: UnexpectedNodesSyntax? {
@@ -5440,18 +4411,11 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenExpressionAndComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = YieldExprListElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenExpressionAndComma` to replace the node's
-  ///                   current `unexpectedBetweenExpressionAndComma`, if present.
-  public func withUnexpectedBetweenExpressionAndComma(_ newChild: UnexpectedNodesSyntax?) -> YieldExprListElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return YieldExprListElementSyntax(newData)
   }
 
   public var comma: TokenSyntax? {
@@ -5461,18 +4425,11 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = YieldExprListElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `comma` replaced.
-  /// - param newChild: The new `comma` to replace the node's
-  ///                   current `comma`, if present.
-  public func withComma(_ newChild: TokenSyntax?) -> YieldExprListElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return YieldExprListElementSyntax(newData)
   }
 
   public var unexpectedAfterComma: UnexpectedNodesSyntax? {
@@ -5482,18 +4439,11 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = YieldExprListElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterComma` replaced.
-  /// - param newChild: The new `unexpectedAfterComma` to replace the node's
-  ///                   current `unexpectedAfterComma`, if present.
-  public func withUnexpectedAfterComma(_ newChild: UnexpectedNodesSyntax?) -> YieldExprListElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return YieldExprListElementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -5588,18 +4538,11 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeEqual(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = TypeInitializerClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeEqual` replaced.
-  /// - param newChild: The new `unexpectedBeforeEqual` to replace the node's
-  ///                   current `unexpectedBeforeEqual`, if present.
-  public func withUnexpectedBeforeEqual(_ newChild: UnexpectedNodesSyntax?) -> TypeInitializerClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return TypeInitializerClauseSyntax(newData)
   }
 
   public var equal: TokenSyntax {
@@ -5608,18 +4551,11 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withEqual(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = TypeInitializerClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `equal` replaced.
-  /// - param newChild: The new `equal` to replace the node's
-  ///                   current `equal`, if present.
-  public func withEqual(_ newChild: TokenSyntax) -> TypeInitializerClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return TypeInitializerClauseSyntax(newData)
   }
 
   public var unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? {
@@ -5629,18 +4565,11 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenEqualAndValue(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = TypeInitializerClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenEqualAndValue` replaced.
-  /// - param newChild: The new `unexpectedBetweenEqualAndValue` to replace the node's
-  ///                   current `unexpectedBetweenEqualAndValue`, if present.
-  public func withUnexpectedBetweenEqualAndValue(_ newChild: UnexpectedNodesSyntax?) -> TypeInitializerClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return TypeInitializerClauseSyntax(newData)
   }
 
   public var value: TypeSyntax {
@@ -5649,18 +4578,11 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withValue(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = TypeInitializerClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `value` replaced.
-  /// - param newChild: The new `value` to replace the node's
-  ///                   current `value`, if present.
-  public func withValue(_ newChild: TypeSyntax) -> TypeInitializerClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return TypeInitializerClauseSyntax(newData)
   }
 
   public var unexpectedAfterValue: UnexpectedNodesSyntax? {
@@ -5670,18 +4592,11 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterValue(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = TypeInitializerClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterValue` replaced.
-  /// - param newChild: The new `unexpectedAfterValue` to replace the node's
-  ///                   current `unexpectedAfterValue`, if present.
-  public func withUnexpectedAfterValue(_ newChild: UnexpectedNodesSyntax?) -> TypeInitializerClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return TypeInitializerClauseSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -5780,18 +4695,11 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ParameterClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
-  ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ParameterClauseSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -5800,18 +4708,11 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ParameterClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> ParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ParameterClauseSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndParameterList: UnexpectedNodesSyntax? {
@@ -5821,18 +4722,11 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndParameterList(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ParameterClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndParameterList` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndParameterList` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndParameterList`, if present.
-  public func withUnexpectedBetweenLeftParenAndParameterList(_ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ParameterClauseSyntax(newData)
   }
 
   public var parameterList: FunctionParameterListSyntax {
@@ -5841,7 +4735,10 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return FunctionParameterListSyntax(childData!)
     }
     set(value) {
-      self = withParameterList(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ParameterClauseSyntax(newData)
     }
   }
 
@@ -5864,16 +4761,6 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return ParameterClauseSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `parameterList` replaced.
-  /// - param newChild: The new `parameterList` to replace the node's
-  ///                   current `parameterList`, if present.
-  public func withParameterList(_ newChild: FunctionParameterListSyntax) -> ParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ParameterClauseSyntax(newData)
-  }
-
   public var unexpectedBetweenParameterListAndRightParen: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -5881,18 +4768,11 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenParameterListAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ParameterClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenParameterListAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenParameterListAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenParameterListAndRightParen`, if present.
-  public func withUnexpectedBetweenParameterListAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ParameterClauseSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -5901,18 +4781,11 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ParameterClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> ParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ParameterClauseSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -5922,18 +4795,11 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ParameterClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ParameterClauseSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -6036,18 +4902,11 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeArrow(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ReturnClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeArrow` replaced.
-  /// - param newChild: The new `unexpectedBeforeArrow` to replace the node's
-  ///                   current `unexpectedBeforeArrow`, if present.
-  public func withUnexpectedBeforeArrow(_ newChild: UnexpectedNodesSyntax?) -> ReturnClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ReturnClauseSyntax(newData)
   }
 
   public var arrow: TokenSyntax {
@@ -6056,18 +4915,11 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withArrow(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ReturnClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `arrow` replaced.
-  /// - param newChild: The new `arrow` to replace the node's
-  ///                   current `arrow`, if present.
-  public func withArrow(_ newChild: TokenSyntax) -> ReturnClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ReturnClauseSyntax(newData)
   }
 
   public var unexpectedBetweenArrowAndReturnType: UnexpectedNodesSyntax? {
@@ -6077,18 +4929,11 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenArrowAndReturnType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ReturnClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenArrowAndReturnType` replaced.
-  /// - param newChild: The new `unexpectedBetweenArrowAndReturnType` to replace the node's
-  ///                   current `unexpectedBetweenArrowAndReturnType`, if present.
-  public func withUnexpectedBetweenArrowAndReturnType(_ newChild: UnexpectedNodesSyntax?) -> ReturnClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ReturnClauseSyntax(newData)
   }
 
   public var returnType: TypeSyntax {
@@ -6097,18 +4942,11 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withReturnType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ReturnClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `returnType` replaced.
-  /// - param newChild: The new `returnType` to replace the node's
-  ///                   current `returnType`, if present.
-  public func withReturnType(_ newChild: TypeSyntax) -> ReturnClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ReturnClauseSyntax(newData)
   }
 
   public var unexpectedAfterReturnType: UnexpectedNodesSyntax? {
@@ -6118,18 +4956,11 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterReturnType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ReturnClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterReturnType` replaced.
-  /// - param newChild: The new `unexpectedAfterReturnType` to replace the node's
-  ///                   current `unexpectedAfterReturnType`, if present.
-  public func withUnexpectedAfterReturnType(_ newChild: UnexpectedNodesSyntax?) -> ReturnClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ReturnClauseSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -6228,18 +5059,11 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeInput(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = FunctionSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeInput` replaced.
-  /// - param newChild: The new `unexpectedBeforeInput` to replace the node's
-  ///                   current `unexpectedBeforeInput`, if present.
-  public func withUnexpectedBeforeInput(_ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return FunctionSignatureSyntax(newData)
   }
 
   public var input: ParameterClauseSyntax {
@@ -6248,18 +5072,11 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return ParameterClauseSyntax(childData!)
     }
     set(value) {
-      self = withInput(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = FunctionSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `input` replaced.
-  /// - param newChild: The new `input` to replace the node's
-  ///                   current `input`, if present.
-  public func withInput(_ newChild: ParameterClauseSyntax) -> FunctionSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return FunctionSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenInputAndEffectSpecifiers: UnexpectedNodesSyntax? {
@@ -6269,18 +5086,11 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInputAndEffectSpecifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = FunctionSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInputAndEffectSpecifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenInputAndEffectSpecifiers` to replace the node's
-  ///                   current `unexpectedBetweenInputAndEffectSpecifiers`, if present.
-  public func withUnexpectedBetweenInputAndEffectSpecifiers(_ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return FunctionSignatureSyntax(newData)
   }
 
   public var effectSpecifiers: DeclEffectSpecifiersSyntax? {
@@ -6290,18 +5100,11 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return DeclEffectSpecifiersSyntax(childData!)
     }
     set(value) {
-      self = withEffectSpecifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = FunctionSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `effectSpecifiers` replaced.
-  /// - param newChild: The new `effectSpecifiers` to replace the node's
-  ///                   current `effectSpecifiers`, if present.
-  public func withEffectSpecifiers(_ newChild: DeclEffectSpecifiersSyntax?) -> FunctionSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return FunctionSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenEffectSpecifiersAndOutput: UnexpectedNodesSyntax? {
@@ -6311,18 +5114,11 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenEffectSpecifiersAndOutput(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = FunctionSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenEffectSpecifiersAndOutput` replaced.
-  /// - param newChild: The new `unexpectedBetweenEffectSpecifiersAndOutput` to replace the node's
-  ///                   current `unexpectedBetweenEffectSpecifiersAndOutput`, if present.
-  public func withUnexpectedBetweenEffectSpecifiersAndOutput(_ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return FunctionSignatureSyntax(newData)
   }
 
   public var output: ReturnClauseSyntax? {
@@ -6332,18 +5128,11 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return ReturnClauseSyntax(childData!)
     }
     set(value) {
-      self = withOutput(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = FunctionSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `output` replaced.
-  /// - param newChild: The new `output` to replace the node's
-  ///                   current `output`, if present.
-  public func withOutput(_ newChild: ReturnClauseSyntax?) -> FunctionSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return FunctionSignatureSyntax(newData)
   }
 
   public var unexpectedAfterOutput: UnexpectedNodesSyntax? {
@@ -6353,18 +5142,11 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterOutput(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = FunctionSignatureSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterOutput` replaced.
-  /// - param newChild: The new `unexpectedAfterOutput` to replace the node's
-  ///                   current `unexpectedAfterOutput`, if present.
-  public func withUnexpectedAfterOutput(_ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return FunctionSignatureSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -6571,18 +5353,11 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforePoundKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = IfConfigClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforePoundKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforePoundKeyword` to replace the node's
-  ///                   current `unexpectedBeforePoundKeyword`, if present.
-  public func withUnexpectedBeforePoundKeyword(_ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return IfConfigClauseSyntax(newData)
   }
 
   public var poundKeyword: TokenSyntax {
@@ -6591,18 +5366,11 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPoundKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = IfConfigClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `poundKeyword` replaced.
-  /// - param newChild: The new `poundKeyword` to replace the node's
-  ///                   current `poundKeyword`, if present.
-  public func withPoundKeyword(_ newChild: TokenSyntax) -> IfConfigClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return IfConfigClauseSyntax(newData)
   }
 
   public var unexpectedBetweenPoundKeywordAndCondition: UnexpectedNodesSyntax? {
@@ -6612,18 +5380,11 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPoundKeywordAndCondition(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = IfConfigClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPoundKeywordAndCondition` replaced.
-  /// - param newChild: The new `unexpectedBetweenPoundKeywordAndCondition` to replace the node's
-  ///                   current `unexpectedBetweenPoundKeywordAndCondition`, if present.
-  public func withUnexpectedBetweenPoundKeywordAndCondition(_ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return IfConfigClauseSyntax(newData)
   }
 
   public var condition: ExprSyntax? {
@@ -6633,18 +5394,11 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withCondition(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = IfConfigClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `condition` replaced.
-  /// - param newChild: The new `condition` to replace the node's
-  ///                   current `condition`, if present.
-  public func withCondition(_ newChild: ExprSyntax?) -> IfConfigClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return IfConfigClauseSyntax(newData)
   }
 
   public var unexpectedBetweenConditionAndElements: UnexpectedNodesSyntax? {
@@ -6654,18 +5408,11 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenConditionAndElements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = IfConfigClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenConditionAndElements` replaced.
-  /// - param newChild: The new `unexpectedBetweenConditionAndElements` to replace the node's
-  ///                   current `unexpectedBetweenConditionAndElements`, if present.
-  public func withUnexpectedBetweenConditionAndElements(_ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return IfConfigClauseSyntax(newData)
   }
 
   public var elements: Elements? {
@@ -6675,18 +5422,11 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return Elements(childData!)
     }
     set(value) {
-      self = withElements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = IfConfigClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `elements` replaced.
-  /// - param newChild: The new `elements` to replace the node's
-  ///                   current `elements`, if present.
-  public func withElements(_ newChild: Elements?) -> IfConfigClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return IfConfigClauseSyntax(newData)
   }
 
   public var unexpectedAfterElements: UnexpectedNodesSyntax? {
@@ -6696,18 +5436,11 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterElements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = IfConfigClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterElements` replaced.
-  /// - param newChild: The new `unexpectedAfterElements` to replace the node's
-  ///                   current `unexpectedAfterElements`, if present.
-  public func withUnexpectedAfterElements(_ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return IfConfigClauseSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -6830,18 +5563,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeFileArgLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PoundSourceLocationArgsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeFileArgLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeFileArgLabel` to replace the node's
-  ///                   current `unexpectedBeforeFileArgLabel`, if present.
-  public func withUnexpectedBeforeFileArgLabel(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var fileArgLabel: TokenSyntax {
@@ -6850,18 +5576,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withFileArgLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PoundSourceLocationArgsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `fileArgLabel` replaced.
-  /// - param newChild: The new `fileArgLabel` to replace the node's
-  ///                   current `fileArgLabel`, if present.
-  public func withFileArgLabel(_ newChild: TokenSyntax) -> PoundSourceLocationArgsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var unexpectedBetweenFileArgLabelAndFileArgColon: UnexpectedNodesSyntax? {
@@ -6871,18 +5590,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenFileArgLabelAndFileArgColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PoundSourceLocationArgsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenFileArgLabelAndFileArgColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenFileArgLabelAndFileArgColon` to replace the node's
-  ///                   current `unexpectedBetweenFileArgLabelAndFileArgColon`, if present.
-  public func withUnexpectedBetweenFileArgLabelAndFileArgColon(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var fileArgColon: TokenSyntax {
@@ -6891,18 +5603,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withFileArgColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PoundSourceLocationArgsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `fileArgColon` replaced.
-  /// - param newChild: The new `fileArgColon` to replace the node's
-  ///                   current `fileArgColon`, if present.
-  public func withFileArgColon(_ newChild: TokenSyntax) -> PoundSourceLocationArgsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var unexpectedBetweenFileArgColonAndFileName: UnexpectedNodesSyntax? {
@@ -6912,18 +5617,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenFileArgColonAndFileName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PoundSourceLocationArgsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenFileArgColonAndFileName` replaced.
-  /// - param newChild: The new `unexpectedBetweenFileArgColonAndFileName` to replace the node's
-  ///                   current `unexpectedBetweenFileArgColonAndFileName`, if present.
-  public func withUnexpectedBetweenFileArgColonAndFileName(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var fileName: StringLiteralExprSyntax {
@@ -6932,18 +5630,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return StringLiteralExprSyntax(childData!)
     }
     set(value) {
-      self = withFileName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = PoundSourceLocationArgsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `fileName` replaced.
-  /// - param newChild: The new `fileName` to replace the node's
-  ///                   current `fileName`, if present.
-  public func withFileName(_ newChild: StringLiteralExprSyntax) -> PoundSourceLocationArgsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var unexpectedBetweenFileNameAndComma: UnexpectedNodesSyntax? {
@@ -6953,18 +5644,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenFileNameAndComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = PoundSourceLocationArgsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenFileNameAndComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenFileNameAndComma` to replace the node's
-  ///                   current `unexpectedBetweenFileNameAndComma`, if present.
-  public func withUnexpectedBetweenFileNameAndComma(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var comma: TokenSyntax {
@@ -6973,18 +5657,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withComma(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = PoundSourceLocationArgsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `comma` replaced.
-  /// - param newChild: The new `comma` to replace the node's
-  ///                   current `comma`, if present.
-  public func withComma(_ newChild: TokenSyntax) -> PoundSourceLocationArgsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var unexpectedBetweenCommaAndLineArgLabel: UnexpectedNodesSyntax? {
@@ -6994,18 +5671,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCommaAndLineArgLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = PoundSourceLocationArgsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndLineArgLabel` replaced.
-  /// - param newChild: The new `unexpectedBetweenCommaAndLineArgLabel` to replace the node's
-  ///                   current `unexpectedBetweenCommaAndLineArgLabel`, if present.
-  public func withUnexpectedBetweenCommaAndLineArgLabel(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var lineArgLabel: TokenSyntax {
@@ -7014,18 +5684,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLineArgLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = PoundSourceLocationArgsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `lineArgLabel` replaced.
-  /// - param newChild: The new `lineArgLabel` to replace the node's
-  ///                   current `lineArgLabel`, if present.
-  public func withLineArgLabel(_ newChild: TokenSyntax) -> PoundSourceLocationArgsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var unexpectedBetweenLineArgLabelAndLineArgColon: UnexpectedNodesSyntax? {
@@ -7035,18 +5698,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLineArgLabelAndLineArgColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = PoundSourceLocationArgsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLineArgLabelAndLineArgColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenLineArgLabelAndLineArgColon` to replace the node's
-  ///                   current `unexpectedBetweenLineArgLabelAndLineArgColon`, if present.
-  public func withUnexpectedBetweenLineArgLabelAndLineArgColon(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var lineArgColon: TokenSyntax {
@@ -7055,18 +5711,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLineArgColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = PoundSourceLocationArgsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `lineArgColon` replaced.
-  /// - param newChild: The new `lineArgColon` to replace the node's
-  ///                   current `lineArgColon`, if present.
-  public func withLineArgColon(_ newChild: TokenSyntax) -> PoundSourceLocationArgsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var unexpectedBetweenLineArgColonAndLineNumber: UnexpectedNodesSyntax? {
@@ -7076,18 +5725,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLineArgColonAndLineNumber(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = PoundSourceLocationArgsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLineArgColonAndLineNumber` replaced.
-  /// - param newChild: The new `unexpectedBetweenLineArgColonAndLineNumber` to replace the node's
-  ///                   current `unexpectedBetweenLineArgColonAndLineNumber`, if present.
-  public func withUnexpectedBetweenLineArgColonAndLineNumber(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var lineNumber: TokenSyntax {
@@ -7096,18 +5738,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLineNumber(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = PoundSourceLocationArgsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `lineNumber` replaced.
-  /// - param newChild: The new `lineNumber` to replace the node's
-  ///                   current `lineNumber`, if present.
-  public func withLineNumber(_ newChild: TokenSyntax) -> PoundSourceLocationArgsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var unexpectedAfterLineNumber: UnexpectedNodesSyntax? {
@@ -7117,18 +5752,11 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterLineNumber(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = PoundSourceLocationArgsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterLineNumber` replaced.
-  /// - param newChild: The new `unexpectedAfterLineNumber` to replace the node's
-  ///                   current `unexpectedAfterLineNumber`, if present.
-  public func withUnexpectedAfterLineNumber(_ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return PoundSourceLocationArgsSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -7267,18 +5895,11 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DeclModifierDetailSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
-  ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DeclModifierDetailSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -7287,18 +5908,11 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DeclModifierDetailSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> DeclModifierDetailSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DeclModifierDetailSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndDetail: UnexpectedNodesSyntax? {
@@ -7308,18 +5922,11 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndDetail(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DeclModifierDetailSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndDetail` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndDetail` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndDetail`, if present.
-  public func withUnexpectedBetweenLeftParenAndDetail(_ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DeclModifierDetailSyntax(newData)
   }
 
   public var detail: TokenSyntax {
@@ -7328,18 +5935,11 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withDetail(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DeclModifierDetailSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `detail` replaced.
-  /// - param newChild: The new `detail` to replace the node's
-  ///                   current `detail`, if present.
-  public func withDetail(_ newChild: TokenSyntax) -> DeclModifierDetailSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DeclModifierDetailSyntax(newData)
   }
 
   public var unexpectedBetweenDetailAndRightParen: UnexpectedNodesSyntax? {
@@ -7349,18 +5949,11 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDetailAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DeclModifierDetailSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDetailAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenDetailAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenDetailAndRightParen`, if present.
-  public func withUnexpectedBetweenDetailAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DeclModifierDetailSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -7369,18 +5962,11 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = DeclModifierDetailSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> DeclModifierDetailSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return DeclModifierDetailSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -7390,18 +5976,11 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = DeclModifierDetailSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return DeclModifierDetailSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -7504,18 +6083,11 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DeclModifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
-  /// - param newChild: The new `unexpectedBeforeName` to replace the node's
-  ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> DeclModifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DeclModifierSyntax(newData)
   }
 
   public var name: TokenSyntax {
@@ -7524,18 +6096,11 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DeclModifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax) -> DeclModifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DeclModifierSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndDetail: UnexpectedNodesSyntax? {
@@ -7545,18 +6110,11 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenNameAndDetail(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DeclModifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenNameAndDetail` replaced.
-  /// - param newChild: The new `unexpectedBetweenNameAndDetail` to replace the node's
-  ///                   current `unexpectedBetweenNameAndDetail`, if present.
-  public func withUnexpectedBetweenNameAndDetail(_ newChild: UnexpectedNodesSyntax?) -> DeclModifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DeclModifierSyntax(newData)
   }
 
   public var detail: DeclModifierDetailSyntax? {
@@ -7566,18 +6124,11 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
       return DeclModifierDetailSyntax(childData!)
     }
     set(value) {
-      self = withDetail(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DeclModifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `detail` replaced.
-  /// - param newChild: The new `detail` to replace the node's
-  ///                   current `detail`, if present.
-  public func withDetail(_ newChild: DeclModifierDetailSyntax?) -> DeclModifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DeclModifierSyntax(newData)
   }
 
   public var unexpectedAfterDetail: UnexpectedNodesSyntax? {
@@ -7587,18 +6138,11 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterDetail(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DeclModifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterDetail` replaced.
-  /// - param newChild: The new `unexpectedAfterDetail` to replace the node's
-  ///                   current `unexpectedAfterDetail`, if present.
-  public func withUnexpectedAfterDetail(_ newChild: UnexpectedNodesSyntax?) -> DeclModifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DeclModifierSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -7693,18 +6237,11 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeTypeName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = InheritedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeTypeName` replaced.
-  /// - param newChild: The new `unexpectedBeforeTypeName` to replace the node's
-  ///                   current `unexpectedBeforeTypeName`, if present.
-  public func withUnexpectedBeforeTypeName(_ newChild: UnexpectedNodesSyntax?) -> InheritedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return InheritedTypeSyntax(newData)
   }
 
   public var typeName: TypeSyntax {
@@ -7713,18 +6250,11 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withTypeName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = InheritedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `typeName` replaced.
-  /// - param newChild: The new `typeName` to replace the node's
-  ///                   current `typeName`, if present.
-  public func withTypeName(_ newChild: TypeSyntax) -> InheritedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return InheritedTypeSyntax(newData)
   }
 
   public var unexpectedBetweenTypeNameAndTrailingComma: UnexpectedNodesSyntax? {
@@ -7734,18 +6264,11 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTypeNameAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = InheritedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTypeNameAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenTypeNameAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenTypeNameAndTrailingComma`, if present.
-  public func withUnexpectedBetweenTypeNameAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> InheritedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return InheritedTypeSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -7755,18 +6278,11 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = InheritedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> InheritedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return InheritedTypeSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -7776,18 +6292,11 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = InheritedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> InheritedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return InheritedTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -7882,18 +6391,11 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = TypeInheritanceClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeColon` replaced.
-  /// - param newChild: The new `unexpectedBeforeColon` to replace the node's
-  ///                   current `unexpectedBeforeColon`, if present.
-  public func withUnexpectedBeforeColon(_ newChild: UnexpectedNodesSyntax?) -> TypeInheritanceClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return TypeInheritanceClauseSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -7902,18 +6404,11 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = TypeInheritanceClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> TypeInheritanceClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return TypeInheritanceClauseSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndInheritedTypeCollection: UnexpectedNodesSyntax? {
@@ -7923,18 +6418,11 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndInheritedTypeCollection(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = TypeInheritanceClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndInheritedTypeCollection` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndInheritedTypeCollection` to replace the node's
-  ///                   current `unexpectedBetweenColonAndInheritedTypeCollection`, if present.
-  public func withUnexpectedBetweenColonAndInheritedTypeCollection(_ newChild: UnexpectedNodesSyntax?) -> TypeInheritanceClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return TypeInheritanceClauseSyntax(newData)
   }
 
   public var inheritedTypeCollection: InheritedTypeListSyntax {
@@ -7943,7 +6431,10 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return InheritedTypeListSyntax(childData!)
     }
     set(value) {
-      self = withInheritedTypeCollection(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = TypeInheritanceClauseSyntax(newData)
     }
   }
 
@@ -7966,16 +6457,6 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return TypeInheritanceClauseSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `inheritedTypeCollection` replaced.
-  /// - param newChild: The new `inheritedTypeCollection` to replace the node's
-  ///                   current `inheritedTypeCollection`, if present.
-  public func withInheritedTypeCollection(_ newChild: InheritedTypeListSyntax) -> TypeInheritanceClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return TypeInheritanceClauseSyntax(newData)
-  }
-
   public var unexpectedAfterInheritedTypeCollection: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -7983,18 +6464,11 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterInheritedTypeCollection(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = TypeInheritanceClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterInheritedTypeCollection` replaced.
-  /// - param newChild: The new `unexpectedAfterInheritedTypeCollection` to replace the node's
-  ///                   current `unexpectedAfterInheritedTypeCollection`, if present.
-  public func withUnexpectedAfterInheritedTypeCollection(_ newChild: UnexpectedNodesSyntax?) -> TypeInheritanceClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return TypeInheritanceClauseSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -8093,18 +6567,11 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = MemberDeclBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftBrace` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftBrace` to replace the node's
-  ///                   current `unexpectedBeforeLeftBrace`, if present.
-  public func withUnexpectedBeforeLeftBrace(_ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return MemberDeclBlockSyntax(newData)
   }
 
   public var leftBrace: TokenSyntax {
@@ -8113,18 +6580,11 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftBrace(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = MemberDeclBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftBrace` replaced.
-  /// - param newChild: The new `leftBrace` to replace the node's
-  ///                   current `leftBrace`, if present.
-  public func withLeftBrace(_ newChild: TokenSyntax) -> MemberDeclBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return MemberDeclBlockSyntax(newData)
   }
 
   public var unexpectedBetweenLeftBraceAndMembers: UnexpectedNodesSyntax? {
@@ -8134,18 +6594,11 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftBraceAndMembers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = MemberDeclBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftBraceAndMembers` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftBraceAndMembers` to replace the node's
-  ///                   current `unexpectedBetweenLeftBraceAndMembers`, if present.
-  public func withUnexpectedBetweenLeftBraceAndMembers(_ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return MemberDeclBlockSyntax(newData)
   }
 
   public var members: MemberDeclListSyntax {
@@ -8154,7 +6607,10 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return MemberDeclListSyntax(childData!)
     }
     set(value) {
-      self = withMembers(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = MemberDeclBlockSyntax(newData)
     }
   }
 
@@ -8177,16 +6633,6 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
     return MemberDeclBlockSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `members` replaced.
-  /// - param newChild: The new `members` to replace the node's
-  ///                   current `members`, if present.
-  public func withMembers(_ newChild: MemberDeclListSyntax) -> MemberDeclBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return MemberDeclBlockSyntax(newData)
-  }
-
   public var unexpectedBetweenMembersAndRightBrace: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -8194,18 +6640,11 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenMembersAndRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = MemberDeclBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenMembersAndRightBrace` replaced.
-  /// - param newChild: The new `unexpectedBetweenMembersAndRightBrace` to replace the node's
-  ///                   current `unexpectedBetweenMembersAndRightBrace`, if present.
-  public func withUnexpectedBetweenMembersAndRightBrace(_ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return MemberDeclBlockSyntax(newData)
   }
 
   public var rightBrace: TokenSyntax {
@@ -8214,18 +6653,11 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = MemberDeclBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightBrace` replaced.
-  /// - param newChild: The new `rightBrace` to replace the node's
-  ///                   current `rightBrace`, if present.
-  public func withRightBrace(_ newChild: TokenSyntax) -> MemberDeclBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return MemberDeclBlockSyntax(newData)
   }
 
   public var unexpectedAfterRightBrace: UnexpectedNodesSyntax? {
@@ -8235,18 +6667,11 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = MemberDeclBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
-  /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
-  ///                   current `unexpectedAfterRightBrace`, if present.
-  public func withUnexpectedAfterRightBrace(_ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return MemberDeclBlockSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -8353,18 +6778,11 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeDecl(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = MemberDeclListItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeDecl` replaced.
-  /// - param newChild: The new `unexpectedBeforeDecl` to replace the node's
-  ///                   current `unexpectedBeforeDecl`, if present.
-  public func withUnexpectedBeforeDecl(_ newChild: UnexpectedNodesSyntax?) -> MemberDeclListItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return MemberDeclListItemSyntax(newData)
   }
 
   /// The declaration of the type member.
@@ -8374,18 +6792,11 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
       return DeclSyntax(childData!)
     }
     set(value) {
-      self = withDecl(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = MemberDeclListItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `decl` replaced.
-  /// - param newChild: The new `decl` to replace the node's
-  ///                   current `decl`, if present.
-  public func withDecl(_ newChild: DeclSyntax) -> MemberDeclListItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return MemberDeclListItemSyntax(newData)
   }
 
   public var unexpectedBetweenDeclAndSemicolon: UnexpectedNodesSyntax? {
@@ -8395,18 +6806,11 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDeclAndSemicolon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = MemberDeclListItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDeclAndSemicolon` replaced.
-  /// - param newChild: The new `unexpectedBetweenDeclAndSemicolon` to replace the node's
-  ///                   current `unexpectedBetweenDeclAndSemicolon`, if present.
-  public func withUnexpectedBetweenDeclAndSemicolon(_ newChild: UnexpectedNodesSyntax?) -> MemberDeclListItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return MemberDeclListItemSyntax(newData)
   }
 
   /// An optional trailing semicolon.
@@ -8417,18 +6821,11 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withSemicolon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = MemberDeclListItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `semicolon` replaced.
-  /// - param newChild: The new `semicolon` to replace the node's
-  ///                   current `semicolon`, if present.
-  public func withSemicolon(_ newChild: TokenSyntax?) -> MemberDeclListItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return MemberDeclListItemSyntax(newData)
   }
 
   public var unexpectedAfterSemicolon: UnexpectedNodesSyntax? {
@@ -8438,18 +6835,11 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterSemicolon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = MemberDeclListItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterSemicolon` replaced.
-  /// - param newChild: The new `unexpectedAfterSemicolon` to replace the node's
-  ///                   current `unexpectedAfterSemicolon`, if present.
-  public func withUnexpectedAfterSemicolon(_ newChild: UnexpectedNodesSyntax?) -> MemberDeclListItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return MemberDeclListItemSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -8544,18 +6934,11 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeStatements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = SourceFileSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeStatements` replaced.
-  /// - param newChild: The new `unexpectedBeforeStatements` to replace the node's
-  ///                   current `unexpectedBeforeStatements`, if present.
-  public func withUnexpectedBeforeStatements(_ newChild: UnexpectedNodesSyntax?) -> SourceFileSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return SourceFileSyntax(newData)
   }
 
   public var statements: CodeBlockItemListSyntax {
@@ -8564,7 +6947,10 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
       return CodeBlockItemListSyntax(childData!)
     }
     set(value) {
-      self = withStatements(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = SourceFileSyntax(newData)
     }
   }
 
@@ -8587,16 +6973,6 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
     return SourceFileSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `statements` replaced.
-  /// - param newChild: The new `statements` to replace the node's
-  ///                   current `statements`, if present.
-  public func withStatements(_ newChild: CodeBlockItemListSyntax) -> SourceFileSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return SourceFileSyntax(newData)
-  }
-
   public var unexpectedBetweenStatementsAndEOFToken: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -8604,18 +6980,11 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenStatementsAndEOFToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = SourceFileSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenStatementsAndEOFToken` replaced.
-  /// - param newChild: The new `unexpectedBetweenStatementsAndEOFToken` to replace the node's
-  ///                   current `unexpectedBetweenStatementsAndEOFToken`, if present.
-  public func withUnexpectedBetweenStatementsAndEOFToken(_ newChild: UnexpectedNodesSyntax?) -> SourceFileSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return SourceFileSyntax(newData)
   }
 
   public var eofToken: TokenSyntax {
@@ -8624,18 +6993,11 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withEOFToken(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = SourceFileSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `eofToken` replaced.
-  /// - param newChild: The new `eofToken` to replace the node's
-  ///                   current `eofToken`, if present.
-  public func withEOFToken(_ newChild: TokenSyntax) -> SourceFileSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return SourceFileSyntax(newData)
   }
 
   public var unexpectedAfterEOFToken: UnexpectedNodesSyntax? {
@@ -8645,18 +7007,11 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterEOFToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = SourceFileSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterEOFToken` replaced.
-  /// - param newChild: The new `unexpectedAfterEOFToken` to replace the node's
-  ///                   current `unexpectedAfterEOFToken`, if present.
-  public func withUnexpectedAfterEOFToken(_ newChild: UnexpectedNodesSyntax?) -> SourceFileSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return SourceFileSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -8751,18 +7106,11 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeEqual(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = InitializerClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeEqual` replaced.
-  /// - param newChild: The new `unexpectedBeforeEqual` to replace the node's
-  ///                   current `unexpectedBeforeEqual`, if present.
-  public func withUnexpectedBeforeEqual(_ newChild: UnexpectedNodesSyntax?) -> InitializerClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return InitializerClauseSyntax(newData)
   }
 
   public var equal: TokenSyntax {
@@ -8771,18 +7119,11 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withEqual(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = InitializerClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `equal` replaced.
-  /// - param newChild: The new `equal` to replace the node's
-  ///                   current `equal`, if present.
-  public func withEqual(_ newChild: TokenSyntax) -> InitializerClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return InitializerClauseSyntax(newData)
   }
 
   public var unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? {
@@ -8792,18 +7133,11 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenEqualAndValue(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = InitializerClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenEqualAndValue` replaced.
-  /// - param newChild: The new `unexpectedBetweenEqualAndValue` to replace the node's
-  ///                   current `unexpectedBetweenEqualAndValue`, if present.
-  public func withUnexpectedBetweenEqualAndValue(_ newChild: UnexpectedNodesSyntax?) -> InitializerClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return InitializerClauseSyntax(newData)
   }
 
   public var value: ExprSyntax {
@@ -8812,18 +7146,11 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withValue(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = InitializerClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `value` replaced.
-  /// - param newChild: The new `value` to replace the node's
-  ///                   current `value`, if present.
-  public func withValue(_ newChild: ExprSyntax) -> InitializerClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return InitializerClauseSyntax(newData)
   }
 
   public var unexpectedAfterValue: UnexpectedNodesSyntax? {
@@ -8833,18 +7160,11 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterValue(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = InitializerClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterValue` replaced.
-  /// - param newChild: The new `unexpectedAfterValue` to replace the node's
-  ///                   current `unexpectedAfterValue`, if present.
-  public func withUnexpectedAfterValue(_ newChild: UnexpectedNodesSyntax?) -> InitializerClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return InitializerClauseSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -9025,18 +7345,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -9046,7 +7359,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
   }
 
@@ -9069,16 +7385,6 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
     return FunctionParameterSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -9086,18 +7392,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndModifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndModifiers` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndModifiers`, if present.
-  public func withUnexpectedBetweenAttributesAndModifiers(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
@@ -9107,7 +7406,10 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return ModifierListSyntax(childData!)
     }
     set(value) {
-      self = withModifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
   }
 
@@ -9130,16 +7432,6 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
     return FunctionParameterSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `modifiers` replaced.
-  /// - param newChild: The new `modifiers` to replace the node's
-  ///                   current `modifiers`, if present.
-  public func withModifiers(_ newChild: ModifierListSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
-  }
-
   public var unexpectedBetweenModifiersAndFirstName: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -9147,18 +7439,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModifiersAndFirstName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModifiersAndFirstName` replaced.
-  /// - param newChild: The new `unexpectedBetweenModifiersAndFirstName` to replace the node's
-  ///                   current `unexpectedBetweenModifiersAndFirstName`, if present.
-  public func withUnexpectedBetweenModifiersAndFirstName(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var firstName: TokenSyntax? {
@@ -9168,18 +7453,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withFirstName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `firstName` replaced.
-  /// - param newChild: The new `firstName` to replace the node's
-  ///                   current `firstName`, if present.
-  public func withFirstName(_ newChild: TokenSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var unexpectedBetweenFirstNameAndSecondName: UnexpectedNodesSyntax? {
@@ -9189,18 +7467,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenFirstNameAndSecondName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenFirstNameAndSecondName` replaced.
-  /// - param newChild: The new `unexpectedBetweenFirstNameAndSecondName` to replace the node's
-  ///                   current `unexpectedBetweenFirstNameAndSecondName`, if present.
-  public func withUnexpectedBetweenFirstNameAndSecondName(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var secondName: TokenSyntax? {
@@ -9210,18 +7481,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withSecondName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `secondName` replaced.
-  /// - param newChild: The new `secondName` to replace the node's
-  ///                   current `secondName`, if present.
-  public func withSecondName(_ newChild: TokenSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? {
@@ -9231,18 +7495,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSecondNameAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSecondNameAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenSecondNameAndColon` to replace the node's
-  ///                   current `unexpectedBetweenSecondNameAndColon`, if present.
-  public func withUnexpectedBetweenSecondNameAndColon(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var colon: TokenSyntax? {
@@ -9252,18 +7509,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndType: UnexpectedNodesSyntax? {
@@ -9273,18 +7523,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndType` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndType` to replace the node's
-  ///                   current `unexpectedBetweenColonAndType`, if present.
-  public func withUnexpectedBetweenColonAndType(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var type: TypeSyntax? {
@@ -9294,18 +7537,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `type` replaced.
-  /// - param newChild: The new `type` to replace the node's
-  ///                   current `type`, if present.
-  public func withType(_ newChild: TypeSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? {
@@ -9315,18 +7551,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTypeAndEllipsis(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTypeAndEllipsis` replaced.
-  /// - param newChild: The new `unexpectedBetweenTypeAndEllipsis` to replace the node's
-  ///                   current `unexpectedBetweenTypeAndEllipsis`, if present.
-  public func withUnexpectedBetweenTypeAndEllipsis(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var ellipsis: TokenSyntax? {
@@ -9336,18 +7565,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withEllipsis(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `ellipsis` replaced.
-  /// - param newChild: The new `ellipsis` to replace the node's
-  ///                   current `ellipsis`, if present.
-  public func withEllipsis(_ newChild: TokenSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var unexpectedBetweenEllipsisAndDefaultArgument: UnexpectedNodesSyntax? {
@@ -9357,18 +7579,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenEllipsisAndDefaultArgument(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenEllipsisAndDefaultArgument` replaced.
-  /// - param newChild: The new `unexpectedBetweenEllipsisAndDefaultArgument` to replace the node's
-  ///                   current `unexpectedBetweenEllipsisAndDefaultArgument`, if present.
-  public func withUnexpectedBetweenEllipsisAndDefaultArgument(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var defaultArgument: InitializerClauseSyntax? {
@@ -9378,18 +7593,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return InitializerClauseSyntax(childData!)
     }
     set(value) {
-      self = withDefaultArgument(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 15, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `defaultArgument` replaced.
-  /// - param newChild: The new `defaultArgument` to replace the node's
-  ///                   current `defaultArgument`, if present.
-  public func withDefaultArgument(_ newChild: InitializerClauseSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 15, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var unexpectedBetweenDefaultArgumentAndTrailingComma: UnexpectedNodesSyntax? {
@@ -9399,18 +7607,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDefaultArgumentAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 16, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDefaultArgumentAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenDefaultArgumentAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenDefaultArgumentAndTrailingComma`, if present.
-  public func withUnexpectedBetweenDefaultArgumentAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 16, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -9420,18 +7621,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 17, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 17, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -9441,18 +7635,11 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 18, with: raw, arena: arena)
+      self = FunctionParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 18, with: raw, arena: arena)
-    return FunctionParameterSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -9603,18 +7790,11 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AccessPathComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
-  /// - param newChild: The new `unexpectedBeforeName` to replace the node's
-  ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> AccessPathComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AccessPathComponentSyntax(newData)
   }
 
   public var name: TokenSyntax {
@@ -9623,18 +7803,11 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AccessPathComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax) -> AccessPathComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AccessPathComponentSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndTrailingDot: UnexpectedNodesSyntax? {
@@ -9644,18 +7817,11 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenNameAndTrailingDot(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AccessPathComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenNameAndTrailingDot` replaced.
-  /// - param newChild: The new `unexpectedBetweenNameAndTrailingDot` to replace the node's
-  ///                   current `unexpectedBetweenNameAndTrailingDot`, if present.
-  public func withUnexpectedBetweenNameAndTrailingDot(_ newChild: UnexpectedNodesSyntax?) -> AccessPathComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AccessPathComponentSyntax(newData)
   }
 
   public var trailingDot: TokenSyntax? {
@@ -9665,18 +7831,11 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingDot(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = AccessPathComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingDot` replaced.
-  /// - param newChild: The new `trailingDot` to replace the node's
-  ///                   current `trailingDot`, if present.
-  public func withTrailingDot(_ newChild: TokenSyntax?) -> AccessPathComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return AccessPathComponentSyntax(newData)
   }
 
   public var unexpectedAfterTrailingDot: UnexpectedNodesSyntax? {
@@ -9686,18 +7845,11 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingDot(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = AccessPathComponentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingDot` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingDot` to replace the node's
-  ///                   current `unexpectedAfterTrailingDot`, if present.
-  public func withUnexpectedAfterTrailingDot(_ newChild: UnexpectedNodesSyntax?) -> AccessPathComponentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return AccessPathComponentSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -9796,18 +7948,11 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AccessorParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
-  ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AccessorParameterSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -9816,18 +7961,11 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AccessorParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> AccessorParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AccessorParameterSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndName: UnexpectedNodesSyntax? {
@@ -9837,18 +7975,11 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AccessorParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndName` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndName` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndName`, if present.
-  public func withUnexpectedBetweenLeftParenAndName(_ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AccessorParameterSyntax(newData)
   }
 
   public var name: TokenSyntax {
@@ -9857,18 +7988,11 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = AccessorParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax) -> AccessorParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return AccessorParameterSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? {
@@ -9878,18 +8002,11 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenNameAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = AccessorParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenNameAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenNameAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenNameAndRightParen`, if present.
-  public func withUnexpectedBetweenNameAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return AccessorParameterSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -9898,18 +8015,11 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = AccessorParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> AccessorParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return AccessorParameterSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -9919,18 +8029,11 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = AccessorParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return AccessorParameterSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -10037,18 +8140,11 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AccessorBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftBrace` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftBrace` to replace the node's
-  ///                   current `unexpectedBeforeLeftBrace`, if present.
-  public func withUnexpectedBeforeLeftBrace(_ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AccessorBlockSyntax(newData)
   }
 
   public var leftBrace: TokenSyntax {
@@ -10057,18 +8153,11 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftBrace(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AccessorBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftBrace` replaced.
-  /// - param newChild: The new `leftBrace` to replace the node's
-  ///                   current `leftBrace`, if present.
-  public func withLeftBrace(_ newChild: TokenSyntax) -> AccessorBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AccessorBlockSyntax(newData)
   }
 
   public var unexpectedBetweenLeftBraceAndAccessors: UnexpectedNodesSyntax? {
@@ -10078,18 +8167,11 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftBraceAndAccessors(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AccessorBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftBraceAndAccessors` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftBraceAndAccessors` to replace the node's
-  ///                   current `unexpectedBetweenLeftBraceAndAccessors`, if present.
-  public func withUnexpectedBetweenLeftBraceAndAccessors(_ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AccessorBlockSyntax(newData)
   }
 
   public var accessors: AccessorListSyntax {
@@ -10098,7 +8180,10 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return AccessorListSyntax(childData!)
     }
     set(value) {
-      self = withAccessors(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = AccessorBlockSyntax(newData)
     }
   }
 
@@ -10121,16 +8206,6 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
     return AccessorBlockSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `accessors` replaced.
-  /// - param newChild: The new `accessors` to replace the node's
-  ///                   current `accessors`, if present.
-  public func withAccessors(_ newChild: AccessorListSyntax) -> AccessorBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return AccessorBlockSyntax(newData)
-  }
-
   public var unexpectedBetweenAccessorsAndRightBrace: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -10138,18 +8213,11 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAccessorsAndRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = AccessorBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAccessorsAndRightBrace` replaced.
-  /// - param newChild: The new `unexpectedBetweenAccessorsAndRightBrace` to replace the node's
-  ///                   current `unexpectedBetweenAccessorsAndRightBrace`, if present.
-  public func withUnexpectedBetweenAccessorsAndRightBrace(_ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return AccessorBlockSyntax(newData)
   }
 
   public var rightBrace: TokenSyntax {
@@ -10158,18 +8226,11 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = AccessorBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightBrace` replaced.
-  /// - param newChild: The new `rightBrace` to replace the node's
-  ///                   current `rightBrace`, if present.
-  public func withRightBrace(_ newChild: TokenSyntax) -> AccessorBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return AccessorBlockSyntax(newData)
   }
 
   public var unexpectedAfterRightBrace: UnexpectedNodesSyntax? {
@@ -10179,18 +8240,11 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = AccessorBlockSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
-  /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
-  ///                   current `unexpectedAfterRightBrace`, if present.
-  public func withUnexpectedAfterRightBrace(_ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return AccessorBlockSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -10341,18 +8395,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforePattern(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PatternBindingSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforePattern` replaced.
-  /// - param newChild: The new `unexpectedBeforePattern` to replace the node's
-  ///                   current `unexpectedBeforePattern`, if present.
-  public func withUnexpectedBeforePattern(_ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PatternBindingSyntax(newData)
   }
 
   public var pattern: PatternSyntax {
@@ -10361,18 +8408,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       return PatternSyntax(childData!)
     }
     set(value) {
-      self = withPattern(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PatternBindingSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `pattern` replaced.
-  /// - param newChild: The new `pattern` to replace the node's
-  ///                   current `pattern`, if present.
-  public func withPattern(_ newChild: PatternSyntax) -> PatternBindingSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PatternBindingSyntax(newData)
   }
 
   public var unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? {
@@ -10382,18 +8422,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPatternAndTypeAnnotation(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PatternBindingSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPatternAndTypeAnnotation` replaced.
-  /// - param newChild: The new `unexpectedBetweenPatternAndTypeAnnotation` to replace the node's
-  ///                   current `unexpectedBetweenPatternAndTypeAnnotation`, if present.
-  public func withUnexpectedBetweenPatternAndTypeAnnotation(_ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PatternBindingSyntax(newData)
   }
 
   public var typeAnnotation: TypeAnnotationSyntax? {
@@ -10403,18 +8436,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeAnnotationSyntax(childData!)
     }
     set(value) {
-      self = withTypeAnnotation(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PatternBindingSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `typeAnnotation` replaced.
-  /// - param newChild: The new `typeAnnotation` to replace the node's
-  ///                   current `typeAnnotation`, if present.
-  public func withTypeAnnotation(_ newChild: TypeAnnotationSyntax?) -> PatternBindingSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PatternBindingSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? {
@@ -10424,18 +8450,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTypeAnnotationAndInitializer(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PatternBindingSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTypeAnnotationAndInitializer` replaced.
-  /// - param newChild: The new `unexpectedBetweenTypeAnnotationAndInitializer` to replace the node's
-  ///                   current `unexpectedBetweenTypeAnnotationAndInitializer`, if present.
-  public func withUnexpectedBetweenTypeAnnotationAndInitializer(_ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PatternBindingSyntax(newData)
   }
 
   public var initializer: InitializerClauseSyntax? {
@@ -10445,18 +8464,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       return InitializerClauseSyntax(childData!)
     }
     set(value) {
-      self = withInitializer(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = PatternBindingSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `initializer` replaced.
-  /// - param newChild: The new `initializer` to replace the node's
-  ///                   current `initializer`, if present.
-  public func withInitializer(_ newChild: InitializerClauseSyntax?) -> PatternBindingSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return PatternBindingSyntax(newData)
   }
 
   public var unexpectedBetweenInitializerAndAccessor: UnexpectedNodesSyntax? {
@@ -10466,18 +8478,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInitializerAndAccessor(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = PatternBindingSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInitializerAndAccessor` replaced.
-  /// - param newChild: The new `unexpectedBetweenInitializerAndAccessor` to replace the node's
-  ///                   current `unexpectedBetweenInitializerAndAccessor`, if present.
-  public func withUnexpectedBetweenInitializerAndAccessor(_ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return PatternBindingSyntax(newData)
   }
 
   public var accessor: Accessor? {
@@ -10487,18 +8492,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       return Accessor(childData!)
     }
     set(value) {
-      self = withAccessor(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = PatternBindingSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `accessor` replaced.
-  /// - param newChild: The new `accessor` to replace the node's
-  ///                   current `accessor`, if present.
-  public func withAccessor(_ newChild: Accessor?) -> PatternBindingSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return PatternBindingSyntax(newData)
   }
 
   public var unexpectedBetweenAccessorAndTrailingComma: UnexpectedNodesSyntax? {
@@ -10508,18 +8506,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAccessorAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = PatternBindingSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAccessorAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenAccessorAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenAccessorAndTrailingComma`, if present.
-  public func withUnexpectedBetweenAccessorAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return PatternBindingSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -10529,18 +8520,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = PatternBindingSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> PatternBindingSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return PatternBindingSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -10550,18 +8534,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = PatternBindingSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return PatternBindingSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -10692,18 +8669,11 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = EnumCaseElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBeforeIdentifier` to replace the node's
-  ///                   current `unexpectedBeforeIdentifier`, if present.
-  public func withUnexpectedBeforeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return EnumCaseElementSyntax(newData)
   }
 
   /// The name of this case.
@@ -10713,18 +8683,11 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = EnumCaseElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> EnumCaseElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return EnumCaseElementSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndAssociatedValue: UnexpectedNodesSyntax? {
@@ -10734,18 +8697,11 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIdentifierAndAssociatedValue(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = EnumCaseElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIdentifierAndAssociatedValue` replaced.
-  /// - param newChild: The new `unexpectedBetweenIdentifierAndAssociatedValue` to replace the node's
-  ///                   current `unexpectedBetweenIdentifierAndAssociatedValue`, if present.
-  public func withUnexpectedBetweenIdentifierAndAssociatedValue(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return EnumCaseElementSyntax(newData)
   }
 
   /// The set of associated values of the case.
@@ -10756,18 +8712,11 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
       return ParameterClauseSyntax(childData!)
     }
     set(value) {
-      self = withAssociatedValue(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = EnumCaseElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `associatedValue` replaced.
-  /// - param newChild: The new `associatedValue` to replace the node's
-  ///                   current `associatedValue`, if present.
-  public func withAssociatedValue(_ newChild: ParameterClauseSyntax?) -> EnumCaseElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return EnumCaseElementSyntax(newData)
   }
 
   public var unexpectedBetweenAssociatedValueAndRawValue: UnexpectedNodesSyntax? {
@@ -10777,18 +8726,11 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAssociatedValueAndRawValue(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = EnumCaseElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAssociatedValueAndRawValue` replaced.
-  /// - param newChild: The new `unexpectedBetweenAssociatedValueAndRawValue` to replace the node's
-  ///                   current `unexpectedBetweenAssociatedValueAndRawValue`, if present.
-  public func withUnexpectedBetweenAssociatedValueAndRawValue(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return EnumCaseElementSyntax(newData)
   }
 
   /// 
@@ -10801,18 +8743,11 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
       return InitializerClauseSyntax(childData!)
     }
     set(value) {
-      self = withRawValue(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = EnumCaseElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rawValue` replaced.
-  /// - param newChild: The new `rawValue` to replace the node's
-  ///                   current `rawValue`, if present.
-  public func withRawValue(_ newChild: InitializerClauseSyntax?) -> EnumCaseElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return EnumCaseElementSyntax(newData)
   }
 
   public var unexpectedBetweenRawValueAndTrailingComma: UnexpectedNodesSyntax? {
@@ -10822,18 +8757,11 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenRawValueAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = EnumCaseElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenRawValueAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenRawValueAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenRawValueAndTrailingComma`, if present.
-  public func withUnexpectedBetweenRawValueAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return EnumCaseElementSyntax(newData)
   }
 
   /// 
@@ -10847,18 +8775,11 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = EnumCaseElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> EnumCaseElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return EnumCaseElementSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -10868,18 +8789,11 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = EnumCaseElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return EnumCaseElementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -10990,18 +8904,11 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeadingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DesignatedTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeadingComma` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeadingComma` to replace the node's
-  ///                   current `unexpectedBeforeLeadingComma`, if present.
-  public func withUnexpectedBeforeLeadingComma(_ newChild: UnexpectedNodesSyntax?) -> DesignatedTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DesignatedTypeElementSyntax(newData)
   }
 
   public var leadingComma: TokenSyntax {
@@ -11010,18 +8917,11 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeadingComma(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DesignatedTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leadingComma` replaced.
-  /// - param newChild: The new `leadingComma` to replace the node's
-  ///                   current `leadingComma`, if present.
-  public func withLeadingComma(_ newChild: TokenSyntax) -> DesignatedTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DesignatedTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenLeadingCommaAndName: UnexpectedNodesSyntax? {
@@ -11031,18 +8931,11 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeadingCommaAndName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DesignatedTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeadingCommaAndName` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeadingCommaAndName` to replace the node's
-  ///                   current `unexpectedBetweenLeadingCommaAndName`, if present.
-  public func withUnexpectedBetweenLeadingCommaAndName(_ newChild: UnexpectedNodesSyntax?) -> DesignatedTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DesignatedTypeElementSyntax(newData)
   }
 
   public var name: TokenSyntax {
@@ -11051,18 +8944,11 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DesignatedTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax) -> DesignatedTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DesignatedTypeElementSyntax(newData)
   }
 
   public var unexpectedAfterName: UnexpectedNodesSyntax? {
@@ -11072,18 +8958,11 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DesignatedTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterName` replaced.
-  /// - param newChild: The new `unexpectedAfterName` to replace the node's
-  ///                   current `unexpectedAfterName`, if present.
-  public func withUnexpectedAfterName(_ newChild: UnexpectedNodesSyntax?) -> DesignatedTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DesignatedTypeElementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -11185,18 +9064,11 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = OperatorPrecedenceAndTypesSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeColon` replaced.
-  /// - param newChild: The new `unexpectedBeforeColon` to replace the node's
-  ///                   current `unexpectedBeforeColon`, if present.
-  public func withUnexpectedBeforeColon(_ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -11205,18 +9077,11 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = OperatorPrecedenceAndTypesSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> OperatorPrecedenceAndTypesSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndPrecedenceGroup: UnexpectedNodesSyntax? {
@@ -11226,18 +9091,11 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndPrecedenceGroup(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = OperatorPrecedenceAndTypesSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndPrecedenceGroup` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndPrecedenceGroup` to replace the node's
-  ///                   current `unexpectedBetweenColonAndPrecedenceGroup`, if present.
-  public func withUnexpectedBetweenColonAndPrecedenceGroup(_ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
   /// 
@@ -11249,18 +9107,11 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPrecedenceGroup(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = OperatorPrecedenceAndTypesSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `precedenceGroup` replaced.
-  /// - param newChild: The new `precedenceGroup` to replace the node's
-  ///                   current `precedenceGroup`, if present.
-  public func withPrecedenceGroup(_ newChild: TokenSyntax) -> OperatorPrecedenceAndTypesSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
   public var unexpectedBetweenPrecedenceGroupAndDesignatedTypes: UnexpectedNodesSyntax? {
@@ -11270,18 +9121,11 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPrecedenceGroupAndDesignatedTypes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = OperatorPrecedenceAndTypesSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPrecedenceGroupAndDesignatedTypes` replaced.
-  /// - param newChild: The new `unexpectedBetweenPrecedenceGroupAndDesignatedTypes` to replace the node's
-  ///                   current `unexpectedBetweenPrecedenceGroupAndDesignatedTypes`, if present.
-  public func withUnexpectedBetweenPrecedenceGroupAndDesignatedTypes(_ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
   /// 
@@ -11293,7 +9137,10 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
       return DesignatedTypeListSyntax(childData!)
     }
     set(value) {
-      self = withDesignatedTypes(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = OperatorPrecedenceAndTypesSyntax(newData)
     }
   }
 
@@ -11316,16 +9163,6 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `designatedTypes` replaced.
-  /// - param newChild: The new `designatedTypes` to replace the node's
-  ///                   current `designatedTypes`, if present.
-  public func withDesignatedTypes(_ newChild: DesignatedTypeListSyntax) -> OperatorPrecedenceAndTypesSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return OperatorPrecedenceAndTypesSyntax(newData)
-  }
-
   public var unexpectedAfterDesignatedTypes: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 6, parent: Syntax(self))
@@ -11333,18 +9170,11 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterDesignatedTypes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = OperatorPrecedenceAndTypesSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterDesignatedTypes` replaced.
-  /// - param newChild: The new `unexpectedAfterDesignatedTypes` to replace the node's
-  ///                   current `unexpectedAfterDesignatedTypes`, if present.
-  public func withUnexpectedAfterDesignatedTypes(_ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -11455,18 +9285,11 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeHigherThanOrLowerThan(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PrecedenceGroupRelationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeHigherThanOrLowerThan` replaced.
-  /// - param newChild: The new `unexpectedBeforeHigherThanOrLowerThan` to replace the node's
-  ///                   current `unexpectedBeforeHigherThanOrLowerThan`, if present.
-  public func withUnexpectedBeforeHigherThanOrLowerThan(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PrecedenceGroupRelationSyntax(newData)
   }
 
   /// 
@@ -11478,18 +9301,11 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withHigherThanOrLowerThan(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PrecedenceGroupRelationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `higherThanOrLowerThan` replaced.
-  /// - param newChild: The new `higherThanOrLowerThan` to replace the node's
-  ///                   current `higherThanOrLowerThan`, if present.
-  public func withHigherThanOrLowerThan(_ newChild: TokenSyntax) -> PrecedenceGroupRelationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PrecedenceGroupRelationSyntax(newData)
   }
 
   public var unexpectedBetweenHigherThanOrLowerThanAndColon: UnexpectedNodesSyntax? {
@@ -11499,18 +9315,11 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenHigherThanOrLowerThanAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PrecedenceGroupRelationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenHigherThanOrLowerThanAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenHigherThanOrLowerThanAndColon` to replace the node's
-  ///                   current `unexpectedBetweenHigherThanOrLowerThanAndColon`, if present.
-  public func withUnexpectedBetweenHigherThanOrLowerThanAndColon(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PrecedenceGroupRelationSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -11519,18 +9328,11 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PrecedenceGroupRelationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> PrecedenceGroupRelationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PrecedenceGroupRelationSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndOtherNames: UnexpectedNodesSyntax? {
@@ -11540,18 +9342,11 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndOtherNames(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PrecedenceGroupRelationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndOtherNames` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndOtherNames` to replace the node's
-  ///                   current `unexpectedBetweenColonAndOtherNames`, if present.
-  public func withUnexpectedBetweenColonAndOtherNames(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PrecedenceGroupRelationSyntax(newData)
   }
 
   /// 
@@ -11564,7 +9359,10 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
       return PrecedenceGroupNameListSyntax(childData!)
     }
     set(value) {
-      self = withOtherNames(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = PrecedenceGroupRelationSyntax(newData)
     }
   }
 
@@ -11587,16 +9385,6 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
     return PrecedenceGroupRelationSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `otherNames` replaced.
-  /// - param newChild: The new `otherNames` to replace the node's
-  ///                   current `otherNames`, if present.
-  public func withOtherNames(_ newChild: PrecedenceGroupNameListSyntax) -> PrecedenceGroupRelationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return PrecedenceGroupRelationSyntax(newData)
-  }
-
   public var unexpectedAfterOtherNames: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 6, parent: Syntax(self))
@@ -11604,18 +9392,11 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterOtherNames(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = PrecedenceGroupRelationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterOtherNames` replaced.
-  /// - param newChild: The new `unexpectedAfterOtherNames` to replace the node's
-  ///                   current `unexpectedAfterOtherNames`, if present.
-  public func withUnexpectedAfterOtherNames(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return PrecedenceGroupRelationSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -11718,18 +9499,11 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PrecedenceGroupNameElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
-  /// - param newChild: The new `unexpectedBeforeName` to replace the node's
-  ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupNameElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PrecedenceGroupNameElementSyntax(newData)
   }
 
   public var name: TokenSyntax {
@@ -11738,18 +9512,11 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PrecedenceGroupNameElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax) -> PrecedenceGroupNameElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PrecedenceGroupNameElementSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? {
@@ -11759,18 +9526,11 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenNameAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PrecedenceGroupNameElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenNameAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenNameAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenNameAndTrailingComma`, if present.
-  public func withUnexpectedBetweenNameAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupNameElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PrecedenceGroupNameElementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -11780,18 +9540,11 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PrecedenceGroupNameElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> PrecedenceGroupNameElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PrecedenceGroupNameElementSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -11801,18 +9554,11 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PrecedenceGroupNameElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupNameElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PrecedenceGroupNameElementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -11915,18 +9661,11 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAssignmentKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PrecedenceGroupAssignmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAssignmentKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeAssignmentKeyword` to replace the node's
-  ///                   current `unexpectedBeforeAssignmentKeyword`, if present.
-  public func withUnexpectedBeforeAssignmentKeyword(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PrecedenceGroupAssignmentSyntax(newData)
   }
 
   public var assignmentKeyword: TokenSyntax {
@@ -11935,18 +9674,11 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAssignmentKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PrecedenceGroupAssignmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `assignmentKeyword` replaced.
-  /// - param newChild: The new `assignmentKeyword` to replace the node's
-  ///                   current `assignmentKeyword`, if present.
-  public func withAssignmentKeyword(_ newChild: TokenSyntax) -> PrecedenceGroupAssignmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PrecedenceGroupAssignmentSyntax(newData)
   }
 
   public var unexpectedBetweenAssignmentKeywordAndColon: UnexpectedNodesSyntax? {
@@ -11956,18 +9688,11 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAssignmentKeywordAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PrecedenceGroupAssignmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAssignmentKeywordAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenAssignmentKeywordAndColon` to replace the node's
-  ///                   current `unexpectedBetweenAssignmentKeywordAndColon`, if present.
-  public func withUnexpectedBetweenAssignmentKeywordAndColon(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PrecedenceGroupAssignmentSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -11976,18 +9701,11 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PrecedenceGroupAssignmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> PrecedenceGroupAssignmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PrecedenceGroupAssignmentSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndFlag: UnexpectedNodesSyntax? {
@@ -11997,18 +9715,11 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndFlag(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PrecedenceGroupAssignmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndFlag` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndFlag` to replace the node's
-  ///                   current `unexpectedBetweenColonAndFlag`, if present.
-  public func withUnexpectedBetweenColonAndFlag(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PrecedenceGroupAssignmentSyntax(newData)
   }
 
   /// 
@@ -12024,18 +9735,11 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withFlag(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = PrecedenceGroupAssignmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `flag` replaced.
-  /// - param newChild: The new `flag` to replace the node's
-  ///                   current `flag`, if present.
-  public func withFlag(_ newChild: TokenSyntax) -> PrecedenceGroupAssignmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return PrecedenceGroupAssignmentSyntax(newData)
   }
 
   public var unexpectedAfterFlag: UnexpectedNodesSyntax? {
@@ -12045,18 +9749,11 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterFlag(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = PrecedenceGroupAssignmentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterFlag` replaced.
-  /// - param newChild: The new `unexpectedAfterFlag` to replace the node's
-  ///                   current `unexpectedAfterFlag`, if present.
-  public func withUnexpectedAfterFlag(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return PrecedenceGroupAssignmentSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -12167,18 +9864,11 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAssociativityKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PrecedenceGroupAssociativitySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAssociativityKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeAssociativityKeyword` to replace the node's
-  ///                   current `unexpectedBeforeAssociativityKeyword`, if present.
-  public func withUnexpectedBeforeAssociativityKeyword(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PrecedenceGroupAssociativitySyntax(newData)
   }
 
   public var associativityKeyword: TokenSyntax {
@@ -12187,18 +9877,11 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAssociativityKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PrecedenceGroupAssociativitySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `associativityKeyword` replaced.
-  /// - param newChild: The new `associativityKeyword` to replace the node's
-  ///                   current `associativityKeyword`, if present.
-  public func withAssociativityKeyword(_ newChild: TokenSyntax) -> PrecedenceGroupAssociativitySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PrecedenceGroupAssociativitySyntax(newData)
   }
 
   public var unexpectedBetweenAssociativityKeywordAndColon: UnexpectedNodesSyntax? {
@@ -12208,18 +9891,11 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAssociativityKeywordAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PrecedenceGroupAssociativitySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAssociativityKeywordAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenAssociativityKeywordAndColon` to replace the node's
-  ///                   current `unexpectedBetweenAssociativityKeywordAndColon`, if present.
-  public func withUnexpectedBetweenAssociativityKeywordAndColon(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PrecedenceGroupAssociativitySyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -12228,18 +9904,11 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PrecedenceGroupAssociativitySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> PrecedenceGroupAssociativitySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PrecedenceGroupAssociativitySyntax(newData)
   }
 
   public var unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? {
@@ -12249,18 +9918,11 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndValue(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PrecedenceGroupAssociativitySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndValue` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndValue` to replace the node's
-  ///                   current `unexpectedBetweenColonAndValue`, if present.
-  public func withUnexpectedBetweenColonAndValue(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PrecedenceGroupAssociativitySyntax(newData)
   }
 
   /// 
@@ -12275,18 +9937,11 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withValue(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = PrecedenceGroupAssociativitySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `value` replaced.
-  /// - param newChild: The new `value` to replace the node's
-  ///                   current `value`, if present.
-  public func withValue(_ newChild: TokenSyntax) -> PrecedenceGroupAssociativitySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return PrecedenceGroupAssociativitySyntax(newData)
   }
 
   public var unexpectedAfterValue: UnexpectedNodesSyntax? {
@@ -12296,18 +9951,11 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterValue(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = PrecedenceGroupAssociativitySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterValue` replaced.
-  /// - param newChild: The new `unexpectedAfterValue` to replace the node's
-  ///                   current `unexpectedAfterValue`, if present.
-  public func withUnexpectedAfterValue(_ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return PrecedenceGroupAssociativitySyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -12641,18 +10289,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAtSignToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AttributeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAtSignToken` replaced.
-  /// - param newChild: The new `unexpectedBeforeAtSignToken` to replace the node's
-  ///                   current `unexpectedBeforeAtSignToken`, if present.
-  public func withUnexpectedBeforeAtSignToken(_ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AttributeSyntax(newData)
   }
 
   /// The `@` sign.
@@ -12662,18 +10303,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAtSignToken(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AttributeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `atSignToken` replaced.
-  /// - param newChild: The new `atSignToken` to replace the node's
-  ///                   current `atSignToken`, if present.
-  public func withAtSignToken(_ newChild: TokenSyntax) -> AttributeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AttributeSyntax(newData)
   }
 
   public var unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodesSyntax? {
@@ -12683,18 +10317,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAtSignTokenAndAttributeName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AttributeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAtSignTokenAndAttributeName` replaced.
-  /// - param newChild: The new `unexpectedBetweenAtSignTokenAndAttributeName` to replace the node's
-  ///                   current `unexpectedBetweenAtSignTokenAndAttributeName`, if present.
-  public func withUnexpectedBetweenAtSignTokenAndAttributeName(_ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AttributeSyntax(newData)
   }
 
   /// The name of the attribute.
@@ -12704,18 +10331,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withAttributeName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = AttributeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `attributeName` replaced.
-  /// - param newChild: The new `attributeName` to replace the node's
-  ///                   current `attributeName`, if present.
-  public func withAttributeName(_ newChild: TypeSyntax) -> AttributeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return AttributeSyntax(newData)
   }
 
   public var unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodesSyntax? {
@@ -12725,18 +10345,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributeNameAndLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = AttributeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributeNameAndLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributeNameAndLeftParen` to replace the node's
-  ///                   current `unexpectedBetweenAttributeNameAndLeftParen`, if present.
-  public func withUnexpectedBetweenAttributeNameAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return AttributeSyntax(newData)
   }
 
   /// 
@@ -12749,18 +10362,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = AttributeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> AttributeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return AttributeSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndArgument: UnexpectedNodesSyntax? {
@@ -12770,18 +10376,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndArgument(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = AttributeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArgument` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndArgument` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndArgument`, if present.
-  public func withUnexpectedBetweenLeftParenAndArgument(_ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return AttributeSyntax(newData)
   }
 
   /// 
@@ -12796,18 +10395,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       return Argument(childData!)
     }
     set(value) {
-      self = withArgument(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = AttributeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `argument` replaced.
-  /// - param newChild: The new `argument` to replace the node's
-  ///                   current `argument`, if present.
-  public func withArgument(_ newChild: Argument?) -> AttributeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return AttributeSyntax(newData)
   }
 
   public var unexpectedBetweenArgumentAndRightParen: UnexpectedNodesSyntax? {
@@ -12817,18 +10409,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenArgumentAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = AttributeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenArgumentAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenArgumentAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenArgumentAndRightParen`, if present.
-  public func withUnexpectedBetweenArgumentAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return AttributeSyntax(newData)
   }
 
   /// 
@@ -12841,18 +10426,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = AttributeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> AttributeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return AttributeSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -12862,18 +10440,11 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = AttributeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return AttributeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -13003,18 +10574,11 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AvailabilityEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeLabel` to replace the node's
-  ///                   current `unexpectedBeforeLabel`, if present.
-  public func withUnexpectedBeforeLabel(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AvailabilityEntrySyntax(newData)
   }
 
   /// The label of the argument
@@ -13024,18 +10588,11 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AvailabilityEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `label` replaced.
-  /// - param newChild: The new `label` to replace the node's
-  ///                   current `label`, if present.
-  public func withLabel(_ newChild: TokenSyntax) -> AvailabilityEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AvailabilityEntrySyntax(newData)
   }
 
   public var unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? {
@@ -13045,18 +10602,11 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AvailabilityEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenLabelAndColon`, if present.
-  public func withUnexpectedBetweenLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AvailabilityEntrySyntax(newData)
   }
 
   /// The colon separating the label and the value
@@ -13066,18 +10616,11 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = AvailabilityEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> AvailabilityEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return AvailabilityEntrySyntax(newData)
   }
 
   public var unexpectedBetweenColonAndAvailabilityList: UnexpectedNodesSyntax? {
@@ -13087,18 +10630,11 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndAvailabilityList(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = AvailabilityEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndAvailabilityList` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndAvailabilityList` to replace the node's
-  ///                   current `unexpectedBetweenColonAndAvailabilityList`, if present.
-  public func withUnexpectedBetweenColonAndAvailabilityList(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return AvailabilityEntrySyntax(newData)
   }
 
   public var availabilityList: AvailabilitySpecListSyntax {
@@ -13107,7 +10643,10 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return AvailabilitySpecListSyntax(childData!)
     }
     set(value) {
-      self = withAvailabilityList(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = AvailabilityEntrySyntax(newData)
     }
   }
 
@@ -13130,16 +10669,6 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
     return AvailabilityEntrySyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `availabilityList` replaced.
-  /// - param newChild: The new `availabilityList` to replace the node's
-  ///                   current `availabilityList`, if present.
-  public func withAvailabilityList(_ newChild: AvailabilitySpecListSyntax) -> AvailabilityEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return AvailabilityEntrySyntax(newData)
-  }
-
   public var unexpectedBetweenAvailabilityListAndSemicolon: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 6, parent: Syntax(self))
@@ -13147,18 +10676,11 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAvailabilityListAndSemicolon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = AvailabilityEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAvailabilityListAndSemicolon` replaced.
-  /// - param newChild: The new `unexpectedBetweenAvailabilityListAndSemicolon` to replace the node's
-  ///                   current `unexpectedBetweenAvailabilityListAndSemicolon`, if present.
-  public func withUnexpectedBetweenAvailabilityListAndSemicolon(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return AvailabilityEntrySyntax(newData)
   }
 
   public var semicolon: TokenSyntax {
@@ -13167,18 +10689,11 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withSemicolon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = AvailabilityEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `semicolon` replaced.
-  /// - param newChild: The new `semicolon` to replace the node's
-  ///                   current `semicolon`, if present.
-  public func withSemicolon(_ newChild: TokenSyntax) -> AvailabilityEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return AvailabilityEntrySyntax(newData)
   }
 
   public var unexpectedAfterSemicolon: UnexpectedNodesSyntax? {
@@ -13188,18 +10703,11 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterSemicolon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = AvailabilityEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterSemicolon` replaced.
-  /// - param newChild: The new `unexpectedAfterSemicolon` to replace the node's
-  ///                   current `unexpectedAfterSemicolon`, if present.
-  public func withUnexpectedAfterSemicolon(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return AvailabilityEntrySyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -13322,18 +10830,11 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = LabeledSpecializeEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeLabel` to replace the node's
-  ///                   current `unexpectedBeforeLabel`, if present.
-  public func withUnexpectedBeforeLabel(_ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return LabeledSpecializeEntrySyntax(newData)
   }
 
   /// The label of the argument
@@ -13343,18 +10844,11 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = LabeledSpecializeEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `label` replaced.
-  /// - param newChild: The new `label` to replace the node's
-  ///                   current `label`, if present.
-  public func withLabel(_ newChild: TokenSyntax) -> LabeledSpecializeEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return LabeledSpecializeEntrySyntax(newData)
   }
 
   public var unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? {
@@ -13364,18 +10858,11 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = LabeledSpecializeEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenLabelAndColon`, if present.
-  public func withUnexpectedBetweenLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return LabeledSpecializeEntrySyntax(newData)
   }
 
   /// The colon separating the label and the value
@@ -13385,18 +10872,11 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = LabeledSpecializeEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> LabeledSpecializeEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return LabeledSpecializeEntrySyntax(newData)
   }
 
   public var unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? {
@@ -13406,18 +10886,11 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndValue(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = LabeledSpecializeEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndValue` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndValue` to replace the node's
-  ///                   current `unexpectedBetweenColonAndValue`, if present.
-  public func withUnexpectedBetweenColonAndValue(_ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return LabeledSpecializeEntrySyntax(newData)
   }
 
   /// The value for this argument
@@ -13427,18 +10900,11 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withValue(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = LabeledSpecializeEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `value` replaced.
-  /// - param newChild: The new `value` to replace the node's
-  ///                   current `value`, if present.
-  public func withValue(_ newChild: TokenSyntax) -> LabeledSpecializeEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return LabeledSpecializeEntrySyntax(newData)
   }
 
   public var unexpectedBetweenValueAndTrailingComma: UnexpectedNodesSyntax? {
@@ -13448,18 +10914,11 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenValueAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = LabeledSpecializeEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenValueAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenValueAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenValueAndTrailingComma`, if present.
-  public func withUnexpectedBetweenValueAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return LabeledSpecializeEntrySyntax(newData)
   }
 
   /// 
@@ -13472,18 +10931,11 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = LabeledSpecializeEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return LabeledSpecializeEntrySyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -13493,18 +10945,11 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = LabeledSpecializeEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return LabeledSpecializeEntrySyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -13628,18 +11073,11 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = TargetFunctionEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeLabel` to replace the node's
-  ///                   current `unexpectedBeforeLabel`, if present.
-  public func withUnexpectedBeforeLabel(_ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return TargetFunctionEntrySyntax(newData)
   }
 
   /// The label of the argument
@@ -13649,18 +11087,11 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = TargetFunctionEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `label` replaced.
-  /// - param newChild: The new `label` to replace the node's
-  ///                   current `label`, if present.
-  public func withLabel(_ newChild: TokenSyntax) -> TargetFunctionEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return TargetFunctionEntrySyntax(newData)
   }
 
   public var unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? {
@@ -13670,18 +11101,11 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = TargetFunctionEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenLabelAndColon`, if present.
-  public func withUnexpectedBetweenLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return TargetFunctionEntrySyntax(newData)
   }
 
   /// The colon separating the label and the value
@@ -13691,18 +11115,11 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = TargetFunctionEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> TargetFunctionEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return TargetFunctionEntrySyntax(newData)
   }
 
   public var unexpectedBetweenColonAndDeclname: UnexpectedNodesSyntax? {
@@ -13712,18 +11129,11 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndDeclname(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = TargetFunctionEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndDeclname` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndDeclname` to replace the node's
-  ///                   current `unexpectedBetweenColonAndDeclname`, if present.
-  public func withUnexpectedBetweenColonAndDeclname(_ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return TargetFunctionEntrySyntax(newData)
   }
 
   /// The value for this argument
@@ -13733,18 +11143,11 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return DeclNameSyntax(childData!)
     }
     set(value) {
-      self = withDeclname(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = TargetFunctionEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `declname` replaced.
-  /// - param newChild: The new `declname` to replace the node's
-  ///                   current `declname`, if present.
-  public func withDeclname(_ newChild: DeclNameSyntax) -> TargetFunctionEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return TargetFunctionEntrySyntax(newData)
   }
 
   public var unexpectedBetweenDeclnameAndTrailingComma: UnexpectedNodesSyntax? {
@@ -13754,18 +11157,11 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDeclnameAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = TargetFunctionEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDeclnameAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenDeclnameAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenDeclnameAndTrailingComma`, if present.
-  public func withUnexpectedBetweenDeclnameAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return TargetFunctionEntrySyntax(newData)
   }
 
   /// 
@@ -13778,18 +11174,11 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = TargetFunctionEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> TargetFunctionEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return TargetFunctionEntrySyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -13799,18 +11188,11 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = TargetFunctionEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return TargetFunctionEntrySyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -13921,18 +11303,11 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeDeclBaseName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DeclNameSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeDeclBaseName` replaced.
-  /// - param newChild: The new `unexpectedBeforeDeclBaseName` to replace the node's
-  ///                   current `unexpectedBeforeDeclBaseName`, if present.
-  public func withUnexpectedBeforeDeclBaseName(_ newChild: UnexpectedNodesSyntax?) -> DeclNameSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DeclNameSyntax(newData)
   }
 
   /// 
@@ -13944,18 +11319,11 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withDeclBaseName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DeclNameSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `declBaseName` replaced.
-  /// - param newChild: The new `declBaseName` to replace the node's
-  ///                   current `declBaseName`, if present.
-  public func withDeclBaseName(_ newChild: TokenSyntax) -> DeclNameSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DeclNameSyntax(newData)
   }
 
   public var unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? {
@@ -13965,18 +11333,11 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDeclBaseNameAndDeclNameArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DeclNameSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDeclBaseNameAndDeclNameArguments` replaced.
-  /// - param newChild: The new `unexpectedBetweenDeclBaseNameAndDeclNameArguments` to replace the node's
-  ///                   current `unexpectedBetweenDeclBaseNameAndDeclNameArguments`, if present.
-  public func withUnexpectedBetweenDeclBaseNameAndDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> DeclNameSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DeclNameSyntax(newData)
   }
 
   /// 
@@ -13990,18 +11351,11 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return DeclNameArgumentsSyntax(childData!)
     }
     set(value) {
-      self = withDeclNameArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DeclNameSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `declNameArguments` replaced.
-  /// - param newChild: The new `declNameArguments` to replace the node's
-  ///                   current `declNameArguments`, if present.
-  public func withDeclNameArguments(_ newChild: DeclNameArgumentsSyntax?) -> DeclNameSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DeclNameSyntax(newData)
   }
 
   public var unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? {
@@ -14011,18 +11365,11 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterDeclNameArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DeclNameSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterDeclNameArguments` replaced.
-  /// - param newChild: The new `unexpectedAfterDeclNameArguments` to replace the node's
-  ///                   current `unexpectedAfterDeclNameArguments`, if present.
-  public func withUnexpectedAfterDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> DeclNameSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DeclNameSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -14129,18 +11476,11 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ImplementsAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeType` replaced.
-  /// - param newChild: The new `unexpectedBeforeType` to replace the node's
-  ///                   current `unexpectedBeforeType`, if present.
-  public func withUnexpectedBeforeType(_ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ImplementsAttributeArgumentsSyntax(newData)
   }
 
   /// 
@@ -14153,18 +11493,11 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ImplementsAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `type` replaced.
-  /// - param newChild: The new `type` to replace the node's
-  ///                   current `type`, if present.
-  public func withType(_ newChild: TypeSyntax) -> ImplementsAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ImplementsAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAndComma: UnexpectedNodesSyntax? {
@@ -14174,18 +11507,11 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTypeAndComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ImplementsAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTypeAndComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenTypeAndComma` to replace the node's
-  ///                   current `unexpectedBetweenTypeAndComma`, if present.
-  public func withUnexpectedBetweenTypeAndComma(_ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ImplementsAttributeArgumentsSyntax(newData)
   }
 
   /// 
@@ -14197,18 +11523,11 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withComma(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ImplementsAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `comma` replaced.
-  /// - param newChild: The new `comma` to replace the node's
-  ///                   current `comma`, if present.
-  public func withComma(_ newChild: TokenSyntax) -> ImplementsAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ImplementsAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenCommaAndDeclBaseName: UnexpectedNodesSyntax? {
@@ -14218,18 +11537,11 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCommaAndDeclBaseName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ImplementsAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndDeclBaseName` replaced.
-  /// - param newChild: The new `unexpectedBetweenCommaAndDeclBaseName` to replace the node's
-  ///                   current `unexpectedBetweenCommaAndDeclBaseName`, if present.
-  public func withUnexpectedBetweenCommaAndDeclBaseName(_ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ImplementsAttributeArgumentsSyntax(newData)
   }
 
   /// 
@@ -14241,18 +11553,11 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withDeclBaseName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ImplementsAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `declBaseName` replaced.
-  /// - param newChild: The new `declBaseName` to replace the node's
-  ///                   current `declBaseName`, if present.
-  public func withDeclBaseName(_ newChild: TokenSyntax) -> ImplementsAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ImplementsAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? {
@@ -14262,18 +11567,11 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDeclBaseNameAndDeclNameArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ImplementsAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDeclBaseNameAndDeclNameArguments` replaced.
-  /// - param newChild: The new `unexpectedBetweenDeclBaseNameAndDeclNameArguments` to replace the node's
-  ///                   current `unexpectedBetweenDeclBaseNameAndDeclNameArguments`, if present.
-  public func withUnexpectedBetweenDeclBaseNameAndDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ImplementsAttributeArgumentsSyntax(newData)
   }
 
   /// 
@@ -14287,18 +11585,11 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return DeclNameArgumentsSyntax(childData!)
     }
     set(value) {
-      self = withDeclNameArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = ImplementsAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `declNameArguments` replaced.
-  /// - param newChild: The new `declNameArguments` to replace the node's
-  ///                   current `declNameArguments`, if present.
-  public func withDeclNameArguments(_ newChild: DeclNameArgumentsSyntax?) -> ImplementsAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return ImplementsAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? {
@@ -14308,18 +11599,11 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterDeclNameArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = ImplementsAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterDeclNameArguments` replaced.
-  /// - param newChild: The new `unexpectedAfterDeclNameArguments` to replace the node's
-  ///                   current `unexpectedAfterDeclNameArguments`, if present.
-  public func withUnexpectedAfterDeclNameArguments(_ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return ImplementsAttributeArgumentsSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -14435,18 +11719,11 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ObjCSelectorPieceSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
-  /// - param newChild: The new `unexpectedBeforeName` to replace the node's
-  ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> ObjCSelectorPieceSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ObjCSelectorPieceSyntax(newData)
   }
 
   public var name: TokenSyntax? {
@@ -14456,18 +11733,11 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ObjCSelectorPieceSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> ObjCSelectorPieceSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ObjCSelectorPieceSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? {
@@ -14477,18 +11747,11 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenNameAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ObjCSelectorPieceSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenNameAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenNameAndColon` to replace the node's
-  ///                   current `unexpectedBetweenNameAndColon`, if present.
-  public func withUnexpectedBetweenNameAndColon(_ newChild: UnexpectedNodesSyntax?) -> ObjCSelectorPieceSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ObjCSelectorPieceSyntax(newData)
   }
 
   public var colon: TokenSyntax? {
@@ -14498,18 +11761,11 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ObjCSelectorPieceSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> ObjCSelectorPieceSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ObjCSelectorPieceSyntax(newData)
   }
 
   public var unexpectedAfterColon: UnexpectedNodesSyntax? {
@@ -14519,18 +11775,11 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ObjCSelectorPieceSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterColon` replaced.
-  /// - param newChild: The new `unexpectedAfterColon` to replace the node's
-  ///                   current `unexpectedAfterColon`, if present.
-  public func withUnexpectedAfterColon(_ newChild: UnexpectedNodesSyntax?) -> ObjCSelectorPieceSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ObjCSelectorPieceSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -14642,18 +11891,11 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeDiffKind(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DifferentiableAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeDiffKind` replaced.
-  /// - param newChild: The new `unexpectedBeforeDiffKind` to replace the node's
-  ///                   current `unexpectedBeforeDiffKind`, if present.
-  public func withUnexpectedBeforeDiffKind(_ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public var diffKind: TokenSyntax? {
@@ -14663,18 +11905,11 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withDiffKind(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DifferentiableAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `diffKind` replaced.
-  /// - param newChild: The new `diffKind` to replace the node's
-  ///                   current `diffKind`, if present.
-  public func withDiffKind(_ newChild: TokenSyntax?) -> DifferentiableAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenDiffKindAndDiffKindComma: UnexpectedNodesSyntax? {
@@ -14684,18 +11919,11 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDiffKindAndDiffKindComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DifferentiableAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDiffKindAndDiffKindComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenDiffKindAndDiffKindComma` to replace the node's
-  ///                   current `unexpectedBetweenDiffKindAndDiffKindComma`, if present.
-  public func withUnexpectedBetweenDiffKindAndDiffKindComma(_ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   /// 
@@ -14708,18 +11936,11 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withDiffKindComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DifferentiableAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `diffKindComma` replaced.
-  /// - param newChild: The new `diffKindComma` to replace the node's
-  ///                   current `diffKindComma`, if present.
-  public func withDiffKindComma(_ newChild: TokenSyntax?) -> DifferentiableAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenDiffKindCommaAndDiffParams: UnexpectedNodesSyntax? {
@@ -14729,18 +11950,11 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDiffKindCommaAndDiffParams(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DifferentiableAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDiffKindCommaAndDiffParams` replaced.
-  /// - param newChild: The new `unexpectedBetweenDiffKindCommaAndDiffParams` to replace the node's
-  ///                   current `unexpectedBetweenDiffKindCommaAndDiffParams`, if present.
-  public func withUnexpectedBetweenDiffKindCommaAndDiffParams(_ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public var diffParams: DifferentiabilityParamsClauseSyntax? {
@@ -14750,18 +11964,11 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
       return DifferentiabilityParamsClauseSyntax(childData!)
     }
     set(value) {
-      self = withDiffParams(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = DifferentiableAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `diffParams` replaced.
-  /// - param newChild: The new `diffParams` to replace the node's
-  ///                   current `diffParams`, if present.
-  public func withDiffParams(_ newChild: DifferentiabilityParamsClauseSyntax?) -> DifferentiableAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenDiffParamsAndDiffParamsComma: UnexpectedNodesSyntax? {
@@ -14771,18 +11978,11 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDiffParamsAndDiffParamsComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = DifferentiableAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDiffParamsAndDiffParamsComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenDiffParamsAndDiffParamsComma` to replace the node's
-  ///                   current `unexpectedBetweenDiffParamsAndDiffParamsComma`, if present.
-  public func withUnexpectedBetweenDiffParamsAndDiffParamsComma(_ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   /// 
@@ -14796,18 +11996,11 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withDiffParamsComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = DifferentiableAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `diffParamsComma` replaced.
-  /// - param newChild: The new `diffParamsComma` to replace the node's
-  ///                   current `diffParamsComma`, if present.
-  public func withDiffParamsComma(_ newChild: TokenSyntax?) -> DifferentiableAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenDiffParamsCommaAndWhereClause: UnexpectedNodesSyntax? {
@@ -14817,18 +12010,11 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDiffParamsCommaAndWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = DifferentiableAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDiffParamsCommaAndWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenDiffParamsCommaAndWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenDiffParamsCommaAndWhereClause`, if present.
-  public func withUnexpectedBetweenDiffParamsCommaAndWhereClause(_ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public var whereClause: GenericWhereClauseSyntax? {
@@ -14838,18 +12024,11 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
       return GenericWhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = DifferentiableAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `whereClause` replaced.
-  /// - param newChild: The new `whereClause` to replace the node's
-  ///                   current `whereClause`, if present.
-  public func withWhereClause(_ newChild: GenericWhereClauseSyntax?) -> DifferentiableAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedAfterWhereClause: UnexpectedNodesSyntax? {
@@ -14859,18 +12038,11 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = DifferentiableAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterWhereClause` replaced.
-  /// - param newChild: The new `unexpectedAfterWhereClause` to replace the node's
-  ///                   current `unexpectedAfterWhereClause`, if present.
-  public func withUnexpectedAfterWhereClause(_ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -15030,18 +12202,11 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeWrtLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DifferentiabilityParamsClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeWrtLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeWrtLabel` to replace the node's
-  ///                   current `unexpectedBeforeWrtLabel`, if present.
-  public func withUnexpectedBeforeWrtLabel(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DifferentiabilityParamsClauseSyntax(newData)
   }
 
   /// The "wrt" label.
@@ -15051,18 +12216,11 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withWrtLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DifferentiabilityParamsClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `wrtLabel` replaced.
-  /// - param newChild: The new `wrtLabel` to replace the node's
-  ///                   current `wrtLabel`, if present.
-  public func withWrtLabel(_ newChild: TokenSyntax) -> DifferentiabilityParamsClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DifferentiabilityParamsClauseSyntax(newData)
   }
 
   public var unexpectedBetweenWrtLabelAndColon: UnexpectedNodesSyntax? {
@@ -15072,18 +12230,11 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenWrtLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DifferentiabilityParamsClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenWrtLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenWrtLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenWrtLabelAndColon`, if present.
-  public func withUnexpectedBetweenWrtLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DifferentiabilityParamsClauseSyntax(newData)
   }
 
   /// 
@@ -15095,18 +12246,11 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DifferentiabilityParamsClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> DifferentiabilityParamsClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DifferentiabilityParamsClauseSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndParameters: UnexpectedNodesSyntax? {
@@ -15116,18 +12260,11 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndParameters(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DifferentiabilityParamsClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndParameters` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndParameters` to replace the node's
-  ///                   current `unexpectedBetweenColonAndParameters`, if present.
-  public func withUnexpectedBetweenColonAndParameters(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DifferentiabilityParamsClauseSyntax(newData)
   }
 
   public var parameters: Parameters {
@@ -15136,18 +12273,11 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
       return Parameters(childData!)
     }
     set(value) {
-      self = withParameters(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = DifferentiabilityParamsClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `parameters` replaced.
-  /// - param newChild: The new `parameters` to replace the node's
-  ///                   current `parameters`, if present.
-  public func withParameters(_ newChild: Parameters) -> DifferentiabilityParamsClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return DifferentiabilityParamsClauseSyntax(newData)
   }
 
   public var unexpectedAfterParameters: UnexpectedNodesSyntax? {
@@ -15157,18 +12287,11 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterParameters(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = DifferentiabilityParamsClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterParameters` replaced.
-  /// - param newChild: The new `unexpectedAfterParameters` to replace the node's
-  ///                   current `unexpectedAfterParameters`, if present.
-  public func withUnexpectedAfterParameters(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return DifferentiabilityParamsClauseSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -15276,18 +12399,11 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DifferentiabilityParamsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
-  ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DifferentiabilityParamsSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -15296,18 +12412,11 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DifferentiabilityParamsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> DifferentiabilityParamsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DifferentiabilityParamsSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndDiffParams: UnexpectedNodesSyntax? {
@@ -15317,18 +12426,11 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndDiffParams(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DifferentiabilityParamsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndDiffParams` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndDiffParams` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndDiffParams`, if present.
-  public func withUnexpectedBetweenLeftParenAndDiffParams(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DifferentiabilityParamsSyntax(newData)
   }
 
   /// The parameters for differentiation.
@@ -15338,7 +12440,10 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
       return DifferentiabilityParamListSyntax(childData!)
     }
     set(value) {
-      self = withDiffParams(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DifferentiabilityParamsSyntax(newData)
     }
   }
 
@@ -15361,16 +12466,6 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
     return DifferentiabilityParamsSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `diffParams` replaced.
-  /// - param newChild: The new `diffParams` to replace the node's
-  ///                   current `diffParams`, if present.
-  public func withDiffParams(_ newChild: DifferentiabilityParamListSyntax) -> DifferentiabilityParamsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DifferentiabilityParamsSyntax(newData)
-  }
-
   public var unexpectedBetweenDiffParamsAndRightParen: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -15378,18 +12473,11 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDiffParamsAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DifferentiabilityParamsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDiffParamsAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenDiffParamsAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenDiffParamsAndRightParen`, if present.
-  public func withUnexpectedBetweenDiffParamsAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DifferentiabilityParamsSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -15398,18 +12486,11 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = DifferentiabilityParamsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> DifferentiabilityParamsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return DifferentiabilityParamsSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -15419,18 +12500,11 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = DifferentiabilityParamsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return DifferentiabilityParamsSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -15537,18 +12611,11 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeParameter(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DifferentiabilityParamSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeParameter` replaced.
-  /// - param newChild: The new `unexpectedBeforeParameter` to replace the node's
-  ///                   current `unexpectedBeforeParameter`, if present.
-  public func withUnexpectedBeforeParameter(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DifferentiabilityParamSyntax(newData)
   }
 
   public var parameter: TokenSyntax {
@@ -15557,18 +12624,11 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withParameter(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DifferentiabilityParamSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `parameter` replaced.
-  /// - param newChild: The new `parameter` to replace the node's
-  ///                   current `parameter`, if present.
-  public func withParameter(_ newChild: TokenSyntax) -> DifferentiabilityParamSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DifferentiabilityParamSyntax(newData)
   }
 
   public var unexpectedBetweenParameterAndTrailingComma: UnexpectedNodesSyntax? {
@@ -15578,18 +12638,11 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenParameterAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DifferentiabilityParamSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenParameterAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenParameterAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenParameterAndTrailingComma`, if present.
-  public func withUnexpectedBetweenParameterAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DifferentiabilityParamSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -15599,18 +12652,11 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DifferentiabilityParamSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> DifferentiabilityParamSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DifferentiabilityParamSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -15620,18 +12666,11 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DifferentiabilityParamSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DifferentiabilityParamSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -15751,18 +12790,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeOfLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DerivativeRegistrationAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeOfLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeOfLabel` to replace the node's
-  ///                   current `unexpectedBeforeOfLabel`, if present.
-  public func withUnexpectedBeforeOfLabel(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   /// The "of" label.
@@ -15772,18 +12804,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withOfLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DerivativeRegistrationAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `ofLabel` replaced.
-  /// - param newChild: The new `ofLabel` to replace the node's
-  ///                   current `ofLabel`, if present.
-  public func withOfLabel(_ newChild: TokenSyntax) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenOfLabelAndColon: UnexpectedNodesSyntax? {
@@ -15793,18 +12818,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenOfLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DerivativeRegistrationAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenOfLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenOfLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenOfLabelAndColon`, if present.
-  public func withUnexpectedBetweenOfLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   /// 
@@ -15817,18 +12835,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DerivativeRegistrationAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndOriginalDeclName: UnexpectedNodesSyntax? {
@@ -15838,18 +12849,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndOriginalDeclName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DerivativeRegistrationAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndOriginalDeclName` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndOriginalDeclName` to replace the node's
-  ///                   current `unexpectedBetweenColonAndOriginalDeclName`, if present.
-  public func withUnexpectedBetweenColonAndOriginalDeclName(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   /// The referenced original declaration name.
@@ -15859,18 +12863,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return QualifiedDeclNameSyntax(childData!)
     }
     set(value) {
-      self = withOriginalDeclName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = DerivativeRegistrationAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `originalDeclName` replaced.
-  /// - param newChild: The new `originalDeclName` to replace the node's
-  ///                   current `originalDeclName`, if present.
-  public func withOriginalDeclName(_ newChild: QualifiedDeclNameSyntax) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenOriginalDeclNameAndPeriod: UnexpectedNodesSyntax? {
@@ -15880,18 +12877,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenOriginalDeclNameAndPeriod(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = DerivativeRegistrationAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenOriginalDeclNameAndPeriod` replaced.
-  /// - param newChild: The new `unexpectedBetweenOriginalDeclNameAndPeriod` to replace the node's
-  ///                   current `unexpectedBetweenOriginalDeclNameAndPeriod`, if present.
-  public func withUnexpectedBetweenOriginalDeclNameAndPeriod(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   /// 
@@ -15905,18 +12895,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPeriod(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = DerivativeRegistrationAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `period` replaced.
-  /// - param newChild: The new `period` to replace the node's
-  ///                   current `period`, if present.
-  public func withPeriod(_ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenPeriodAndAccessorKind: UnexpectedNodesSyntax? {
@@ -15926,18 +12909,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPeriodAndAccessorKind(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = DerivativeRegistrationAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPeriodAndAccessorKind` replaced.
-  /// - param newChild: The new `unexpectedBetweenPeriodAndAccessorKind` to replace the node's
-  ///                   current `unexpectedBetweenPeriodAndAccessorKind`, if present.
-  public func withUnexpectedBetweenPeriodAndAccessorKind(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   /// The accessor name.
@@ -15948,18 +12924,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAccessorKind(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = DerivativeRegistrationAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `accessorKind` replaced.
-  /// - param newChild: The new `accessorKind` to replace the node's
-  ///                   current `accessorKind`, if present.
-  public func withAccessorKind(_ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenAccessorKindAndComma: UnexpectedNodesSyntax? {
@@ -15969,18 +12938,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAccessorKindAndComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = DerivativeRegistrationAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAccessorKindAndComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenAccessorKindAndComma` to replace the node's
-  ///                   current `unexpectedBetweenAccessorKindAndComma`, if present.
-  public func withUnexpectedBetweenAccessorKindAndComma(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var comma: TokenSyntax? {
@@ -15990,18 +12952,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = DerivativeRegistrationAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `comma` replaced.
-  /// - param newChild: The new `comma` to replace the node's
-  ///                   current `comma`, if present.
-  public func withComma(_ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenCommaAndDiffParams: UnexpectedNodesSyntax? {
@@ -16011,18 +12966,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCommaAndDiffParams(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = DerivativeRegistrationAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndDiffParams` replaced.
-  /// - param newChild: The new `unexpectedBetweenCommaAndDiffParams` to replace the node's
-  ///                   current `unexpectedBetweenCommaAndDiffParams`, if present.
-  public func withUnexpectedBetweenCommaAndDiffParams(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var diffParams: DifferentiabilityParamsClauseSyntax? {
@@ -16032,18 +12980,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return DifferentiabilityParamsClauseSyntax(childData!)
     }
     set(value) {
-      self = withDiffParams(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = DerivativeRegistrationAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `diffParams` replaced.
-  /// - param newChild: The new `diffParams` to replace the node's
-  ///                   current `diffParams`, if present.
-  public func withDiffParams(_ newChild: DifferentiabilityParamsClauseSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedAfterDiffParams: UnexpectedNodesSyntax? {
@@ -16053,18 +12994,11 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterDiffParams(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = DerivativeRegistrationAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterDiffParams` replaced.
-  /// - param newChild: The new `unexpectedAfterDiffParams` to replace the node's
-  ///                   current `unexpectedAfterDiffParams`, if present.
-  public func withUnexpectedAfterDiffParams(_ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -16249,18 +13183,11 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeBaseType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = QualifiedDeclNameSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeBaseType` replaced.
-  /// - param newChild: The new `unexpectedBeforeBaseType` to replace the node's
-  ///                   current `unexpectedBeforeBaseType`, if present.
-  public func withUnexpectedBeforeBaseType(_ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return QualifiedDeclNameSyntax(newData)
   }
 
   /// 
@@ -16273,18 +13200,11 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withBaseType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = QualifiedDeclNameSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `baseType` replaced.
-  /// - param newChild: The new `baseType` to replace the node's
-  ///                   current `baseType`, if present.
-  public func withBaseType(_ newChild: TypeSyntax?) -> QualifiedDeclNameSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return QualifiedDeclNameSyntax(newData)
   }
 
   public var unexpectedBetweenBaseTypeAndDot: UnexpectedNodesSyntax? {
@@ -16294,18 +13214,11 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenBaseTypeAndDot(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = QualifiedDeclNameSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenBaseTypeAndDot` replaced.
-  /// - param newChild: The new `unexpectedBetweenBaseTypeAndDot` to replace the node's
-  ///                   current `unexpectedBetweenBaseTypeAndDot`, if present.
-  public func withUnexpectedBetweenBaseTypeAndDot(_ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return QualifiedDeclNameSyntax(newData)
   }
 
   public var dot: TokenSyntax? {
@@ -16315,18 +13228,11 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withDot(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = QualifiedDeclNameSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `dot` replaced.
-  /// - param newChild: The new `dot` to replace the node's
-  ///                   current `dot`, if present.
-  public func withDot(_ newChild: TokenSyntax?) -> QualifiedDeclNameSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return QualifiedDeclNameSyntax(newData)
   }
 
   public var unexpectedBetweenDotAndName: UnexpectedNodesSyntax? {
@@ -16336,18 +13242,11 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDotAndName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = QualifiedDeclNameSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDotAndName` replaced.
-  /// - param newChild: The new `unexpectedBetweenDotAndName` to replace the node's
-  ///                   current `unexpectedBetweenDotAndName`, if present.
-  public func withUnexpectedBetweenDotAndName(_ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return QualifiedDeclNameSyntax(newData)
   }
 
   /// 
@@ -16359,18 +13258,11 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = QualifiedDeclNameSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax) -> QualifiedDeclNameSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return QualifiedDeclNameSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? {
@@ -16380,18 +13272,11 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenNameAndArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = QualifiedDeclNameSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenNameAndArguments` replaced.
-  /// - param newChild: The new `unexpectedBetweenNameAndArguments` to replace the node's
-  ///                   current `unexpectedBetweenNameAndArguments`, if present.
-  public func withUnexpectedBetweenNameAndArguments(_ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return QualifiedDeclNameSyntax(newData)
   }
 
   /// 
@@ -16405,18 +13290,11 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return DeclNameArgumentsSyntax(childData!)
     }
     set(value) {
-      self = withArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = QualifiedDeclNameSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `arguments` replaced.
-  /// - param newChild: The new `arguments` to replace the node's
-  ///                   current `arguments`, if present.
-  public func withArguments(_ newChild: DeclNameArgumentsSyntax?) -> QualifiedDeclNameSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return QualifiedDeclNameSyntax(newData)
   }
 
   public var unexpectedAfterArguments: UnexpectedNodesSyntax? {
@@ -16426,18 +13304,11 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = QualifiedDeclNameSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterArguments` replaced.
-  /// - param newChild: The new `unexpectedAfterArguments` to replace the node's
-  ///                   current `unexpectedAfterArguments`, if present.
-  public func withUnexpectedAfterArguments(_ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return QualifiedDeclNameSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -16555,18 +13426,11 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeBeforeLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = BackDeployAttributeSpecListSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeBeforeLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeBeforeLabel` to replace the node's
-  ///                   current `unexpectedBeforeBeforeLabel`, if present.
-  public func withUnexpectedBeforeBeforeLabel(_ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return BackDeployAttributeSpecListSyntax(newData)
   }
 
   /// The "before" label.
@@ -16576,18 +13440,11 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withBeforeLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = BackDeployAttributeSpecListSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `beforeLabel` replaced.
-  /// - param newChild: The new `beforeLabel` to replace the node's
-  ///                   current `beforeLabel`, if present.
-  public func withBeforeLabel(_ newChild: TokenSyntax) -> BackDeployAttributeSpecListSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return BackDeployAttributeSpecListSyntax(newData)
   }
 
   public var unexpectedBetweenBeforeLabelAndColon: UnexpectedNodesSyntax? {
@@ -16597,18 +13454,11 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenBeforeLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = BackDeployAttributeSpecListSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenBeforeLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenBeforeLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenBeforeLabelAndColon`, if present.
-  public func withUnexpectedBetweenBeforeLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return BackDeployAttributeSpecListSyntax(newData)
   }
 
   /// 
@@ -16620,18 +13470,11 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = BackDeployAttributeSpecListSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> BackDeployAttributeSpecListSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return BackDeployAttributeSpecListSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndVersionList: UnexpectedNodesSyntax? {
@@ -16641,18 +13484,11 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndVersionList(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = BackDeployAttributeSpecListSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndVersionList` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndVersionList` to replace the node's
-  ///                   current `unexpectedBetweenColonAndVersionList`, if present.
-  public func withUnexpectedBetweenColonAndVersionList(_ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return BackDeployAttributeSpecListSyntax(newData)
   }
 
   /// 
@@ -16665,7 +13501,10 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       return AvailabilityVersionRestrictionListSyntax(childData!)
     }
     set(value) {
-      self = withVersionList(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = BackDeployAttributeSpecListSyntax(newData)
     }
   }
 
@@ -16688,16 +13527,6 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `versionList` replaced.
-  /// - param newChild: The new `versionList` to replace the node's
-  ///                   current `versionList`, if present.
-  public func withVersionList(_ newChild: AvailabilityVersionRestrictionListSyntax) -> BackDeployAttributeSpecListSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return BackDeployAttributeSpecListSyntax(newData)
-  }
-
   public var unexpectedAfterVersionList: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 6, parent: Syntax(self))
@@ -16705,18 +13534,11 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterVersionList(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = BackDeployAttributeSpecListSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterVersionList` replaced.
-  /// - param newChild: The new `unexpectedAfterVersionList` to replace the node's
-  ///                   current `unexpectedAfterVersionList`, if present.
-  public func withUnexpectedAfterVersionList(_ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return BackDeployAttributeSpecListSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -16822,18 +13644,11 @@ public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, Syn
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAvailabilityVersionRestriction(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AvailabilityVersionRestrictionListEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAvailabilityVersionRestriction` replaced.
-  /// - param newChild: The new `unexpectedBeforeAvailabilityVersionRestriction` to replace the node's
-  ///                   current `unexpectedBeforeAvailabilityVersionRestriction`, if present.
-  public func withUnexpectedBeforeAvailabilityVersionRestriction(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityVersionRestrictionListEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AvailabilityVersionRestrictionListEntrySyntax(newData)
   }
 
   public var availabilityVersionRestriction: AvailabilityVersionRestrictionSyntax {
@@ -16842,18 +13657,11 @@ public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, Syn
       return AvailabilityVersionRestrictionSyntax(childData!)
     }
     set(value) {
-      self = withAvailabilityVersionRestriction(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AvailabilityVersionRestrictionListEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `availabilityVersionRestriction` replaced.
-  /// - param newChild: The new `availabilityVersionRestriction` to replace the node's
-  ///                   current `availabilityVersionRestriction`, if present.
-  public func withAvailabilityVersionRestriction(_ newChild: AvailabilityVersionRestrictionSyntax) -> AvailabilityVersionRestrictionListEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AvailabilityVersionRestrictionListEntrySyntax(newData)
   }
 
   public var unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma: UnexpectedNodesSyntax? {
@@ -16863,18 +13671,11 @@ public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, Syn
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AvailabilityVersionRestrictionListEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma`, if present.
-  public func withUnexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityVersionRestrictionListEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AvailabilityVersionRestrictionListEntrySyntax(newData)
   }
 
   /// 
@@ -16888,18 +13689,11 @@ public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, Syn
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = AvailabilityVersionRestrictionListEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> AvailabilityVersionRestrictionListEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return AvailabilityVersionRestrictionListEntrySyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -16909,18 +13703,11 @@ public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, Syn
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = AvailabilityVersionRestrictionListEntrySyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityVersionRestrictionListEntrySyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return AvailabilityVersionRestrictionListEntrySyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -17022,18 +13809,11 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeMangledName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeMangledName` replaced.
-  /// - param newChild: The new `unexpectedBeforeMangledName` to replace the node's
-  ///                   current `unexpectedBeforeMangledName`, if present.
-  public func withUnexpectedBeforeMangledName(_ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
 
   /// The mangled name of a declaration.
@@ -17043,18 +13823,11 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
       return StringLiteralExprSyntax(childData!)
     }
     set(value) {
-      self = withMangledName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `mangledName` replaced.
-  /// - param newChild: The new `mangledName` to replace the node's
-  ///                   current `mangledName`, if present.
-  public func withMangledName(_ newChild: StringLiteralExprSyntax) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenMangledNameAndComma: UnexpectedNodesSyntax? {
@@ -17064,18 +13837,11 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenMangledNameAndComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenMangledNameAndComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenMangledNameAndComma` to replace the node's
-  ///                   current `unexpectedBetweenMangledNameAndComma`, if present.
-  public func withUnexpectedBetweenMangledNameAndComma(_ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
 
   public var comma: TokenSyntax {
@@ -17084,18 +13850,11 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withComma(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `comma` replaced.
-  /// - param newChild: The new `comma` to replace the node's
-  ///                   current `comma`, if present.
-  public func withComma(_ newChild: TokenSyntax) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenCommaAndOrdinal: UnexpectedNodesSyntax? {
@@ -17105,18 +13864,11 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCommaAndOrdinal(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndOrdinal` replaced.
-  /// - param newChild: The new `unexpectedBetweenCommaAndOrdinal` to replace the node's
-  ///                   current `unexpectedBetweenCommaAndOrdinal`, if present.
-  public func withUnexpectedBetweenCommaAndOrdinal(_ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
 
   /// The ordinal corresponding to the 'some' keyword that introduced this opaque type.
@@ -17126,18 +13878,11 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withOrdinal(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `ordinal` replaced.
-  /// - param newChild: The new `ordinal` to replace the node's
-  ///                   current `ordinal`, if present.
-  public func withOrdinal(_ newChild: TokenSyntax) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedAfterOrdinal: UnexpectedNodesSyntax? {
@@ -17147,18 +13892,11 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterOrdinal(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterOrdinal` replaced.
-  /// - param newChild: The new `unexpectedAfterOrdinal` to replace the node's
-  ///                   current `unexpectedAfterOrdinal`, if present.
-  public func withUnexpectedAfterOrdinal(_ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -17276,18 +14014,11 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeConventionLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ConventionAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeConventionLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeConventionLabel` to replace the node's
-  ///                   current `unexpectedBeforeConventionLabel`, if present.
-  public func withUnexpectedBeforeConventionLabel(_ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ConventionAttributeArgumentsSyntax(newData)
   }
 
   /// The convention label.
@@ -17297,18 +14028,11 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withConventionLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ConventionAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `conventionLabel` replaced.
-  /// - param newChild: The new `conventionLabel` to replace the node's
-  ///                   current `conventionLabel`, if present.
-  public func withConventionLabel(_ newChild: TokenSyntax) -> ConventionAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ConventionAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenConventionLabelAndComma: UnexpectedNodesSyntax? {
@@ -17318,18 +14042,11 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenConventionLabelAndComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ConventionAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenConventionLabelAndComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenConventionLabelAndComma` to replace the node's
-  ///                   current `unexpectedBetweenConventionLabelAndComma`, if present.
-  public func withUnexpectedBetweenConventionLabelAndComma(_ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ConventionAttributeArgumentsSyntax(newData)
   }
 
   public var comma: TokenSyntax? {
@@ -17339,18 +14056,11 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ConventionAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `comma` replaced.
-  /// - param newChild: The new `comma` to replace the node's
-  ///                   current `comma`, if present.
-  public func withComma(_ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ConventionAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenCommaAndCTypeLabel: UnexpectedNodesSyntax? {
@@ -17360,18 +14070,11 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCommaAndCTypeLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ConventionAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndCTypeLabel` replaced.
-  /// - param newChild: The new `unexpectedBetweenCommaAndCTypeLabel` to replace the node's
-  ///                   current `unexpectedBetweenCommaAndCTypeLabel`, if present.
-  public func withUnexpectedBetweenCommaAndCTypeLabel(_ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ConventionAttributeArgumentsSyntax(newData)
   }
 
   public var cTypeLabel: TokenSyntax? {
@@ -17381,18 +14084,11 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withCTypeLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ConventionAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `cTypeLabel` replaced.
-  /// - param newChild: The new `cTypeLabel` to replace the node's
-  ///                   current `cTypeLabel`, if present.
-  public func withCTypeLabel(_ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ConventionAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenCTypeLabelAndColon: UnexpectedNodesSyntax? {
@@ -17402,18 +14098,11 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCTypeLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ConventionAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCTypeLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenCTypeLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenCTypeLabelAndColon`, if present.
-  public func withUnexpectedBetweenCTypeLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ConventionAttributeArgumentsSyntax(newData)
   }
 
   public var colon: TokenSyntax? {
@@ -17423,18 +14112,11 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = ConventionAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return ConventionAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndCTypeString: UnexpectedNodesSyntax? {
@@ -17444,18 +14126,11 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndCTypeString(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = ConventionAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndCTypeString` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndCTypeString` to replace the node's
-  ///                   current `unexpectedBetweenColonAndCTypeString`, if present.
-  public func withUnexpectedBetweenColonAndCTypeString(_ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return ConventionAttributeArgumentsSyntax(newData)
   }
 
   public var cTypeString: StringLiteralExprSyntax? {
@@ -17465,18 +14140,11 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return StringLiteralExprSyntax(childData!)
     }
     set(value) {
-      self = withCTypeString(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = ConventionAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `cTypeString` replaced.
-  /// - param newChild: The new `cTypeString` to replace the node's
-  ///                   current `cTypeString`, if present.
-  public func withCTypeString(_ newChild: StringLiteralExprSyntax?) -> ConventionAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return ConventionAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedAfterCTypeString: UnexpectedNodesSyntax? {
@@ -17486,18 +14154,11 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterCTypeString(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = ConventionAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterCTypeString` replaced.
-  /// - param newChild: The new `unexpectedAfterCTypeString` to replace the node's
-  ///                   current `unexpectedAfterCTypeString`, if present.
-  public func withUnexpectedAfterCTypeString(_ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return ConventionAttributeArgumentsSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -17623,18 +14284,11 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeWitnessMethodLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ConventionWitnessMethodAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeWitnessMethodLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeWitnessMethodLabel` to replace the node's
-  ///                   current `unexpectedBeforeWitnessMethodLabel`, if present.
-  public func withUnexpectedBeforeWitnessMethodLabel(_ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
 
   public var witnessMethodLabel: TokenSyntax {
@@ -17643,18 +14297,11 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withWitnessMethodLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ConventionWitnessMethodAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `witnessMethodLabel` replaced.
-  /// - param newChild: The new `witnessMethodLabel` to replace the node's
-  ///                   current `witnessMethodLabel`, if present.
-  public func withWitnessMethodLabel(_ newChild: TokenSyntax) -> ConventionWitnessMethodAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenWitnessMethodLabelAndColon: UnexpectedNodesSyntax? {
@@ -17664,18 +14311,11 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenWitnessMethodLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ConventionWitnessMethodAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenWitnessMethodLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenWitnessMethodLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenWitnessMethodLabelAndColon`, if present.
-  public func withUnexpectedBetweenWitnessMethodLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -17684,18 +14324,11 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ConventionWitnessMethodAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> ConventionWitnessMethodAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndProtocolName: UnexpectedNodesSyntax? {
@@ -17705,18 +14338,11 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndProtocolName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ConventionWitnessMethodAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndProtocolName` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndProtocolName` to replace the node's
-  ///                   current `unexpectedBetweenColonAndProtocolName`, if present.
-  public func withUnexpectedBetweenColonAndProtocolName(_ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
 
   public var protocolName: TokenSyntax {
@@ -17725,18 +14351,11 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withProtocolName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ConventionWitnessMethodAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `protocolName` replaced.
-  /// - param newChild: The new `protocolName` to replace the node's
-  ///                   current `protocolName`, if present.
-  public func withProtocolName(_ newChild: TokenSyntax) -> ConventionWitnessMethodAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedAfterProtocolName: UnexpectedNodesSyntax? {
@@ -17746,18 +14365,11 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterProtocolName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ConventionWitnessMethodAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterProtocolName` replaced.
-  /// - param newChild: The new `unexpectedAfterProtocolName` to replace the node's
-  ///                   current `unexpectedAfterProtocolName`, if present.
-  public func withUnexpectedAfterProtocolName(_ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -17867,18 +14479,11 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLanguage(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ExposeAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLanguage` replaced.
-  /// - param newChild: The new `unexpectedBeforeLanguage` to replace the node's
-  ///                   current `unexpectedBeforeLanguage`, if present.
-  public func withUnexpectedBeforeLanguage(_ newChild: UnexpectedNodesSyntax?) -> ExposeAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ExposeAttributeArgumentsSyntax(newData)
   }
 
   public var language: TokenSyntax {
@@ -17887,18 +14492,11 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLanguage(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ExposeAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `language` replaced.
-  /// - param newChild: The new `language` to replace the node's
-  ///                   current `language`, if present.
-  public func withLanguage(_ newChild: TokenSyntax) -> ExposeAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ExposeAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenLanguageAndComma: UnexpectedNodesSyntax? {
@@ -17908,18 +14506,11 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLanguageAndComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ExposeAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLanguageAndComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenLanguageAndComma` to replace the node's
-  ///                   current `unexpectedBetweenLanguageAndComma`, if present.
-  public func withUnexpectedBetweenLanguageAndComma(_ newChild: UnexpectedNodesSyntax?) -> ExposeAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ExposeAttributeArgumentsSyntax(newData)
   }
 
   public var comma: TokenSyntax? {
@@ -17929,18 +14520,11 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ExposeAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `comma` replaced.
-  /// - param newChild: The new `comma` to replace the node's
-  ///                   current `comma`, if present.
-  public func withComma(_ newChild: TokenSyntax?) -> ExposeAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ExposeAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenCommaAndCxxName: UnexpectedNodesSyntax? {
@@ -17950,18 +14534,11 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCommaAndCxxName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ExposeAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndCxxName` replaced.
-  /// - param newChild: The new `unexpectedBetweenCommaAndCxxName` to replace the node's
-  ///                   current `unexpectedBetweenCommaAndCxxName`, if present.
-  public func withUnexpectedBetweenCommaAndCxxName(_ newChild: UnexpectedNodesSyntax?) -> ExposeAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ExposeAttributeArgumentsSyntax(newData)
   }
 
   public var cxxName: StringLiteralExprSyntax? {
@@ -17971,18 +14548,11 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       return StringLiteralExprSyntax(childData!)
     }
     set(value) {
-      self = withCxxName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ExposeAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `cxxName` replaced.
-  /// - param newChild: The new `cxxName` to replace the node's
-  ///                   current `cxxName`, if present.
-  public func withCxxName(_ newChild: StringLiteralExprSyntax?) -> ExposeAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ExposeAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedAfterCxxName: UnexpectedNodesSyntax? {
@@ -17992,18 +14562,11 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterCxxName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ExposeAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterCxxName` replaced.
-  /// - param newChild: The new `unexpectedAfterCxxName` to replace the node's
-  ///                   current `unexpectedAfterCxxName`, if present.
-  public func withUnexpectedAfterCxxName(_ newChild: UnexpectedNodesSyntax?) -> ExposeAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ExposeAttributeArgumentsSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -18121,18 +14684,11 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeModuleLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = OriginallyDefinedInArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeModuleLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeModuleLabel` to replace the node's
-  ///                   current `unexpectedBeforeModuleLabel`, if present.
-  public func withUnexpectedBeforeModuleLabel(_ newChild: UnexpectedNodesSyntax?) -> OriginallyDefinedInArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return OriginallyDefinedInArgumentsSyntax(newData)
   }
 
   public var moduleLabel: TokenSyntax {
@@ -18141,18 +14697,11 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withModuleLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = OriginallyDefinedInArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `moduleLabel` replaced.
-  /// - param newChild: The new `moduleLabel` to replace the node's
-  ///                   current `moduleLabel`, if present.
-  public func withModuleLabel(_ newChild: TokenSyntax) -> OriginallyDefinedInArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return OriginallyDefinedInArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenModuleLabelAndColon: UnexpectedNodesSyntax? {
@@ -18162,18 +14711,11 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModuleLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = OriginallyDefinedInArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModuleLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenModuleLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenModuleLabelAndColon`, if present.
-  public func withUnexpectedBetweenModuleLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> OriginallyDefinedInArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return OriginallyDefinedInArgumentsSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -18182,18 +14724,11 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = OriginallyDefinedInArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> OriginallyDefinedInArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return OriginallyDefinedInArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndModuleName: UnexpectedNodesSyntax? {
@@ -18203,18 +14738,11 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndModuleName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = OriginallyDefinedInArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndModuleName` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndModuleName` to replace the node's
-  ///                   current `unexpectedBetweenColonAndModuleName`, if present.
-  public func withUnexpectedBetweenColonAndModuleName(_ newChild: UnexpectedNodesSyntax?) -> OriginallyDefinedInArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return OriginallyDefinedInArgumentsSyntax(newData)
   }
 
   public var moduleName: StringLiteralExprSyntax {
@@ -18223,18 +14751,11 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return StringLiteralExprSyntax(childData!)
     }
     set(value) {
-      self = withModuleName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = OriginallyDefinedInArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `moduleName` replaced.
-  /// - param newChild: The new `moduleName` to replace the node's
-  ///                   current `moduleName`, if present.
-  public func withModuleName(_ newChild: StringLiteralExprSyntax) -> OriginallyDefinedInArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return OriginallyDefinedInArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenModuleNameAndComma: UnexpectedNodesSyntax? {
@@ -18244,18 +14765,11 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenModuleNameAndComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = OriginallyDefinedInArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenModuleNameAndComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenModuleNameAndComma` to replace the node's
-  ///                   current `unexpectedBetweenModuleNameAndComma`, if present.
-  public func withUnexpectedBetweenModuleNameAndComma(_ newChild: UnexpectedNodesSyntax?) -> OriginallyDefinedInArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return OriginallyDefinedInArgumentsSyntax(newData)
   }
 
   public var comma: TokenSyntax {
@@ -18264,18 +14778,11 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withComma(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = OriginallyDefinedInArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `comma` replaced.
-  /// - param newChild: The new `comma` to replace the node's
-  ///                   current `comma`, if present.
-  public func withComma(_ newChild: TokenSyntax) -> OriginallyDefinedInArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return OriginallyDefinedInArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenCommaAndPlatforms: UnexpectedNodesSyntax? {
@@ -18285,18 +14792,11 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCommaAndPlatforms(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = OriginallyDefinedInArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndPlatforms` replaced.
-  /// - param newChild: The new `unexpectedBetweenCommaAndPlatforms` to replace the node's
-  ///                   current `unexpectedBetweenCommaAndPlatforms`, if present.
-  public func withUnexpectedBetweenCommaAndPlatforms(_ newChild: UnexpectedNodesSyntax?) -> OriginallyDefinedInArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return OriginallyDefinedInArgumentsSyntax(newData)
   }
 
   public var platforms: AvailabilityVersionRestrictionListSyntax {
@@ -18305,7 +14805,10 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return AvailabilityVersionRestrictionListSyntax(childData!)
     }
     set(value) {
-      self = withPlatforms(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = OriginallyDefinedInArgumentsSyntax(newData)
     }
   }
 
@@ -18328,16 +14831,6 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     return OriginallyDefinedInArgumentsSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `platforms` replaced.
-  /// - param newChild: The new `platforms` to replace the node's
-  ///                   current `platforms`, if present.
-  public func withPlatforms(_ newChild: AvailabilityVersionRestrictionListSyntax) -> OriginallyDefinedInArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return OriginallyDefinedInArgumentsSyntax(newData)
-  }
-
   public var unexpectedAfterPlatforms: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 10, parent: Syntax(self))
@@ -18345,18 +14838,11 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterPlatforms(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = OriginallyDefinedInArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterPlatforms` replaced.
-  /// - param newChild: The new `unexpectedAfterPlatforms` to replace the node's
-  ///                   current `unexpectedAfterPlatforms`, if present.
-  public func withUnexpectedAfterPlatforms(_ newChild: UnexpectedNodesSyntax?) -> OriginallyDefinedInArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return OriginallyDefinedInArgumentsSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -18482,18 +14968,11 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeSourceFileLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = UnderscorePrivateAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeSourceFileLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeSourceFileLabel` to replace the node's
-  ///                   current `unexpectedBeforeSourceFileLabel`, if present.
-  public func withUnexpectedBeforeSourceFileLabel(_ newChild: UnexpectedNodesSyntax?) -> UnderscorePrivateAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return UnderscorePrivateAttributeArgumentsSyntax(newData)
   }
 
   public var sourceFileLabel: TokenSyntax {
@@ -18502,18 +14981,11 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withSourceFileLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = UnderscorePrivateAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `sourceFileLabel` replaced.
-  /// - param newChild: The new `sourceFileLabel` to replace the node's
-  ///                   current `sourceFileLabel`, if present.
-  public func withSourceFileLabel(_ newChild: TokenSyntax) -> UnderscorePrivateAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return UnderscorePrivateAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenSourceFileLabelAndColon: UnexpectedNodesSyntax? {
@@ -18523,18 +14995,11 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSourceFileLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = UnderscorePrivateAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSourceFileLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenSourceFileLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenSourceFileLabelAndColon`, if present.
-  public func withUnexpectedBetweenSourceFileLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> UnderscorePrivateAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return UnderscorePrivateAttributeArgumentsSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -18543,18 +15008,11 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = UnderscorePrivateAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> UnderscorePrivateAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return UnderscorePrivateAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndFilename: UnexpectedNodesSyntax? {
@@ -18564,18 +15022,11 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndFilename(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = UnderscorePrivateAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndFilename` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndFilename` to replace the node's
-  ///                   current `unexpectedBetweenColonAndFilename`, if present.
-  public func withUnexpectedBetweenColonAndFilename(_ newChild: UnexpectedNodesSyntax?) -> UnderscorePrivateAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return UnderscorePrivateAttributeArgumentsSyntax(newData)
   }
 
   public var filename: StringLiteralExprSyntax {
@@ -18584,18 +15035,11 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
       return StringLiteralExprSyntax(childData!)
     }
     set(value) {
-      self = withFilename(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = UnderscorePrivateAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `filename` replaced.
-  /// - param newChild: The new `filename` to replace the node's
-  ///                   current `filename`, if present.
-  public func withFilename(_ newChild: StringLiteralExprSyntax) -> UnderscorePrivateAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return UnderscorePrivateAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedAfterFilename: UnexpectedNodesSyntax? {
@@ -18605,18 +15049,11 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterFilename(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = UnderscorePrivateAttributeArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterFilename` replaced.
-  /// - param newChild: The new `unexpectedAfterFilename` to replace the node's
-  ///                   current `unexpectedAfterFilename`, if present.
-  public func withUnexpectedAfterFilename(_ newChild: UnexpectedNodesSyntax?) -> UnderscorePrivateAttributeArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return UnderscorePrivateAttributeArgumentsSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -18726,18 +15163,11 @@ public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeForLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DynamicReplacementArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeForLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeForLabel` to replace the node's
-  ///                   current `unexpectedBeforeForLabel`, if present.
-  public func withUnexpectedBeforeForLabel(_ newChild: UnexpectedNodesSyntax?) -> DynamicReplacementArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DynamicReplacementArgumentsSyntax(newData)
   }
 
   public var forLabel: TokenSyntax {
@@ -18746,18 +15176,11 @@ public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable 
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withForLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DynamicReplacementArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `forLabel` replaced.
-  /// - param newChild: The new `forLabel` to replace the node's
-  ///                   current `forLabel`, if present.
-  public func withForLabel(_ newChild: TokenSyntax) -> DynamicReplacementArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DynamicReplacementArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenForLabelAndColon: UnexpectedNodesSyntax? {
@@ -18767,18 +15190,11 @@ public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenForLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DynamicReplacementArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenForLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenForLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenForLabelAndColon`, if present.
-  public func withUnexpectedBetweenForLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> DynamicReplacementArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DynamicReplacementArgumentsSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -18787,18 +15203,11 @@ public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable 
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DynamicReplacementArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> DynamicReplacementArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DynamicReplacementArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndDeclname: UnexpectedNodesSyntax? {
@@ -18808,18 +15217,11 @@ public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndDeclname(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DynamicReplacementArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndDeclname` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndDeclname` to replace the node's
-  ///                   current `unexpectedBetweenColonAndDeclname`, if present.
-  public func withUnexpectedBetweenColonAndDeclname(_ newChild: UnexpectedNodesSyntax?) -> DynamicReplacementArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DynamicReplacementArgumentsSyntax(newData)
   }
 
   public var declname: DeclNameSyntax {
@@ -18828,18 +15230,11 @@ public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable 
       return DeclNameSyntax(childData!)
     }
     set(value) {
-      self = withDeclname(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = DynamicReplacementArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `declname` replaced.
-  /// - param newChild: The new `declname` to replace the node's
-  ///                   current `declname`, if present.
-  public func withDeclname(_ newChild: DeclNameSyntax) -> DynamicReplacementArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return DynamicReplacementArgumentsSyntax(newData)
   }
 
   public var unexpectedAfterDeclname: UnexpectedNodesSyntax? {
@@ -18849,18 +15244,11 @@ public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterDeclname(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = DynamicReplacementArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterDeclname` replaced.
-  /// - param newChild: The new `unexpectedAfterDeclname` to replace the node's
-  ///                   current `unexpectedAfterDeclname`, if present.
-  public func withUnexpectedAfterDeclname(_ newChild: UnexpectedNodesSyntax?) -> DynamicReplacementArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return DynamicReplacementArgumentsSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -18970,18 +15358,11 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeMessageLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = UnavailableFromAsyncArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeMessageLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeMessageLabel` to replace the node's
-  ///                   current `unexpectedBeforeMessageLabel`, if present.
-  public func withUnexpectedBeforeMessageLabel(_ newChild: UnexpectedNodesSyntax?) -> UnavailableFromAsyncArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return UnavailableFromAsyncArgumentsSyntax(newData)
   }
 
   public var messageLabel: TokenSyntax {
@@ -18990,18 +15371,11 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withMessageLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = UnavailableFromAsyncArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `messageLabel` replaced.
-  /// - param newChild: The new `messageLabel` to replace the node's
-  ///                   current `messageLabel`, if present.
-  public func withMessageLabel(_ newChild: TokenSyntax) -> UnavailableFromAsyncArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return UnavailableFromAsyncArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenMessageLabelAndColon: UnexpectedNodesSyntax? {
@@ -19011,18 +15385,11 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenMessageLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = UnavailableFromAsyncArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenMessageLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenMessageLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenMessageLabelAndColon`, if present.
-  public func withUnexpectedBetweenMessageLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> UnavailableFromAsyncArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return UnavailableFromAsyncArgumentsSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -19031,18 +15398,11 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = UnavailableFromAsyncArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> UnavailableFromAsyncArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return UnavailableFromAsyncArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndMessage: UnexpectedNodesSyntax? {
@@ -19052,18 +15412,11 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndMessage(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = UnavailableFromAsyncArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndMessage` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndMessage` to replace the node's
-  ///                   current `unexpectedBetweenColonAndMessage`, if present.
-  public func withUnexpectedBetweenColonAndMessage(_ newChild: UnexpectedNodesSyntax?) -> UnavailableFromAsyncArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return UnavailableFromAsyncArgumentsSyntax(newData)
   }
 
   public var message: StringLiteralExprSyntax {
@@ -19072,18 +15425,11 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
       return StringLiteralExprSyntax(childData!)
     }
     set(value) {
-      self = withMessage(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = UnavailableFromAsyncArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `message` replaced.
-  /// - param newChild: The new `message` to replace the node's
-  ///                   current `message`, if present.
-  public func withMessage(_ newChild: StringLiteralExprSyntax) -> UnavailableFromAsyncArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return UnavailableFromAsyncArgumentsSyntax(newData)
   }
 
   public var unexpectedAfterMessage: UnexpectedNodesSyntax? {
@@ -19093,18 +15439,11 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterMessage(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = UnavailableFromAsyncArgumentsSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterMessage` replaced.
-  /// - param newChild: The new `unexpectedAfterMessage` to replace the node's
-  ///                   current `unexpectedAfterMessage`, if present.
-  public func withUnexpectedAfterMessage(_ newChild: UnexpectedNodesSyntax?) -> UnavailableFromAsyncArgumentsSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return UnavailableFromAsyncArgumentsSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -19251,18 +15590,11 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DocumentationAttributeArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeLabel` to replace the node's
-  ///                   current `unexpectedBeforeLabel`, if present.
-  public func withUnexpectedBeforeLabel(_ newChild: UnexpectedNodesSyntax?) -> DocumentationAttributeArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DocumentationAttributeArgumentSyntax(newData)
   }
 
   public var label: TokenSyntax {
@@ -19271,18 +15603,11 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DocumentationAttributeArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `label` replaced.
-  /// - param newChild: The new `label` to replace the node's
-  ///                   current `label`, if present.
-  public func withLabel(_ newChild: TokenSyntax) -> DocumentationAttributeArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DocumentationAttributeArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? {
@@ -19292,18 +15617,11 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DocumentationAttributeArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenLabelAndColon`, if present.
-  public func withUnexpectedBetweenLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> DocumentationAttributeArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DocumentationAttributeArgumentSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -19312,18 +15630,11 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DocumentationAttributeArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> DocumentationAttributeArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DocumentationAttributeArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? {
@@ -19333,18 +15644,11 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndValue(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DocumentationAttributeArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndValue` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndValue` to replace the node's
-  ///                   current `unexpectedBetweenColonAndValue`, if present.
-  public func withUnexpectedBetweenColonAndValue(_ newChild: UnexpectedNodesSyntax?) -> DocumentationAttributeArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DocumentationAttributeArgumentSyntax(newData)
   }
 
   public var value: Value {
@@ -19353,18 +15657,11 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
       return Value(childData!)
     }
     set(value) {
-      self = withValue(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = DocumentationAttributeArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `value` replaced.
-  /// - param newChild: The new `value` to replace the node's
-  ///                   current `value`, if present.
-  public func withValue(_ newChild: Value) -> DocumentationAttributeArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return DocumentationAttributeArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenValueAndTrailingComma: UnexpectedNodesSyntax? {
@@ -19374,18 +15671,11 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenValueAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = DocumentationAttributeArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenValueAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenValueAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenValueAndTrailingComma`, if present.
-  public func withUnexpectedBetweenValueAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> DocumentationAttributeArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return DocumentationAttributeArgumentSyntax(newData)
   }
 
   /// 
@@ -19398,18 +15688,11 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = DocumentationAttributeArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> DocumentationAttributeArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return DocumentationAttributeArgumentSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -19419,18 +15702,11 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = DocumentationAttributeArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> DocumentationAttributeArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return DocumentationAttributeArgumentSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -19541,18 +15817,11 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeWhereKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = WhereClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeWhereKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeWhereKeyword` to replace the node's
-  ///                   current `unexpectedBeforeWhereKeyword`, if present.
-  public func withUnexpectedBeforeWhereKeyword(_ newChild: UnexpectedNodesSyntax?) -> WhereClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return WhereClauseSyntax(newData)
   }
 
   public var whereKeyword: TokenSyntax {
@@ -19561,18 +15830,11 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withWhereKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = WhereClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `whereKeyword` replaced.
-  /// - param newChild: The new `whereKeyword` to replace the node's
-  ///                   current `whereKeyword`, if present.
-  public func withWhereKeyword(_ newChild: TokenSyntax) -> WhereClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return WhereClauseSyntax(newData)
   }
 
   public var unexpectedBetweenWhereKeywordAndGuardResult: UnexpectedNodesSyntax? {
@@ -19582,18 +15844,11 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenWhereKeywordAndGuardResult(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = WhereClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenWhereKeywordAndGuardResult` replaced.
-  /// - param newChild: The new `unexpectedBetweenWhereKeywordAndGuardResult` to replace the node's
-  ///                   current `unexpectedBetweenWhereKeywordAndGuardResult`, if present.
-  public func withUnexpectedBetweenWhereKeywordAndGuardResult(_ newChild: UnexpectedNodesSyntax?) -> WhereClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return WhereClauseSyntax(newData)
   }
 
   public var guardResult: ExprSyntax {
@@ -19602,18 +15857,11 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withGuardResult(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = WhereClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `guardResult` replaced.
-  /// - param newChild: The new `guardResult` to replace the node's
-  ///                   current `guardResult`, if present.
-  public func withGuardResult(_ newChild: ExprSyntax) -> WhereClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return WhereClauseSyntax(newData)
   }
 
   public var unexpectedAfterGuardResult: UnexpectedNodesSyntax? {
@@ -19623,18 +15871,11 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterGuardResult(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = WhereClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterGuardResult` replaced.
-  /// - param newChild: The new `unexpectedAfterGuardResult` to replace the node's
-  ///                   current `unexpectedAfterGuardResult`, if present.
-  public func withUnexpectedAfterGuardResult(_ newChild: UnexpectedNodesSyntax?) -> WhereClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return WhereClauseSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -19733,18 +15974,11 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = YieldListSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
-  ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return YieldListSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -19753,18 +15987,11 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = YieldListSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> YieldListSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return YieldListSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? {
@@ -19774,18 +16001,11 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndElementList(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = YieldListSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndElementList` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndElementList` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndElementList`, if present.
-  public func withUnexpectedBetweenLeftParenAndElementList(_ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return YieldListSyntax(newData)
   }
 
   public var elementList: YieldExprListSyntax {
@@ -19794,7 +16014,10 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
       return YieldExprListSyntax(childData!)
     }
     set(value) {
-      self = withElementList(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = YieldListSyntax(newData)
     }
   }
 
@@ -19817,16 +16040,6 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
     return YieldListSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `elementList` replaced.
-  /// - param newChild: The new `elementList` to replace the node's
-  ///                   current `elementList`, if present.
-  public func withElementList(_ newChild: YieldExprListSyntax) -> YieldListSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return YieldListSyntax(newData)
-  }
-
   public var unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -19834,18 +16047,11 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenElementListAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = YieldListSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenElementListAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenElementListAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenElementListAndRightParen`, if present.
-  public func withUnexpectedBetweenElementListAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return YieldListSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -19854,18 +16060,11 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = YieldListSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> YieldListSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return YieldListSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -19875,18 +16074,11 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = YieldListSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return YieldListSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -20055,18 +16247,11 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeCondition(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ConditionElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeCondition` replaced.
-  /// - param newChild: The new `unexpectedBeforeCondition` to replace the node's
-  ///                   current `unexpectedBeforeCondition`, if present.
-  public func withUnexpectedBeforeCondition(_ newChild: UnexpectedNodesSyntax?) -> ConditionElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ConditionElementSyntax(newData)
   }
 
   public var condition: Condition {
@@ -20075,18 +16260,11 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
       return Condition(childData!)
     }
     set(value) {
-      self = withCondition(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ConditionElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `condition` replaced.
-  /// - param newChild: The new `condition` to replace the node's
-  ///                   current `condition`, if present.
-  public func withCondition(_ newChild: Condition) -> ConditionElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ConditionElementSyntax(newData)
   }
 
   public var unexpectedBetweenConditionAndTrailingComma: UnexpectedNodesSyntax? {
@@ -20096,18 +16274,11 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenConditionAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ConditionElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenConditionAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenConditionAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenConditionAndTrailingComma`, if present.
-  public func withUnexpectedBetweenConditionAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ConditionElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ConditionElementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -20117,18 +16288,11 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ConditionElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> ConditionElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ConditionElementSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -20138,18 +16302,11 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ConditionElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> ConditionElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ConditionElementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -20252,18 +16409,11 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAvailabilityKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AvailabilityConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAvailabilityKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeAvailabilityKeyword` to replace the node's
-  ///                   current `unexpectedBeforeAvailabilityKeyword`, if present.
-  public func withUnexpectedBeforeAvailabilityKeyword(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AvailabilityConditionSyntax(newData)
   }
 
   public var availabilityKeyword: TokenSyntax {
@@ -20272,18 +16422,11 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAvailabilityKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AvailabilityConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `availabilityKeyword` replaced.
-  /// - param newChild: The new `availabilityKeyword` to replace the node's
-  ///                   current `availabilityKeyword`, if present.
-  public func withAvailabilityKeyword(_ newChild: TokenSyntax) -> AvailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AvailabilityConditionSyntax(newData)
   }
 
   public var unexpectedBetweenAvailabilityKeywordAndLeftParen: UnexpectedNodesSyntax? {
@@ -20293,18 +16436,11 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAvailabilityKeywordAndLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AvailabilityConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAvailabilityKeywordAndLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenAvailabilityKeywordAndLeftParen` to replace the node's
-  ///                   current `unexpectedBetweenAvailabilityKeywordAndLeftParen`, if present.
-  public func withUnexpectedBetweenAvailabilityKeywordAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AvailabilityConditionSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -20313,18 +16449,11 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = AvailabilityConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> AvailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return AvailabilityConditionSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? {
@@ -20334,18 +16463,11 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndAvailabilitySpec(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = AvailabilityConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndAvailabilitySpec` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndAvailabilitySpec` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndAvailabilitySpec`, if present.
-  public func withUnexpectedBetweenLeftParenAndAvailabilitySpec(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return AvailabilityConditionSyntax(newData)
   }
 
   public var availabilitySpec: AvailabilitySpecListSyntax {
@@ -20354,7 +16476,10 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return AvailabilitySpecListSyntax(childData!)
     }
     set(value) {
-      self = withAvailabilitySpec(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = AvailabilityConditionSyntax(newData)
     }
   }
 
@@ -20377,16 +16502,6 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
     return AvailabilityConditionSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `availabilitySpec` replaced.
-  /// - param newChild: The new `availabilitySpec` to replace the node's
-  ///                   current `availabilitySpec`, if present.
-  public func withAvailabilitySpec(_ newChild: AvailabilitySpecListSyntax) -> AvailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return AvailabilityConditionSyntax(newData)
-  }
-
   public var unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 6, parent: Syntax(self))
@@ -20394,18 +16509,11 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAvailabilitySpecAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = AvailabilityConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAvailabilitySpecAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenAvailabilitySpecAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenAvailabilitySpecAndRightParen`, if present.
-  public func withUnexpectedBetweenAvailabilitySpecAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return AvailabilityConditionSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -20414,18 +16522,11 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = AvailabilityConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> AvailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return AvailabilityConditionSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -20435,18 +16536,11 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = AvailabilityConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return AvailabilityConditionSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -20565,18 +16659,11 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeCaseKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = MatchingPatternConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeCaseKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeCaseKeyword` to replace the node's
-  ///                   current `unexpectedBeforeCaseKeyword`, if present.
-  public func withUnexpectedBeforeCaseKeyword(_ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return MatchingPatternConditionSyntax(newData)
   }
 
   public var caseKeyword: TokenSyntax {
@@ -20585,18 +16672,11 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withCaseKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = MatchingPatternConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `caseKeyword` replaced.
-  /// - param newChild: The new `caseKeyword` to replace the node's
-  ///                   current `caseKeyword`, if present.
-  public func withCaseKeyword(_ newChild: TokenSyntax) -> MatchingPatternConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return MatchingPatternConditionSyntax(newData)
   }
 
   public var unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodesSyntax? {
@@ -20606,18 +16686,11 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCaseKeywordAndPattern(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = MatchingPatternConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCaseKeywordAndPattern` replaced.
-  /// - param newChild: The new `unexpectedBetweenCaseKeywordAndPattern` to replace the node's
-  ///                   current `unexpectedBetweenCaseKeywordAndPattern`, if present.
-  public func withUnexpectedBetweenCaseKeywordAndPattern(_ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return MatchingPatternConditionSyntax(newData)
   }
 
   public var pattern: PatternSyntax {
@@ -20626,18 +16699,11 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return PatternSyntax(childData!)
     }
     set(value) {
-      self = withPattern(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = MatchingPatternConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `pattern` replaced.
-  /// - param newChild: The new `pattern` to replace the node's
-  ///                   current `pattern`, if present.
-  public func withPattern(_ newChild: PatternSyntax) -> MatchingPatternConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return MatchingPatternConditionSyntax(newData)
   }
 
   public var unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? {
@@ -20647,18 +16713,11 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPatternAndTypeAnnotation(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = MatchingPatternConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPatternAndTypeAnnotation` replaced.
-  /// - param newChild: The new `unexpectedBetweenPatternAndTypeAnnotation` to replace the node's
-  ///                   current `unexpectedBetweenPatternAndTypeAnnotation`, if present.
-  public func withUnexpectedBetweenPatternAndTypeAnnotation(_ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return MatchingPatternConditionSyntax(newData)
   }
 
   public var typeAnnotation: TypeAnnotationSyntax? {
@@ -20668,18 +16727,11 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeAnnotationSyntax(childData!)
     }
     set(value) {
-      self = withTypeAnnotation(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = MatchingPatternConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `typeAnnotation` replaced.
-  /// - param newChild: The new `typeAnnotation` to replace the node's
-  ///                   current `typeAnnotation`, if present.
-  public func withTypeAnnotation(_ newChild: TypeAnnotationSyntax?) -> MatchingPatternConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return MatchingPatternConditionSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? {
@@ -20689,18 +16741,11 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTypeAnnotationAndInitializer(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = MatchingPatternConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTypeAnnotationAndInitializer` replaced.
-  /// - param newChild: The new `unexpectedBetweenTypeAnnotationAndInitializer` to replace the node's
-  ///                   current `unexpectedBetweenTypeAnnotationAndInitializer`, if present.
-  public func withUnexpectedBetweenTypeAnnotationAndInitializer(_ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return MatchingPatternConditionSyntax(newData)
   }
 
   public var initializer: InitializerClauseSyntax {
@@ -20709,18 +16754,11 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return InitializerClauseSyntax(childData!)
     }
     set(value) {
-      self = withInitializer(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = MatchingPatternConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `initializer` replaced.
-  /// - param newChild: The new `initializer` to replace the node's
-  ///                   current `initializer`, if present.
-  public func withInitializer(_ newChild: InitializerClauseSyntax) -> MatchingPatternConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return MatchingPatternConditionSyntax(newData)
   }
 
   public var unexpectedAfterInitializer: UnexpectedNodesSyntax? {
@@ -20730,18 +16768,11 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterInitializer(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = MatchingPatternConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterInitializer` replaced.
-  /// - param newChild: The new `unexpectedAfterInitializer` to replace the node's
-  ///                   current `unexpectedAfterInitializer`, if present.
-  public func withUnexpectedAfterInitializer(_ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return MatchingPatternConditionSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -20860,18 +16891,11 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLetOrVarKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = OptionalBindingConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLetOrVarKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeLetOrVarKeyword` to replace the node's
-  ///                   current `unexpectedBeforeLetOrVarKeyword`, if present.
-  public func withUnexpectedBeforeLetOrVarKeyword(_ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return OptionalBindingConditionSyntax(newData)
   }
 
   public var letOrVarKeyword: TokenSyntax {
@@ -20880,18 +16904,11 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLetOrVarKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = OptionalBindingConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `letOrVarKeyword` replaced.
-  /// - param newChild: The new `letOrVarKeyword` to replace the node's
-  ///                   current `letOrVarKeyword`, if present.
-  public func withLetOrVarKeyword(_ newChild: TokenSyntax) -> OptionalBindingConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return OptionalBindingConditionSyntax(newData)
   }
 
   public var unexpectedBetweenLetOrVarKeywordAndPattern: UnexpectedNodesSyntax? {
@@ -20901,18 +16918,11 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLetOrVarKeywordAndPattern(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = OptionalBindingConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLetOrVarKeywordAndPattern` replaced.
-  /// - param newChild: The new `unexpectedBetweenLetOrVarKeywordAndPattern` to replace the node's
-  ///                   current `unexpectedBetweenLetOrVarKeywordAndPattern`, if present.
-  public func withUnexpectedBetweenLetOrVarKeywordAndPattern(_ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return OptionalBindingConditionSyntax(newData)
   }
 
   public var pattern: PatternSyntax {
@@ -20921,18 +16931,11 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return PatternSyntax(childData!)
     }
     set(value) {
-      self = withPattern(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = OptionalBindingConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `pattern` replaced.
-  /// - param newChild: The new `pattern` to replace the node's
-  ///                   current `pattern`, if present.
-  public func withPattern(_ newChild: PatternSyntax) -> OptionalBindingConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return OptionalBindingConditionSyntax(newData)
   }
 
   public var unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? {
@@ -20942,18 +16945,11 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPatternAndTypeAnnotation(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = OptionalBindingConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPatternAndTypeAnnotation` replaced.
-  /// - param newChild: The new `unexpectedBetweenPatternAndTypeAnnotation` to replace the node's
-  ///                   current `unexpectedBetweenPatternAndTypeAnnotation`, if present.
-  public func withUnexpectedBetweenPatternAndTypeAnnotation(_ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return OptionalBindingConditionSyntax(newData)
   }
 
   public var typeAnnotation: TypeAnnotationSyntax? {
@@ -20963,18 +16959,11 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeAnnotationSyntax(childData!)
     }
     set(value) {
-      self = withTypeAnnotation(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = OptionalBindingConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `typeAnnotation` replaced.
-  /// - param newChild: The new `typeAnnotation` to replace the node's
-  ///                   current `typeAnnotation`, if present.
-  public func withTypeAnnotation(_ newChild: TypeAnnotationSyntax?) -> OptionalBindingConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return OptionalBindingConditionSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? {
@@ -20984,18 +16973,11 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTypeAnnotationAndInitializer(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = OptionalBindingConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTypeAnnotationAndInitializer` replaced.
-  /// - param newChild: The new `unexpectedBetweenTypeAnnotationAndInitializer` to replace the node's
-  ///                   current `unexpectedBetweenTypeAnnotationAndInitializer`, if present.
-  public func withUnexpectedBetweenTypeAnnotationAndInitializer(_ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return OptionalBindingConditionSyntax(newData)
   }
 
   public var initializer: InitializerClauseSyntax? {
@@ -21005,18 +16987,11 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return InitializerClauseSyntax(childData!)
     }
     set(value) {
-      self = withInitializer(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = OptionalBindingConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `initializer` replaced.
-  /// - param newChild: The new `initializer` to replace the node's
-  ///                   current `initializer`, if present.
-  public func withInitializer(_ newChild: InitializerClauseSyntax?) -> OptionalBindingConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return OptionalBindingConditionSyntax(newData)
   }
 
   public var unexpectedAfterInitializer: UnexpectedNodesSyntax? {
@@ -21026,18 +17001,11 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterInitializer(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = OptionalBindingConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterInitializer` replaced.
-  /// - param newChild: The new `unexpectedAfterInitializer` to replace the node's
-  ///                   current `unexpectedAfterInitializer`, if present.
-  public func withUnexpectedAfterInitializer(_ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return OptionalBindingConditionSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -21156,18 +17124,11 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeHasSymbolKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = HasSymbolConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeHasSymbolKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeHasSymbolKeyword` to replace the node's
-  ///                   current `unexpectedBeforeHasSymbolKeyword`, if present.
-  public func withUnexpectedBeforeHasSymbolKeyword(_ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return HasSymbolConditionSyntax(newData)
   }
 
   public var hasSymbolKeyword: TokenSyntax {
@@ -21176,18 +17137,11 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withHasSymbolKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = HasSymbolConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `hasSymbolKeyword` replaced.
-  /// - param newChild: The new `hasSymbolKeyword` to replace the node's
-  ///                   current `hasSymbolKeyword`, if present.
-  public func withHasSymbolKeyword(_ newChild: TokenSyntax) -> HasSymbolConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return HasSymbolConditionSyntax(newData)
   }
 
   public var unexpectedBetweenHasSymbolKeywordAndLeftParen: UnexpectedNodesSyntax? {
@@ -21197,18 +17151,11 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenHasSymbolKeywordAndLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = HasSymbolConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenHasSymbolKeywordAndLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenHasSymbolKeywordAndLeftParen` to replace the node's
-  ///                   current `unexpectedBetweenHasSymbolKeywordAndLeftParen`, if present.
-  public func withUnexpectedBetweenHasSymbolKeywordAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return HasSymbolConditionSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -21217,18 +17164,11 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = HasSymbolConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> HasSymbolConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return HasSymbolConditionSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndExpression: UnexpectedNodesSyntax? {
@@ -21238,18 +17178,11 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = HasSymbolConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndExpression` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndExpression` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndExpression`, if present.
-  public func withUnexpectedBetweenLeftParenAndExpression(_ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return HasSymbolConditionSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -21258,18 +17191,11 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = HasSymbolConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> HasSymbolConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return HasSymbolConditionSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndRightParen: UnexpectedNodesSyntax? {
@@ -21279,18 +17205,11 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenExpressionAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = HasSymbolConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenExpressionAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenExpressionAndRightParen`, if present.
-  public func withUnexpectedBetweenExpressionAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return HasSymbolConditionSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -21299,18 +17218,11 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = HasSymbolConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> HasSymbolConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return HasSymbolConditionSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -21320,18 +17232,11 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = HasSymbolConditionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return HasSymbolConditionSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -21482,18 +17387,11 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeUnknownAttr(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = SwitchCaseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeUnknownAttr` replaced.
-  /// - param newChild: The new `unexpectedBeforeUnknownAttr` to replace the node's
-  ///                   current `unexpectedBeforeUnknownAttr`, if present.
-  public func withUnexpectedBeforeUnknownAttr(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return SwitchCaseSyntax(newData)
   }
 
   public var unknownAttr: AttributeSyntax? {
@@ -21503,18 +17401,11 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
       return AttributeSyntax(childData!)
     }
     set(value) {
-      self = withUnknownAttr(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = SwitchCaseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unknownAttr` replaced.
-  /// - param newChild: The new `unknownAttr` to replace the node's
-  ///                   current `unknownAttr`, if present.
-  public func withUnknownAttr(_ newChild: AttributeSyntax?) -> SwitchCaseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return SwitchCaseSyntax(newData)
   }
 
   public var unexpectedBetweenUnknownAttrAndLabel: UnexpectedNodesSyntax? {
@@ -21524,18 +17415,11 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenUnknownAttrAndLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = SwitchCaseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenUnknownAttrAndLabel` replaced.
-  /// - param newChild: The new `unexpectedBetweenUnknownAttrAndLabel` to replace the node's
-  ///                   current `unexpectedBetweenUnknownAttrAndLabel`, if present.
-  public func withUnexpectedBetweenUnknownAttrAndLabel(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return SwitchCaseSyntax(newData)
   }
 
   public var label: Label {
@@ -21544,18 +17428,11 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
       return Label(childData!)
     }
     set(value) {
-      self = withLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = SwitchCaseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `label` replaced.
-  /// - param newChild: The new `label` to replace the node's
-  ///                   current `label`, if present.
-  public func withLabel(_ newChild: Label) -> SwitchCaseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return SwitchCaseSyntax(newData)
   }
 
   public var unexpectedBetweenLabelAndStatements: UnexpectedNodesSyntax? {
@@ -21565,18 +17442,11 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLabelAndStatements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = SwitchCaseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLabelAndStatements` replaced.
-  /// - param newChild: The new `unexpectedBetweenLabelAndStatements` to replace the node's
-  ///                   current `unexpectedBetweenLabelAndStatements`, if present.
-  public func withUnexpectedBetweenLabelAndStatements(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return SwitchCaseSyntax(newData)
   }
 
   public var statements: CodeBlockItemListSyntax {
@@ -21585,7 +17455,10 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
       return CodeBlockItemListSyntax(childData!)
     }
     set(value) {
-      self = withStatements(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = SwitchCaseSyntax(newData)
     }
   }
 
@@ -21608,16 +17481,6 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
     return SwitchCaseSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `statements` replaced.
-  /// - param newChild: The new `statements` to replace the node's
-  ///                   current `statements`, if present.
-  public func withStatements(_ newChild: CodeBlockItemListSyntax) -> SwitchCaseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return SwitchCaseSyntax(newData)
-  }
-
   public var unexpectedAfterStatements: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 6, parent: Syntax(self))
@@ -21625,18 +17488,11 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterStatements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = SwitchCaseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterStatements` replaced.
-  /// - param newChild: The new `unexpectedAfterStatements` to replace the node's
-  ///                   current `unexpectedAfterStatements`, if present.
-  public func withUnexpectedAfterStatements(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return SwitchCaseSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -21739,18 +17595,11 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeDefaultKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = SwitchDefaultLabelSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeDefaultKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeDefaultKeyword` to replace the node's
-  ///                   current `unexpectedBeforeDefaultKeyword`, if present.
-  public func withUnexpectedBeforeDefaultKeyword(_ newChild: UnexpectedNodesSyntax?) -> SwitchDefaultLabelSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return SwitchDefaultLabelSyntax(newData)
   }
 
   public var defaultKeyword: TokenSyntax {
@@ -21759,18 +17608,11 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withDefaultKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = SwitchDefaultLabelSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `defaultKeyword` replaced.
-  /// - param newChild: The new `defaultKeyword` to replace the node's
-  ///                   current `defaultKeyword`, if present.
-  public func withDefaultKeyword(_ newChild: TokenSyntax) -> SwitchDefaultLabelSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return SwitchDefaultLabelSyntax(newData)
   }
 
   public var unexpectedBetweenDefaultKeywordAndColon: UnexpectedNodesSyntax? {
@@ -21780,18 +17622,11 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDefaultKeywordAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = SwitchDefaultLabelSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDefaultKeywordAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenDefaultKeywordAndColon` to replace the node's
-  ///                   current `unexpectedBetweenDefaultKeywordAndColon`, if present.
-  public func withUnexpectedBetweenDefaultKeywordAndColon(_ newChild: UnexpectedNodesSyntax?) -> SwitchDefaultLabelSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return SwitchDefaultLabelSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -21800,18 +17635,11 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = SwitchDefaultLabelSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> SwitchDefaultLabelSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return SwitchDefaultLabelSyntax(newData)
   }
 
   public var unexpectedAfterColon: UnexpectedNodesSyntax? {
@@ -21821,18 +17649,11 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = SwitchDefaultLabelSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterColon` replaced.
-  /// - param newChild: The new `unexpectedAfterColon` to replace the node's
-  ///                   current `unexpectedAfterColon`, if present.
-  public func withUnexpectedAfterColon(_ newChild: UnexpectedNodesSyntax?) -> SwitchDefaultLabelSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return SwitchDefaultLabelSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -21931,18 +17752,11 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforePattern(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = CaseItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforePattern` replaced.
-  /// - param newChild: The new `unexpectedBeforePattern` to replace the node's
-  ///                   current `unexpectedBeforePattern`, if present.
-  public func withUnexpectedBeforePattern(_ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return CaseItemSyntax(newData)
   }
 
   public var pattern: PatternSyntax {
@@ -21951,18 +17765,11 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
       return PatternSyntax(childData!)
     }
     set(value) {
-      self = withPattern(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = CaseItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `pattern` replaced.
-  /// - param newChild: The new `pattern` to replace the node's
-  ///                   current `pattern`, if present.
-  public func withPattern(_ newChild: PatternSyntax) -> CaseItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return CaseItemSyntax(newData)
   }
 
   public var unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? {
@@ -21972,18 +17779,11 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPatternAndWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = CaseItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPatternAndWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenPatternAndWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenPatternAndWhereClause`, if present.
-  public func withUnexpectedBetweenPatternAndWhereClause(_ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return CaseItemSyntax(newData)
   }
 
   public var whereClause: WhereClauseSyntax? {
@@ -21993,18 +17793,11 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
       return WhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = CaseItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `whereClause` replaced.
-  /// - param newChild: The new `whereClause` to replace the node's
-  ///                   current `whereClause`, if present.
-  public func withWhereClause(_ newChild: WhereClauseSyntax?) -> CaseItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return CaseItemSyntax(newData)
   }
 
   public var unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? {
@@ -22014,18 +17807,11 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenWhereClauseAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = CaseItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenWhereClauseAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenWhereClauseAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenWhereClauseAndTrailingComma`, if present.
-  public func withUnexpectedBetweenWhereClauseAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return CaseItemSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -22035,18 +17821,11 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = CaseItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> CaseItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return CaseItemSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -22056,18 +17835,11 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = CaseItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return CaseItemSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -22208,18 +17980,11 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforePattern(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = CatchItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforePattern` replaced.
-  /// - param newChild: The new `unexpectedBeforePattern` to replace the node's
-  ///                   current `unexpectedBeforePattern`, if present.
-  public func withUnexpectedBeforePattern(_ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return CatchItemSyntax(newData)
   }
 
   public var pattern: PatternSyntax? {
@@ -22229,18 +17994,11 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
       return PatternSyntax(childData!)
     }
     set(value) {
-      self = withPattern(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = CatchItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `pattern` replaced.
-  /// - param newChild: The new `pattern` to replace the node's
-  ///                   current `pattern`, if present.
-  public func withPattern(_ newChild: PatternSyntax?) -> CatchItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return CatchItemSyntax(newData)
   }
 
   public var unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? {
@@ -22250,18 +18008,11 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPatternAndWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = CatchItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPatternAndWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenPatternAndWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenPatternAndWhereClause`, if present.
-  public func withUnexpectedBetweenPatternAndWhereClause(_ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return CatchItemSyntax(newData)
   }
 
   public var whereClause: WhereClauseSyntax? {
@@ -22271,18 +18022,11 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
       return WhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = CatchItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `whereClause` replaced.
-  /// - param newChild: The new `whereClause` to replace the node's
-  ///                   current `whereClause`, if present.
-  public func withWhereClause(_ newChild: WhereClauseSyntax?) -> CatchItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return CatchItemSyntax(newData)
   }
 
   public var unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? {
@@ -22292,18 +18036,11 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenWhereClauseAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = CatchItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenWhereClauseAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenWhereClauseAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenWhereClauseAndTrailingComma`, if present.
-  public func withUnexpectedBetweenWhereClauseAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return CatchItemSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -22313,18 +18050,11 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = CatchItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> CatchItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return CatchItemSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -22334,18 +18064,11 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = CatchItemSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return CatchItemSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -22452,18 +18175,11 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeCaseKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = SwitchCaseLabelSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeCaseKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeCaseKeyword` to replace the node's
-  ///                   current `unexpectedBeforeCaseKeyword`, if present.
-  public func withUnexpectedBeforeCaseKeyword(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return SwitchCaseLabelSyntax(newData)
   }
 
   public var caseKeyword: TokenSyntax {
@@ -22472,18 +18188,11 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withCaseKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = SwitchCaseLabelSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `caseKeyword` replaced.
-  /// - param newChild: The new `caseKeyword` to replace the node's
-  ///                   current `caseKeyword`, if present.
-  public func withCaseKeyword(_ newChild: TokenSyntax) -> SwitchCaseLabelSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return SwitchCaseLabelSyntax(newData)
   }
 
   public var unexpectedBetweenCaseKeywordAndCaseItems: UnexpectedNodesSyntax? {
@@ -22493,18 +18202,11 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCaseKeywordAndCaseItems(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = SwitchCaseLabelSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCaseKeywordAndCaseItems` replaced.
-  /// - param newChild: The new `unexpectedBetweenCaseKeywordAndCaseItems` to replace the node's
-  ///                   current `unexpectedBetweenCaseKeywordAndCaseItems`, if present.
-  public func withUnexpectedBetweenCaseKeywordAndCaseItems(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return SwitchCaseLabelSyntax(newData)
   }
 
   public var caseItems: CaseItemListSyntax {
@@ -22513,7 +18215,10 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
       return CaseItemListSyntax(childData!)
     }
     set(value) {
-      self = withCaseItems(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = SwitchCaseLabelSyntax(newData)
     }
   }
 
@@ -22536,16 +18241,6 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
     return SwitchCaseLabelSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `caseItems` replaced.
-  /// - param newChild: The new `caseItems` to replace the node's
-  ///                   current `caseItems`, if present.
-  public func withCaseItems(_ newChild: CaseItemListSyntax) -> SwitchCaseLabelSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return SwitchCaseLabelSyntax(newData)
-  }
-
   public var unexpectedBetweenCaseItemsAndColon: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -22553,18 +18248,11 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCaseItemsAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = SwitchCaseLabelSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCaseItemsAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenCaseItemsAndColon` to replace the node's
-  ///                   current `unexpectedBetweenCaseItemsAndColon`, if present.
-  public func withUnexpectedBetweenCaseItemsAndColon(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return SwitchCaseLabelSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -22573,18 +18261,11 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = SwitchCaseLabelSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> SwitchCaseLabelSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return SwitchCaseLabelSyntax(newData)
   }
 
   public var unexpectedAfterColon: UnexpectedNodesSyntax? {
@@ -22594,18 +18275,11 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = SwitchCaseLabelSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterColon` replaced.
-  /// - param newChild: The new `unexpectedAfterColon` to replace the node's
-  ///                   current `unexpectedAfterColon`, if present.
-  public func withUnexpectedAfterColon(_ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return SwitchCaseLabelSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -22712,18 +18386,11 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeCatchKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = CatchClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeCatchKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeCatchKeyword` to replace the node's
-  ///                   current `unexpectedBeforeCatchKeyword`, if present.
-  public func withUnexpectedBeforeCatchKeyword(_ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return CatchClauseSyntax(newData)
   }
 
   public var catchKeyword: TokenSyntax {
@@ -22732,18 +18399,11 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withCatchKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = CatchClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `catchKeyword` replaced.
-  /// - param newChild: The new `catchKeyword` to replace the node's
-  ///                   current `catchKeyword`, if present.
-  public func withCatchKeyword(_ newChild: TokenSyntax) -> CatchClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return CatchClauseSyntax(newData)
   }
 
   public var unexpectedBetweenCatchKeywordAndCatchItems: UnexpectedNodesSyntax? {
@@ -22753,18 +18413,11 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCatchKeywordAndCatchItems(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = CatchClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCatchKeywordAndCatchItems` replaced.
-  /// - param newChild: The new `unexpectedBetweenCatchKeywordAndCatchItems` to replace the node's
-  ///                   current `unexpectedBetweenCatchKeywordAndCatchItems`, if present.
-  public func withUnexpectedBetweenCatchKeywordAndCatchItems(_ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return CatchClauseSyntax(newData)
   }
 
   public var catchItems: CatchItemListSyntax? {
@@ -22774,7 +18427,10 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return CatchItemListSyntax(childData!)
     }
     set(value) {
-      self = withCatchItems(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = CatchClauseSyntax(newData)
     }
   }
 
@@ -22797,16 +18453,6 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return CatchClauseSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `catchItems` replaced.
-  /// - param newChild: The new `catchItems` to replace the node's
-  ///                   current `catchItems`, if present.
-  public func withCatchItems(_ newChild: CatchItemListSyntax?) -> CatchClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return CatchClauseSyntax(newData)
-  }
-
   public var unexpectedBetweenCatchItemsAndBody: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -22814,18 +18460,11 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCatchItemsAndBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = CatchClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCatchItemsAndBody` replaced.
-  /// - param newChild: The new `unexpectedBetweenCatchItemsAndBody` to replace the node's
-  ///                   current `unexpectedBetweenCatchItemsAndBody`, if present.
-  public func withUnexpectedBetweenCatchItemsAndBody(_ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return CatchClauseSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
@@ -22834,18 +18473,11 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return CodeBlockSyntax(childData!)
     }
     set(value) {
-      self = withBody(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = CatchClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `body` replaced.
-  /// - param newChild: The new `body` to replace the node's
-  ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax) -> CatchClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return CatchClauseSyntax(newData)
   }
 
   public var unexpectedAfterBody: UnexpectedNodesSyntax? {
@@ -22855,18 +18487,11 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = CatchClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
-  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
-  ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return CatchClauseSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -22969,18 +18594,11 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeWhereKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = GenericWhereClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeWhereKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeWhereKeyword` to replace the node's
-  ///                   current `unexpectedBeforeWhereKeyword`, if present.
-  public func withUnexpectedBeforeWhereKeyword(_ newChild: UnexpectedNodesSyntax?) -> GenericWhereClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return GenericWhereClauseSyntax(newData)
   }
 
   public var whereKeyword: TokenSyntax {
@@ -22989,18 +18607,11 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withWhereKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = GenericWhereClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `whereKeyword` replaced.
-  /// - param newChild: The new `whereKeyword` to replace the node's
-  ///                   current `whereKeyword`, if present.
-  public func withWhereKeyword(_ newChild: TokenSyntax) -> GenericWhereClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return GenericWhereClauseSyntax(newData)
   }
 
   public var unexpectedBetweenWhereKeywordAndRequirementList: UnexpectedNodesSyntax? {
@@ -23010,18 +18621,11 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenWhereKeywordAndRequirementList(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = GenericWhereClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenWhereKeywordAndRequirementList` replaced.
-  /// - param newChild: The new `unexpectedBetweenWhereKeywordAndRequirementList` to replace the node's
-  ///                   current `unexpectedBetweenWhereKeywordAndRequirementList`, if present.
-  public func withUnexpectedBetweenWhereKeywordAndRequirementList(_ newChild: UnexpectedNodesSyntax?) -> GenericWhereClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return GenericWhereClauseSyntax(newData)
   }
 
   public var requirementList: GenericRequirementListSyntax {
@@ -23030,7 +18634,10 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return GenericRequirementListSyntax(childData!)
     }
     set(value) {
-      self = withRequirementList(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = GenericWhereClauseSyntax(newData)
     }
   }
 
@@ -23053,16 +18660,6 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return GenericWhereClauseSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `requirementList` replaced.
-  /// - param newChild: The new `requirementList` to replace the node's
-  ///                   current `requirementList`, if present.
-  public func withRequirementList(_ newChild: GenericRequirementListSyntax) -> GenericWhereClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return GenericWhereClauseSyntax(newData)
-  }
-
   public var unexpectedAfterRequirementList: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -23070,18 +18667,11 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRequirementList(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = GenericWhereClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRequirementList` replaced.
-  /// - param newChild: The new `unexpectedAfterRequirementList` to replace the node's
-  ///                   current `unexpectedAfterRequirementList`, if present.
-  public func withUnexpectedAfterRequirementList(_ newChild: UnexpectedNodesSyntax?) -> GenericWhereClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return GenericWhereClauseSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -23222,18 +18812,11 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = GenericRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeBody` replaced.
-  /// - param newChild: The new `unexpectedBeforeBody` to replace the node's
-  ///                   current `unexpectedBeforeBody`, if present.
-  public func withUnexpectedBeforeBody(_ newChild: UnexpectedNodesSyntax?) -> GenericRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return GenericRequirementSyntax(newData)
   }
 
   public var body: Body {
@@ -23242,18 +18825,11 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return Body(childData!)
     }
     set(value) {
-      self = withBody(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = GenericRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `body` replaced.
-  /// - param newChild: The new `body` to replace the node's
-  ///                   current `body`, if present.
-  public func withBody(_ newChild: Body) -> GenericRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return GenericRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenBodyAndTrailingComma: UnexpectedNodesSyntax? {
@@ -23263,18 +18839,11 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenBodyAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = GenericRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenBodyAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenBodyAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenBodyAndTrailingComma`, if present.
-  public func withUnexpectedBetweenBodyAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> GenericRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return GenericRequirementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -23284,18 +18853,11 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = GenericRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> GenericRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return GenericRequirementSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -23305,18 +18867,11 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = GenericRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> GenericRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return GenericRequirementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -23415,18 +18970,11 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftTypeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = SameTypeRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftTypeIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftTypeIdentifier` to replace the node's
-  ///                   current `unexpectedBeforeLeftTypeIdentifier`, if present.
-  public func withUnexpectedBeforeLeftTypeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return SameTypeRequirementSyntax(newData)
   }
 
   public var leftTypeIdentifier: TypeSyntax {
@@ -23435,18 +18983,11 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withLeftTypeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = SameTypeRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftTypeIdentifier` replaced.
-  /// - param newChild: The new `leftTypeIdentifier` to replace the node's
-  ///                   current `leftTypeIdentifier`, if present.
-  public func withLeftTypeIdentifier(_ newChild: TypeSyntax) -> SameTypeRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return SameTypeRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenLeftTypeIdentifierAndEqualityToken: UnexpectedNodesSyntax? {
@@ -23456,18 +18997,11 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftTypeIdentifierAndEqualityToken(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = SameTypeRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftTypeIdentifierAndEqualityToken` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftTypeIdentifierAndEqualityToken` to replace the node's
-  ///                   current `unexpectedBetweenLeftTypeIdentifierAndEqualityToken`, if present.
-  public func withUnexpectedBetweenLeftTypeIdentifierAndEqualityToken(_ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return SameTypeRequirementSyntax(newData)
   }
 
   public var equalityToken: TokenSyntax {
@@ -23476,18 +19010,11 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withEqualityToken(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = SameTypeRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `equalityToken` replaced.
-  /// - param newChild: The new `equalityToken` to replace the node's
-  ///                   current `equalityToken`, if present.
-  public func withEqualityToken(_ newChild: TokenSyntax) -> SameTypeRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return SameTypeRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenEqualityTokenAndRightTypeIdentifier: UnexpectedNodesSyntax? {
@@ -23497,18 +19024,11 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenEqualityTokenAndRightTypeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = SameTypeRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenEqualityTokenAndRightTypeIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenEqualityTokenAndRightTypeIdentifier` to replace the node's
-  ///                   current `unexpectedBetweenEqualityTokenAndRightTypeIdentifier`, if present.
-  public func withUnexpectedBetweenEqualityTokenAndRightTypeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return SameTypeRequirementSyntax(newData)
   }
 
   public var rightTypeIdentifier: TypeSyntax {
@@ -23517,18 +19037,11 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withRightTypeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = SameTypeRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightTypeIdentifier` replaced.
-  /// - param newChild: The new `rightTypeIdentifier` to replace the node's
-  ///                   current `rightTypeIdentifier`, if present.
-  public func withRightTypeIdentifier(_ newChild: TypeSyntax) -> SameTypeRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return SameTypeRequirementSyntax(newData)
   }
 
   public var unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? {
@@ -23538,18 +19051,11 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightTypeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = SameTypeRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightTypeIdentifier` replaced.
-  /// - param newChild: The new `unexpectedAfterRightTypeIdentifier` to replace the node's
-  ///                   current `unexpectedAfterRightTypeIdentifier`, if present.
-  public func withUnexpectedAfterRightTypeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return SameTypeRequirementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -23676,18 +19182,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeTypeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeTypeIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBeforeTypeIdentifier` to replace the node's
-  ///                   current `unexpectedBeforeTypeIdentifier`, if present.
-  public func withUnexpectedBeforeTypeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var typeIdentifier: TypeSyntax {
@@ -23696,18 +19195,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withTypeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `typeIdentifier` replaced.
-  /// - param newChild: The new `typeIdentifier` to replace the node's
-  ///                   current `typeIdentifier`, if present.
-  public func withTypeIdentifier(_ newChild: TypeSyntax) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenTypeIdentifierAndColon: UnexpectedNodesSyntax? {
@@ -23717,18 +19209,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTypeIdentifierAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTypeIdentifierAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenTypeIdentifierAndColon` to replace the node's
-  ///                   current `unexpectedBetweenTypeIdentifierAndColon`, if present.
-  public func withUnexpectedBetweenTypeIdentifierAndColon(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -23737,18 +19222,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndLayoutConstraint: UnexpectedNodesSyntax? {
@@ -23758,18 +19236,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndLayoutConstraint(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndLayoutConstraint` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndLayoutConstraint` to replace the node's
-  ///                   current `unexpectedBetweenColonAndLayoutConstraint`, if present.
-  public func withUnexpectedBetweenColonAndLayoutConstraint(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var layoutConstraint: TokenSyntax {
@@ -23778,18 +19249,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLayoutConstraint(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `layoutConstraint` replaced.
-  /// - param newChild: The new `layoutConstraint` to replace the node's
-  ///                   current `layoutConstraint`, if present.
-  public func withLayoutConstraint(_ newChild: TokenSyntax) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenLayoutConstraintAndLeftParen: UnexpectedNodesSyntax? {
@@ -23799,18 +19263,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLayoutConstraintAndLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLayoutConstraintAndLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenLayoutConstraintAndLeftParen` to replace the node's
-  ///                   current `unexpectedBetweenLayoutConstraintAndLeftParen`, if present.
-  public func withUnexpectedBetweenLayoutConstraintAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var leftParen: TokenSyntax? {
@@ -23820,18 +19277,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndSize: UnexpectedNodesSyntax? {
@@ -23841,18 +19291,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndSize(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndSize` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndSize` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndSize`, if present.
-  public func withUnexpectedBetweenLeftParenAndSize(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var size: TokenSyntax? {
@@ -23862,18 +19305,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withSize(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `size` replaced.
-  /// - param newChild: The new `size` to replace the node's
-  ///                   current `size`, if present.
-  public func withSize(_ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenSizeAndComma: UnexpectedNodesSyntax? {
@@ -23883,18 +19319,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSizeAndComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSizeAndComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenSizeAndComma` to replace the node's
-  ///                   current `unexpectedBetweenSizeAndComma`, if present.
-  public func withUnexpectedBetweenSizeAndComma(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var comma: TokenSyntax? {
@@ -23904,18 +19333,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `comma` replaced.
-  /// - param newChild: The new `comma` to replace the node's
-  ///                   current `comma`, if present.
-  public func withComma(_ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenCommaAndAlignment: UnexpectedNodesSyntax? {
@@ -23925,18 +19347,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCommaAndAlignment(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndAlignment` replaced.
-  /// - param newChild: The new `unexpectedBetweenCommaAndAlignment` to replace the node's
-  ///                   current `unexpectedBetweenCommaAndAlignment`, if present.
-  public func withUnexpectedBetweenCommaAndAlignment(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var alignment: TokenSyntax? {
@@ -23946,18 +19361,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAlignment(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `alignment` replaced.
-  /// - param newChild: The new `alignment` to replace the node's
-  ///                   current `alignment`, if present.
-  public func withAlignment(_ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenAlignmentAndRightParen: UnexpectedNodesSyntax? {
@@ -23967,18 +19375,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAlignmentAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAlignmentAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenAlignmentAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenAlignmentAndRightParen`, if present.
-  public func withUnexpectedBetweenAlignmentAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var rightParen: TokenSyntax? {
@@ -23988,18 +19389,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 15, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 15, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -24009,18 +19403,11 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 16, with: raw, arena: arena)
+      self = LayoutRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 16, with: raw, arena: arena)
-    return LayoutRequirementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -24225,18 +19612,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = GenericParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeAttributes` replaced.
-  /// - param newChild: The new `unexpectedBeforeAttributes` to replace the node's
-  ///                   current `unexpectedBeforeAttributes`, if present.
-  public func withUnexpectedBeforeAttributes(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return GenericParameterSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -24246,7 +19626,10 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = GenericParameterSyntax(newData)
     }
   }
 
@@ -24269,16 +19652,6 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
     return GenericParameterSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> GenericParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return GenericParameterSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndName: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -24286,18 +19659,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = GenericParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndName` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndName` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndName`, if present.
-  public func withUnexpectedBetweenAttributesAndName(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return GenericParameterSyntax(newData)
   }
 
   public var name: TokenSyntax {
@@ -24306,18 +19672,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = GenericParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax) -> GenericParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return GenericParameterSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndEllipsis: UnexpectedNodesSyntax? {
@@ -24327,18 +19686,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenNameAndEllipsis(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = GenericParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenNameAndEllipsis` replaced.
-  /// - param newChild: The new `unexpectedBetweenNameAndEllipsis` to replace the node's
-  ///                   current `unexpectedBetweenNameAndEllipsis`, if present.
-  public func withUnexpectedBetweenNameAndEllipsis(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return GenericParameterSyntax(newData)
   }
 
   public var ellipsis: TokenSyntax? {
@@ -24348,18 +19700,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withEllipsis(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = GenericParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `ellipsis` replaced.
-  /// - param newChild: The new `ellipsis` to replace the node's
-  ///                   current `ellipsis`, if present.
-  public func withEllipsis(_ newChild: TokenSyntax?) -> GenericParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return GenericParameterSyntax(newData)
   }
 
   public var unexpectedBetweenEllipsisAndColon: UnexpectedNodesSyntax? {
@@ -24369,18 +19714,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenEllipsisAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = GenericParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenEllipsisAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenEllipsisAndColon` to replace the node's
-  ///                   current `unexpectedBetweenEllipsisAndColon`, if present.
-  public func withUnexpectedBetweenEllipsisAndColon(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return GenericParameterSyntax(newData)
   }
 
   public var colon: TokenSyntax? {
@@ -24390,18 +19728,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = GenericParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> GenericParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return GenericParameterSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndInheritedType: UnexpectedNodesSyntax? {
@@ -24411,18 +19742,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndInheritedType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = GenericParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndInheritedType` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndInheritedType` to replace the node's
-  ///                   current `unexpectedBetweenColonAndInheritedType`, if present.
-  public func withUnexpectedBetweenColonAndInheritedType(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return GenericParameterSyntax(newData)
   }
 
   public var inheritedType: TypeSyntax? {
@@ -24432,18 +19756,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withInheritedType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = GenericParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `inheritedType` replaced.
-  /// - param newChild: The new `inheritedType` to replace the node's
-  ///                   current `inheritedType`, if present.
-  public func withInheritedType(_ newChild: TypeSyntax?) -> GenericParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return GenericParameterSyntax(newData)
   }
 
   public var unexpectedBetweenInheritedTypeAndTrailingComma: UnexpectedNodesSyntax? {
@@ -24453,18 +19770,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInheritedTypeAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = GenericParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInheritedTypeAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenInheritedTypeAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenInheritedTypeAndTrailingComma`, if present.
-  public func withUnexpectedBetweenInheritedTypeAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return GenericParameterSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -24474,18 +19784,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = GenericParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> GenericParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return GenericParameterSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -24495,18 +19798,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = GenericParameterSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return GenericParameterSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -24633,18 +19929,11 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PrimaryAssociatedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
-  /// - param newChild: The new `unexpectedBeforeName` to replace the node's
-  ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PrimaryAssociatedTypeSyntax(newData)
   }
 
   public var name: TokenSyntax {
@@ -24653,18 +19942,11 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PrimaryAssociatedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax) -> PrimaryAssociatedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PrimaryAssociatedTypeSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? {
@@ -24674,18 +19956,11 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenNameAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PrimaryAssociatedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenNameAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenNameAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenNameAndTrailingComma`, if present.
-  public func withUnexpectedBetweenNameAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PrimaryAssociatedTypeSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -24695,18 +19970,11 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PrimaryAssociatedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> PrimaryAssociatedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PrimaryAssociatedTypeSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -24716,18 +19984,11 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PrimaryAssociatedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PrimaryAssociatedTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -24830,18 +20091,11 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftAngleBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = GenericParameterClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftAngleBracket` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftAngleBracket` to replace the node's
-  ///                   current `unexpectedBeforeLeftAngleBracket`, if present.
-  public func withUnexpectedBeforeLeftAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return GenericParameterClauseSyntax(newData)
   }
 
   public var leftAngleBracket: TokenSyntax {
@@ -24850,18 +20104,11 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftAngleBracket(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = GenericParameterClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftAngleBracket` replaced.
-  /// - param newChild: The new `leftAngleBracket` to replace the node's
-  ///                   current `leftAngleBracket`, if present.
-  public func withLeftAngleBracket(_ newChild: TokenSyntax) -> GenericParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return GenericParameterClauseSyntax(newData)
   }
 
   public var unexpectedBetweenLeftAngleBracketAndGenericParameterList: UnexpectedNodesSyntax? {
@@ -24871,18 +20118,11 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftAngleBracketAndGenericParameterList(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = GenericParameterClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftAngleBracketAndGenericParameterList` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftAngleBracketAndGenericParameterList` to replace the node's
-  ///                   current `unexpectedBetweenLeftAngleBracketAndGenericParameterList`, if present.
-  public func withUnexpectedBetweenLeftAngleBracketAndGenericParameterList(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return GenericParameterClauseSyntax(newData)
   }
 
   public var genericParameterList: GenericParameterListSyntax {
@@ -24891,7 +20131,10 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return GenericParameterListSyntax(childData!)
     }
     set(value) {
-      self = withGenericParameterList(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = GenericParameterClauseSyntax(newData)
     }
   }
 
@@ -24914,16 +20157,6 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return GenericParameterClauseSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `genericParameterList` replaced.
-  /// - param newChild: The new `genericParameterList` to replace the node's
-  ///                   current `genericParameterList`, if present.
-  public func withGenericParameterList(_ newChild: GenericParameterListSyntax) -> GenericParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return GenericParameterClauseSyntax(newData)
-  }
-
   public var unexpectedBetweenGenericParameterListAndGenericWhereClause: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -24931,18 +20164,11 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericParameterListAndGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = GenericParameterClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericParameterListAndGenericWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericParameterListAndGenericWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenGenericParameterListAndGenericWhereClause`, if present.
-  public func withUnexpectedBetweenGenericParameterListAndGenericWhereClause(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return GenericParameterClauseSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
@@ -24952,18 +20178,11 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return GenericWhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = GenericParameterClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericWhereClause` replaced.
-  /// - param newChild: The new `genericWhereClause` to replace the node's
-  ///                   current `genericWhereClause`, if present.
-  public func withGenericWhereClause(_ newChild: GenericWhereClauseSyntax?) -> GenericParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return GenericParameterClauseSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndRightAngleBracket: UnexpectedNodesSyntax? {
@@ -24973,18 +20192,11 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericWhereClauseAndRightAngleBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = GenericParameterClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericWhereClauseAndRightAngleBracket` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericWhereClauseAndRightAngleBracket` to replace the node's
-  ///                   current `unexpectedBetweenGenericWhereClauseAndRightAngleBracket`, if present.
-  public func withUnexpectedBetweenGenericWhereClauseAndRightAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return GenericParameterClauseSyntax(newData)
   }
 
   public var rightAngleBracket: TokenSyntax {
@@ -24993,18 +20205,11 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightAngleBracket(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = GenericParameterClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightAngleBracket` replaced.
-  /// - param newChild: The new `rightAngleBracket` to replace the node's
-  ///                   current `rightAngleBracket`, if present.
-  public func withRightAngleBracket(_ newChild: TokenSyntax) -> GenericParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return GenericParameterClauseSyntax(newData)
   }
 
   public var unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? {
@@ -25014,18 +20219,11 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightAngleBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = GenericParameterClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightAngleBracket` replaced.
-  /// - param newChild: The new `unexpectedAfterRightAngleBracket` to replace the node's
-  ///                   current `unexpectedAfterRightAngleBracket`, if present.
-  public func withUnexpectedAfterRightAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return GenericParameterClauseSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -25140,18 +20338,11 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftTypeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ConformanceRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftTypeIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftTypeIdentifier` to replace the node's
-  ///                   current `unexpectedBeforeLeftTypeIdentifier`, if present.
-  public func withUnexpectedBeforeLeftTypeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ConformanceRequirementSyntax(newData)
   }
 
   public var leftTypeIdentifier: TypeSyntax {
@@ -25160,18 +20351,11 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withLeftTypeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ConformanceRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftTypeIdentifier` replaced.
-  /// - param newChild: The new `leftTypeIdentifier` to replace the node's
-  ///                   current `leftTypeIdentifier`, if present.
-  public func withLeftTypeIdentifier(_ newChild: TypeSyntax) -> ConformanceRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ConformanceRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenLeftTypeIdentifierAndColon: UnexpectedNodesSyntax? {
@@ -25181,18 +20365,11 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftTypeIdentifierAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ConformanceRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftTypeIdentifierAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftTypeIdentifierAndColon` to replace the node's
-  ///                   current `unexpectedBetweenLeftTypeIdentifierAndColon`, if present.
-  public func withUnexpectedBetweenLeftTypeIdentifierAndColon(_ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ConformanceRequirementSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -25201,18 +20378,11 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ConformanceRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> ConformanceRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ConformanceRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndRightTypeIdentifier: UnexpectedNodesSyntax? {
@@ -25222,18 +20392,11 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndRightTypeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ConformanceRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndRightTypeIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndRightTypeIdentifier` to replace the node's
-  ///                   current `unexpectedBetweenColonAndRightTypeIdentifier`, if present.
-  public func withUnexpectedBetweenColonAndRightTypeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ConformanceRequirementSyntax(newData)
   }
 
   public var rightTypeIdentifier: TypeSyntax {
@@ -25242,18 +20405,11 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withRightTypeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ConformanceRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightTypeIdentifier` replaced.
-  /// - param newChild: The new `rightTypeIdentifier` to replace the node's
-  ///                   current `rightTypeIdentifier`, if present.
-  public func withRightTypeIdentifier(_ newChild: TypeSyntax) -> ConformanceRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ConformanceRequirementSyntax(newData)
   }
 
   public var unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? {
@@ -25263,18 +20419,11 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightTypeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ConformanceRequirementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightTypeIdentifier` replaced.
-  /// - param newChild: The new `unexpectedAfterRightTypeIdentifier` to replace the node's
-  ///                   current `unexpectedAfterRightTypeIdentifier`, if present.
-  public func withUnexpectedAfterRightTypeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ConformanceRequirementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -25381,18 +20530,11 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftAngleBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PrimaryAssociatedTypeClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftAngleBracket` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftAngleBracket` to replace the node's
-  ///                   current `unexpectedBeforeLeftAngleBracket`, if present.
-  public func withUnexpectedBeforeLeftAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
   public var leftAngleBracket: TokenSyntax {
@@ -25401,18 +20543,11 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftAngleBracket(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PrimaryAssociatedTypeClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftAngleBracket` replaced.
-  /// - param newChild: The new `leftAngleBracket` to replace the node's
-  ///                   current `leftAngleBracket`, if present.
-  public func withLeftAngleBracket(_ newChild: TokenSyntax) -> PrimaryAssociatedTypeClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
   public var unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList: UnexpectedNodesSyntax? {
@@ -25422,18 +20557,11 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PrimaryAssociatedTypeClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList` to replace the node's
-  ///                   current `unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList`, if present.
-  public func withUnexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList(_ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
   public var primaryAssociatedTypeList: PrimaryAssociatedTypeListSyntax {
@@ -25442,7 +20570,10 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
       return PrimaryAssociatedTypeListSyntax(childData!)
     }
     set(value) {
-      self = withPrimaryAssociatedTypeList(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PrimaryAssociatedTypeClauseSyntax(newData)
     }
   }
 
@@ -25465,16 +20596,6 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `primaryAssociatedTypeList` replaced.
-  /// - param newChild: The new `primaryAssociatedTypeList` to replace the node's
-  ///                   current `primaryAssociatedTypeList`, if present.
-  public func withPrimaryAssociatedTypeList(_ newChild: PrimaryAssociatedTypeListSyntax) -> PrimaryAssociatedTypeClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PrimaryAssociatedTypeClauseSyntax(newData)
-  }
-
   public var unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -25482,18 +20603,11 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PrimaryAssociatedTypeClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket` replaced.
-  /// - param newChild: The new `unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket` to replace the node's
-  ///                   current `unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket`, if present.
-  public func withUnexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
   public var rightAngleBracket: TokenSyntax {
@@ -25502,18 +20616,11 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightAngleBracket(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = PrimaryAssociatedTypeClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightAngleBracket` replaced.
-  /// - param newChild: The new `rightAngleBracket` to replace the node's
-  ///                   current `rightAngleBracket`, if present.
-  public func withRightAngleBracket(_ newChild: TokenSyntax) -> PrimaryAssociatedTypeClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
   public var unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? {
@@ -25523,18 +20630,11 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightAngleBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = PrimaryAssociatedTypeClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightAngleBracket` replaced.
-  /// - param newChild: The new `unexpectedAfterRightAngleBracket` to replace the node's
-  ///                   current `unexpectedAfterRightAngleBracket`, if present.
-  public func withUnexpectedAfterRightAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -25637,18 +20737,11 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = CompositionTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeType` replaced.
-  /// - param newChild: The new `unexpectedBeforeType` to replace the node's
-  ///                   current `unexpectedBeforeType`, if present.
-  public func withUnexpectedBeforeType(_ newChild: UnexpectedNodesSyntax?) -> CompositionTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return CompositionTypeElementSyntax(newData)
   }
 
   public var type: TypeSyntax {
@@ -25657,18 +20750,11 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = CompositionTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `type` replaced.
-  /// - param newChild: The new `type` to replace the node's
-  ///                   current `type`, if present.
-  public func withType(_ newChild: TypeSyntax) -> CompositionTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return CompositionTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAndAmpersand: UnexpectedNodesSyntax? {
@@ -25678,18 +20764,11 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTypeAndAmpersand(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = CompositionTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTypeAndAmpersand` replaced.
-  /// - param newChild: The new `unexpectedBetweenTypeAndAmpersand` to replace the node's
-  ///                   current `unexpectedBetweenTypeAndAmpersand`, if present.
-  public func withUnexpectedBetweenTypeAndAmpersand(_ newChild: UnexpectedNodesSyntax?) -> CompositionTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return CompositionTypeElementSyntax(newData)
   }
 
   public var ampersand: TokenSyntax? {
@@ -25699,18 +20778,11 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAmpersand(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = CompositionTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `ampersand` replaced.
-  /// - param newChild: The new `ampersand` to replace the node's
-  ///                   current `ampersand`, if present.
-  public func withAmpersand(_ newChild: TokenSyntax?) -> CompositionTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return CompositionTypeElementSyntax(newData)
   }
 
   public var unexpectedAfterAmpersand: UnexpectedNodesSyntax? {
@@ -25720,18 +20792,11 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterAmpersand(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = CompositionTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterAmpersand` replaced.
-  /// - param newChild: The new `unexpectedAfterAmpersand` to replace the node's
-  ///                   current `unexpectedAfterAmpersand`, if present.
-  public func withUnexpectedAfterAmpersand(_ newChild: UnexpectedNodesSyntax?) -> CompositionTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return CompositionTypeElementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -25850,18 +20915,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeInOut(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeInOut` replaced.
-  /// - param newChild: The new `unexpectedBeforeInOut` to replace the node's
-  ///                   current `unexpectedBeforeInOut`, if present.
-  public func withUnexpectedBeforeInOut(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var inOut: TokenSyntax? {
@@ -25871,18 +20929,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withInOut(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `inOut` replaced.
-  /// - param newChild: The new `inOut` to replace the node's
-  ///                   current `inOut`, if present.
-  public func withInOut(_ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenInOutAndName: UnexpectedNodesSyntax? {
@@ -25892,18 +20943,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInOutAndName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInOutAndName` replaced.
-  /// - param newChild: The new `unexpectedBetweenInOutAndName` to replace the node's
-  ///                   current `unexpectedBetweenInOutAndName`, if present.
-  public func withUnexpectedBetweenInOutAndName(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var name: TokenSyntax? {
@@ -25913,18 +20957,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndSecondName: UnexpectedNodesSyntax? {
@@ -25934,18 +20971,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenNameAndSecondName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenNameAndSecondName` replaced.
-  /// - param newChild: The new `unexpectedBetweenNameAndSecondName` to replace the node's
-  ///                   current `unexpectedBetweenNameAndSecondName`, if present.
-  public func withUnexpectedBetweenNameAndSecondName(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var secondName: TokenSyntax? {
@@ -25955,18 +20985,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withSecondName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `secondName` replaced.
-  /// - param newChild: The new `secondName` to replace the node's
-  ///                   current `secondName`, if present.
-  public func withSecondName(_ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? {
@@ -25976,18 +20999,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSecondNameAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSecondNameAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenSecondNameAndColon` to replace the node's
-  ///                   current `unexpectedBetweenSecondNameAndColon`, if present.
-  public func withUnexpectedBetweenSecondNameAndColon(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var colon: TokenSyntax? {
@@ -25997,18 +21013,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndType: UnexpectedNodesSyntax? {
@@ -26018,18 +21027,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndType` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndType` to replace the node's
-  ///                   current `unexpectedBetweenColonAndType`, if present.
-  public func withUnexpectedBetweenColonAndType(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var type: TypeSyntax {
@@ -26038,18 +21040,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `type` replaced.
-  /// - param newChild: The new `type` to replace the node's
-  ///                   current `type`, if present.
-  public func withType(_ newChild: TypeSyntax) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? {
@@ -26059,18 +21054,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTypeAndEllipsis(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTypeAndEllipsis` replaced.
-  /// - param newChild: The new `unexpectedBetweenTypeAndEllipsis` to replace the node's
-  ///                   current `unexpectedBetweenTypeAndEllipsis`, if present.
-  public func withUnexpectedBetweenTypeAndEllipsis(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var ellipsis: TokenSyntax? {
@@ -26080,18 +21068,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withEllipsis(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `ellipsis` replaced.
-  /// - param newChild: The new `ellipsis` to replace the node's
-  ///                   current `ellipsis`, if present.
-  public func withEllipsis(_ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenEllipsisAndInitializer: UnexpectedNodesSyntax? {
@@ -26101,18 +21082,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenEllipsisAndInitializer(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenEllipsisAndInitializer` replaced.
-  /// - param newChild: The new `unexpectedBetweenEllipsisAndInitializer` to replace the node's
-  ///                   current `unexpectedBetweenEllipsisAndInitializer`, if present.
-  public func withUnexpectedBetweenEllipsisAndInitializer(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var initializer: InitializerClauseSyntax? {
@@ -26122,18 +21096,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return InitializerClauseSyntax(childData!)
     }
     set(value) {
-      self = withInitializer(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `initializer` replaced.
-  /// - param newChild: The new `initializer` to replace the node's
-  ///                   current `initializer`, if present.
-  public func withInitializer(_ newChild: InitializerClauseSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenInitializerAndTrailingComma: UnexpectedNodesSyntax? {
@@ -26143,18 +21110,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInitializerAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInitializerAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenInitializerAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenInitializerAndTrailingComma`, if present.
-  public func withUnexpectedBetweenInitializerAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -26164,18 +21124,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 15, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 15, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -26185,18 +21138,11 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 16, with: raw, arena: arena)
+      self = TupleTypeElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 16, with: raw, arena: arena)
-    return TupleTypeElementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -26339,18 +21285,11 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeArgumentType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = GenericArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeArgumentType` replaced.
-  /// - param newChild: The new `unexpectedBeforeArgumentType` to replace the node's
-  ///                   current `unexpectedBeforeArgumentType`, if present.
-  public func withUnexpectedBeforeArgumentType(_ newChild: UnexpectedNodesSyntax?) -> GenericArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return GenericArgumentSyntax(newData)
   }
 
   public var argumentType: TypeSyntax {
@@ -26359,18 +21298,11 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withArgumentType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = GenericArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `argumentType` replaced.
-  /// - param newChild: The new `argumentType` to replace the node's
-  ///                   current `argumentType`, if present.
-  public func withArgumentType(_ newChild: TypeSyntax) -> GenericArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return GenericArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenArgumentTypeAndTrailingComma: UnexpectedNodesSyntax? {
@@ -26380,18 +21312,11 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenArgumentTypeAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = GenericArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenArgumentTypeAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenArgumentTypeAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenArgumentTypeAndTrailingComma`, if present.
-  public func withUnexpectedBetweenArgumentTypeAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> GenericArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return GenericArgumentSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -26401,18 +21326,11 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = GenericArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> GenericArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return GenericArgumentSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -26422,18 +21340,11 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = GenericArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> GenericArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return GenericArgumentSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -26532,18 +21443,11 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftAngleBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = GenericArgumentClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftAngleBracket` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftAngleBracket` to replace the node's
-  ///                   current `unexpectedBeforeLeftAngleBracket`, if present.
-  public func withUnexpectedBeforeLeftAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return GenericArgumentClauseSyntax(newData)
   }
 
   public var leftAngleBracket: TokenSyntax {
@@ -26552,18 +21456,11 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftAngleBracket(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = GenericArgumentClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftAngleBracket` replaced.
-  /// - param newChild: The new `leftAngleBracket` to replace the node's
-  ///                   current `leftAngleBracket`, if present.
-  public func withLeftAngleBracket(_ newChild: TokenSyntax) -> GenericArgumentClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return GenericArgumentClauseSyntax(newData)
   }
 
   public var unexpectedBetweenLeftAngleBracketAndArguments: UnexpectedNodesSyntax? {
@@ -26573,18 +21470,11 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftAngleBracketAndArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = GenericArgumentClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftAngleBracketAndArguments` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftAngleBracketAndArguments` to replace the node's
-  ///                   current `unexpectedBetweenLeftAngleBracketAndArguments`, if present.
-  public func withUnexpectedBetweenLeftAngleBracketAndArguments(_ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return GenericArgumentClauseSyntax(newData)
   }
 
   public var arguments: GenericArgumentListSyntax {
@@ -26593,7 +21483,10 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return GenericArgumentListSyntax(childData!)
     }
     set(value) {
-      self = withArguments(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = GenericArgumentClauseSyntax(newData)
     }
   }
 
@@ -26616,16 +21509,6 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return GenericArgumentClauseSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `arguments` replaced.
-  /// - param newChild: The new `arguments` to replace the node's
-  ///                   current `arguments`, if present.
-  public func withArguments(_ newChild: GenericArgumentListSyntax) -> GenericArgumentClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return GenericArgumentClauseSyntax(newData)
-  }
-
   public var unexpectedBetweenArgumentsAndRightAngleBracket: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -26633,18 +21516,11 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenArgumentsAndRightAngleBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = GenericArgumentClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenArgumentsAndRightAngleBracket` replaced.
-  /// - param newChild: The new `unexpectedBetweenArgumentsAndRightAngleBracket` to replace the node's
-  ///                   current `unexpectedBetweenArgumentsAndRightAngleBracket`, if present.
-  public func withUnexpectedBetweenArgumentsAndRightAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return GenericArgumentClauseSyntax(newData)
   }
 
   public var rightAngleBracket: TokenSyntax {
@@ -26653,18 +21529,11 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightAngleBracket(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = GenericArgumentClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightAngleBracket` replaced.
-  /// - param newChild: The new `rightAngleBracket` to replace the node's
-  ///                   current `rightAngleBracket`, if present.
-  public func withRightAngleBracket(_ newChild: TokenSyntax) -> GenericArgumentClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return GenericArgumentClauseSyntax(newData)
   }
 
   public var unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? {
@@ -26674,18 +21543,11 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightAngleBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = GenericArgumentClauseSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightAngleBracket` replaced.
-  /// - param newChild: The new `unexpectedAfterRightAngleBracket` to replace the node's
-  ///                   current `unexpectedAfterRightAngleBracket`, if present.
-  public func withUnexpectedAfterRightAngleBracket(_ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return GenericArgumentClauseSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -26788,18 +21650,11 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = TypeAnnotationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeColon` replaced.
-  /// - param newChild: The new `unexpectedBeforeColon` to replace the node's
-  ///                   current `unexpectedBeforeColon`, if present.
-  public func withUnexpectedBeforeColon(_ newChild: UnexpectedNodesSyntax?) -> TypeAnnotationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return TypeAnnotationSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -26808,18 +21663,11 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = TypeAnnotationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> TypeAnnotationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return TypeAnnotationSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndType: UnexpectedNodesSyntax? {
@@ -26829,18 +21677,11 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = TypeAnnotationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndType` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndType` to replace the node's
-  ///                   current `unexpectedBetweenColonAndType`, if present.
-  public func withUnexpectedBetweenColonAndType(_ newChild: UnexpectedNodesSyntax?) -> TypeAnnotationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return TypeAnnotationSyntax(newData)
   }
 
   public var type: TypeSyntax {
@@ -26849,18 +21690,11 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = TypeAnnotationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `type` replaced.
-  /// - param newChild: The new `type` to replace the node's
-  ///                   current `type`, if present.
-  public func withType(_ newChild: TypeSyntax) -> TypeAnnotationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return TypeAnnotationSyntax(newData)
   }
 
   public var unexpectedAfterType: UnexpectedNodesSyntax? {
@@ -26870,18 +21704,11 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = TypeAnnotationSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterType` replaced.
-  /// - param newChild: The new `unexpectedAfterType` to replace the node's
-  ///                   current `unexpectedAfterType`, if present.
-  public func withUnexpectedAfterType(_ newChild: UnexpectedNodesSyntax?) -> TypeAnnotationSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return TypeAnnotationSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -26984,18 +21811,11 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLabelName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = TuplePatternElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLabelName` replaced.
-  /// - param newChild: The new `unexpectedBeforeLabelName` to replace the node's
-  ///                   current `unexpectedBeforeLabelName`, if present.
-  public func withUnexpectedBeforeLabelName(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return TuplePatternElementSyntax(newData)
   }
 
   public var labelName: TokenSyntax? {
@@ -27005,18 +21825,11 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLabelName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = TuplePatternElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `labelName` replaced.
-  /// - param newChild: The new `labelName` to replace the node's
-  ///                   current `labelName`, if present.
-  public func withLabelName(_ newChild: TokenSyntax?) -> TuplePatternElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return TuplePatternElementSyntax(newData)
   }
 
   public var unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? {
@@ -27026,18 +21839,11 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLabelNameAndLabelColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = TuplePatternElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLabelNameAndLabelColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenLabelNameAndLabelColon` to replace the node's
-  ///                   current `unexpectedBetweenLabelNameAndLabelColon`, if present.
-  public func withUnexpectedBetweenLabelNameAndLabelColon(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return TuplePatternElementSyntax(newData)
   }
 
   public var labelColon: TokenSyntax? {
@@ -27047,18 +21853,11 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLabelColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = TuplePatternElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `labelColon` replaced.
-  /// - param newChild: The new `labelColon` to replace the node's
-  ///                   current `labelColon`, if present.
-  public func withLabelColon(_ newChild: TokenSyntax?) -> TuplePatternElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return TuplePatternElementSyntax(newData)
   }
 
   public var unexpectedBetweenLabelColonAndPattern: UnexpectedNodesSyntax? {
@@ -27068,18 +21867,11 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLabelColonAndPattern(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = TuplePatternElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLabelColonAndPattern` replaced.
-  /// - param newChild: The new `unexpectedBetweenLabelColonAndPattern` to replace the node's
-  ///                   current `unexpectedBetweenLabelColonAndPattern`, if present.
-  public func withUnexpectedBetweenLabelColonAndPattern(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return TuplePatternElementSyntax(newData)
   }
 
   public var pattern: PatternSyntax {
@@ -27088,18 +21880,11 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
       return PatternSyntax(childData!)
     }
     set(value) {
-      self = withPattern(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = TuplePatternElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `pattern` replaced.
-  /// - param newChild: The new `pattern` to replace the node's
-  ///                   current `pattern`, if present.
-  public func withPattern(_ newChild: PatternSyntax) -> TuplePatternElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return TuplePatternElementSyntax(newData)
   }
 
   public var unexpectedBetweenPatternAndTrailingComma: UnexpectedNodesSyntax? {
@@ -27109,18 +21894,11 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPatternAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = TuplePatternElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPatternAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenPatternAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenPatternAndTrailingComma`, if present.
-  public func withUnexpectedBetweenPatternAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return TuplePatternElementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
@@ -27130,18 +21908,11 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = TuplePatternElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> TuplePatternElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return TuplePatternElementSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -27151,18 +21922,11 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = TuplePatternElementSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return TuplePatternElementSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -27323,18 +22087,11 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeEntry(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AvailabilityArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeEntry` replaced.
-  /// - param newChild: The new `unexpectedBeforeEntry` to replace the node's
-  ///                   current `unexpectedBeforeEntry`, if present.
-  public func withUnexpectedBeforeEntry(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AvailabilityArgumentSyntax(newData)
   }
 
   /// The actual argument
@@ -27344,18 +22101,11 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       return Entry(childData!)
     }
     set(value) {
-      self = withEntry(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AvailabilityArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `entry` replaced.
-  /// - param newChild: The new `entry` to replace the node's
-  ///                   current `entry`, if present.
-  public func withEntry(_ newChild: Entry) -> AvailabilityArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AvailabilityArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenEntryAndTrailingComma: UnexpectedNodesSyntax? {
@@ -27365,18 +22115,11 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenEntryAndTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AvailabilityArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenEntryAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenEntryAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenEntryAndTrailingComma`, if present.
-  public func withUnexpectedBetweenEntryAndTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AvailabilityArgumentSyntax(newData)
   }
 
   /// 
@@ -27390,18 +22133,11 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = AvailabilityArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(_ newChild: TokenSyntax?) -> AvailabilityArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return AvailabilityArgumentSyntax(newData)
   }
 
   public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
@@ -27411,18 +22147,11 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTrailingComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = AvailabilityArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
-  ///                   current `unexpectedAfterTrailingComma`, if present.
-  public func withUnexpectedAfterTrailingComma(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return AvailabilityArgumentSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -27561,18 +22290,11 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AvailabilityLabeledArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLabel` replaced.
-  /// - param newChild: The new `unexpectedBeforeLabel` to replace the node's
-  ///                   current `unexpectedBeforeLabel`, if present.
-  public func withUnexpectedBeforeLabel(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AvailabilityLabeledArgumentSyntax(newData)
   }
 
   /// The label of the argument
@@ -27582,18 +22304,11 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLabel(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AvailabilityLabeledArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `label` replaced.
-  /// - param newChild: The new `label` to replace the node's
-  ///                   current `label`, if present.
-  public func withLabel(_ newChild: TokenSyntax) -> AvailabilityLabeledArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AvailabilityLabeledArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? {
@@ -27603,18 +22318,11 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLabelAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AvailabilityLabeledArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLabelAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenLabelAndColon` to replace the node's
-  ///                   current `unexpectedBetweenLabelAndColon`, if present.
-  public func withUnexpectedBetweenLabelAndColon(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AvailabilityLabeledArgumentSyntax(newData)
   }
 
   /// The colon separating label and value
@@ -27624,18 +22332,11 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = AvailabilityLabeledArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> AvailabilityLabeledArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return AvailabilityLabeledArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? {
@@ -27645,18 +22346,11 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndValue(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = AvailabilityLabeledArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndValue` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndValue` to replace the node's
-  ///                   current `unexpectedBetweenColonAndValue`, if present.
-  public func withUnexpectedBetweenColonAndValue(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return AvailabilityLabeledArgumentSyntax(newData)
   }
 
   /// The value of this labeled argument
@@ -27666,18 +22360,11 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
       return Value(childData!)
     }
     set(value) {
-      self = withValue(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = AvailabilityLabeledArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `value` replaced.
-  /// - param newChild: The new `value` to replace the node's
-  ///                   current `value`, if present.
-  public func withValue(_ newChild: Value) -> AvailabilityLabeledArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return AvailabilityLabeledArgumentSyntax(newData)
   }
 
   public var unexpectedAfterValue: UnexpectedNodesSyntax? {
@@ -27687,18 +22374,11 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterValue(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = AvailabilityLabeledArgumentSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterValue` replaced.
-  /// - param newChild: The new `unexpectedAfterValue` to replace the node's
-  ///                   current `unexpectedAfterValue`, if present.
-  public func withUnexpectedAfterValue(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return AvailabilityLabeledArgumentSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -27805,18 +22485,11 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforePlatform(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AvailabilityVersionRestrictionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforePlatform` replaced.
-  /// - param newChild: The new `unexpectedBeforePlatform` to replace the node's
-  ///                   current `unexpectedBeforePlatform`, if present.
-  public func withUnexpectedBeforePlatform(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityVersionRestrictionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AvailabilityVersionRestrictionSyntax(newData)
   }
 
   /// 
@@ -27830,18 +22503,11 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPlatform(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AvailabilityVersionRestrictionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `platform` replaced.
-  /// - param newChild: The new `platform` to replace the node's
-  ///                   current `platform`, if present.
-  public func withPlatform(_ newChild: TokenSyntax) -> AvailabilityVersionRestrictionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AvailabilityVersionRestrictionSyntax(newData)
   }
 
   public var unexpectedBetweenPlatformAndVersion: UnexpectedNodesSyntax? {
@@ -27851,18 +22517,11 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPlatformAndVersion(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AvailabilityVersionRestrictionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPlatformAndVersion` replaced.
-  /// - param newChild: The new `unexpectedBetweenPlatformAndVersion` to replace the node's
-  ///                   current `unexpectedBetweenPlatformAndVersion`, if present.
-  public func withUnexpectedBetweenPlatformAndVersion(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityVersionRestrictionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AvailabilityVersionRestrictionSyntax(newData)
   }
 
   public var version: VersionTupleSyntax? {
@@ -27872,18 +22531,11 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
       return VersionTupleSyntax(childData!)
     }
     set(value) {
-      self = withVersion(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = AvailabilityVersionRestrictionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `version` replaced.
-  /// - param newChild: The new `version` to replace the node's
-  ///                   current `version`, if present.
-  public func withVersion(_ newChild: VersionTupleSyntax?) -> AvailabilityVersionRestrictionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return AvailabilityVersionRestrictionSyntax(newData)
   }
 
   public var unexpectedAfterVersion: UnexpectedNodesSyntax? {
@@ -27893,18 +22545,11 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterVersion(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = AvailabilityVersionRestrictionSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterVersion` replaced.
-  /// - param newChild: The new `unexpectedAfterVersion` to replace the node's
-  ///                   current `unexpectedAfterVersion`, if present.
-  public func withUnexpectedAfterVersion(_ newChild: UnexpectedNodesSyntax?) -> AvailabilityVersionRestrictionSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return AvailabilityVersionRestrictionSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -28007,18 +22652,11 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeMajorMinor(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = VersionTupleSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeMajorMinor` replaced.
-  /// - param newChild: The new `unexpectedBeforeMajorMinor` to replace the node's
-  ///                   current `unexpectedBeforeMajorMinor`, if present.
-  public func withUnexpectedBeforeMajorMinor(_ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return VersionTupleSyntax(newData)
   }
 
   /// 
@@ -28034,18 +22672,11 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withMajorMinor(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = VersionTupleSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `majorMinor` replaced.
-  /// - param newChild: The new `majorMinor` to replace the node's
-  ///                   current `majorMinor`, if present.
-  public func withMajorMinor(_ newChild: TokenSyntax) -> VersionTupleSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return VersionTupleSyntax(newData)
   }
 
   public var unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodesSyntax? {
@@ -28055,18 +22686,11 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenMajorMinorAndPatchPeriod(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = VersionTupleSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenMajorMinorAndPatchPeriod` replaced.
-  /// - param newChild: The new `unexpectedBetweenMajorMinorAndPatchPeriod` to replace the node's
-  ///                   current `unexpectedBetweenMajorMinorAndPatchPeriod`, if present.
-  public func withUnexpectedBetweenMajorMinorAndPatchPeriod(_ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return VersionTupleSyntax(newData)
   }
 
   /// 
@@ -28080,18 +22704,11 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPatchPeriod(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = VersionTupleSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `patchPeriod` replaced.
-  /// - param newChild: The new `patchPeriod` to replace the node's
-  ///                   current `patchPeriod`, if present.
-  public func withPatchPeriod(_ newChild: TokenSyntax?) -> VersionTupleSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return VersionTupleSyntax(newData)
   }
 
   public var unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodesSyntax? {
@@ -28101,18 +22718,11 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPatchPeriodAndPatchVersion(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = VersionTupleSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPatchPeriodAndPatchVersion` replaced.
-  /// - param newChild: The new `unexpectedBetweenPatchPeriodAndPatchVersion` to replace the node's
-  ///                   current `unexpectedBetweenPatchPeriodAndPatchVersion`, if present.
-  public func withUnexpectedBetweenPatchPeriodAndPatchVersion(_ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return VersionTupleSyntax(newData)
   }
 
   /// 
@@ -28125,18 +22735,11 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPatchVersion(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = VersionTupleSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `patchVersion` replaced.
-  /// - param newChild: The new `patchVersion` to replace the node's
-  ///                   current `patchVersion`, if present.
-  public func withPatchVersion(_ newChild: TokenSyntax?) -> VersionTupleSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return VersionTupleSyntax(newData)
   }
 
   public var unexpectedAfterPatchVersion: UnexpectedNodesSyntax? {
@@ -28146,18 +22749,11 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterPatchVersion(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = VersionTupleSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterPatchVersion` replaced.
-  /// - param newChild: The new `unexpectedAfterPatchVersion` to replace the node's
-  ///                   current `unexpectedAfterPatchVersion`, if present.
-  public func withUnexpectedAfterPatchVersion(_ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return VersionTupleSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
@@ -113,18 +113,11 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeIsKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = IsTypePatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeIsKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeIsKeyword` to replace the node's
-  ///                   current `unexpectedBeforeIsKeyword`, if present.
-  public func withUnexpectedBeforeIsKeyword(_ newChild: UnexpectedNodesSyntax?) -> IsTypePatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return IsTypePatternSyntax(newData)
   }
 
   public var isKeyword: TokenSyntax {
@@ -133,18 +126,11 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIsKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = IsTypePatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `isKeyword` replaced.
-  /// - param newChild: The new `isKeyword` to replace the node's
-  ///                   current `isKeyword`, if present.
-  public func withIsKeyword(_ newChild: TokenSyntax) -> IsTypePatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return IsTypePatternSyntax(newData)
   }
 
   public var unexpectedBetweenIsKeywordAndType: UnexpectedNodesSyntax? {
@@ -154,18 +140,11 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIsKeywordAndType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = IsTypePatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIsKeywordAndType` replaced.
-  /// - param newChild: The new `unexpectedBetweenIsKeywordAndType` to replace the node's
-  ///                   current `unexpectedBetweenIsKeywordAndType`, if present.
-  public func withUnexpectedBetweenIsKeywordAndType(_ newChild: UnexpectedNodesSyntax?) -> IsTypePatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return IsTypePatternSyntax(newData)
   }
 
   public var type: TypeSyntax {
@@ -174,18 +153,11 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = IsTypePatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `type` replaced.
-  /// - param newChild: The new `type` to replace the node's
-  ///                   current `type`, if present.
-  public func withType(_ newChild: TypeSyntax) -> IsTypePatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return IsTypePatternSyntax(newData)
   }
 
   public var unexpectedAfterType: UnexpectedNodesSyntax? {
@@ -195,18 +167,11 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = IsTypePatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterType` replaced.
-  /// - param newChild: The new `unexpectedAfterType` to replace the node's
-  ///                   current `unexpectedAfterType`, if present.
-  public func withUnexpectedAfterType(_ newChild: UnexpectedNodesSyntax?) -> IsTypePatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return IsTypePatternSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -297,18 +262,11 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = IdentifierPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeIdentifier` replaced.
-  /// - param newChild: The new `unexpectedBeforeIdentifier` to replace the node's
-  ///                   current `unexpectedBeforeIdentifier`, if present.
-  public func withUnexpectedBeforeIdentifier(_ newChild: UnexpectedNodesSyntax?) -> IdentifierPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return IdentifierPatternSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
@@ -317,18 +275,11 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = IdentifierPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `identifier` replaced.
-  /// - param newChild: The new `identifier` to replace the node's
-  ///                   current `identifier`, if present.
-  public func withIdentifier(_ newChild: TokenSyntax) -> IdentifierPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return IdentifierPatternSyntax(newData)
   }
 
   public var unexpectedAfterIdentifier: UnexpectedNodesSyntax? {
@@ -338,18 +289,11 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterIdentifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = IdentifierPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterIdentifier` replaced.
-  /// - param newChild: The new `unexpectedAfterIdentifier` to replace the node's
-  ///                   current `unexpectedAfterIdentifier`, if present.
-  public func withUnexpectedAfterIdentifier(_ newChild: UnexpectedNodesSyntax?) -> IdentifierPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return IdentifierPatternSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -440,18 +384,11 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = TuplePatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
-  ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return TuplePatternSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -460,18 +397,11 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = TuplePatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> TuplePatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return TuplePatternSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? {
@@ -481,18 +411,11 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndElements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = TuplePatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndElements` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndElements` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndElements`, if present.
-  public func withUnexpectedBetweenLeftParenAndElements(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return TuplePatternSyntax(newData)
   }
 
   public var elements: TuplePatternElementListSyntax {
@@ -501,7 +424,10 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return TuplePatternElementListSyntax(childData!)
     }
     set(value) {
-      self = withElements(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = TuplePatternSyntax(newData)
     }
   }
 
@@ -524,16 +450,6 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     return TuplePatternSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `elements` replaced.
-  /// - param newChild: The new `elements` to replace the node's
-  ///                   current `elements`, if present.
-  public func withElements(_ newChild: TuplePatternElementListSyntax) -> TuplePatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return TuplePatternSyntax(newData)
-  }
-
   public var unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -541,18 +457,11 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenElementsAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = TuplePatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenElementsAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenElementsAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenElementsAndRightParen`, if present.
-  public func withUnexpectedBetweenElementsAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return TuplePatternSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -561,18 +470,11 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = TuplePatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> TuplePatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return TuplePatternSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -582,18 +484,11 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = TuplePatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return TuplePatternSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -696,18 +591,11 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeWildcard(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = WildcardPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeWildcard` replaced.
-  /// - param newChild: The new `unexpectedBeforeWildcard` to replace the node's
-  ///                   current `unexpectedBeforeWildcard`, if present.
-  public func withUnexpectedBeforeWildcard(_ newChild: UnexpectedNodesSyntax?) -> WildcardPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return WildcardPatternSyntax(newData)
   }
 
   public var wildcard: TokenSyntax {
@@ -716,18 +604,11 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withWildcard(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = WildcardPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `wildcard` replaced.
-  /// - param newChild: The new `wildcard` to replace the node's
-  ///                   current `wildcard`, if present.
-  public func withWildcard(_ newChild: TokenSyntax) -> WildcardPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return WildcardPatternSyntax(newData)
   }
 
   public var unexpectedBetweenWildcardAndTypeAnnotation: UnexpectedNodesSyntax? {
@@ -737,18 +618,11 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenWildcardAndTypeAnnotation(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = WildcardPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenWildcardAndTypeAnnotation` replaced.
-  /// - param newChild: The new `unexpectedBetweenWildcardAndTypeAnnotation` to replace the node's
-  ///                   current `unexpectedBetweenWildcardAndTypeAnnotation`, if present.
-  public func withUnexpectedBetweenWildcardAndTypeAnnotation(_ newChild: UnexpectedNodesSyntax?) -> WildcardPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return WildcardPatternSyntax(newData)
   }
 
   public var typeAnnotation: TypeAnnotationSyntax? {
@@ -758,18 +632,11 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return TypeAnnotationSyntax(childData!)
     }
     set(value) {
-      self = withTypeAnnotation(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = WildcardPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `typeAnnotation` replaced.
-  /// - param newChild: The new `typeAnnotation` to replace the node's
-  ///                   current `typeAnnotation`, if present.
-  public func withTypeAnnotation(_ newChild: TypeAnnotationSyntax?) -> WildcardPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return WildcardPatternSyntax(newData)
   }
 
   public var unexpectedAfterTypeAnnotation: UnexpectedNodesSyntax? {
@@ -779,18 +646,11 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTypeAnnotation(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = WildcardPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTypeAnnotation` replaced.
-  /// - param newChild: The new `unexpectedAfterTypeAnnotation` to replace the node's
-  ///                   current `unexpectedAfterTypeAnnotation`, if present.
-  public func withUnexpectedAfterTypeAnnotation(_ newChild: UnexpectedNodesSyntax?) -> WildcardPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return WildcardPatternSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -881,18 +741,11 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ExpressionPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
-  /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
-  ///                   current `unexpectedBeforeExpression`, if present.
-  public func withUnexpectedBeforeExpression(_ newChild: UnexpectedNodesSyntax?) -> ExpressionPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ExpressionPatternSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -901,18 +754,11 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ExpressionPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> ExpressionPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ExpressionPatternSyntax(newData)
   }
 
   public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
@@ -922,18 +768,11 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ExpressionPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
-  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
-  ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> ExpressionPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ExpressionPatternSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1020,18 +859,11 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLetOrVarKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ValueBindingPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLetOrVarKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeLetOrVarKeyword` to replace the node's
-  ///                   current `unexpectedBeforeLetOrVarKeyword`, if present.
-  public func withUnexpectedBeforeLetOrVarKeyword(_ newChild: UnexpectedNodesSyntax?) -> ValueBindingPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ValueBindingPatternSyntax(newData)
   }
 
   public var letOrVarKeyword: TokenSyntax {
@@ -1040,18 +872,11 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLetOrVarKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ValueBindingPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `letOrVarKeyword` replaced.
-  /// - param newChild: The new `letOrVarKeyword` to replace the node's
-  ///                   current `letOrVarKeyword`, if present.
-  public func withLetOrVarKeyword(_ newChild: TokenSyntax) -> ValueBindingPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ValueBindingPatternSyntax(newData)
   }
 
   public var unexpectedBetweenLetOrVarKeywordAndValuePattern: UnexpectedNodesSyntax? {
@@ -1061,18 +886,11 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLetOrVarKeywordAndValuePattern(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ValueBindingPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLetOrVarKeywordAndValuePattern` replaced.
-  /// - param newChild: The new `unexpectedBetweenLetOrVarKeywordAndValuePattern` to replace the node's
-  ///                   current `unexpectedBetweenLetOrVarKeywordAndValuePattern`, if present.
-  public func withUnexpectedBetweenLetOrVarKeywordAndValuePattern(_ newChild: UnexpectedNodesSyntax?) -> ValueBindingPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ValueBindingPatternSyntax(newData)
   }
 
   public var valuePattern: PatternSyntax {
@@ -1081,18 +899,11 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return PatternSyntax(childData!)
     }
     set(value) {
-      self = withValuePattern(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ValueBindingPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `valuePattern` replaced.
-  /// - param newChild: The new `valuePattern` to replace the node's
-  ///                   current `valuePattern`, if present.
-  public func withValuePattern(_ newChild: PatternSyntax) -> ValueBindingPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ValueBindingPatternSyntax(newData)
   }
 
   public var unexpectedAfterValuePattern: UnexpectedNodesSyntax? {
@@ -1102,18 +913,11 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterValuePattern(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ValueBindingPatternSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterValuePattern` replaced.
-  /// - param newChild: The new `unexpectedAfterValuePattern` to replace the node's
-  ///                   current `unexpectedAfterValuePattern`, if present.
-  public func withUnexpectedAfterValuePattern(_ newChild: UnexpectedNodesSyntax?) -> ValueBindingPatternSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ValueBindingPatternSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -117,18 +117,11 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLabelName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = LabeledStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLabelName` replaced.
-  /// - param newChild: The new `unexpectedBeforeLabelName` to replace the node's
-  ///                   current `unexpectedBeforeLabelName`, if present.
-  public func withUnexpectedBeforeLabelName(_ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return LabeledStmtSyntax(newData)
   }
 
   public var labelName: TokenSyntax {
@@ -137,18 +130,11 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLabelName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = LabeledStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `labelName` replaced.
-  /// - param newChild: The new `labelName` to replace the node's
-  ///                   current `labelName`, if present.
-  public func withLabelName(_ newChild: TokenSyntax) -> LabeledStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return LabeledStmtSyntax(newData)
   }
 
   public var unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? {
@@ -158,18 +144,11 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLabelNameAndLabelColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = LabeledStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLabelNameAndLabelColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenLabelNameAndLabelColon` to replace the node's
-  ///                   current `unexpectedBetweenLabelNameAndLabelColon`, if present.
-  public func withUnexpectedBetweenLabelNameAndLabelColon(_ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return LabeledStmtSyntax(newData)
   }
 
   public var labelColon: TokenSyntax {
@@ -178,18 +157,11 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLabelColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = LabeledStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `labelColon` replaced.
-  /// - param newChild: The new `labelColon` to replace the node's
-  ///                   current `labelColon`, if present.
-  public func withLabelColon(_ newChild: TokenSyntax) -> LabeledStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return LabeledStmtSyntax(newData)
   }
 
   public var unexpectedBetweenLabelColonAndStatement: UnexpectedNodesSyntax? {
@@ -199,18 +171,11 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLabelColonAndStatement(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = LabeledStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLabelColonAndStatement` replaced.
-  /// - param newChild: The new `unexpectedBetweenLabelColonAndStatement` to replace the node's
-  ///                   current `unexpectedBetweenLabelColonAndStatement`, if present.
-  public func withUnexpectedBetweenLabelColonAndStatement(_ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return LabeledStmtSyntax(newData)
   }
 
   public var statement: StmtSyntax {
@@ -219,18 +184,11 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return StmtSyntax(childData!)
     }
     set(value) {
-      self = withStatement(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = LabeledStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `statement` replaced.
-  /// - param newChild: The new `statement` to replace the node's
-  ///                   current `statement`, if present.
-  public func withStatement(_ newChild: StmtSyntax) -> LabeledStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return LabeledStmtSyntax(newData)
   }
 
   public var unexpectedAfterStatement: UnexpectedNodesSyntax? {
@@ -240,18 +198,11 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterStatement(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = LabeledStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterStatement` replaced.
-  /// - param newChild: The new `unexpectedAfterStatement` to replace the node's
-  ///                   current `unexpectedAfterStatement`, if present.
-  public func withUnexpectedAfterStatement(_ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return LabeledStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -354,18 +305,11 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeContinueKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ContinueStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeContinueKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeContinueKeyword` to replace the node's
-  ///                   current `unexpectedBeforeContinueKeyword`, if present.
-  public func withUnexpectedBeforeContinueKeyword(_ newChild: UnexpectedNodesSyntax?) -> ContinueStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ContinueStmtSyntax(newData)
   }
 
   public var continueKeyword: TokenSyntax {
@@ -374,18 +318,11 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withContinueKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ContinueStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `continueKeyword` replaced.
-  /// - param newChild: The new `continueKeyword` to replace the node's
-  ///                   current `continueKeyword`, if present.
-  public func withContinueKeyword(_ newChild: TokenSyntax) -> ContinueStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ContinueStmtSyntax(newData)
   }
 
   public var unexpectedBetweenContinueKeywordAndLabel: UnexpectedNodesSyntax? {
@@ -395,18 +332,11 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenContinueKeywordAndLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ContinueStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenContinueKeywordAndLabel` replaced.
-  /// - param newChild: The new `unexpectedBetweenContinueKeywordAndLabel` to replace the node's
-  ///                   current `unexpectedBetweenContinueKeywordAndLabel`, if present.
-  public func withUnexpectedBetweenContinueKeywordAndLabel(_ newChild: UnexpectedNodesSyntax?) -> ContinueStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ContinueStmtSyntax(newData)
   }
 
   public var label: TokenSyntax? {
@@ -416,18 +346,11 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ContinueStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `label` replaced.
-  /// - param newChild: The new `label` to replace the node's
-  ///                   current `label`, if present.
-  public func withLabel(_ newChild: TokenSyntax?) -> ContinueStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ContinueStmtSyntax(newData)
   }
 
   public var unexpectedAfterLabel: UnexpectedNodesSyntax? {
@@ -437,18 +360,11 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ContinueStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterLabel` replaced.
-  /// - param newChild: The new `unexpectedAfterLabel` to replace the node's
-  ///                   current `unexpectedAfterLabel`, if present.
-  public func withUnexpectedAfterLabel(_ newChild: UnexpectedNodesSyntax?) -> ContinueStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ContinueStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -547,18 +463,11 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeWhileKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = WhileStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeWhileKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeWhileKeyword` to replace the node's
-  ///                   current `unexpectedBeforeWhileKeyword`, if present.
-  public func withUnexpectedBeforeWhileKeyword(_ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return WhileStmtSyntax(newData)
   }
 
   public var whileKeyword: TokenSyntax {
@@ -567,18 +476,11 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withWhileKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = WhileStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `whileKeyword` replaced.
-  /// - param newChild: The new `whileKeyword` to replace the node's
-  ///                   current `whileKeyword`, if present.
-  public func withWhileKeyword(_ newChild: TokenSyntax) -> WhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return WhileStmtSyntax(newData)
   }
 
   public var unexpectedBetweenWhileKeywordAndConditions: UnexpectedNodesSyntax? {
@@ -588,18 +490,11 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenWhileKeywordAndConditions(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = WhileStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenWhileKeywordAndConditions` replaced.
-  /// - param newChild: The new `unexpectedBetweenWhileKeywordAndConditions` to replace the node's
-  ///                   current `unexpectedBetweenWhileKeywordAndConditions`, if present.
-  public func withUnexpectedBetweenWhileKeywordAndConditions(_ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return WhileStmtSyntax(newData)
   }
 
   public var conditions: ConditionElementListSyntax {
@@ -608,7 +503,10 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return ConditionElementListSyntax(childData!)
     }
     set(value) {
-      self = withConditions(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = WhileStmtSyntax(newData)
     }
   }
 
@@ -631,16 +529,6 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return WhileStmtSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `conditions` replaced.
-  /// - param newChild: The new `conditions` to replace the node's
-  ///                   current `conditions`, if present.
-  public func withConditions(_ newChild: ConditionElementListSyntax) -> WhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return WhileStmtSyntax(newData)
-  }
-
   public var unexpectedBetweenConditionsAndBody: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -648,18 +536,11 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenConditionsAndBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = WhileStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenConditionsAndBody` replaced.
-  /// - param newChild: The new `unexpectedBetweenConditionsAndBody` to replace the node's
-  ///                   current `unexpectedBetweenConditionsAndBody`, if present.
-  public func withUnexpectedBetweenConditionsAndBody(_ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return WhileStmtSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
@@ -668,18 +549,11 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return CodeBlockSyntax(childData!)
     }
     set(value) {
-      self = withBody(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = WhileStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `body` replaced.
-  /// - param newChild: The new `body` to replace the node's
-  ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax) -> WhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return WhileStmtSyntax(newData)
   }
 
   public var unexpectedAfterBody: UnexpectedNodesSyntax? {
@@ -689,18 +563,11 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = WhileStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
-  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
-  ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return WhileStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -803,18 +670,11 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeDeferKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DeferStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeDeferKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeDeferKeyword` to replace the node's
-  ///                   current `unexpectedBeforeDeferKeyword`, if present.
-  public func withUnexpectedBeforeDeferKeyword(_ newChild: UnexpectedNodesSyntax?) -> DeferStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DeferStmtSyntax(newData)
   }
 
   public var deferKeyword: TokenSyntax {
@@ -823,18 +683,11 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withDeferKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DeferStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `deferKeyword` replaced.
-  /// - param newChild: The new `deferKeyword` to replace the node's
-  ///                   current `deferKeyword`, if present.
-  public func withDeferKeyword(_ newChild: TokenSyntax) -> DeferStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DeferStmtSyntax(newData)
   }
 
   public var unexpectedBetweenDeferKeywordAndBody: UnexpectedNodesSyntax? {
@@ -844,18 +697,11 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDeferKeywordAndBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DeferStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDeferKeywordAndBody` replaced.
-  /// - param newChild: The new `unexpectedBetweenDeferKeywordAndBody` to replace the node's
-  ///                   current `unexpectedBetweenDeferKeywordAndBody`, if present.
-  public func withUnexpectedBetweenDeferKeywordAndBody(_ newChild: UnexpectedNodesSyntax?) -> DeferStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DeferStmtSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
@@ -864,18 +710,11 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return CodeBlockSyntax(childData!)
     }
     set(value) {
-      self = withBody(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DeferStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `body` replaced.
-  /// - param newChild: The new `body` to replace the node's
-  ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax) -> DeferStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DeferStmtSyntax(newData)
   }
 
   public var unexpectedAfterBody: UnexpectedNodesSyntax? {
@@ -885,18 +724,11 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DeferStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
-  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
-  ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> DeferStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DeferStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -999,18 +831,11 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeRepeatKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = RepeatWhileStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeRepeatKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeRepeatKeyword` to replace the node's
-  ///                   current `unexpectedBeforeRepeatKeyword`, if present.
-  public func withUnexpectedBeforeRepeatKeyword(_ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return RepeatWhileStmtSyntax(newData)
   }
 
   public var repeatKeyword: TokenSyntax {
@@ -1019,18 +844,11 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRepeatKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = RepeatWhileStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `repeatKeyword` replaced.
-  /// - param newChild: The new `repeatKeyword` to replace the node's
-  ///                   current `repeatKeyword`, if present.
-  public func withRepeatKeyword(_ newChild: TokenSyntax) -> RepeatWhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return RepeatWhileStmtSyntax(newData)
   }
 
   public var unexpectedBetweenRepeatKeywordAndBody: UnexpectedNodesSyntax? {
@@ -1040,18 +858,11 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenRepeatKeywordAndBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = RepeatWhileStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenRepeatKeywordAndBody` replaced.
-  /// - param newChild: The new `unexpectedBetweenRepeatKeywordAndBody` to replace the node's
-  ///                   current `unexpectedBetweenRepeatKeywordAndBody`, if present.
-  public func withUnexpectedBetweenRepeatKeywordAndBody(_ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return RepeatWhileStmtSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
@@ -1060,18 +871,11 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return CodeBlockSyntax(childData!)
     }
     set(value) {
-      self = withBody(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = RepeatWhileStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `body` replaced.
-  /// - param newChild: The new `body` to replace the node's
-  ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax) -> RepeatWhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return RepeatWhileStmtSyntax(newData)
   }
 
   public var unexpectedBetweenBodyAndWhileKeyword: UnexpectedNodesSyntax? {
@@ -1081,18 +885,11 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenBodyAndWhileKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = RepeatWhileStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenBodyAndWhileKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenBodyAndWhileKeyword` to replace the node's
-  ///                   current `unexpectedBetweenBodyAndWhileKeyword`, if present.
-  public func withUnexpectedBetweenBodyAndWhileKeyword(_ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return RepeatWhileStmtSyntax(newData)
   }
 
   public var whileKeyword: TokenSyntax {
@@ -1101,18 +898,11 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withWhileKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = RepeatWhileStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `whileKeyword` replaced.
-  /// - param newChild: The new `whileKeyword` to replace the node's
-  ///                   current `whileKeyword`, if present.
-  public func withWhileKeyword(_ newChild: TokenSyntax) -> RepeatWhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return RepeatWhileStmtSyntax(newData)
   }
 
   public var unexpectedBetweenWhileKeywordAndCondition: UnexpectedNodesSyntax? {
@@ -1122,18 +912,11 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenWhileKeywordAndCondition(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = RepeatWhileStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenWhileKeywordAndCondition` replaced.
-  /// - param newChild: The new `unexpectedBetweenWhileKeywordAndCondition` to replace the node's
-  ///                   current `unexpectedBetweenWhileKeywordAndCondition`, if present.
-  public func withUnexpectedBetweenWhileKeywordAndCondition(_ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return RepeatWhileStmtSyntax(newData)
   }
 
   public var condition: ExprSyntax {
@@ -1142,18 +925,11 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withCondition(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = RepeatWhileStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `condition` replaced.
-  /// - param newChild: The new `condition` to replace the node's
-  ///                   current `condition`, if present.
-  public func withCondition(_ newChild: ExprSyntax) -> RepeatWhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return RepeatWhileStmtSyntax(newData)
   }
 
   public var unexpectedAfterCondition: UnexpectedNodesSyntax? {
@@ -1163,18 +939,11 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterCondition(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = RepeatWhileStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterCondition` replaced.
-  /// - param newChild: The new `unexpectedAfterCondition` to replace the node's
-  ///                   current `unexpectedAfterCondition`, if present.
-  public func withUnexpectedAfterCondition(_ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return RepeatWhileStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1293,18 +1062,11 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeGuardKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = GuardStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeGuardKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeGuardKeyword` to replace the node's
-  ///                   current `unexpectedBeforeGuardKeyword`, if present.
-  public func withUnexpectedBeforeGuardKeyword(_ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return GuardStmtSyntax(newData)
   }
 
   public var guardKeyword: TokenSyntax {
@@ -1313,18 +1075,11 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withGuardKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = GuardStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `guardKeyword` replaced.
-  /// - param newChild: The new `guardKeyword` to replace the node's
-  ///                   current `guardKeyword`, if present.
-  public func withGuardKeyword(_ newChild: TokenSyntax) -> GuardStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return GuardStmtSyntax(newData)
   }
 
   public var unexpectedBetweenGuardKeywordAndConditions: UnexpectedNodesSyntax? {
@@ -1334,18 +1089,11 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGuardKeywordAndConditions(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = GuardStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGuardKeywordAndConditions` replaced.
-  /// - param newChild: The new `unexpectedBetweenGuardKeywordAndConditions` to replace the node's
-  ///                   current `unexpectedBetweenGuardKeywordAndConditions`, if present.
-  public func withUnexpectedBetweenGuardKeywordAndConditions(_ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return GuardStmtSyntax(newData)
   }
 
   public var conditions: ConditionElementListSyntax {
@@ -1354,7 +1102,10 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return ConditionElementListSyntax(childData!)
     }
     set(value) {
-      self = withConditions(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = GuardStmtSyntax(newData)
     }
   }
 
@@ -1377,16 +1128,6 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return GuardStmtSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `conditions` replaced.
-  /// - param newChild: The new `conditions` to replace the node's
-  ///                   current `conditions`, if present.
-  public func withConditions(_ newChild: ConditionElementListSyntax) -> GuardStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return GuardStmtSyntax(newData)
-  }
-
   public var unexpectedBetweenConditionsAndElseKeyword: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -1394,18 +1135,11 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenConditionsAndElseKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = GuardStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenConditionsAndElseKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenConditionsAndElseKeyword` to replace the node's
-  ///                   current `unexpectedBetweenConditionsAndElseKeyword`, if present.
-  public func withUnexpectedBetweenConditionsAndElseKeyword(_ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return GuardStmtSyntax(newData)
   }
 
   public var elseKeyword: TokenSyntax {
@@ -1414,18 +1148,11 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withElseKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = GuardStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `elseKeyword` replaced.
-  /// - param newChild: The new `elseKeyword` to replace the node's
-  ///                   current `elseKeyword`, if present.
-  public func withElseKeyword(_ newChild: TokenSyntax) -> GuardStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return GuardStmtSyntax(newData)
   }
 
   public var unexpectedBetweenElseKeywordAndBody: UnexpectedNodesSyntax? {
@@ -1435,18 +1162,11 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenElseKeywordAndBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = GuardStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenElseKeywordAndBody` replaced.
-  /// - param newChild: The new `unexpectedBetweenElseKeywordAndBody` to replace the node's
-  ///                   current `unexpectedBetweenElseKeywordAndBody`, if present.
-  public func withUnexpectedBetweenElseKeywordAndBody(_ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return GuardStmtSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
@@ -1455,18 +1175,11 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return CodeBlockSyntax(childData!)
     }
     set(value) {
-      self = withBody(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = GuardStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `body` replaced.
-  /// - param newChild: The new `body` to replace the node's
-  ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax) -> GuardStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return GuardStmtSyntax(newData)
   }
 
   public var unexpectedAfterBody: UnexpectedNodesSyntax? {
@@ -1476,18 +1189,11 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = GuardStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
-  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
-  ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return GuardStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1630,18 +1336,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeForKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeForKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeForKeyword` to replace the node's
-  ///                   current `unexpectedBeforeForKeyword`, if present.
-  public func withUnexpectedBeforeForKeyword(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var forKeyword: TokenSyntax {
@@ -1650,18 +1349,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withForKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `forKeyword` replaced.
-  /// - param newChild: The new `forKeyword` to replace the node's
-  ///                   current `forKeyword`, if present.
-  public func withForKeyword(_ newChild: TokenSyntax) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenForKeywordAndTryKeyword: UnexpectedNodesSyntax? {
@@ -1671,18 +1363,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenForKeywordAndTryKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenForKeywordAndTryKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenForKeywordAndTryKeyword` to replace the node's
-  ///                   current `unexpectedBetweenForKeywordAndTryKeyword`, if present.
-  public func withUnexpectedBetweenForKeywordAndTryKeyword(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var tryKeyword: TokenSyntax? {
@@ -1692,18 +1377,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTryKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `tryKeyword` replaced.
-  /// - param newChild: The new `tryKeyword` to replace the node's
-  ///                   current `tryKeyword`, if present.
-  public func withTryKeyword(_ newChild: TokenSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenTryKeywordAndAwaitKeyword: UnexpectedNodesSyntax? {
@@ -1713,18 +1391,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTryKeywordAndAwaitKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTryKeywordAndAwaitKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenTryKeywordAndAwaitKeyword` to replace the node's
-  ///                   current `unexpectedBetweenTryKeywordAndAwaitKeyword`, if present.
-  public func withUnexpectedBetweenTryKeywordAndAwaitKeyword(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var awaitKeyword: TokenSyntax? {
@@ -1734,18 +1405,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withAwaitKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `awaitKeyword` replaced.
-  /// - param newChild: The new `awaitKeyword` to replace the node's
-  ///                   current `awaitKeyword`, if present.
-  public func withAwaitKeyword(_ newChild: TokenSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenAwaitKeywordAndCaseKeyword: UnexpectedNodesSyntax? {
@@ -1755,18 +1419,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAwaitKeywordAndCaseKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAwaitKeywordAndCaseKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenAwaitKeywordAndCaseKeyword` to replace the node's
-  ///                   current `unexpectedBetweenAwaitKeywordAndCaseKeyword`, if present.
-  public func withUnexpectedBetweenAwaitKeywordAndCaseKeyword(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var caseKeyword: TokenSyntax? {
@@ -1776,18 +1433,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withCaseKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `caseKeyword` replaced.
-  /// - param newChild: The new `caseKeyword` to replace the node's
-  ///                   current `caseKeyword`, if present.
-  public func withCaseKeyword(_ newChild: TokenSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodesSyntax? {
@@ -1797,18 +1447,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCaseKeywordAndPattern(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCaseKeywordAndPattern` replaced.
-  /// - param newChild: The new `unexpectedBetweenCaseKeywordAndPattern` to replace the node's
-  ///                   current `unexpectedBetweenCaseKeywordAndPattern`, if present.
-  public func withUnexpectedBetweenCaseKeywordAndPattern(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var pattern: PatternSyntax {
@@ -1817,18 +1460,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return PatternSyntax(childData!)
     }
     set(value) {
-      self = withPattern(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `pattern` replaced.
-  /// - param newChild: The new `pattern` to replace the node's
-  ///                   current `pattern`, if present.
-  public func withPattern(_ newChild: PatternSyntax) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? {
@@ -1838,18 +1474,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPatternAndTypeAnnotation(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPatternAndTypeAnnotation` replaced.
-  /// - param newChild: The new `unexpectedBetweenPatternAndTypeAnnotation` to replace the node's
-  ///                   current `unexpectedBetweenPatternAndTypeAnnotation`, if present.
-  public func withUnexpectedBetweenPatternAndTypeAnnotation(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var typeAnnotation: TypeAnnotationSyntax? {
@@ -1859,18 +1488,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TypeAnnotationSyntax(childData!)
     }
     set(value) {
-      self = withTypeAnnotation(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `typeAnnotation` replaced.
-  /// - param newChild: The new `typeAnnotation` to replace the node's
-  ///                   current `typeAnnotation`, if present.
-  public func withTypeAnnotation(_ newChild: TypeAnnotationSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAnnotationAndInKeyword: UnexpectedNodesSyntax? {
@@ -1880,18 +1502,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenTypeAnnotationAndInKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTypeAnnotationAndInKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenTypeAnnotationAndInKeyword` to replace the node's
-  ///                   current `unexpectedBetweenTypeAnnotationAndInKeyword`, if present.
-  public func withUnexpectedBetweenTypeAnnotationAndInKeyword(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var inKeyword: TokenSyntax {
@@ -1900,18 +1515,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withInKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 13, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `inKeyword` replaced.
-  /// - param newChild: The new `inKeyword` to replace the node's
-  ///                   current `inKeyword`, if present.
-  public func withInKeyword(_ newChild: TokenSyntax) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 13, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenInKeywordAndSequenceExpr: UnexpectedNodesSyntax? {
@@ -1921,18 +1529,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenInKeywordAndSequenceExpr(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 14, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenInKeywordAndSequenceExpr` replaced.
-  /// - param newChild: The new `unexpectedBetweenInKeywordAndSequenceExpr` to replace the node's
-  ///                   current `unexpectedBetweenInKeywordAndSequenceExpr`, if present.
-  public func withUnexpectedBetweenInKeywordAndSequenceExpr(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 14, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var sequenceExpr: ExprSyntax {
@@ -1941,18 +1542,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withSequenceExpr(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 15, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `sequenceExpr` replaced.
-  /// - param newChild: The new `sequenceExpr` to replace the node's
-  ///                   current `sequenceExpr`, if present.
-  public func withSequenceExpr(_ newChild: ExprSyntax) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 15, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenSequenceExprAndWhereClause: UnexpectedNodesSyntax? {
@@ -1962,18 +1556,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSequenceExprAndWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 16, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSequenceExprAndWhereClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenSequenceExprAndWhereClause` to replace the node's
-  ///                   current `unexpectedBetweenSequenceExprAndWhereClause`, if present.
-  public func withUnexpectedBetweenSequenceExprAndWhereClause(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 16, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var whereClause: WhereClauseSyntax? {
@@ -1983,18 +1570,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return WhereClauseSyntax(childData!)
     }
     set(value) {
-      self = withWhereClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 17, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `whereClause` replaced.
-  /// - param newChild: The new `whereClause` to replace the node's
-  ///                   current `whereClause`, if present.
-  public func withWhereClause(_ newChild: WhereClauseSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 17, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenWhereClauseAndBody: UnexpectedNodesSyntax? {
@@ -2004,18 +1584,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenWhereClauseAndBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 18, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenWhereClauseAndBody` replaced.
-  /// - param newChild: The new `unexpectedBetweenWhereClauseAndBody` to replace the node's
-  ///                   current `unexpectedBetweenWhereClauseAndBody`, if present.
-  public func withUnexpectedBetweenWhereClauseAndBody(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 18, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
@@ -2024,18 +1597,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return CodeBlockSyntax(childData!)
     }
     set(value) {
-      self = withBody(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 19, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `body` replaced.
-  /// - param newChild: The new `body` to replace the node's
-  ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 19, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public var unexpectedAfterBody: UnexpectedNodesSyntax? {
@@ -2045,18 +1611,11 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 20, with: raw, arena: arena)
+      self = ForInStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
-  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
-  ///                   current `unexpectedAfterBody`, if present.
-  public func withUnexpectedAfterBody(_ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 20, with: raw, arena: arena)
-    return ForInStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2227,18 +1786,11 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeSwitchKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = SwitchStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeSwitchKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeSwitchKeyword` to replace the node's
-  ///                   current `unexpectedBeforeSwitchKeyword`, if present.
-  public func withUnexpectedBeforeSwitchKeyword(_ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return SwitchStmtSyntax(newData)
   }
 
   public var switchKeyword: TokenSyntax {
@@ -2247,18 +1799,11 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withSwitchKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = SwitchStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `switchKeyword` replaced.
-  /// - param newChild: The new `switchKeyword` to replace the node's
-  ///                   current `switchKeyword`, if present.
-  public func withSwitchKeyword(_ newChild: TokenSyntax) -> SwitchStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return SwitchStmtSyntax(newData)
   }
 
   public var unexpectedBetweenSwitchKeywordAndExpression: UnexpectedNodesSyntax? {
@@ -2268,18 +1813,11 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSwitchKeywordAndExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = SwitchStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSwitchKeywordAndExpression` replaced.
-  /// - param newChild: The new `unexpectedBetweenSwitchKeywordAndExpression` to replace the node's
-  ///                   current `unexpectedBetweenSwitchKeywordAndExpression`, if present.
-  public func withUnexpectedBetweenSwitchKeywordAndExpression(_ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return SwitchStmtSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -2288,18 +1826,11 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = SwitchStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> SwitchStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return SwitchStmtSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndLeftBrace: UnexpectedNodesSyntax? {
@@ -2309,18 +1840,11 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenExpressionAndLeftBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = SwitchStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndLeftBrace` replaced.
-  /// - param newChild: The new `unexpectedBetweenExpressionAndLeftBrace` to replace the node's
-  ///                   current `unexpectedBetweenExpressionAndLeftBrace`, if present.
-  public func withUnexpectedBetweenExpressionAndLeftBrace(_ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return SwitchStmtSyntax(newData)
   }
 
   public var leftBrace: TokenSyntax {
@@ -2329,18 +1853,11 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftBrace(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = SwitchStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftBrace` replaced.
-  /// - param newChild: The new `leftBrace` to replace the node's
-  ///                   current `leftBrace`, if present.
-  public func withLeftBrace(_ newChild: TokenSyntax) -> SwitchStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return SwitchStmtSyntax(newData)
   }
 
   public var unexpectedBetweenLeftBraceAndCases: UnexpectedNodesSyntax? {
@@ -2350,18 +1867,11 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftBraceAndCases(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = SwitchStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftBraceAndCases` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftBraceAndCases` to replace the node's
-  ///                   current `unexpectedBetweenLeftBraceAndCases`, if present.
-  public func withUnexpectedBetweenLeftBraceAndCases(_ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return SwitchStmtSyntax(newData)
   }
 
   public var cases: SwitchCaseListSyntax {
@@ -2370,7 +1880,10 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return SwitchCaseListSyntax(childData!)
     }
     set(value) {
-      self = withCases(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = SwitchStmtSyntax(newData)
     }
   }
 
@@ -2393,16 +1906,6 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return SwitchStmtSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `cases` replaced.
-  /// - param newChild: The new `cases` to replace the node's
-  ///                   current `cases`, if present.
-  public func withCases(_ newChild: SwitchCaseListSyntax) -> SwitchStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return SwitchStmtSyntax(newData)
-  }
-
   public var unexpectedBetweenCasesAndRightBrace: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 8, parent: Syntax(self))
@@ -2410,18 +1913,11 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCasesAndRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = SwitchStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCasesAndRightBrace` replaced.
-  /// - param newChild: The new `unexpectedBetweenCasesAndRightBrace` to replace the node's
-  ///                   current `unexpectedBetweenCasesAndRightBrace`, if present.
-  public func withUnexpectedBetweenCasesAndRightBrace(_ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return SwitchStmtSyntax(newData)
   }
 
   public var rightBrace: TokenSyntax {
@@ -2430,18 +1926,11 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = SwitchStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightBrace` replaced.
-  /// - param newChild: The new `rightBrace` to replace the node's
-  ///                   current `rightBrace`, if present.
-  public func withRightBrace(_ newChild: TokenSyntax) -> SwitchStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return SwitchStmtSyntax(newData)
   }
 
   public var unexpectedAfterRightBrace: UnexpectedNodesSyntax? {
@@ -2451,18 +1940,11 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightBrace(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = SwitchStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
-  /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
-  ///                   current `unexpectedAfterRightBrace`, if present.
-  public func withUnexpectedAfterRightBrace(_ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return SwitchStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2585,18 +2067,11 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeDoKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DoStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeDoKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeDoKeyword` to replace the node's
-  ///                   current `unexpectedBeforeDoKeyword`, if present.
-  public func withUnexpectedBeforeDoKeyword(_ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DoStmtSyntax(newData)
   }
 
   public var doKeyword: TokenSyntax {
@@ -2605,18 +2080,11 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withDoKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DoStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `doKeyword` replaced.
-  /// - param newChild: The new `doKeyword` to replace the node's
-  ///                   current `doKeyword`, if present.
-  public func withDoKeyword(_ newChild: TokenSyntax) -> DoStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DoStmtSyntax(newData)
   }
 
   public var unexpectedBetweenDoKeywordAndBody: UnexpectedNodesSyntax? {
@@ -2626,18 +2094,11 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenDoKeywordAndBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DoStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenDoKeywordAndBody` replaced.
-  /// - param newChild: The new `unexpectedBetweenDoKeywordAndBody` to replace the node's
-  ///                   current `unexpectedBetweenDoKeywordAndBody`, if present.
-  public func withUnexpectedBetweenDoKeywordAndBody(_ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DoStmtSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
@@ -2646,18 +2107,11 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return CodeBlockSyntax(childData!)
     }
     set(value) {
-      self = withBody(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DoStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `body` replaced.
-  /// - param newChild: The new `body` to replace the node's
-  ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax) -> DoStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DoStmtSyntax(newData)
   }
 
   public var unexpectedBetweenBodyAndCatchClauses: UnexpectedNodesSyntax? {
@@ -2667,18 +2121,11 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenBodyAndCatchClauses(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DoStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenBodyAndCatchClauses` replaced.
-  /// - param newChild: The new `unexpectedBetweenBodyAndCatchClauses` to replace the node's
-  ///                   current `unexpectedBetweenBodyAndCatchClauses`, if present.
-  public func withUnexpectedBetweenBodyAndCatchClauses(_ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DoStmtSyntax(newData)
   }
 
   public var catchClauses: CatchClauseListSyntax? {
@@ -2688,7 +2135,10 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return CatchClauseListSyntax(childData!)
     }
     set(value) {
-      self = withCatchClauses(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = DoStmtSyntax(newData)
     }
   }
 
@@ -2711,16 +2161,6 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return DoStmtSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `catchClauses` replaced.
-  /// - param newChild: The new `catchClauses` to replace the node's
-  ///                   current `catchClauses`, if present.
-  public func withCatchClauses(_ newChild: CatchClauseListSyntax?) -> DoStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return DoStmtSyntax(newData)
-  }
-
   public var unexpectedAfterCatchClauses: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 6, parent: Syntax(self))
@@ -2728,18 +2168,11 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterCatchClauses(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = DoStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterCatchClauses` replaced.
-  /// - param newChild: The new `unexpectedAfterCatchClauses` to replace the node's
-  ///                   current `unexpectedAfterCatchClauses`, if present.
-  public func withUnexpectedAfterCatchClauses(_ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return DoStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2872,18 +2305,11 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeReturnKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ReturnStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeReturnKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeReturnKeyword` to replace the node's
-  ///                   current `unexpectedBeforeReturnKeyword`, if present.
-  public func withUnexpectedBeforeReturnKeyword(_ newChild: UnexpectedNodesSyntax?) -> ReturnStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ReturnStmtSyntax(newData)
   }
 
   public var returnKeyword: TokenSyntax {
@@ -2892,18 +2318,11 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withReturnKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ReturnStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `returnKeyword` replaced.
-  /// - param newChild: The new `returnKeyword` to replace the node's
-  ///                   current `returnKeyword`, if present.
-  public func withReturnKeyword(_ newChild: TokenSyntax) -> ReturnStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ReturnStmtSyntax(newData)
   }
 
   public var unexpectedBetweenReturnKeywordAndExpression: UnexpectedNodesSyntax? {
@@ -2913,18 +2332,11 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenReturnKeywordAndExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ReturnStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenReturnKeywordAndExpression` replaced.
-  /// - param newChild: The new `unexpectedBetweenReturnKeywordAndExpression` to replace the node's
-  ///                   current `unexpectedBetweenReturnKeywordAndExpression`, if present.
-  public func withUnexpectedBetweenReturnKeywordAndExpression(_ newChild: UnexpectedNodesSyntax?) -> ReturnStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ReturnStmtSyntax(newData)
   }
 
   public var expression: ExprSyntax? {
@@ -2934,18 +2346,11 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ReturnStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax?) -> ReturnStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ReturnStmtSyntax(newData)
   }
 
   public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
@@ -2955,18 +2360,11 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ReturnStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
-  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
-  ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> ReturnStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ReturnStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -3097,18 +2495,11 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeYieldKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = YieldStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeYieldKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeYieldKeyword` to replace the node's
-  ///                   current `unexpectedBeforeYieldKeyword`, if present.
-  public func withUnexpectedBeforeYieldKeyword(_ newChild: UnexpectedNodesSyntax?) -> YieldStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return YieldStmtSyntax(newData)
   }
 
   public var yieldKeyword: TokenSyntax {
@@ -3117,18 +2508,11 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withYieldKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = YieldStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `yieldKeyword` replaced.
-  /// - param newChild: The new `yieldKeyword` to replace the node's
-  ///                   current `yieldKeyword`, if present.
-  public func withYieldKeyword(_ newChild: TokenSyntax) -> YieldStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return YieldStmtSyntax(newData)
   }
 
   public var unexpectedBetweenYieldKeywordAndYields: UnexpectedNodesSyntax? {
@@ -3138,18 +2522,11 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenYieldKeywordAndYields(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = YieldStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenYieldKeywordAndYields` replaced.
-  /// - param newChild: The new `unexpectedBetweenYieldKeywordAndYields` to replace the node's
-  ///                   current `unexpectedBetweenYieldKeywordAndYields`, if present.
-  public func withUnexpectedBetweenYieldKeywordAndYields(_ newChild: UnexpectedNodesSyntax?) -> YieldStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return YieldStmtSyntax(newData)
   }
 
   public var yields: Yields {
@@ -3158,18 +2535,11 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return Yields(childData!)
     }
     set(value) {
-      self = withYields(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = YieldStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `yields` replaced.
-  /// - param newChild: The new `yields` to replace the node's
-  ///                   current `yields`, if present.
-  public func withYields(_ newChild: Yields) -> YieldStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return YieldStmtSyntax(newData)
   }
 
   public var unexpectedAfterYields: UnexpectedNodesSyntax? {
@@ -3179,18 +2549,11 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterYields(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = YieldStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterYields` replaced.
-  /// - param newChild: The new `unexpectedAfterYields` to replace the node's
-  ///                   current `unexpectedAfterYields`, if present.
-  public func withUnexpectedAfterYields(_ newChild: UnexpectedNodesSyntax?) -> YieldStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return YieldStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -3281,18 +2644,11 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeFallthroughKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = FallthroughStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeFallthroughKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeFallthroughKeyword` to replace the node's
-  ///                   current `unexpectedBeforeFallthroughKeyword`, if present.
-  public func withUnexpectedBeforeFallthroughKeyword(_ newChild: UnexpectedNodesSyntax?) -> FallthroughStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return FallthroughStmtSyntax(newData)
   }
 
   public var fallthroughKeyword: TokenSyntax {
@@ -3301,18 +2657,11 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withFallthroughKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = FallthroughStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `fallthroughKeyword` replaced.
-  /// - param newChild: The new `fallthroughKeyword` to replace the node's
-  ///                   current `fallthroughKeyword`, if present.
-  public func withFallthroughKeyword(_ newChild: TokenSyntax) -> FallthroughStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return FallthroughStmtSyntax(newData)
   }
 
   public var unexpectedAfterFallthroughKeyword: UnexpectedNodesSyntax? {
@@ -3322,18 +2671,11 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterFallthroughKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = FallthroughStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterFallthroughKeyword` replaced.
-  /// - param newChild: The new `unexpectedAfterFallthroughKeyword` to replace the node's
-  ///                   current `unexpectedAfterFallthroughKeyword`, if present.
-  public func withUnexpectedAfterFallthroughKeyword(_ newChild: UnexpectedNodesSyntax?) -> FallthroughStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return FallthroughStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -3420,18 +2762,11 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeBreakKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = BreakStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeBreakKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeBreakKeyword` to replace the node's
-  ///                   current `unexpectedBeforeBreakKeyword`, if present.
-  public func withUnexpectedBeforeBreakKeyword(_ newChild: UnexpectedNodesSyntax?) -> BreakStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return BreakStmtSyntax(newData)
   }
 
   public var breakKeyword: TokenSyntax {
@@ -3440,18 +2775,11 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withBreakKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = BreakStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `breakKeyword` replaced.
-  /// - param newChild: The new `breakKeyword` to replace the node's
-  ///                   current `breakKeyword`, if present.
-  public func withBreakKeyword(_ newChild: TokenSyntax) -> BreakStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return BreakStmtSyntax(newData)
   }
 
   public var unexpectedBetweenBreakKeywordAndLabel: UnexpectedNodesSyntax? {
@@ -3461,18 +2789,11 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenBreakKeywordAndLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = BreakStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenBreakKeywordAndLabel` replaced.
-  /// - param newChild: The new `unexpectedBetweenBreakKeywordAndLabel` to replace the node's
-  ///                   current `unexpectedBetweenBreakKeywordAndLabel`, if present.
-  public func withUnexpectedBetweenBreakKeywordAndLabel(_ newChild: UnexpectedNodesSyntax?) -> BreakStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return BreakStmtSyntax(newData)
   }
 
   public var label: TokenSyntax? {
@@ -3482,18 +2803,11 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = BreakStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `label` replaced.
-  /// - param newChild: The new `label` to replace the node's
-  ///                   current `label`, if present.
-  public func withLabel(_ newChild: TokenSyntax?) -> BreakStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return BreakStmtSyntax(newData)
   }
 
   public var unexpectedAfterLabel: UnexpectedNodesSyntax? {
@@ -3503,18 +2817,11 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterLabel(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = BreakStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterLabel` replaced.
-  /// - param newChild: The new `unexpectedAfterLabel` to replace the node's
-  ///                   current `unexpectedAfterLabel`, if present.
-  public func withUnexpectedAfterLabel(_ newChild: UnexpectedNodesSyntax?) -> BreakStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return BreakStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -3609,18 +2916,11 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeThrowKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ThrowStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeThrowKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeThrowKeyword` to replace the node's
-  ///                   current `unexpectedBeforeThrowKeyword`, if present.
-  public func withUnexpectedBeforeThrowKeyword(_ newChild: UnexpectedNodesSyntax?) -> ThrowStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ThrowStmtSyntax(newData)
   }
 
   public var throwKeyword: TokenSyntax {
@@ -3629,18 +2929,11 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withThrowKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ThrowStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `throwKeyword` replaced.
-  /// - param newChild: The new `throwKeyword` to replace the node's
-  ///                   current `throwKeyword`, if present.
-  public func withThrowKeyword(_ newChild: TokenSyntax) -> ThrowStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ThrowStmtSyntax(newData)
   }
 
   public var unexpectedBetweenThrowKeywordAndExpression: UnexpectedNodesSyntax? {
@@ -3650,18 +2943,11 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenThrowKeywordAndExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ThrowStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenThrowKeywordAndExpression` replaced.
-  /// - param newChild: The new `unexpectedBetweenThrowKeywordAndExpression` to replace the node's
-  ///                   current `unexpectedBetweenThrowKeywordAndExpression`, if present.
-  public func withUnexpectedBetweenThrowKeywordAndExpression(_ newChild: UnexpectedNodesSyntax?) -> ThrowStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ThrowStmtSyntax(newData)
   }
 
   public var expression: ExprSyntax {
@@ -3670,18 +2956,11 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withExpression(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ThrowStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `expression` replaced.
-  /// - param newChild: The new `expression` to replace the node's
-  ///                   current `expression`, if present.
-  public func withExpression(_ newChild: ExprSyntax) -> ThrowStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ThrowStmtSyntax(newData)
   }
 
   public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
@@ -3691,18 +2970,11 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterExpression(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ThrowStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
-  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
-  ///                   current `unexpectedAfterExpression`, if present.
-  public func withUnexpectedAfterExpression(_ newChild: UnexpectedNodesSyntax?) -> ThrowStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ThrowStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -3845,18 +3117,11 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeIfKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = IfStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeIfKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeIfKeyword` to replace the node's
-  ///                   current `unexpectedBeforeIfKeyword`, if present.
-  public func withUnexpectedBeforeIfKeyword(_ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return IfStmtSyntax(newData)
   }
 
   public var ifKeyword: TokenSyntax {
@@ -3865,18 +3130,11 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withIfKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = IfStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `ifKeyword` replaced.
-  /// - param newChild: The new `ifKeyword` to replace the node's
-  ///                   current `ifKeyword`, if present.
-  public func withIfKeyword(_ newChild: TokenSyntax) -> IfStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return IfStmtSyntax(newData)
   }
 
   public var unexpectedBetweenIfKeywordAndConditions: UnexpectedNodesSyntax? {
@@ -3886,18 +3144,11 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenIfKeywordAndConditions(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = IfStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenIfKeywordAndConditions` replaced.
-  /// - param newChild: The new `unexpectedBetweenIfKeywordAndConditions` to replace the node's
-  ///                   current `unexpectedBetweenIfKeywordAndConditions`, if present.
-  public func withUnexpectedBetweenIfKeywordAndConditions(_ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return IfStmtSyntax(newData)
   }
 
   public var conditions: ConditionElementListSyntax {
@@ -3906,7 +3157,10 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return ConditionElementListSyntax(childData!)
     }
     set(value) {
-      self = withConditions(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = IfStmtSyntax(newData)
     }
   }
 
@@ -3929,16 +3183,6 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return IfStmtSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `conditions` replaced.
-  /// - param newChild: The new `conditions` to replace the node's
-  ///                   current `conditions`, if present.
-  public func withConditions(_ newChild: ConditionElementListSyntax) -> IfStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return IfStmtSyntax(newData)
-  }
-
   public var unexpectedBetweenConditionsAndBody: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -3946,18 +3190,11 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenConditionsAndBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = IfStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenConditionsAndBody` replaced.
-  /// - param newChild: The new `unexpectedBetweenConditionsAndBody` to replace the node's
-  ///                   current `unexpectedBetweenConditionsAndBody`, if present.
-  public func withUnexpectedBetweenConditionsAndBody(_ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return IfStmtSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
@@ -3966,18 +3203,11 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return CodeBlockSyntax(childData!)
     }
     set(value) {
-      self = withBody(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = IfStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `body` replaced.
-  /// - param newChild: The new `body` to replace the node's
-  ///                   current `body`, if present.
-  public func withBody(_ newChild: CodeBlockSyntax) -> IfStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return IfStmtSyntax(newData)
   }
 
   public var unexpectedBetweenBodyAndElseKeyword: UnexpectedNodesSyntax? {
@@ -3987,18 +3217,11 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenBodyAndElseKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = IfStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenBodyAndElseKeyword` replaced.
-  /// - param newChild: The new `unexpectedBetweenBodyAndElseKeyword` to replace the node's
-  ///                   current `unexpectedBetweenBodyAndElseKeyword`, if present.
-  public func withUnexpectedBetweenBodyAndElseKeyword(_ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return IfStmtSyntax(newData)
   }
 
   public var elseKeyword: TokenSyntax? {
@@ -4008,18 +3231,11 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withElseKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = IfStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `elseKeyword` replaced.
-  /// - param newChild: The new `elseKeyword` to replace the node's
-  ///                   current `elseKeyword`, if present.
-  public func withElseKeyword(_ newChild: TokenSyntax?) -> IfStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return IfStmtSyntax(newData)
   }
 
   public var unexpectedBetweenElseKeywordAndElseBody: UnexpectedNodesSyntax? {
@@ -4029,18 +3245,11 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenElseKeywordAndElseBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = IfStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenElseKeywordAndElseBody` replaced.
-  /// - param newChild: The new `unexpectedBetweenElseKeywordAndElseBody` to replace the node's
-  ///                   current `unexpectedBetweenElseKeywordAndElseBody`, if present.
-  public func withUnexpectedBetweenElseKeywordAndElseBody(_ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return IfStmtSyntax(newData)
   }
 
   public var elseBody: ElseBody? {
@@ -4050,18 +3259,11 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return ElseBody(childData!)
     }
     set(value) {
-      self = withElseBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = IfStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `elseBody` replaced.
-  /// - param newChild: The new `elseBody` to replace the node's
-  ///                   current `elseBody`, if present.
-  public func withElseBody(_ newChild: ElseBody?) -> IfStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return IfStmtSyntax(newData)
   }
 
   public var unexpectedAfterElseBody: UnexpectedNodesSyntax? {
@@ -4071,18 +3273,11 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterElseBody(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = IfStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterElseBody` replaced.
-  /// - param newChild: The new `unexpectedAfterElseBody` to replace the node's
-  ///                   current `unexpectedAfterElseBody`, if present.
-  public func withUnexpectedAfterElseBody(_ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return IfStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -4217,18 +3412,11 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforePoundAssert(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PoundAssertStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforePoundAssert` replaced.
-  /// - param newChild: The new `unexpectedBeforePoundAssert` to replace the node's
-  ///                   current `unexpectedBeforePoundAssert`, if present.
-  public func withUnexpectedBeforePoundAssert(_ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PoundAssertStmtSyntax(newData)
   }
 
   public var poundAssert: TokenSyntax {
@@ -4237,18 +3425,11 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPoundAssert(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PoundAssertStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `poundAssert` replaced.
-  /// - param newChild: The new `poundAssert` to replace the node's
-  ///                   current `poundAssert`, if present.
-  public func withPoundAssert(_ newChild: TokenSyntax) -> PoundAssertStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PoundAssertStmtSyntax(newData)
   }
 
   public var unexpectedBetweenPoundAssertAndLeftParen: UnexpectedNodesSyntax? {
@@ -4258,18 +3439,11 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPoundAssertAndLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PoundAssertStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPoundAssertAndLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenPoundAssertAndLeftParen` to replace the node's
-  ///                   current `unexpectedBetweenPoundAssertAndLeftParen`, if present.
-  public func withUnexpectedBetweenPoundAssertAndLeftParen(_ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PoundAssertStmtSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -4278,18 +3452,11 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PoundAssertStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> PoundAssertStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PoundAssertStmtSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndCondition: UnexpectedNodesSyntax? {
@@ -4299,18 +3466,11 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndCondition(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PoundAssertStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndCondition` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndCondition` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndCondition`, if present.
-  public func withUnexpectedBetweenLeftParenAndCondition(_ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PoundAssertStmtSyntax(newData)
   }
 
   /// The assertion condition.
@@ -4320,18 +3480,11 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return ExprSyntax(childData!)
     }
     set(value) {
-      self = withCondition(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = PoundAssertStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `condition` replaced.
-  /// - param newChild: The new `condition` to replace the node's
-  ///                   current `condition`, if present.
-  public func withCondition(_ newChild: ExprSyntax) -> PoundAssertStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return PoundAssertStmtSyntax(newData)
   }
 
   public var unexpectedBetweenConditionAndComma: UnexpectedNodesSyntax? {
@@ -4341,18 +3494,11 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenConditionAndComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = PoundAssertStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenConditionAndComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenConditionAndComma` to replace the node's
-  ///                   current `unexpectedBetweenConditionAndComma`, if present.
-  public func withUnexpectedBetweenConditionAndComma(_ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return PoundAssertStmtSyntax(newData)
   }
 
   /// The comma after the assertion condition.
@@ -4363,18 +3509,11 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withComma(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = PoundAssertStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `comma` replaced.
-  /// - param newChild: The new `comma` to replace the node's
-  ///                   current `comma`, if present.
-  public func withComma(_ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return PoundAssertStmtSyntax(newData)
   }
 
   public var unexpectedBetweenCommaAndMessage: UnexpectedNodesSyntax? {
@@ -4384,18 +3523,11 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenCommaAndMessage(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = PoundAssertStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndMessage` replaced.
-  /// - param newChild: The new `unexpectedBetweenCommaAndMessage` to replace the node's
-  ///                   current `unexpectedBetweenCommaAndMessage`, if present.
-  public func withUnexpectedBetweenCommaAndMessage(_ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return PoundAssertStmtSyntax(newData)
   }
 
   /// The assertion message.
@@ -4406,18 +3538,11 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return StringLiteralExprSyntax(childData!)
     }
     set(value) {
-      self = withMessage(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = PoundAssertStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `message` replaced.
-  /// - param newChild: The new `message` to replace the node's
-  ///                   current `message`, if present.
-  public func withMessage(_ newChild: StringLiteralExprSyntax?) -> PoundAssertStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return PoundAssertStmtSyntax(newData)
   }
 
   public var unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? {
@@ -4427,18 +3552,11 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenMessageAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = PoundAssertStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenMessageAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenMessageAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenMessageAndRightParen`, if present.
-  public func withUnexpectedBetweenMessageAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return PoundAssertStmtSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -4447,18 +3565,11 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 11, with: raw, arena: arena)
+      self = PoundAssertStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> PoundAssertStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 11, with: raw, arena: arena)
-    return PoundAssertStmtSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -4468,18 +3579,11 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 12, with: raw, arena: arena)
+      self = PoundAssertStmtSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 12, with: raw, arena: arena)
-    return PoundAssertStmtSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -113,18 +113,11 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = SimpleTypeIdentifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeName` replaced.
-  /// - param newChild: The new `unexpectedBeforeName` to replace the node's
-  ///                   current `unexpectedBeforeName`, if present.
-  public func withUnexpectedBeforeName(_ newChild: UnexpectedNodesSyntax?) -> SimpleTypeIdentifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return SimpleTypeIdentifierSyntax(newData)
   }
 
   public var name: TokenSyntax {
@@ -133,18 +126,11 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = SimpleTypeIdentifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax) -> SimpleTypeIdentifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return SimpleTypeIdentifierSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodesSyntax? {
@@ -154,18 +140,11 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenNameAndGenericArgumentClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = SimpleTypeIdentifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenNameAndGenericArgumentClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenNameAndGenericArgumentClause` to replace the node's
-  ///                   current `unexpectedBetweenNameAndGenericArgumentClause`, if present.
-  public func withUnexpectedBetweenNameAndGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> SimpleTypeIdentifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return SimpleTypeIdentifierSyntax(newData)
   }
 
   public var genericArgumentClause: GenericArgumentClauseSyntax? {
@@ -175,18 +154,11 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return GenericArgumentClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericArgumentClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = SimpleTypeIdentifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericArgumentClause` replaced.
-  /// - param newChild: The new `genericArgumentClause` to replace the node's
-  ///                   current `genericArgumentClause`, if present.
-  public func withGenericArgumentClause(_ newChild: GenericArgumentClauseSyntax?) -> SimpleTypeIdentifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return SimpleTypeIdentifierSyntax(newData)
   }
 
   public var unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? {
@@ -196,18 +168,11 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterGenericArgumentClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = SimpleTypeIdentifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterGenericArgumentClause` replaced.
-  /// - param newChild: The new `unexpectedAfterGenericArgumentClause` to replace the node's
-  ///                   current `unexpectedAfterGenericArgumentClause`, if present.
-  public func withUnexpectedAfterGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> SimpleTypeIdentifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return SimpleTypeIdentifierSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -310,18 +275,11 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeBaseType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = MemberTypeIdentifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeBaseType` replaced.
-  /// - param newChild: The new `unexpectedBeforeBaseType` to replace the node's
-  ///                   current `unexpectedBeforeBaseType`, if present.
-  public func withUnexpectedBeforeBaseType(_ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return MemberTypeIdentifierSyntax(newData)
   }
 
   public var baseType: TypeSyntax {
@@ -330,18 +288,11 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withBaseType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = MemberTypeIdentifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `baseType` replaced.
-  /// - param newChild: The new `baseType` to replace the node's
-  ///                   current `baseType`, if present.
-  public func withBaseType(_ newChild: TypeSyntax) -> MemberTypeIdentifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return MemberTypeIdentifierSyntax(newData)
   }
 
   public var unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? {
@@ -351,18 +302,11 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenBaseTypeAndPeriod(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = MemberTypeIdentifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenBaseTypeAndPeriod` replaced.
-  /// - param newChild: The new `unexpectedBetweenBaseTypeAndPeriod` to replace the node's
-  ///                   current `unexpectedBetweenBaseTypeAndPeriod`, if present.
-  public func withUnexpectedBetweenBaseTypeAndPeriod(_ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return MemberTypeIdentifierSyntax(newData)
   }
 
   public var period: TokenSyntax {
@@ -371,18 +315,11 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPeriod(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = MemberTypeIdentifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `period` replaced.
-  /// - param newChild: The new `period` to replace the node's
-  ///                   current `period`, if present.
-  public func withPeriod(_ newChild: TokenSyntax) -> MemberTypeIdentifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return MemberTypeIdentifierSyntax(newData)
   }
 
   public var unexpectedBetweenPeriodAndName: UnexpectedNodesSyntax? {
@@ -392,18 +329,11 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPeriodAndName(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = MemberTypeIdentifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPeriodAndName` replaced.
-  /// - param newChild: The new `unexpectedBetweenPeriodAndName` to replace the node's
-  ///                   current `unexpectedBetweenPeriodAndName`, if present.
-  public func withUnexpectedBetweenPeriodAndName(_ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return MemberTypeIdentifierSyntax(newData)
   }
 
   public var name: TokenSyntax {
@@ -412,18 +342,11 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withName(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = MemberTypeIdentifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `name` replaced.
-  /// - param newChild: The new `name` to replace the node's
-  ///                   current `name`, if present.
-  public func withName(_ newChild: TokenSyntax) -> MemberTypeIdentifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return MemberTypeIdentifierSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodesSyntax? {
@@ -433,18 +356,11 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenNameAndGenericArgumentClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = MemberTypeIdentifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenNameAndGenericArgumentClause` replaced.
-  /// - param newChild: The new `unexpectedBetweenNameAndGenericArgumentClause` to replace the node's
-  ///                   current `unexpectedBetweenNameAndGenericArgumentClause`, if present.
-  public func withUnexpectedBetweenNameAndGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return MemberTypeIdentifierSyntax(newData)
   }
 
   public var genericArgumentClause: GenericArgumentClauseSyntax? {
@@ -454,18 +370,11 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return GenericArgumentClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericArgumentClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = MemberTypeIdentifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericArgumentClause` replaced.
-  /// - param newChild: The new `genericArgumentClause` to replace the node's
-  ///                   current `genericArgumentClause`, if present.
-  public func withGenericArgumentClause(_ newChild: GenericArgumentClauseSyntax?) -> MemberTypeIdentifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return MemberTypeIdentifierSyntax(newData)
   }
 
   public var unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? {
@@ -475,18 +384,11 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterGenericArgumentClause(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = MemberTypeIdentifierSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterGenericArgumentClause` replaced.
-  /// - param newChild: The new `unexpectedAfterGenericArgumentClause` to replace the node's
-  ///                   current `unexpectedAfterGenericArgumentClause`, if present.
-  public func withUnexpectedAfterGenericArgumentClause(_ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return MemberTypeIdentifierSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -593,18 +495,11 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeClassKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ClassRestrictionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeClassKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeClassKeyword` to replace the node's
-  ///                   current `unexpectedBeforeClassKeyword`, if present.
-  public func withUnexpectedBeforeClassKeyword(_ newChild: UnexpectedNodesSyntax?) -> ClassRestrictionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ClassRestrictionTypeSyntax(newData)
   }
 
   public var classKeyword: TokenSyntax {
@@ -613,18 +508,11 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withClassKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ClassRestrictionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `classKeyword` replaced.
-  /// - param newChild: The new `classKeyword` to replace the node's
-  ///                   current `classKeyword`, if present.
-  public func withClassKeyword(_ newChild: TokenSyntax) -> ClassRestrictionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ClassRestrictionTypeSyntax(newData)
   }
 
   public var unexpectedAfterClassKeyword: UnexpectedNodesSyntax? {
@@ -634,18 +522,11 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterClassKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ClassRestrictionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterClassKeyword` replaced.
-  /// - param newChild: The new `unexpectedAfterClassKeyword` to replace the node's
-  ///                   current `unexpectedAfterClassKeyword`, if present.
-  public func withUnexpectedAfterClassKeyword(_ newChild: UnexpectedNodesSyntax?) -> ClassRestrictionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ClassRestrictionTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -736,18 +617,11 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftSquareBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ArrayTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftSquareBracket` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftSquareBracket` to replace the node's
-  ///                   current `unexpectedBeforeLeftSquareBracket`, if present.
-  public func withUnexpectedBeforeLeftSquareBracket(_ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ArrayTypeSyntax(newData)
   }
 
   public var leftSquareBracket: TokenSyntax {
@@ -756,18 +630,11 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftSquareBracket(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ArrayTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftSquareBracket` replaced.
-  /// - param newChild: The new `leftSquareBracket` to replace the node's
-  ///                   current `leftSquareBracket`, if present.
-  public func withLeftSquareBracket(_ newChild: TokenSyntax) -> ArrayTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ArrayTypeSyntax(newData)
   }
 
   public var unexpectedBetweenLeftSquareBracketAndElementType: UnexpectedNodesSyntax? {
@@ -777,18 +644,11 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftSquareBracketAndElementType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ArrayTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftSquareBracketAndElementType` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftSquareBracketAndElementType` to replace the node's
-  ///                   current `unexpectedBetweenLeftSquareBracketAndElementType`, if present.
-  public func withUnexpectedBetweenLeftSquareBracketAndElementType(_ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ArrayTypeSyntax(newData)
   }
 
   public var elementType: TypeSyntax {
@@ -797,18 +657,11 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withElementType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ArrayTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `elementType` replaced.
-  /// - param newChild: The new `elementType` to replace the node's
-  ///                   current `elementType`, if present.
-  public func withElementType(_ newChild: TypeSyntax) -> ArrayTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ArrayTypeSyntax(newData)
   }
 
   public var unexpectedBetweenElementTypeAndRightSquareBracket: UnexpectedNodesSyntax? {
@@ -818,18 +671,11 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenElementTypeAndRightSquareBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ArrayTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenElementTypeAndRightSquareBracket` replaced.
-  /// - param newChild: The new `unexpectedBetweenElementTypeAndRightSquareBracket` to replace the node's
-  ///                   current `unexpectedBetweenElementTypeAndRightSquareBracket`, if present.
-  public func withUnexpectedBetweenElementTypeAndRightSquareBracket(_ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ArrayTypeSyntax(newData)
   }
 
   public var rightSquareBracket: TokenSyntax {
@@ -838,18 +684,11 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightSquareBracket(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = ArrayTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightSquareBracket` replaced.
-  /// - param newChild: The new `rightSquareBracket` to replace the node's
-  ///                   current `rightSquareBracket`, if present.
-  public func withRightSquareBracket(_ newChild: TokenSyntax) -> ArrayTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return ArrayTypeSyntax(newData)
   }
 
   public var unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? {
@@ -859,18 +698,11 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightSquareBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = ArrayTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightSquareBracket` replaced.
-  /// - param newChild: The new `unexpectedAfterRightSquareBracket` to replace the node's
-  ///                   current `unexpectedAfterRightSquareBracket`, if present.
-  public func withUnexpectedAfterRightSquareBracket(_ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return ArrayTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -985,18 +817,11 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftSquareBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = DictionaryTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftSquareBracket` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftSquareBracket` to replace the node's
-  ///                   current `unexpectedBeforeLeftSquareBracket`, if present.
-  public func withUnexpectedBeforeLeftSquareBracket(_ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return DictionaryTypeSyntax(newData)
   }
 
   public var leftSquareBracket: TokenSyntax {
@@ -1005,18 +830,11 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftSquareBracket(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = DictionaryTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftSquareBracket` replaced.
-  /// - param newChild: The new `leftSquareBracket` to replace the node's
-  ///                   current `leftSquareBracket`, if present.
-  public func withLeftSquareBracket(_ newChild: TokenSyntax) -> DictionaryTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return DictionaryTypeSyntax(newData)
   }
 
   public var unexpectedBetweenLeftSquareBracketAndKeyType: UnexpectedNodesSyntax? {
@@ -1026,18 +844,11 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftSquareBracketAndKeyType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = DictionaryTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftSquareBracketAndKeyType` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftSquareBracketAndKeyType` to replace the node's
-  ///                   current `unexpectedBetweenLeftSquareBracketAndKeyType`, if present.
-  public func withUnexpectedBetweenLeftSquareBracketAndKeyType(_ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return DictionaryTypeSyntax(newData)
   }
 
   public var keyType: TypeSyntax {
@@ -1046,18 +857,11 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withKeyType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = DictionaryTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `keyType` replaced.
-  /// - param newChild: The new `keyType` to replace the node's
-  ///                   current `keyType`, if present.
-  public func withKeyType(_ newChild: TypeSyntax) -> DictionaryTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return DictionaryTypeSyntax(newData)
   }
 
   public var unexpectedBetweenKeyTypeAndColon: UnexpectedNodesSyntax? {
@@ -1067,18 +871,11 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenKeyTypeAndColon(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = DictionaryTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenKeyTypeAndColon` replaced.
-  /// - param newChild: The new `unexpectedBetweenKeyTypeAndColon` to replace the node's
-  ///                   current `unexpectedBetweenKeyTypeAndColon`, if present.
-  public func withUnexpectedBetweenKeyTypeAndColon(_ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return DictionaryTypeSyntax(newData)
   }
 
   public var colon: TokenSyntax {
@@ -1087,18 +884,11 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withColon(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = DictionaryTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `colon` replaced.
-  /// - param newChild: The new `colon` to replace the node's
-  ///                   current `colon`, if present.
-  public func withColon(_ newChild: TokenSyntax) -> DictionaryTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return DictionaryTypeSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndValueType: UnexpectedNodesSyntax? {
@@ -1108,18 +898,11 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndValueType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = DictionaryTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndValueType` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndValueType` to replace the node's
-  ///                   current `unexpectedBetweenColonAndValueType`, if present.
-  public func withUnexpectedBetweenColonAndValueType(_ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return DictionaryTypeSyntax(newData)
   }
 
   public var valueType: TypeSyntax {
@@ -1128,18 +911,11 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withValueType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = DictionaryTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `valueType` replaced.
-  /// - param newChild: The new `valueType` to replace the node's
-  ///                   current `valueType`, if present.
-  public func withValueType(_ newChild: TypeSyntax) -> DictionaryTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return DictionaryTypeSyntax(newData)
   }
 
   public var unexpectedBetweenValueTypeAndRightSquareBracket: UnexpectedNodesSyntax? {
@@ -1149,18 +925,11 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenValueTypeAndRightSquareBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = DictionaryTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenValueTypeAndRightSquareBracket` replaced.
-  /// - param newChild: The new `unexpectedBetweenValueTypeAndRightSquareBracket` to replace the node's
-  ///                   current `unexpectedBetweenValueTypeAndRightSquareBracket`, if present.
-  public func withUnexpectedBetweenValueTypeAndRightSquareBracket(_ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return DictionaryTypeSyntax(newData)
   }
 
   public var rightSquareBracket: TokenSyntax {
@@ -1169,18 +938,11 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightSquareBracket(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = DictionaryTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightSquareBracket` replaced.
-  /// - param newChild: The new `rightSquareBracket` to replace the node's
-  ///                   current `rightSquareBracket`, if present.
-  public func withRightSquareBracket(_ newChild: TokenSyntax) -> DictionaryTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return DictionaryTypeSyntax(newData)
   }
 
   public var unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? {
@@ -1190,18 +952,11 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightSquareBracket(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = DictionaryTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightSquareBracket` replaced.
-  /// - param newChild: The new `unexpectedAfterRightSquareBracket` to replace the node's
-  ///                   current `unexpectedAfterRightSquareBracket`, if present.
-  public func withUnexpectedAfterRightSquareBracket(_ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return DictionaryTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1324,18 +1079,11 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeBaseType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = MetatypeTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeBaseType` replaced.
-  /// - param newChild: The new `unexpectedBeforeBaseType` to replace the node's
-  ///                   current `unexpectedBeforeBaseType`, if present.
-  public func withUnexpectedBeforeBaseType(_ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return MetatypeTypeSyntax(newData)
   }
 
   public var baseType: TypeSyntax {
@@ -1344,18 +1092,11 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withBaseType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = MetatypeTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `baseType` replaced.
-  /// - param newChild: The new `baseType` to replace the node's
-  ///                   current `baseType`, if present.
-  public func withBaseType(_ newChild: TypeSyntax) -> MetatypeTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return MetatypeTypeSyntax(newData)
   }
 
   public var unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? {
@@ -1365,18 +1106,11 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenBaseTypeAndPeriod(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = MetatypeTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenBaseTypeAndPeriod` replaced.
-  /// - param newChild: The new `unexpectedBetweenBaseTypeAndPeriod` to replace the node's
-  ///                   current `unexpectedBetweenBaseTypeAndPeriod`, if present.
-  public func withUnexpectedBetweenBaseTypeAndPeriod(_ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return MetatypeTypeSyntax(newData)
   }
 
   public var period: TokenSyntax {
@@ -1385,18 +1119,11 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPeriod(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = MetatypeTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `period` replaced.
-  /// - param newChild: The new `period` to replace the node's
-  ///                   current `period`, if present.
-  public func withPeriod(_ newChild: TokenSyntax) -> MetatypeTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return MetatypeTypeSyntax(newData)
   }
 
   public var unexpectedBetweenPeriodAndTypeOrProtocol: UnexpectedNodesSyntax? {
@@ -1406,18 +1133,11 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPeriodAndTypeOrProtocol(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = MetatypeTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenPeriodAndTypeOrProtocol` replaced.
-  /// - param newChild: The new `unexpectedBetweenPeriodAndTypeOrProtocol` to replace the node's
-  ///                   current `unexpectedBetweenPeriodAndTypeOrProtocol`, if present.
-  public func withUnexpectedBetweenPeriodAndTypeOrProtocol(_ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return MetatypeTypeSyntax(newData)
   }
 
   public var typeOrProtocol: TokenSyntax {
@@ -1426,18 +1146,11 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withTypeOrProtocol(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = MetatypeTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `typeOrProtocol` replaced.
-  /// - param newChild: The new `typeOrProtocol` to replace the node's
-  ///                   current `typeOrProtocol`, if present.
-  public func withTypeOrProtocol(_ newChild: TokenSyntax) -> MetatypeTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return MetatypeTypeSyntax(newData)
   }
 
   public var unexpectedAfterTypeOrProtocol: UnexpectedNodesSyntax? {
@@ -1447,18 +1160,11 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterTypeOrProtocol(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = MetatypeTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterTypeOrProtocol` replaced.
-  /// - param newChild: The new `unexpectedAfterTypeOrProtocol` to replace the node's
-  ///                   current `unexpectedAfterTypeOrProtocol`, if present.
-  public func withUnexpectedAfterTypeOrProtocol(_ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return MetatypeTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1561,18 +1267,11 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeWrappedType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = OptionalTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeWrappedType` replaced.
-  /// - param newChild: The new `unexpectedBeforeWrappedType` to replace the node's
-  ///                   current `unexpectedBeforeWrappedType`, if present.
-  public func withUnexpectedBeforeWrappedType(_ newChild: UnexpectedNodesSyntax?) -> OptionalTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return OptionalTypeSyntax(newData)
   }
 
   public var wrappedType: TypeSyntax {
@@ -1581,18 +1280,11 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withWrappedType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = OptionalTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `wrappedType` replaced.
-  /// - param newChild: The new `wrappedType` to replace the node's
-  ///                   current `wrappedType`, if present.
-  public func withWrappedType(_ newChild: TypeSyntax) -> OptionalTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return OptionalTypeSyntax(newData)
   }
 
   public var unexpectedBetweenWrappedTypeAndQuestionMark: UnexpectedNodesSyntax? {
@@ -1602,18 +1294,11 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenWrappedTypeAndQuestionMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = OptionalTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenWrappedTypeAndQuestionMark` replaced.
-  /// - param newChild: The new `unexpectedBetweenWrappedTypeAndQuestionMark` to replace the node's
-  ///                   current `unexpectedBetweenWrappedTypeAndQuestionMark`, if present.
-  public func withUnexpectedBetweenWrappedTypeAndQuestionMark(_ newChild: UnexpectedNodesSyntax?) -> OptionalTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return OptionalTypeSyntax(newData)
   }
 
   public var questionMark: TokenSyntax {
@@ -1622,18 +1307,11 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withQuestionMark(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = OptionalTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `questionMark` replaced.
-  /// - param newChild: The new `questionMark` to replace the node's
-  ///                   current `questionMark`, if present.
-  public func withQuestionMark(_ newChild: TokenSyntax) -> OptionalTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return OptionalTypeSyntax(newData)
   }
 
   public var unexpectedAfterQuestionMark: UnexpectedNodesSyntax? {
@@ -1643,18 +1321,11 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterQuestionMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = OptionalTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterQuestionMark` replaced.
-  /// - param newChild: The new `unexpectedAfterQuestionMark` to replace the node's
-  ///                   current `unexpectedAfterQuestionMark`, if present.
-  public func withUnexpectedAfterQuestionMark(_ newChild: UnexpectedNodesSyntax?) -> OptionalTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return OptionalTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1749,18 +1420,11 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeSomeOrAnySpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ConstrainedSugarTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeSomeOrAnySpecifier` replaced.
-  /// - param newChild: The new `unexpectedBeforeSomeOrAnySpecifier` to replace the node's
-  ///                   current `unexpectedBeforeSomeOrAnySpecifier`, if present.
-  public func withUnexpectedBeforeSomeOrAnySpecifier(_ newChild: UnexpectedNodesSyntax?) -> ConstrainedSugarTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ConstrainedSugarTypeSyntax(newData)
   }
 
   public var someOrAnySpecifier: TokenSyntax {
@@ -1769,18 +1433,11 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withSomeOrAnySpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ConstrainedSugarTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `someOrAnySpecifier` replaced.
-  /// - param newChild: The new `someOrAnySpecifier` to replace the node's
-  ///                   current `someOrAnySpecifier`, if present.
-  public func withSomeOrAnySpecifier(_ newChild: TokenSyntax) -> ConstrainedSugarTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ConstrainedSugarTypeSyntax(newData)
   }
 
   public var unexpectedBetweenSomeOrAnySpecifierAndBaseType: UnexpectedNodesSyntax? {
@@ -1790,18 +1447,11 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSomeOrAnySpecifierAndBaseType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ConstrainedSugarTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSomeOrAnySpecifierAndBaseType` replaced.
-  /// - param newChild: The new `unexpectedBetweenSomeOrAnySpecifierAndBaseType` to replace the node's
-  ///                   current `unexpectedBetweenSomeOrAnySpecifierAndBaseType`, if present.
-  public func withUnexpectedBetweenSomeOrAnySpecifierAndBaseType(_ newChild: UnexpectedNodesSyntax?) -> ConstrainedSugarTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ConstrainedSugarTypeSyntax(newData)
   }
 
   public var baseType: TypeSyntax {
@@ -1810,18 +1460,11 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withBaseType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ConstrainedSugarTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `baseType` replaced.
-  /// - param newChild: The new `baseType` to replace the node's
-  ///                   current `baseType`, if present.
-  public func withBaseType(_ newChild: TypeSyntax) -> ConstrainedSugarTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ConstrainedSugarTypeSyntax(newData)
   }
 
   public var unexpectedAfterBaseType: UnexpectedNodesSyntax? {
@@ -1831,18 +1474,11 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterBaseType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ConstrainedSugarTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterBaseType` replaced.
-  /// - param newChild: The new `unexpectedAfterBaseType` to replace the node's
-  ///                   current `unexpectedAfterBaseType`, if present.
-  public func withUnexpectedAfterBaseType(_ newChild: UnexpectedNodesSyntax?) -> ConstrainedSugarTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ConstrainedSugarTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -1937,18 +1573,11 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeWrappedType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = ImplicitlyUnwrappedOptionalTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeWrappedType` replaced.
-  /// - param newChild: The new `unexpectedBeforeWrappedType` to replace the node's
-  ///                   current `unexpectedBeforeWrappedType`, if present.
-  public func withUnexpectedBeforeWrappedType(_ newChild: UnexpectedNodesSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
 
   public var wrappedType: TypeSyntax {
@@ -1957,18 +1586,11 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withWrappedType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = ImplicitlyUnwrappedOptionalTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `wrappedType` replaced.
-  /// - param newChild: The new `wrappedType` to replace the node's
-  ///                   current `wrappedType`, if present.
-  public func withWrappedType(_ newChild: TypeSyntax) -> ImplicitlyUnwrappedOptionalTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
 
   public var unexpectedBetweenWrappedTypeAndExclamationMark: UnexpectedNodesSyntax? {
@@ -1978,18 +1600,11 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenWrappedTypeAndExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = ImplicitlyUnwrappedOptionalTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenWrappedTypeAndExclamationMark` replaced.
-  /// - param newChild: The new `unexpectedBetweenWrappedTypeAndExclamationMark` to replace the node's
-  ///                   current `unexpectedBetweenWrappedTypeAndExclamationMark`, if present.
-  public func withUnexpectedBetweenWrappedTypeAndExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
 
   public var exclamationMark: TokenSyntax {
@@ -1998,18 +1613,11 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = ImplicitlyUnwrappedOptionalTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `exclamationMark` replaced.
-  /// - param newChild: The new `exclamationMark` to replace the node's
-  ///                   current `exclamationMark`, if present.
-  public func withExclamationMark(_ newChild: TokenSyntax) -> ImplicitlyUnwrappedOptionalTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
 
   public var unexpectedAfterExclamationMark: UnexpectedNodesSyntax? {
@@ -2019,18 +1627,11 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterExclamationMark(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = ImplicitlyUnwrappedOptionalTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterExclamationMark` replaced.
-  /// - param newChild: The new `unexpectedAfterExclamationMark` to replace the node's
-  ///                   current `unexpectedAfterExclamationMark`, if present.
-  public func withUnexpectedAfterExclamationMark(_ newChild: UnexpectedNodesSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2121,18 +1722,11 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeElements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = CompositionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeElements` replaced.
-  /// - param newChild: The new `unexpectedBeforeElements` to replace the node's
-  ///                   current `unexpectedBeforeElements`, if present.
-  public func withUnexpectedBeforeElements(_ newChild: UnexpectedNodesSyntax?) -> CompositionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return CompositionTypeSyntax(newData)
   }
 
   public var elements: CompositionTypeElementListSyntax {
@@ -2141,7 +1735,10 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return CompositionTypeElementListSyntax(childData!)
     }
     set(value) {
-      self = withElements(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = CompositionTypeSyntax(newData)
     }
   }
 
@@ -2164,16 +1761,6 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return CompositionTypeSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `elements` replaced.
-  /// - param newChild: The new `elements` to replace the node's
-  ///                   current `elements`, if present.
-  public func withElements(_ newChild: CompositionTypeElementListSyntax) -> CompositionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return CompositionTypeSyntax(newData)
-  }
-
   public var unexpectedAfterElements: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
@@ -2181,18 +1768,11 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterElements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = CompositionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterElements` replaced.
-  /// - param newChild: The new `unexpectedAfterElements` to replace the node's
-  ///                   current `unexpectedAfterElements`, if present.
-  public func withUnexpectedAfterElements(_ newChild: UnexpectedNodesSyntax?) -> CompositionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return CompositionTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2279,18 +1859,11 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeRepeatKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PackExpansionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeRepeatKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeRepeatKeyword` to replace the node's
-  ///                   current `unexpectedBeforeRepeatKeyword`, if present.
-  public func withUnexpectedBeforeRepeatKeyword(_ newChild: UnexpectedNodesSyntax?) -> PackExpansionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PackExpansionTypeSyntax(newData)
   }
 
   public var repeatKeyword: TokenSyntax {
@@ -2299,18 +1872,11 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRepeatKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PackExpansionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `repeatKeyword` replaced.
-  /// - param newChild: The new `repeatKeyword` to replace the node's
-  ///                   current `repeatKeyword`, if present.
-  public func withRepeatKeyword(_ newChild: TokenSyntax) -> PackExpansionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PackExpansionTypeSyntax(newData)
   }
 
   public var unexpectedBetweenRepeatKeywordAndPatternType: UnexpectedNodesSyntax? {
@@ -2320,18 +1886,11 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenRepeatKeywordAndPatternType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PackExpansionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenRepeatKeywordAndPatternType` replaced.
-  /// - param newChild: The new `unexpectedBetweenRepeatKeywordAndPatternType` to replace the node's
-  ///                   current `unexpectedBetweenRepeatKeywordAndPatternType`, if present.
-  public func withUnexpectedBetweenRepeatKeywordAndPatternType(_ newChild: UnexpectedNodesSyntax?) -> PackExpansionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PackExpansionTypeSyntax(newData)
   }
 
   public var patternType: TypeSyntax {
@@ -2340,18 +1899,11 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withPatternType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PackExpansionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `patternType` replaced.
-  /// - param newChild: The new `patternType` to replace the node's
-  ///                   current `patternType`, if present.
-  public func withPatternType(_ newChild: TypeSyntax) -> PackExpansionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PackExpansionTypeSyntax(newData)
   }
 
   public var unexpectedAfterPatternType: UnexpectedNodesSyntax? {
@@ -2361,18 +1913,11 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterPatternType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PackExpansionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterPatternType` replaced.
-  /// - param newChild: The new `unexpectedAfterPatternType` to replace the node's
-  ///                   current `unexpectedAfterPatternType`, if present.
-  public func withUnexpectedAfterPatternType(_ newChild: UnexpectedNodesSyntax?) -> PackExpansionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PackExpansionTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2467,18 +2012,11 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeEachKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = PackReferenceTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeEachKeyword` replaced.
-  /// - param newChild: The new `unexpectedBeforeEachKeyword` to replace the node's
-  ///                   current `unexpectedBeforeEachKeyword`, if present.
-  public func withUnexpectedBeforeEachKeyword(_ newChild: UnexpectedNodesSyntax?) -> PackReferenceTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return PackReferenceTypeSyntax(newData)
   }
 
   public var eachKeyword: TokenSyntax {
@@ -2487,18 +2025,11 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withEachKeyword(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = PackReferenceTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `eachKeyword` replaced.
-  /// - param newChild: The new `eachKeyword` to replace the node's
-  ///                   current `eachKeyword`, if present.
-  public func withEachKeyword(_ newChild: TokenSyntax) -> PackReferenceTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return PackReferenceTypeSyntax(newData)
   }
 
   public var unexpectedBetweenEachKeywordAndPackType: UnexpectedNodesSyntax? {
@@ -2508,18 +2039,11 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenEachKeywordAndPackType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = PackReferenceTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenEachKeywordAndPackType` replaced.
-  /// - param newChild: The new `unexpectedBetweenEachKeywordAndPackType` to replace the node's
-  ///                   current `unexpectedBetweenEachKeywordAndPackType`, if present.
-  public func withUnexpectedBetweenEachKeywordAndPackType(_ newChild: UnexpectedNodesSyntax?) -> PackReferenceTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return PackReferenceTypeSyntax(newData)
   }
 
   public var packType: TypeSyntax {
@@ -2528,18 +2052,11 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withPackType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = PackReferenceTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `packType` replaced.
-  /// - param newChild: The new `packType` to replace the node's
-  ///                   current `packType`, if present.
-  public func withPackType(_ newChild: TypeSyntax) -> PackReferenceTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return PackReferenceTypeSyntax(newData)
   }
 
   public var unexpectedAfterPackType: UnexpectedNodesSyntax? {
@@ -2549,18 +2066,11 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterPackType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = PackReferenceTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterPackType` replaced.
-  /// - param newChild: The new `unexpectedAfterPackType` to replace the node's
-  ///                   current `unexpectedAfterPackType`, if present.
-  public func withUnexpectedAfterPackType(_ newChild: UnexpectedNodesSyntax?) -> PackReferenceTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return PackReferenceTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2659,18 +2169,11 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = TupleTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
-  ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return TupleTypeSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -2679,18 +2182,11 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = TupleTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> TupleTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return TupleTypeSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? {
@@ -2700,18 +2196,11 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndElements(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = TupleTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndElements` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndElements` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndElements`, if present.
-  public func withUnexpectedBetweenLeftParenAndElements(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return TupleTypeSyntax(newData)
   }
 
   public var elements: TupleTypeElementListSyntax {
@@ -2720,7 +2209,10 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TupleTypeElementListSyntax(childData!)
     }
     set(value) {
-      self = withElements(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = TupleTypeSyntax(newData)
     }
   }
 
@@ -2743,16 +2235,6 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return TupleTypeSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `elements` replaced.
-  /// - param newChild: The new `elements` to replace the node's
-  ///                   current `elements`, if present.
-  public func withElements(_ newChild: TupleTypeElementListSyntax) -> TupleTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return TupleTypeSyntax(newData)
-  }
-
   public var unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -2760,18 +2242,11 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenElementsAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = TupleTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenElementsAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenElementsAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenElementsAndRightParen`, if present.
-  public func withUnexpectedBetweenElementsAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return TupleTypeSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -2780,18 +2255,11 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = TupleTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> TupleTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return TupleTypeSyntax(newData)
   }
 
   public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
@@ -2801,18 +2269,11 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = TupleTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
-  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
-  ///                   current `unexpectedAfterRightParen`, if present.
-  public func withUnexpectedAfterRightParen(_ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return TupleTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -2927,18 +2388,11 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = FunctionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeLeftParen` replaced.
-  /// - param newChild: The new `unexpectedBeforeLeftParen` to replace the node's
-  ///                   current `unexpectedBeforeLeftParen`, if present.
-  public func withUnexpectedBeforeLeftParen(_ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return FunctionTypeSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
@@ -2947,18 +2401,11 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withLeftParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = FunctionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `leftParen` replaced.
-  /// - param newChild: The new `leftParen` to replace the node's
-  ///                   current `leftParen`, if present.
-  public func withLeftParen(_ newChild: TokenSyntax) -> FunctionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return FunctionTypeSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? {
@@ -2968,18 +2415,11 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenLeftParenAndArguments(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = FunctionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenLeftParenAndArguments` replaced.
-  /// - param newChild: The new `unexpectedBetweenLeftParenAndArguments` to replace the node's
-  ///                   current `unexpectedBetweenLeftParenAndArguments`, if present.
-  public func withUnexpectedBetweenLeftParenAndArguments(_ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return FunctionTypeSyntax(newData)
   }
 
   public var arguments: TupleTypeElementListSyntax {
@@ -2988,7 +2428,10 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TupleTypeElementListSyntax(childData!)
     }
     set(value) {
-      self = withArguments(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = FunctionTypeSyntax(newData)
     }
   }
 
@@ -3011,16 +2454,6 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return FunctionTypeSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `arguments` replaced.
-  /// - param newChild: The new `arguments` to replace the node's
-  ///                   current `arguments`, if present.
-  public func withArguments(_ newChild: TupleTypeElementListSyntax) -> FunctionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return FunctionTypeSyntax(newData)
-  }
-
   public var unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -3028,18 +2461,11 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenArgumentsAndRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = FunctionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenArgumentsAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenArgumentsAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenArgumentsAndRightParen`, if present.
-  public func withUnexpectedBetweenArgumentsAndRightParen(_ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return FunctionTypeSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
@@ -3048,18 +2474,11 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withRightParen(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = FunctionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `rightParen` replaced.
-  /// - param newChild: The new `rightParen` to replace the node's
-  ///                   current `rightParen`, if present.
-  public func withRightParen(_ newChild: TokenSyntax) -> FunctionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return FunctionTypeSyntax(newData)
   }
 
   public var unexpectedBetweenRightParenAndEffectSpecifiers: UnexpectedNodesSyntax? {
@@ -3069,18 +2488,11 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenRightParenAndEffectSpecifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = FunctionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenRightParenAndEffectSpecifiers` replaced.
-  /// - param newChild: The new `unexpectedBetweenRightParenAndEffectSpecifiers` to replace the node's
-  ///                   current `unexpectedBetweenRightParenAndEffectSpecifiers`, if present.
-  public func withUnexpectedBetweenRightParenAndEffectSpecifiers(_ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return FunctionTypeSyntax(newData)
   }
 
   public var effectSpecifiers: TypeEffectSpecifiersSyntax? {
@@ -3090,18 +2502,11 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TypeEffectSpecifiersSyntax(childData!)
     }
     set(value) {
-      self = withEffectSpecifiers(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 7, with: raw, arena: arena)
+      self = FunctionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `effectSpecifiers` replaced.
-  /// - param newChild: The new `effectSpecifiers` to replace the node's
-  ///                   current `effectSpecifiers`, if present.
-  public func withEffectSpecifiers(_ newChild: TypeEffectSpecifiersSyntax?) -> FunctionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 7, with: raw, arena: arena)
-    return FunctionTypeSyntax(newData)
   }
 
   public var unexpectedBetweenEffectSpecifiersAndOutput: UnexpectedNodesSyntax? {
@@ -3111,18 +2516,11 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenEffectSpecifiersAndOutput(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 8, with: raw, arena: arena)
+      self = FunctionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenEffectSpecifiersAndOutput` replaced.
-  /// - param newChild: The new `unexpectedBetweenEffectSpecifiersAndOutput` to replace the node's
-  ///                   current `unexpectedBetweenEffectSpecifiersAndOutput`, if present.
-  public func withUnexpectedBetweenEffectSpecifiersAndOutput(_ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 8, with: raw, arena: arena)
-    return FunctionTypeSyntax(newData)
   }
 
   public var output: ReturnClauseSyntax {
@@ -3131,18 +2529,11 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return ReturnClauseSyntax(childData!)
     }
     set(value) {
-      self = withOutput(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 9, with: raw, arena: arena)
+      self = FunctionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `output` replaced.
-  /// - param newChild: The new `output` to replace the node's
-  ///                   current `output`, if present.
-  public func withOutput(_ newChild: ReturnClauseSyntax) -> FunctionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 9, with: raw, arena: arena)
-    return FunctionTypeSyntax(newData)
   }
 
   public var unexpectedAfterOutput: UnexpectedNodesSyntax? {
@@ -3152,18 +2543,11 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterOutput(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 10, with: raw, arena: arena)
+      self = FunctionTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterOutput` replaced.
-  /// - param newChild: The new `unexpectedAfterOutput` to replace the node's
-  ///                   current `unexpectedAfterOutput`, if present.
-  public func withUnexpectedAfterOutput(_ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 10, with: raw, arena: arena)
-    return FunctionTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -3286,18 +2670,11 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = AttributedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeSpecifier` replaced.
-  /// - param newChild: The new `unexpectedBeforeSpecifier` to replace the node's
-  ///                   current `unexpectedBeforeSpecifier`, if present.
-  public func withUnexpectedBeforeSpecifier(_ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return AttributedTypeSyntax(newData)
   }
 
   public var specifier: TokenSyntax? {
@@ -3307,18 +2684,11 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withSpecifier(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = AttributedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `specifier` replaced.
-  /// - param newChild: The new `specifier` to replace the node's
-  ///                   current `specifier`, if present.
-  public func withSpecifier(_ newChild: TokenSyntax?) -> AttributedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return AttributedTypeSyntax(newData)
   }
 
   public var unexpectedBetweenSpecifierAndAttributes: UnexpectedNodesSyntax? {
@@ -3328,18 +2698,11 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenSpecifierAndAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = AttributedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenSpecifierAndAttributes` replaced.
-  /// - param newChild: The new `unexpectedBetweenSpecifierAndAttributes` to replace the node's
-  ///                   current `unexpectedBetweenSpecifierAndAttributes`, if present.
-  public func withUnexpectedBetweenSpecifierAndAttributes(_ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return AttributedTypeSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
@@ -3349,7 +2712,10 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return AttributeListSyntax(childData!)
     }
     set(value) {
-      self = withAttributes(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = AttributedTypeSyntax(newData)
     }
   }
 
@@ -3372,16 +2738,6 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return AttributedTypeSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `attributes` replaced.
-  /// - param newChild: The new `attributes` to replace the node's
-  ///                   current `attributes`, if present.
-  public func withAttributes(_ newChild: AttributeListSyntax?) -> AttributedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return AttributedTypeSyntax(newData)
-  }
-
   public var unexpectedBetweenAttributesAndBaseType: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
@@ -3389,18 +2745,11 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenAttributesAndBaseType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = AttributedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenAttributesAndBaseType` replaced.
-  /// - param newChild: The new `unexpectedBetweenAttributesAndBaseType` to replace the node's
-  ///                   current `unexpectedBetweenAttributesAndBaseType`, if present.
-  public func withUnexpectedBetweenAttributesAndBaseType(_ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return AttributedTypeSyntax(newData)
   }
 
   public var baseType: TypeSyntax {
@@ -3409,18 +2758,11 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withBaseType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 5, with: raw, arena: arena)
+      self = AttributedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `baseType` replaced.
-  /// - param newChild: The new `baseType` to replace the node's
-  ///                   current `baseType`, if present.
-  public func withBaseType(_ newChild: TypeSyntax) -> AttributedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 5, with: raw, arena: arena)
-    return AttributedTypeSyntax(newData)
   }
 
   public var unexpectedAfterBaseType: UnexpectedNodesSyntax? {
@@ -3430,18 +2772,11 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterBaseType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 6, with: raw, arena: arena)
+      self = AttributedTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterBaseType` replaced.
-  /// - param newChild: The new `unexpectedAfterBaseType` to replace the node's
-  ///                   current `unexpectedAfterBaseType`, if present.
-  public func withUnexpectedAfterBaseType(_ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 6, with: raw, arena: arena)
-    return AttributedTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {
@@ -3544,18 +2879,11 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBeforeGenericParameters(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 0, with: raw, arena: arena)
+      self = NamedOpaqueReturnTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBeforeGenericParameters` replaced.
-  /// - param newChild: The new `unexpectedBeforeGenericParameters` to replace the node's
-  ///                   current `unexpectedBeforeGenericParameters`, if present.
-  public func withUnexpectedBeforeGenericParameters(_ newChild: UnexpectedNodesSyntax?) -> NamedOpaqueReturnTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 0, with: raw, arena: arena)
-    return NamedOpaqueReturnTypeSyntax(newData)
   }
 
   public var genericParameters: GenericParameterClauseSyntax {
@@ -3564,18 +2892,11 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return GenericParameterClauseSyntax(childData!)
     }
     set(value) {
-      self = withGenericParameters(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 1, with: raw, arena: arena)
+      self = NamedOpaqueReturnTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `genericParameters` replaced.
-  /// - param newChild: The new `genericParameters` to replace the node's
-  ///                   current `genericParameters`, if present.
-  public func withGenericParameters(_ newChild: GenericParameterClauseSyntax) -> NamedOpaqueReturnTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 1, with: raw, arena: arena)
-    return NamedOpaqueReturnTypeSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParametersAndBaseType: UnexpectedNodesSyntax? {
@@ -3585,18 +2906,11 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenGenericParametersAndBaseType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 2, with: raw, arena: arena)
+      self = NamedOpaqueReturnTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenGenericParametersAndBaseType` replaced.
-  /// - param newChild: The new `unexpectedBetweenGenericParametersAndBaseType` to replace the node's
-  ///                   current `unexpectedBetweenGenericParametersAndBaseType`, if present.
-  public func withUnexpectedBetweenGenericParametersAndBaseType(_ newChild: UnexpectedNodesSyntax?) -> NamedOpaqueReturnTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 2, with: raw, arena: arena)
-    return NamedOpaqueReturnTypeSyntax(newData)
   }
 
   public var baseType: TypeSyntax {
@@ -3605,18 +2919,11 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return TypeSyntax(childData!)
     }
     set(value) {
-      self = withBaseType(value)
+      let arena = SyntaxArena()
+      let raw = value.raw
+      let newData = data.replacingChild(at: 3, with: raw, arena: arena)
+      self = NamedOpaqueReturnTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `baseType` replaced.
-  /// - param newChild: The new `baseType` to replace the node's
-  ///                   current `baseType`, if present.
-  public func withBaseType(_ newChild: TypeSyntax) -> NamedOpaqueReturnTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild.raw
-    let newData = data.replacingChild(at: 3, with: raw, arena: arena)
-    return NamedOpaqueReturnTypeSyntax(newData)
   }
 
   public var unexpectedAfterBaseType: UnexpectedNodesSyntax? {
@@ -3626,18 +2933,11 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedAfterBaseType(value)
+      let arena = SyntaxArena()
+      let raw = value?.raw
+      let newData = data.replacingChild(at: 4, with: raw, arena: arena)
+      self = NamedOpaqueReturnTypeSyntax(newData)
     }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedAfterBaseType` replaced.
-  /// - param newChild: The new `unexpectedAfterBaseType` to replace the node's
-  ///                   current `unexpectedAfterBaseType`, if present.
-  public func withUnexpectedAfterBaseType(_ newChild: UnexpectedNodesSyntax?) -> NamedOpaqueReturnTypeSyntax {
-    let arena = SyntaxArena()
-    let raw = newChild?.raw
-    let newData = data.replacingChild(at: 4, with: raw, arena: arena)
-    return NamedOpaqueReturnTypeSyntax(newData)
   }
 
   public static var structure: SyntaxNodeStructure {

--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
@@ -414,7 +414,7 @@ extension VariableDeclSyntax {
   ) {
     self.init(
       leadingTrivia: leadingTrivia,
-      attributes: attributes?.withTrailingTrivia(.space),
+      attributes: attributes?.with(\.trailingTrivia, .space),
       modifiers: modifiers,
       letOrVarKeyword: .keyword(letOrVarKeyword)
     ) {
@@ -437,7 +437,7 @@ extension VariableDeclSyntax {
   ) {
     self.init(
       leadingTrivia: leadingTrivia,
-      attributes: attributes?.withTrailingTrivia(.space),
+      attributes: attributes?.with(\.trailingTrivia, .space),
       modifiers: modifiers,
       letOrVarKeyword: .keyword(.var)
     ) {

--- a/Sources/SwiftSyntaxBuilder/WithTrailingCommaSyntax+EnsuringTrailingComma.swift
+++ b/Sources/SwiftSyntaxBuilder/WithTrailingCommaSyntax+EnsuringTrailingComma.swift
@@ -15,7 +15,7 @@ import SwiftSyntax
 extension WithTrailingCommaSyntax {
   func ensuringTrailingComma() -> Self {
     if trailingComma == nil {
-      return self.withTrailingComma(.commaToken())
+      return self.with(\.trailingComma, .commaToken())
     } else {
       return self
     }

--- a/Sources/_SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem.swift
@@ -113,10 +113,10 @@ class MacroApplication: SyntaxRewriter {
       }
 
       if newAttributes.isEmpty {
-        return Syntax(fromProtocol: visitedNode.withAttributes(nil))
+        return Syntax(fromProtocol: visitedNode.with(\.attributes, nil))
       }
 
-      return Syntax(fromProtocol: visitedNode.withAttributes(AttributeListSyntax(newAttributes)))
+      return Syntax(fromProtocol: visitedNode.with(\.attributes, AttributeListSyntax(newAttributes)))
     }
 
     return nil
@@ -158,7 +158,7 @@ class MacroApplication: SyntaxRewriter {
 
       // Recurse on the child node.
       let newItem = visit(item.item)
-      newItems.append(item.withItem(newItem))
+      newItems.append(item.with(\.item, newItem))
 
       // Expand any peer declarations triggered by macros used as attributes.
       if case let .decl(decl) = item.item {
@@ -220,7 +220,7 @@ class MacroApplication: SyntaxRewriter {
 
       // Recurse on the child node.
       let newDecl = visit(attributedMember.decl)
-      newItems.append(attributedMember.withDecl(newDecl))
+      newItems.append(attributedMember.with(\.decl, newDecl))
 
       // Expand any peer declarations triggered by macros used as attributes.
       let peers = expandPeers(of: item.decl)
@@ -251,7 +251,7 @@ class MacroApplication: SyntaxRewriter {
     // Recurse into member decls.
     let newMembers = visit(expandedDeclGroup.members)
 
-    return DeclSyntax(expandedDeclGroup.withMembers(newMembers))
+    return DeclSyntax(expandedDeclGroup.with(\.members, newMembers))
   }
 
   override func visit(_ node: ActorDeclSyntax) -> DeclSyntax {
@@ -313,10 +313,12 @@ class MacroApplication: SyntaxRewriter {
     }
 
     return DeclSyntax(
-      visitedVarDecl.withBindings(
+      visitedVarDecl.with(
+        \.bindings,
         visitedVarDecl.bindings.replacing(
           childAt: 0,
-          with: binding.withAccessor(
+          with: binding.with(
+            \.accessor,
             .accessors(
               .init(
                 leftBrace: .leftBraceToken(leadingTrivia: .space),
@@ -409,7 +411,8 @@ extension MacroApplication {
     }
 
     // FIXME: Is there a better way to add N members to a decl?
-    return decl.withMembers(
+    return decl.with(
+      \.members,
       newMembers.reduce(decl.members) { partialMembers, newMember in
         partialMembers.addMember(.init(decl: newMember))
       }
@@ -451,8 +454,8 @@ extension MacroApplication {
       $0.appending(AttributeListSyntax.Element($1))
     }
 
-    let newDecl = attributedDecl.withAttributes(newAttributes).as(DeclSyntax.self)!
-    return member.withDecl(newDecl)
+    let newDecl = attributedDecl.with(\.attributes, newAttributes).as(DeclSyntax.self)!
+    return member.with(\.decl, newDecl)
   }
 }
 

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
@@ -26,12 +26,12 @@ private class InitializerExprFormat: BasicFormat {
       if $0.leadingTrivia?.first?.isNewline == true {
         return $0
       } else {
-        return $0.withLeadingTrivia(indentedNewline + ($0.leadingTrivia ?? []))
+        return $0.with(\.leadingTrivia, indentedNewline + ($0.leadingTrivia ?? []))
       }
     }
     indentationLevel -= 1
     if !formattedChildren.isEmpty {
-      formattedChildren[formattedChildren.count - 1] = formattedChildren[formattedChildren.count - 1].withTrailingTrivia(indentedNewline)
+      formattedChildren[formattedChildren.count - 1] = formattedChildren[formattedChildren.count - 1].with(\.trailingTrivia, indentedNewline)
     }
     return formattedChildren
   }

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -300,9 +300,9 @@ class FixItApplier: SyntaxRewriter {
     for change in changes {
       switch change {
       case .replaceLeadingTrivia(token: let changedNode, newTrivia: let newTrivia) where changedNode.id == node.id:
-        modifiedNode = node.withLeadingTrivia(newTrivia)
+        modifiedNode = node.with(\.leadingTrivia, newTrivia)
       case .replaceTrailingTrivia(token: let changedNode, newTrivia: let newTrivia) where changedNode.id == node.id:
-        modifiedNode = node.withTrailingTrivia(newTrivia)
+        modifiedNode = node.with(\.trailingTrivia, newTrivia)
       default:
         break
       }

--- a/Tests/SwiftParserTest/TypeMemberTests.swift
+++ b/Tests/SwiftParserTest/TypeMemberTests.swift
@@ -144,7 +144,8 @@ final class TypeMemberTests: XCTestCase {
         "\(baseType).Z<W>",
         TypeSyntax.parse,
         substructure: Syntax(
-          expectedSyntax.withGenericArgumentClause(
+          expectedSyntax.with(
+            \.genericArgumentClause,
             GenericArgumentClauseSyntax(
               arguments: .init([
                 GenericArgumentSyntax(argumentType: SimpleTypeIdentifierSyntax(name: .identifier("W")))

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolation.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolation.swift
@@ -244,8 +244,8 @@ final class StringInterpolationTests: XCTestCase {
     class Rewriter: SyntaxRewriter {
       override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
         let newFunc = DeclSyntax("func newName() {}")
-          .withLeadingTrivia(node.leadingTrivia!)
-          .withTrailingTrivia(node.trailingTrivia!)
+          .with(\.leadingTrivia, node.leadingTrivia!)
+          .with(\.trailingTrivia, node.trailingTrivia!)
         return DeclSyntax(newFunc)
       }
     }

--- a/Tests/SwiftSyntaxBuilderTest/TriviaTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/TriviaTests.swift
@@ -56,11 +56,11 @@ final class TriviaTests: XCTestCase {
   func testAttachedTrivia() {
     let testCases: [UInt: (VariableDeclSyntax, String)] = [
       #line: (
-        VariableDeclSyntax("let x: Int").withLeadingTrivia(.space),
+        VariableDeclSyntax("let x: Int").with(\.leadingTrivia, .space),
         " let x: Int"
       ),
       #line: (
-        VariableDeclSyntax("let x: Int").withTrailingTrivia(.space),
+        VariableDeclSyntax("let x: Int").with(\.trailingTrivia, .space),
         "let x: Int "
       ),
     ]
@@ -74,14 +74,14 @@ final class TriviaTests: XCTestCase {
     let testCases: [UInt: (AttributeListSyntax, String)] = [
       #line: (
         AttributeListSyntax {
-          AttributeSyntax(attributeName: TypeSyntax("Test")).withLeadingTrivia(.space)
+          AttributeSyntax(attributeName: TypeSyntax("Test")).with(\.leadingTrivia, .space)
         },
         " @Test"
       ),
       #line: (
         AttributeListSyntax {
-          AttributeSyntax(attributeName: TypeSyntax("A")).withTrailingTrivia(.space)
-          AttributeSyntax(attributeName: TypeSyntax("B")).withTrailingTrivia(.space)
+          AttributeSyntax(attributeName: TypeSyntax("A")).with(\.trailingTrivia, .space)
+          AttributeSyntax(attributeName: TypeSyntax("B")).with(\.trailingTrivia, .space)
         },
         "@A @B "
       ),

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -122,7 +122,7 @@ final class VariableTests: XCTestCase {
               for i in 1...3 {
                 ArrayElementSyntax(
                   expression: IntegerLiteralExprSyntax(i),
-                  trailingComma: .commaToken().withTrailingTrivia(.spaces(3))
+                  trailingComma: .commaToken().with(\.trailingTrivia, .spaces(3))
                 )
               }
             }

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -45,7 +45,7 @@ private func replaceFirstLabel(
 
   return tuple.replacing(
     childAt: 0,
-    with: firstElement.withLabel(.identifier(newLabel))
+    with: firstElement.with(\.label, .identifier(newLabel))
   )
 }
 
@@ -60,7 +60,7 @@ public struct ColorLiteralMacro: ExpressionMacro {
     )
     let initSyntax: ExprSyntax = ".init(\(argList))"
     if let leadingTrivia = macro.leadingTrivia {
-      return initSyntax.withLeadingTrivia(leadingTrivia)
+      return initSyntax.with(\.leadingTrivia, leadingTrivia)
     }
     return initSyntax
   }
@@ -77,7 +77,7 @@ public struct FileLiteralMacro: ExpressionMacro {
     )
     let initSyntax: ExprSyntax = ".init(\(argList))"
     if let leadingTrivia = macro.leadingTrivia {
-      return initSyntax.withLeadingTrivia(leadingTrivia)
+      return initSyntax.with(\.leadingTrivia, leadingTrivia)
     }
     return initSyntax
   }
@@ -94,7 +94,7 @@ public struct ImageLiteralMacro: ExpressionMacro {
     )
     let initSyntax: ExprSyntax = ".init(\(argList))"
     if let leadingTrivia = macro.leadingTrivia {
-      return initSyntax.withLeadingTrivia(leadingTrivia)
+      return initSyntax.with(\.leadingTrivia, leadingTrivia)
     }
     return initSyntax
   }
@@ -109,7 +109,7 @@ public struct FileIDMacro: ExpressionMacro {
     let fileID = "\(context.moduleName)/\(context.fileName)"
     let fileLiteral: ExprSyntax = "\(literal: fileID)"
     if let leadingTrivia = macro.leadingTrivia {
-      return fileLiteral.withLeadingTrivia(leadingTrivia)
+      return fileLiteral.with(\.leadingTrivia, leadingTrivia)
     }
     return fileLiteral
   }
@@ -298,7 +298,7 @@ public struct AddCompletionHandler: PeerMacro {
     }
 
     // Form the completion handler parameter.
-    let resultType: TypeSyntax? = funcDecl.signature.output?.returnType.withoutTrivia()
+    let resultType: TypeSyntax? = funcDecl.signature.output?.returnType.with(\.leadingTrivia, []).with(\.trailingTrivia, [])
 
     let completionHandlerParam =
       FunctionParameterSyntax(
@@ -314,7 +314,8 @@ public struct AddCompletionHandler: PeerMacro {
       // We need to add a trailing comma to the preceding list.
       newParameterList = parameterList.removingLast()
         .appending(
-          lastParam.withTrailingComma(
+          lastParam.with(
+            \.trailingComma,
             .commaToken(trailingTrivia: .space)
           )
         )
@@ -331,10 +332,10 @@ public struct AddCompletionHandler: PeerMacro {
       }
 
       if let paramName = param.firstName, paramName.text != "_" {
-        return "\(paramName.withoutTrivia()): \(argName.withoutTrivia())"
+        return "\(paramName.text): \(argName.text)"
       }
 
-      return "\(argName.withoutTrivia())"
+      return "\(argName.text)"
     }
 
     let call: ExprSyntax =
@@ -364,18 +365,22 @@ public struct AddCompletionHandler: PeerMacro {
 
     let newFunc =
       funcDecl
-      .withSignature(
+      .with(
+        \.signature,
         funcDecl.signature
-          .withEffectSpecifiers(
-            funcDecl.signature.effectSpecifiers?.withAsyncSpecifier(nil)  // drop async
+          .with(
+            \.effectSpecifiers,
+            funcDecl.signature.effectSpecifiers?.with(\.asyncSpecifier, nil)  // drop async
           )
-          .withOutput(nil)  // drop result type
-          .withInput(  // add completion handler parameter
-            funcDecl.signature.input.withParameterList(newParameterList)
-              .withoutTrailingTrivia()
+          .with(\.output, nil)  // drop result type
+          .with(
+            \.input,  // add completion handler parameter
+            funcDecl.signature.input.with(\.parameterList, newParameterList)
+              .with(\.trailingTrivia, [])
           )
       )
-      .withBody(
+      .with(
+        \.body,
         CodeBlockSyntax(
           leftBrace: .leftBraceToken(leadingTrivia: .space),
           statements: CodeBlockItemListSyntax(
@@ -384,8 +389,8 @@ public struct AddCompletionHandler: PeerMacro {
           rightBrace: .rightBraceToken(leadingTrivia: .newline)
         )
       )
-      .withAttributes(newAttributeList)
-      .withLeadingTrivia(.newlines(2))
+      .with(\.attributes, newAttributeList)
+      .with(\.leadingTrivia, .newlines(2))
 
     return [DeclSyntax(newFunc)]
   }
@@ -401,7 +406,7 @@ public struct AddBackingStorage: MemberMacro {
   {
     let storage: DeclSyntax = "var _storage: Storage<Self>"
     return [
-      storage.withLeadingTrivia([.newlines(1), .spaces(2)])
+      storage.with(\.leadingTrivia, [.newlines(1), .spaces(2)])
     ]
   }
 }
@@ -423,7 +428,7 @@ public struct WrapAllProperties: MemberAttributeMacro {
           name: .identifier("Wrapper")
         )
       )
-      .withLeadingTrivia([.newlines(1), .spaces(2)])
+      .with(\.leadingTrivia, [.newlines(1), .spaces(2)])
     ]
   }
 }
@@ -465,7 +470,7 @@ public struct WrapStoredProperties: MemberAttributeMacro {
           name: .identifier("Wrapper")
         )
       )
-      .withLeadingTrivia([.newlines(1), .spaces(2)])
+      .with(\.leadingTrivia, [.newlines(1), .spaces(2)])
     ]
   }
 }
@@ -500,7 +505,7 @@ extension CustomTypeWrapperMacro: MemberAttributeMacro {
           name: .identifier("customTypeWrapper")
         )
       )
-      .withLeadingTrivia([.newlines(1), .spaces(2)])
+      .with(\.leadingTrivia, [.newlines(1), .spaces(2)])
     ]
   }
 }

--- a/Tests/SwiftSyntaxParserTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftSyntaxParserTest/AbsolutePositionTests.swift
@@ -18,9 +18,7 @@ import _SwiftSyntaxTestSupport
 fileprivate class FuncRenamer: SyntaxRewriter {
   override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
     let rewritten = super.visit(node).as(FunctionDeclSyntax.self)!
-    let modifiedFunctionDecl = rewritten.withIdentifier(
-      .identifier("anotherName")
-    )
+    let modifiedFunctionDecl = rewritten.with(\.identifier, .identifier("anotherName"))
     return DeclSyntax(modifiedFunctionDecl)
   }
 }
@@ -168,13 +166,13 @@ public class AbsolutePositionTests: XCTestCase {
     XCTAssertEqual(AbsolutePositionTests.leadingTrivia, root.leadingTrivia)
     XCTAssertEqual([], root.trailingTrivia)
 
-    var modifiedRoot1 = root.withLeadingTrivia([.spaces(6), .tabs(1)])
+    var modifiedRoot1 = root.with(\.leadingTrivia, [.spaces(6), .tabs(1)])
     XCTAssertEqual([.spaces(6), .tabs(1)], modifiedRoot1.leadingTrivia)
     XCTAssertEqual(AbsolutePositionTests.leadingTrivia, root.leadingTrivia)
     modifiedRoot1.leadingTrivia = [.blockComment("/* this is a comment */")]
     XCTAssertEqual([.blockComment("/* this is a comment */")], modifiedRoot1.leadingTrivia)
 
-    var modifiedRoot2 = root.withTrailingTrivia([.tabs(2)])
+    var modifiedRoot2 = root.with(\.trailingTrivia, [.tabs(2)])
     XCTAssertEqual([.tabs(2)], modifiedRoot2.trailingTrivia)
     XCTAssertEqual([], root.trailingTrivia)
     modifiedRoot2.trailingTrivia = [.carriageReturns(1), .newlines(2)]
@@ -185,13 +183,13 @@ public class AbsolutePositionTests: XCTestCase {
     XCTAssertEqual(AbsolutePositionTests.leadingTrivia, root.statements.leadingTrivia)
     XCTAssertEqual(AbsolutePositionTests.trailingTrivia, root.statements.trailingTrivia)
 
-    var modifiedStatements1 = root.withLeadingTrivia([.carriageReturnLineFeeds(3)])
+    var modifiedStatements1 = root.with(\.leadingTrivia, [.carriageReturnLineFeeds(3)])
     XCTAssertEqual([.carriageReturnLineFeeds(3)], modifiedStatements1.leadingTrivia)
     XCTAssertEqual(AbsolutePositionTests.leadingTrivia, root.statements.leadingTrivia)
     modifiedStatements1.leadingTrivia = [.unexpectedText("UNEXPECTED")]
     XCTAssertEqual([.unexpectedText("UNEXPECTED")], modifiedStatements1.leadingTrivia)
 
-    var modifiedStatements2 = root.withTrailingTrivia([.formfeeds(1), .carriageReturns(3)])
+    var modifiedStatements2 = root.with(\.trailingTrivia, [.formfeeds(1), .carriageReturns(3)])
     XCTAssertEqual([.formfeeds(1), .carriageReturns(3)], modifiedStatements2.trailingTrivia)
     XCTAssertEqual(AbsolutePositionTests.trailingTrivia, root.statements.trailingTrivia)
     modifiedStatements2.trailingTrivia = [.verticalTabs(4)]

--- a/Tests/SwiftSyntaxParserTest/SyntaxComparisonTests.swift
+++ b/Tests/SwiftSyntaxParserTest/SyntaxComparisonTests.swift
@@ -206,7 +206,7 @@ public class SyntaxComparisonTests: XCTestCase {
       body: funcBody
     )
     if indent > 0 {
-      return fd.withLeadingTrivia(.spaces(indent))
+      return fd.with(\.leadingTrivia, .spaces(indent))
     }
     return fd
   }

--- a/Tests/SwiftSyntaxParserTest/SyntaxVisitorTests.swift
+++ b/Tests/SwiftSyntaxParserTest/SyntaxVisitorTests.swift
@@ -41,7 +41,7 @@ public class SyntaxVisitorTests: XCTestCase {
     class ClosureRewriter: SyntaxRewriter {
       override func visit(_ node: ClosureExprSyntax) -> ExprSyntax {
         // Perform a no-op transform that requires rebuilding the node.
-        return ExprSyntax(node.withSignature(node.signature))
+        return ExprSyntax(node.with(\.signature, node.signature))
       }
     }
     XCTAssertNoThrow(
@@ -122,7 +122,7 @@ public class SyntaxVisitorTests: XCTestCase {
   public func testRewriteTrivia() {
     class TriviaRemover: SyntaxRewriter {
       override func visit(_ token: TokenSyntax) -> TokenSyntax {
-        return token.withTrailingTrivia(.zero)
+        return token.with(\.trailingTrivia, .zero)
       }
     }
 

--- a/Tests/SwiftSyntaxTest/MultithreadingTests.swift
+++ b/Tests/SwiftSyntaxTest/MultithreadingTests.swift
@@ -55,7 +55,7 @@ public class MultithreadingTests: XCTestCase {
         .calledExpression[as: MemberAccessExprSyntax.self]
         .base![as: IdentifierExprSyntax.self]
         .identifier = .identifier("ident\(i)")
-      copied = copied.withLeadingTrivia([.newlines(1)])
+      copied = copied.with(\.leadingTrivia, [.newlines(1)])
 
       XCTAssertEqual(copied.description, "\nident\(i).member()")
     }

--- a/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
@@ -46,10 +46,11 @@ public class SyntaxCreationTests: XCTestCase {
     let forType = TokenSyntax.identifier("`for`", trailingTrivia: .space)
     let newBrace = TokenSyntax.rightBraceToken(leadingTrivia: .newlines(2))
 
-    let renamed = structDecl.withIdentifier(forType)
-      .withMembers(
+    let renamed = structDecl.with(\.identifier, forType)
+      .with(
+        \.members,
         structDecl.members
-          .withRightBrace(newBrace)
+          .with(\.rightBrace, newBrace)
       )
 
     XCTAssertEqual(
@@ -81,21 +82,21 @@ public class SyntaxCreationTests: XCTestCase {
     XCTAssertEqual("\(tok)", "struct ")
     XCTAssertEqual(tok.presence, .present)
 
-    let preSpacedTok = tok.withLeadingTrivia(.spaces(3))
+    let preSpacedTok = tok.with(\.leadingTrivia, .spaces(3))
     XCTAssertEqual("\(preSpacedTok)", "   struct ")
 
     var mutablePreSpacedTok = tok
     mutablePreSpacedTok.leadingTrivia = .spaces(4)
     XCTAssertEqual("\(mutablePreSpacedTok)", "    struct ")
 
-    let postSpacedTok = tok.withTrailingTrivia(.spaces(6))
+    let postSpacedTok = tok.with(\.trailingTrivia, .spaces(6))
     XCTAssertEqual("\(postSpacedTok)", "struct      ")
 
     var mutablePostSpacedTok = tok
     mutablePostSpacedTok.trailingTrivia = .spaces(3)
     XCTAssertEqual("\(mutablePostSpacedTok)", "struct   ")
 
-    let prePostSpacedTok = preSpacedTok.withTrailingTrivia(.spaces(4))
+    let prePostSpacedTok = preSpacedTok.with(\.trailingTrivia, .spaces(4))
     XCTAssertEqual("\(prePostSpacedTok)", "   struct    ")
 
     mutablePreSpacedTok.trailingTrivia = .spaces(2)
@@ -132,9 +133,11 @@ public class SyntaxCreationTests: XCTestCase {
       colon: .colonToken(trailingTrivia: .space),
       expression: emptyString
     )
-    let callWithTerminator = call.withArgumentList(
+    let callWithTerminator = call.with(
+      \.argumentList,
       TupleExprElementListSyntax([
-        arg.withTrailingComma(
+        arg.with(
+          \.trailingComma,
           .commaToken(trailingTrivia: .space)
         ),
         terminatorArg,
@@ -166,7 +169,7 @@ public class SyntaxCreationTests: XCTestCase {
     XCTAssertNotNil(call1.leftParen)
     XCTAssertNotNil(call1.rightParen)
 
-    let call2 = call1.withLeftParen(nil).withRightParen(nil)
+    let call2 = call1.with(\.leftParen, nil).with(\.rightParen, nil)
     XCTAssertNil(call2.leftParen)
     XCTAssertNil(call2.rightParen)
 


### PR DESCRIPTION
Instead, provide a single `with` function that takes a key path of the child you want to replace. This significatnly reduces the amout of code that is being generated for SwiftSyntax.

While at it, also remove the `without(Leading|Trailing)?Trivia` functions.

@DougGregor I changed a few calls of `token.withoutTrivia()` in macros to `token.text`, which should perform the same thing while also being slightly more efficient.