### PR TITLE
Implement basic DiagnosticFormatter output coloring support

### DIFF
--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -133,9 +133,11 @@ public struct DiagnosticsFormatter {
       return message.message
     }
   }
+}
 
-  enum ANSIColor: UInt8 {
-    case reset = 0
+struct ANSIAnnotation {
+  enum Color: UInt8 {
+    case normal = 0
     case black = 30
     case red = 31
     case green = 32
@@ -146,33 +148,32 @@ public struct DiagnosticsFormatter {
     case white = 37
   }
 
-  enum ANSITrait: UInt8 {
+  enum Trait: UInt8 {
+    case normal = 0
     case bold = 1
     case underline = 4
   }
 
-  struct ANSIAnnotation {
-    var color: ANSIColor
-    var trait: ANSITrait?
+  var color: Color
+  var trait: Trait
 
-    /// The textual representation of the annotation.
-    var code: String {
-      "\u{001B}[\(trait?.rawValue ?? 0);\(color.rawValue)m"
-    }
+  /// The textual representation of the annotation.
+  var code: String {
+    "\u{001B}[\(trait.rawValue);\(color.rawValue)m"
+  }
 
-    init(color: ANSIColor, trait: ANSITrait? = nil) {
-      self.color = color
-      self.trait = trait
-    }
+  init(color: Color, trait: Trait = .normal) {
+    self.color = color
+    self.trait = trait
+  }
 
-    func applied(to message: String) -> String {
-      // Resetting after the message ensures that we don't color unintended lines in the output
-      return "\(code)\(message)\(ANSIAnnotation.reset.code)"
-    }
+  func applied(to message: String) -> String {
+    // Resetting after the message ensures that we don't color unintended lines in the output
+    return "\(code)\(message)\(ANSIAnnotation.reset.code)"
+  }
 
-    /// The "reset" ANSI code used to unset any previously added annotation.
-    static var reset: ANSIAnnotation {
-      self.init(color: .reset, trait: nil)
-    }
+  /// The "reset" ANSI code used to unset any previously added annotation.
+  static var reset: ANSIAnnotation {
+    self.init(color: .normal, trait: .normal)
   }
 }

--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -183,11 +183,11 @@ struct ANSIAnnotation {
 
   func applied(to message: String) -> String {
     // Resetting after the message ensures that we don't color unintended lines in the output
-    return "\(code)\(message)\(ANSIAnnotation.reset.code)"
+    return "\(code)\(message)\(ANSIAnnotation.normal.code)"
   }
 
-  /// The "reset" ANSI code used to unset any previously added annotation.
-  static var reset: ANSIAnnotation {
+  /// The "normal" or "reset" ANSI code used to unset any previously added annotation.
+  static var normal: ANSIAnnotation {
     self.init(color: .normal, trait: .normal)
   }
 }

--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -162,6 +162,9 @@ class PrintDiags: ParsableCommand {
   @Flag(name: .long, help: "Perform sequence folding with the standard operators")
   var foldSequences: Bool = false
 
+  @Flag(name: .long, help: "Colorize output with ANSI color codes")
+  var colorize: Bool = false
+
   func run() throws {
     let source = try getContentsOfSourceFile(at: sourceFile)
 
@@ -169,7 +172,7 @@ class PrintDiags: ParsableCommand {
       let tree = Parser.parse(source: sourceBuffer)
 
       var diags = ParseDiagnosticsGenerator.diagnostics(for: tree)
-      print(DiagnosticsFormatter.annotatedSource(tree: tree, diags: diags))
+      print(DiagnosticsFormatter.annotatedSource(tree: tree, diags: diags, colorize: colorize))
 
       if foldSequences {
         diags += foldAllSequences(tree).1


### PR DESCRIPTION
As the title implies this PR implements some rudimentary output coloring in the `DiagnosticFormatter` using ANSI color codes. As of this PR, only errors and warnings are colored (using bold red or yellow text respectively). It should be fairly trivial to add further coloring so if you see any low-hanging fruit please let me know!

To get colored output, append the `--colorized` flag to an invocation of `swift-parser-cli print-diags`:
```sh
$ swift-parser-cli print-diags source.swift --colorize
```

Some notes:
 - Being a first-time contributor (hi! 👋🏻 ) I'm not sure about code style in terms of type nesting or visibility of introduced types. I ran the formatter against the code before committing though so that _should_ be good.
 - I did not find any cases of `DiagnosticMessage`s with the `.warning` severity in the codebase, making it hard to test this coloring case. Is there anything I'm missing here?

Lastly, I'm more than happy to make any changes to this code. Excited to finally be contributing directly to the Swift core libraries 🎉 