### PR TITLE
Fix performance regressions introduced by my recent changes

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/KeywordFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/KeywordFile.swift
@@ -15,6 +15,12 @@ import SwiftSyntaxBuilder
 import SyntaxSupport
 import Utils
 
+let lookupTable = ArrayExprSyntax {
+  for keyword in KEYWORDS {
+    ArrayElementSyntax(expression: ExprSyntax("\(literal: keyword.name)"))
+  }
+}
+
 let keywordFile = SourceFileSyntax {
   ExtensionDeclSyntax(
     """
@@ -31,10 +37,10 @@ let keywordFile = SourceFileSyntax {
 
   EnumDeclSyntax("""
     @frozen  // FIXME: Not actually stable, works around a miscompile
-    public enum Keyword: StaticString
+    public enum Keyword: UInt8, Hashable
     """) {
-    for keyword in KEYWORDS {
-      EnumCaseDeclSyntax("case \(raw: keyword.escapedName)")
+    for (index, keyword) in KEYWORDS.enumerated() {
+      EnumCaseDeclSyntax("case \(raw: keyword.escapedName) = \(literal: index)")
     }
 
     InitializerDeclSyntax("@_spi(RawSyntax) public init?(_ text: SyntaxText)") {
@@ -75,10 +81,20 @@ let keywordFile = SourceFileSyntax {
       }
     }
 
+    VariableDeclSyntax("""
+    /// This is really unfortunate. Really, we should have a `switch` in
+    /// `Keyword.defaultText` to return the keyword's kind but the constant lookup
+    /// table is significantly faster. Ideally, we could also get the compiler to
+    /// constant-evaluate `Keyword.spi.defaultText` to a `SyntaxText` but I don't
+    /// see how that's possible right now.
+    private static let keywordTextLookupTable: [SyntaxText] = \(lookupTable)
+    """)
+
     VariableDeclSyntax(
       """
-      var defaultText: SyntaxText {
-        return SyntaxText(self.rawValue)
+      @_spi(RawSyntax)
+      public var defaultText: SyntaxText {
+        return Keyword.keywordTextLookupTable[Int(self.rawValue)]
       }
       """
     )

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/ideutils/SyntaxClassificationFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/ideutils/SyntaxClassificationFile.swift
@@ -94,7 +94,7 @@ let syntaxClassificationFile = SourceFileSyntax {
       modifiers: [DeclModifierSyntax(name: .keyword(.internal))],
       name: IdentifierPatternSyntax("classification"),
       type: TypeAnnotationSyntax(type: TypeSyntax("SyntaxClassification"))) {
-        SwitchStmtSyntax(expression: ExprSyntax("self")) {
+        SwitchStmtSyntax(expression: ExprSyntax("self.base")) {
           for token in SYNTAX_TOKENS {
             SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
               if let classification = token.classification {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
@@ -203,19 +203,82 @@ let tokenKindFile = SourceFileSyntax {
   }
   
   EnumDeclSyntax("""
-    /// Plain token kind value, without an associated `String` value.
+    // Note: It's important that this enum is marked as having a raw base kind
+    // because it significantly improves performance when comparing two
+    // `RawTokenBaseKind` for equality. With the raw value, it compiles down to
+    // a primitive integer compare, without, it calls into `__derived_enum_equals`.
     @frozen // FIXME: Not actually stable, works around a miscompile
-    public enum RawTokenKind: Equatable, Hashable
+    public enum RawTokenBaseKind: UInt8, Equatable, Hashable
     """) {
     EnumCaseDeclSyntax("case eof")
     
     for token in SYNTAX_TOKENS {
-      if let associatedValueClass = token.associatedValueClass {
-        EnumCaseDeclSyntax("case \(raw: token.swiftKind)(\(raw: associatedValueClass))")
-      } else {
-        EnumCaseDeclSyntax("case \(raw: token.swiftKind)")
+      EnumCaseDeclSyntax("case \(raw: token.swiftKind)")
+    }
+  }
+
+  DeclSyntax("""
+  fileprivate extension Keyword {
+    static var rawValueZero: Keyword {
+      return Keyword(rawValue: 0)!
+    }
+  }
+  """)
+
+  StructDeclSyntax("""
+    /// Similar to `TokenKind` but without a `String` associated value.
+    /// Technically, this should be an enum like
+    /// ```
+    /// enum RawTokenKind {
+    ///   case eof
+    ///   case associatedtypeKeyword
+    ///   // remaining case from `RawTokenBaseKind`...
+    ///   case keyword(Keyword)
+    /// }
+    /// ```
+    ///
+    /// But modelling it this way has significant performance implications since
+    /// comparing two `RawTokenKind` calls into `__derived_enum_equals`. It's more
+    /// effient to model the base kind as an enum with a raw value and store the
+    /// keyword separately.
+    ///
+    /// Whenever `base` is not `keyword`, `keyword` should have a raw value
+    /// of `0`.
+    @frozen // FIXME: Not actually stable, works around a miscompile
+    public struct RawTokenKind: Equatable, Hashable
+    """) {
+    DeclSyntax("public let base: RawTokenBaseKind")
+    DeclSyntax("public let keyword: Keyword")
+
+    DeclSyntax("""
+      public init(base: RawTokenBaseKind, keyword: Keyword) {
+        assert(base == .keyword || keyword.rawValue == 0)
+        self.base = base
+        self.keyword = keyword
+      }
+      """
+    )
+
+    DeclSyntax("""
+    public static var eof: RawTokenKind {
+      return RawTokenKind(base: .eof, keyword: .rawValueZero)
+    }
+    """)
+    for token in SYNTAX_TOKENS where token.swiftKind != "keyword" {
+      VariableDeclSyntax(
+        modifiers: [DeclModifierSyntax(leadingTrivia: .newline, name: .keyword(.public)), DeclModifierSyntax(name: .keyword(.static))],
+        name: IdentifierPatternSyntax("\(raw: token.swiftKind)"),
+        type: TypeAnnotationSyntax(type: TypeSyntax("RawTokenKind"))
+      ) {
+        StmtSyntax("return RawTokenKind(base: .\(raw: token.swiftKind), keyword: .rawValueZero)")
       }
     }
+
+    DeclSyntax("""
+    public static func keyword(_ keyword: Keyword) -> RawTokenKind {
+      return RawTokenKind(base: .keyword, keyword: keyword)
+    }
+    """)
     
     VariableDeclSyntax(
       attributes: [.attribute(AttributeSyntax(attributeName: TypeSyntax("_spi"), leftParen: .leftParenToken(), argument: .token(.identifier("RawSyntax")), rightParen: .rightParenToken()))],
@@ -223,15 +286,15 @@ let tokenKindFile = SourceFileSyntax {
       name: IdentifierPatternSyntax("defaultText"),
       type: TypeAnnotationSyntax(type: OptionalTypeSyntax("SyntaxText?"))
     ) {
-      SwitchStmtSyntax(expression: ExprSyntax("self")) {
+      SwitchStmtSyntax(expression: ExprSyntax("self.base")) {
         SwitchCaseSyntax("case .eof:") {
           ReturnStmtSyntax(#"return """#)
         }
 
         for token in SYNTAX_TOKENS {
-          if token.associatedValueClass != nil {
-            SwitchCaseSyntax("case .\(raw: token.swiftKind)(let assoc):") {
-              ReturnStmtSyntax("return assoc.defaultText")
+          if token.swiftKind == "keyword" {
+            SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
+              ReturnStmtSyntax("return self.keyword.defaultText")
             }
           } else if let text = token.text {
             SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
@@ -251,7 +314,7 @@ let tokenKindFile = SourceFileSyntax {
       name: IdentifierPatternSyntax("nameForDiagnostics"),
       type: TypeAnnotationSyntax(type: TypeSyntax("String"))
     ) {
-      SwitchStmtSyntax(expression: ExprSyntax("self")) {
+      SwitchStmtSyntax(expression: ExprSyntax("self.base")) {
         SwitchCaseSyntax("case .eof:") {
           ReturnStmtSyntax(#"return "end of file""#)
         }
@@ -261,12 +324,12 @@ let tokenKindFile = SourceFileSyntax {
             ReturnStmtSyntax("return #\"\(raw: token.nameForDiagnostics)\"#")
           }
         }
-        SwitchCaseSyntax("case .keyword(let keyword):") {
-          ReturnStmtSyntax("return String(syntaxText: keyword.defaultText)")
+        SwitchCaseSyntax("case .keyword:") {
+          ReturnStmtSyntax("return String(syntaxText: self.keyword.defaultText)")
         }
       }
     }
-    
+
     VariableDeclSyntax(
       leadingTrivia: [
         .docBlockComment("/// Returns `true` if the token is a Swift keyword."),
@@ -284,7 +347,7 @@ let tokenKindFile = SourceFileSyntax {
       name: IdentifierPatternSyntax("isLexerClassifiedKeyword"),
       type: TypeAnnotationSyntax(type: TypeSyntax("Bool"))
     ) {
-      SwitchStmtSyntax(expression: ExprSyntax("self")) {
+      SwitchStmtSyntax(expression: ExprSyntax("self.base")) {
         SwitchCaseSyntax("case .eof:") {
           ReturnStmtSyntax("return false")
         }
@@ -294,8 +357,8 @@ let tokenKindFile = SourceFileSyntax {
             ReturnStmtSyntax("return \(raw: token.isKeyword)")
           }
         }
-        SwitchCaseSyntax("case .keyword(let keyword):") {
-          ReturnStmtSyntax("return keyword.isLexerClassified")
+        SwitchCaseSyntax("case .keyword:") {
+          ReturnStmtSyntax("return self.keyword.isLexerClassified")
         }
       }
     }
@@ -317,7 +380,7 @@ let tokenKindFile = SourceFileSyntax {
       name: IdentifierPatternSyntax("isPunctuation"),
       type: TypeAnnotationSyntax(type: TypeSyntax("Bool"))
     ) {
-      SwitchStmtSyntax(expression: ExprSyntax("self")) {
+      SwitchStmtSyntax(expression: ExprSyntax("self.base")) {
         SwitchCaseSyntax("case .eof:") {
           ReturnStmtSyntax("return false")
         }
@@ -370,16 +433,16 @@ let tokenKindFile = SourceFileSyntax {
       @_spi(RawSyntax)
       public static func fromRaw(kind rawKind: RawTokenKind, text: String) -> TokenKind
       """) {
-      SwitchStmtSyntax(expression: ExprSyntax("rawKind")) {
+      SwitchStmtSyntax(expression: ExprSyntax("rawKind.base")) {
         SwitchCaseSyntax("case .eof:") {
           ReturnStmtSyntax("return .eof")
         }
 
         for token in SYNTAX_TOKENS {
-          if token.associatedValueClass != nil {
-            SwitchCaseSyntax("case .\(raw: token.swiftKind)(let assoc):") {
-              FunctionCallExprSyntax("assert(text.isEmpty || String(syntaxText: assoc.defaultText) == text)")
-              ReturnStmtSyntax("return .\(raw: token.swiftKind)(assoc)")
+          if token.swiftKind == "keyword" {
+            SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
+              FunctionCallExprSyntax("assert(text.isEmpty || String(syntaxText: rawKind.keyword.defaultText) == text)")
+              ReturnStmtSyntax("return .keyword(rawKind.keyword)")
             }
           } else if token.text != nil {
             SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
@@ -407,9 +470,9 @@ let tokenKindFile = SourceFileSyntax {
         }
         
         for token in SYNTAX_TOKENS {
-          if token.associatedValueClass != nil {
-            SwitchCaseSyntax("case .\(raw: token.swiftKind)(let assoc):") {
-              ReturnStmtSyntax("return (.\(raw: token.swiftKind)(assoc), nil)")
+          if token.swiftKind == "keyword" {
+            SwitchCaseSyntax("case .\(raw: token.swiftKind)(let keyword):") {
+              ReturnStmtSyntax("return (.\(raw: token.swiftKind)(keyword), nil)")
             }
           } else if token.text != nil {
             SwitchCaseSyntax("case .\(raw: token.swiftKind):") {

--- a/Sources/IDEUtils/generated/SyntaxClassification.swift
+++ b/Sources/IDEUtils/generated/SyntaxClassification.swift
@@ -137,7 +137,7 @@ extension SyntaxClassification {
 
 extension RawTokenKind {
   internal var classification: SyntaxClassification {
-    switch self {
+    switch self.base {
     case .wildcard: 
       return .none
     case .leftParen: 

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -170,7 +170,7 @@ extension Parser {
     case .required:
       shouldParseArgument = true
     case .customAttribute:
-      shouldParseArgument = self.lookahead().isCustomAttributeArgument() && self.at(.leftParen, allowTokenAtStartOfLine: false)
+      shouldParseArgument = self.withLookahead { $0.isCustomAttributeArgument() } && self.at(.leftParen, allowTokenAtStartOfLine: false)
     case .optional:
       shouldParseArgument = self.at(.leftParen)
     }
@@ -1113,7 +1113,7 @@ extension Parser {
 // MARK: Lookahead
 
 extension Parser.Lookahead {
-  func isCustomAttributeArgument() -> Bool {
+  mutating func isCustomAttributeArgument() -> Bool {
     var lookahead = self.lookahead()
     lookahead.skipSingle()
 
@@ -1146,7 +1146,7 @@ extension Parser.Lookahead {
       return false
     }
 
-    if self.at(.leftParen, allowTokenAtStartOfLine: false) && self.lookahead().isCustomAttributeArgument() {
+    if self.at(.leftParen, allowTokenAtStartOfLine: false) && self.withLookahead({ $0.isCustomAttributeArgument() }) {
       self.skipSingle()
     }
 

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -29,7 +29,7 @@ extension DeclarationModifier {
 }
 
 extension TokenConsumer {
-  func atStartOfDeclaration(
+  mutating func atStartOfDeclaration(
     isAtTopLevel: Bool = false,
     allowInitDecl: Bool = true,
     allowRecovery: Bool = false
@@ -1242,7 +1242,7 @@ extension Parser {
 
 extension Parser {
   /// Are we at a regular expression literal that could act as an operator?
-  private func atRegexLiteralThatCouldBeAnOperator() -> Bool {
+  private mutating func atRegexLiteralThatCouldBeAnOperator() -> Bool {
     guard self.at(.regexLiteral) else {
       return false
     }
@@ -2258,7 +2258,7 @@ extension Parser {
 
     // Parse the optional generic argument list.
     let generics: RawGenericArgumentClauseSyntax?
-    if self.lookahead().canParseAsGenericArgumentList() {
+    if self.withLookahead({ $0.canParseAsGenericArgumentList() }) {
       generics = self.parseGenericArguments()
     } else {
       generics = nil
@@ -2282,7 +2282,7 @@ extension Parser {
     let trailingClosure: RawClosureExprSyntax?
     let additionalTrailingClosures: RawMultipleTrailingClosureElementListSyntax?
     if self.at(.leftBrace),
-      self.lookahead().isValidTrailingClosure(.trailingClosure)
+      self.withLookahead({ $0.isValidTrailingClosure(.trailingClosure) })
     {
       (trailingClosure, additionalTrailingClosures) =
         self.parseTrailingClosures(.trailingClosure)

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -249,7 +249,7 @@ extension Parser.Lookahead {
 // MARK: Lookahead
 
 extension Parser.Lookahead {
-  func isStartOfGetSetAccessor() -> Bool {
+  mutating func isStartOfGetSetAccessor() -> Bool {
     assert(self.at(.leftBrace), "not checking a brace?")
 
     // The only case this can happen is if the accessor label is immediately after

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -240,7 +240,7 @@ extension Parser {
   /// Checks if it can reach a token of the given `kind` by skipping unexpected
   /// tokens that have lower ``TokenPrecedence`` than expected token.
   @_spi(RawSyntax)
-  public func canRecoverTo(
+  public mutating func canRecoverTo(
     _ kind: RawTokenKind,
     recoveryPrecedence: TokenPrecedence? = nil
   ) -> RecoveryConsumptionHandle? {
@@ -257,7 +257,7 @@ extension Parser {
   /// Checks if it can reach a token whose kind is in `kinds` by skipping
   /// unexpected tokens that have lower ``TokenPrecedence`` than `precedence`.
   @_spi(RawSyntax)
-  public func canRecoverTo(
+  public mutating func canRecoverTo(
     any kinds: [RawTokenKind]
   ) -> RecoveryConsumptionHandle? {
     if self.at(any: kinds) {
@@ -275,7 +275,7 @@ extension Parser {
   /// precedence of a token in that subset.
   /// If so, return the token that we can recover to and a handle that can be
   /// used to consume the unexpected tokens and the token we recovered to.
-  func canRecoverTo<Subset: RawTokenKindSubset>(
+  mutating func canRecoverTo<Subset: RawTokenKindSubset>(
     anyIn subset: Subset.Type,
     recoveryPrecedence: TokenPrecedence? = nil
   ) -> (Subset, RecoveryConsumptionHandle)? {

--- a/Sources/SwiftParser/RawTokenKindMatch.swift
+++ b/Sources/SwiftParser/RawTokenKindMatch.swift
@@ -14,35 +14,39 @@
 
 /// Allows pattern matching of lexemes and tokens against `RawTokenKind` in a way
 /// that considers keywords and identifiers the same if their contents match.
+///
+/// All the methods in here need to be marked `@inline(__always)` so the compiler
+/// inlines the RawTokenKind we are matching against and is thus able to rule
+/// out one of the branches in `matches(rawTokenKind:text:)` based on the
+/// matched kind.
 struct RawTokenKindMatch {
-  var rawTokenKind: RawTokenKind
+  private var rawTokenKind: RawTokenKind
 
+  @inline(__always)
   init(_ rawTokenKind: RawTokenKind) {
     self.rawTokenKind = rawTokenKind
   }
 
+  @inline(__always)
   init(_ keyword: Keyword) {
     self.rawTokenKind = .keyword(keyword)
   }
 
+  @inline(__always)
   func matches(rawTokenKind: RawTokenKind, text: SyntaxText) -> Bool {
-    if rawTokenKind == self.rawTokenKind {
-      return true
-    } else if rawTokenKind == .identifier, self.rawTokenKind.base == .keyword {
-      // We are looking for a contextual keyword but have an identifier.
-      // If the contents match, we want to interpret the identifier as a keyword.
-      let defaultText = self.rawTokenKind.defaultText
-      assert(defaultText != nil)
-      return text == defaultText
+    if self.rawTokenKind.base == .keyword {
+      return rawTokenKind == self.rawTokenKind || (rawTokenKind == .identifier && self.rawTokenKind.keyword.defaultText == text)
     } else {
-      return false
+      return rawTokenKind == self.rawTokenKind
     }
   }
 
+  @inline(__always)
   static func ~= (kind: RawTokenKindMatch, lexeme: Lexer.Lexeme) -> Bool {
     return kind.matches(rawTokenKind: lexeme.rawTokenKind, text: lexeme.tokenText)
   }
 
+  @inline(__always)
   static func ~= (kind: RawTokenKindMatch, token: TokenSyntax) -> Bool {
     return kind.matches(rawTokenKind: token.rawTokenKind, text: token.tokenView.rawText)
   }

--- a/Sources/SwiftParser/RawTokenKindMatch.swift
+++ b/Sources/SwiftParser/RawTokenKindMatch.swift
@@ -28,7 +28,7 @@ struct RawTokenKindMatch {
   func matches(rawTokenKind: RawTokenKind, text: SyntaxText) -> Bool {
     if rawTokenKind == self.rawTokenKind {
       return true
-    } else if rawTokenKind == .identifier, case .keyword = self.rawTokenKind {
+    } else if rawTokenKind == .identifier, self.rawTokenKind.base == .keyword {
       // We are looking for a contextual keyword but have an identifier.
       // If the contents match, we want to interpret the identifier as a keyword.
       let defaultText = self.rawTokenKind.defaultText

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -31,7 +31,7 @@ protocol RawTokenKindSubset: CaseIterable {
 
 extension RawTokenKindSubset {
   var remappedKind: RawTokenKind? {
-    if case .keyword = self.rawTokenKind {
+    if .keyword == self.rawTokenKind.base {
       return self.rawTokenKind
     } else {
       return nil

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -733,7 +733,7 @@ extension Parser {
     while !self.at(any: [.eof, .rightBrace, .poundEndifKeyword, .poundElseifKeyword, .poundElseKeyword])
       && elementsProgress.evaluate(currentToken)
     {
-      if self.lookahead().isAtStartOfSwitchCase(allowRecovery: false) {
+      if self.withLookahead({ $0.isAtStartOfSwitchCase(allowRecovery: false) }) {
         elements.append(.switchCase(self.parseSwitchCase()))
       } else if self.canRecoverTo(.poundIfKeyword) != nil {
         // '#if' in 'case' position can enclose zero or more 'case' or 'default'
@@ -787,7 +787,7 @@ extension Parser {
             )
           )
         )
-      } else if self.lookahead().isAtStartOfSwitchCase(allowRecovery: true) {
+      } else if self.withLookahead({ $0.isAtStartOfSwitchCase(allowRecovery: true) }) {
         elements.append(.switchCase(self.parseSwitchCase()))
       } else {
         break
@@ -800,7 +800,7 @@ extension Parser {
     var items = [RawCodeBlockItemSyntax]()
     var loopProgress = LoopProgressCondition()
     while !self.at(any: [.rightBrace, .poundEndifKeyword, .poundElseifKeyword, .poundElseKeyword])
-      && !self.lookahead().isStartOfConditionalSwitchCases(),
+      && !self.withLookahead({ $0.isStartOfConditionalSwitchCases() }),
       let newItem = self.parseCodeBlockItem(),
       loopProgress.evaluate(currentToken)
     {
@@ -1271,7 +1271,7 @@ extension Parser.Lookahead {
 
   /// Returns whether the parser's current position is the start of a switch case,
   /// given that we're in the middle of a switch already.
-  func isAtStartOfSwitchCase(allowRecovery: Bool = false) -> Bool {
+  mutating func isAtStartOfSwitchCase(allowRecovery: Bool = false) -> Bool {
     // Check for and consume attributes. The only valid attribute is `@unknown`
     // but that's a semantic restriction.
     var lookahead = self.lookahead()
@@ -1303,7 +1303,7 @@ extension Parser.Lookahead {
     }
   }
 
-  func isStartOfConditionalSwitchCases() -> Bool {
+  mutating func isStartOfConditionalSwitchCases() -> Bool {
     guard self.at(.poundIfKeyword) else {
       return self.isAtStartOfSwitchCase()
     }

--- a/Sources/SwiftParser/SyntaxUtils.swift
+++ b/Sources/SwiftParser/SyntaxUtils.swift
@@ -28,7 +28,7 @@ extension RawUnexpectedNodesSyntax {
 
   /// If `nodes` is not empty, construct a `RawUnexpectedNodesSyntax`
   /// containing those tokens, otherwise return `nil`.
-  init?<SyntaxType: RawSyntaxNodeProtocol>(_ nodes: [SyntaxType], arena: SyntaxArena) {
+  init?<SyntaxType: RawSyntaxNodeProtocol>(_ nodes: [SyntaxType], arena: __shared SyntaxArena) {
     if nodes.isEmpty {
       return nil
     } else {
@@ -38,7 +38,7 @@ extension RawUnexpectedNodesSyntax {
 
   /// If `nodes` contains non-`nil` values, construct a `RawUnexpectedNodesSyntax`
   /// containing those tokens, otherwise return `nil`.
-  init?<SyntaxType: RawSyntaxNodeProtocol>(_ nodes: [SyntaxType?], arena: SyntaxArena) {
+  init?<SyntaxType: RawSyntaxNodeProtocol>(_ nodes: [SyntaxType?], arena: __shared SyntaxArena) {
     self.init(nodes.compactMap({ $0 }), arena: arena)
   }
 }
@@ -73,11 +73,11 @@ extension RawTokenSyntax: UnexpectedNodesCombinable {
 extension RawUnexpectedNodesSyntax: UnexpectedNodesCombinable {}
 
 extension RawUnexpectedNodesSyntax {
-  init?<T1: UnexpectedNodesCombinable, T2: UnexpectedNodesCombinable>(combining syntax1: T1, _ syntax2: T2, arena: SyntaxArena) {
+  init?<T1: UnexpectedNodesCombinable, T2: UnexpectedNodesCombinable>(combining syntax1: T1, _ syntax2: T2, arena: __shared SyntaxArena) {
     self.init(syntax1.elements + syntax2.elements, arena: arena)
   }
 
-  init?<T1: UnexpectedNodesCombinable, T2: UnexpectedNodesCombinable, T3: UnexpectedNodesCombinable>(combining syntax1: T1, _ syntax2: T2, _ syntax3: T3, arena: SyntaxArena) {
+  init?<T1: UnexpectedNodesCombinable, T2: UnexpectedNodesCombinable, T3: UnexpectedNodesCombinable>(combining syntax1: T1, _ syntax2: T2, _ syntax3: T3, arena: __shared SyntaxArena) {
     self.init(syntax1.elements + syntax2.elements + syntax3.elements, arena: arena)
   }
 }

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -114,7 +114,7 @@ extension TokenConsumer {
     } else if let remappedKind = handle.remappedKind {
       assert(self.at(handle.tokenKind))
       return consumeAnyToken(remapping: remappedKind)
-    } else if case .keyword = handle.tokenKind {
+    } else if handle.tokenKind.base == .keyword {
       // We support remapping identifiers to contextual keywords
       assert(self.currentToken.rawTokenKind == .identifier || self.currentToken.rawTokenKind == handle.tokenKind)
       return consumeAnyToken(remapping: handle.tokenKind)
@@ -150,7 +150,7 @@ extension TokenConsumer {
     if self.at(kind, allowTokenAtStartOfLine: allowTokenAtStartOfLine) {
       if let remapping = remapping {
         return self.consumeAnyToken(remapping: remapping)
-      } else if case .keyword = kind {
+      } else if kind.base == .keyword {
         // We support remapping identifiers to contextual keywords
         return self.consumeAnyToken(remapping: kind)
       } else {
@@ -186,7 +186,7 @@ extension TokenConsumer {
     }
     for kind in kinds {
       if case RawTokenKindMatch(kind) = self.currentToken {
-        if case .keyword = kind {
+        if kind.base == .keyword {
           return self.consumeAnyToken(remapping: kind)
         } else {
           return self.consumeAnyToken()

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -57,7 +57,7 @@ extension TokenConsumer {
   /// - Parameter condition: An additional condition that must be satisfied for
   ///                        this function to return `true`.
   /// - Returns: `true` if the given `kind` matches the current token's kind.
-  public func at(
+  public mutating func at(
     _ kind: RawTokenKind,
     allowTokenAtStartOfLine: Bool = true
   ) -> Bool {
@@ -69,7 +69,7 @@ extension TokenConsumer {
 
   /// Returns whether the current token is an operator with the given `name`.
   @_spi(RawSyntax)
-  public func atContextualPunctuator(_ name: SyntaxText) -> Bool {
+  public mutating func atContextualPunctuator(_ name: SyntaxText) -> Bool {
     return self.currentToken.isContextualPunctuator(name)
   }
 
@@ -81,7 +81,7 @@ extension TokenConsumer {
   ///                        this function to return `true`.
   /// - Returns: `true` if the current token's kind is in `kinds`.
   @_spi(RawSyntax)
-  public func at(
+  public mutating func at(
     any kinds: [RawTokenKind],
     allowTokenAtStartOfLine: Bool = true
   ) -> Bool {
@@ -94,7 +94,7 @@ extension TokenConsumer {
   /// Checks whether the parser is currently positioned at any token in `Subset`.
   /// If this is the case, return the `Subset` case that the parser is positioned in
   /// as well as a handle to consume that token.
-  func at<Subset: RawTokenKindSubset>(anyIn subset: Subset.Type) -> (Subset, TokenConsumptionHandle)? {
+  mutating func at<Subset: RawTokenKindSubset>(anyIn subset: Subset.Type) -> (Subset, TokenConsumptionHandle)? {
     if let matchedKind = Subset(lexeme: self.currentToken) {
       return (
         matchedKind,

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -43,7 +43,7 @@ extension Parser {
   mutating func parseTypeScalar(misplacedSpecifiers: [RawTokenSyntax] = []) -> RawTypeSyntax {
     let (specifier, unexpectedBeforeAttrList, attrList) = self.parseTypeAttributeList(misplacedSpecifiers: misplacedSpecifiers)
     var base = RawTypeSyntax(self.parseSimpleOrCompositionType())
-    if self.lookahead().isAtFunctionTypeArrow() {
+    if self.withLookahead({ $0.isAtFunctionTypeArrow() }) {
       let firstEffect = self.parseEffectsSpecifier()
       let secondEffect = self.parseEffectsSpecifier()
       let (unexpectedBeforeArrow, arrow) = self.expect(.arrow)
@@ -841,7 +841,7 @@ extension Parser.Lookahead {
     return self.consume(if: .rightParen) != nil
   }
 
-  func isAtFunctionTypeArrow() -> Bool {
+  mutating func isAtFunctionTypeArrow() -> Bool {
     if self.at(.arrow) {
       return true
     }
@@ -884,7 +884,7 @@ extension Parser.Lookahead {
     return true
   }
 
-  func canParseAsGenericArgumentList() -> Bool {
+  mutating func canParseAsGenericArgumentList() -> Bool {
     guard self.atContextualPunctuator("<") else {
       return false
     }

--- a/Sources/SwiftSyntax/BumpPtrAllocator.swift
+++ b/Sources/SwiftSyntax/BumpPtrAllocator.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Bump-pointer allocation.
-@_spi(Testing)
+@_spi(RawSyntax) @_spi(Testing)
 public class BumpPtrAllocator {
   typealias Slab = UnsafeMutableRawBufferPointer
 

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -471,7 +471,7 @@ extension RawSyntax {
     wholeText: SyntaxText,
     textRange: Range<SyntaxText.Index>,
     presence: SourcePresence,
-    arena: SyntaxArena,
+    arena: __shared SyntaxArena,
     lexerError: LexerError?
   ) -> RawSyntax {
     assert(
@@ -513,7 +513,7 @@ extension RawSyntax {
     numLeadingTrivia: UInt32,
     byteLength: UInt32,
     presence: SourcePresence,
-    arena: SyntaxArena
+    arena: __shared SyntaxArena
   ) -> RawSyntax {
     let payload = RawSyntaxData.MaterializedToken(
       tokenKind: kind,
@@ -543,7 +543,7 @@ extension RawSyntax {
     leadingTriviaPieceCount: Int,
     trailingTriviaPieceCount: Int,
     presence: SourcePresence,
-    arena: SyntaxArena,
+    arena: __shared SyntaxArena,
     initializingLeadingTriviaWith: (UnsafeMutableBufferPointer<RawTriviaPiece>) -> Void,
     initializingTrailingTriviaWith: (UnsafeMutableBufferPointer<RawTriviaPiece>) -> Void
   ) -> RawSyntax {
@@ -582,7 +582,7 @@ extension RawSyntax {
     leadingTrivia: Trivia,
     trailingTrivia: Trivia,
     presence: SourcePresence,
-    arena: SyntaxArena
+    arena: __shared SyntaxArena
   ) -> RawSyntax {
     let decomposed = kind.decomposeToRaw()
     let rawKind = decomposed.rawKind
@@ -614,7 +614,7 @@ extension RawSyntax {
 
   static func makeMissingToken(
     kind: TokenKind,
-    arena: SyntaxArena
+    arena: __shared SyntaxArena
   ) -> RawSyntax {
     let (rawKind, _) = kind.decomposeToRaw()
     return .materializedToken(
@@ -648,7 +648,7 @@ extension RawSyntax {
     byteLength: Int,
     descendantCount: Int,
     recursiveFlags: RecursiveRawSyntaxFlags,
-    arena: SyntaxArena
+    arena: __shared SyntaxArena
   ) -> RawSyntax {
     validateLayout(layout: layout, as: kind)
     let payload = RawSyntaxData.Layout(
@@ -672,7 +672,7 @@ extension RawSyntax {
     kind: SyntaxKind,
     uninitializedCount count: Int,
     isMaximumNestingLevelOverflow: Bool = false,
-    arena: SyntaxArena,
+    arena: __shared SyntaxArena,
     initializingWith initializer: (UnsafeMutableBufferPointer<RawSyntax?>) -> Void
   ) -> RawSyntax {
     // Allocate and initialize the list.
@@ -710,7 +710,7 @@ extension RawSyntax {
 
   static func makeEmptyLayout(
     kind: SyntaxKind,
-    arena: SyntaxArena
+    arena: __shared SyntaxArena
   ) -> RawSyntax {
     var recursiveFlags = RecursiveRawSyntaxFlags()
     if kind.hasError {
@@ -729,7 +729,7 @@ extension RawSyntax {
   static func makeLayout<C: Collection>(
     kind: SyntaxKind,
     from collection: C,
-    arena: SyntaxArena,
+    arena: __shared SyntaxArena,
     leadingTrivia: Trivia? = nil,
     trailingTrivia: Trivia? = nil
   ) -> RawSyntax where C.Element == RawSyntax? {

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -24,372 +24,372 @@ extension StaticString: Equatable {
 }
 
 @frozen  // FIXME: Not actually stable, works around a miscompile
-public enum Keyword: StaticString {
-  case __consuming
+public enum Keyword: UInt8, Hashable {
+  case __consuming = 0
   
-  case __owned
+  case __owned = 1
   
-  case __setter_access
+  case __setter_access = 2
   
-  case __shared
+  case __shared = 3
   
-  case _alignment
+  case _alignment = 4
   
-  case _backDeploy
+  case _backDeploy = 5
   
-  case _borrow
+  case _borrow = 6
   
-  case _cdecl
+  case _cdecl = 7
   
-  case _Class
+  case _Class = 8
   
-  case _compilerInitialized
+  case _compilerInitialized = 9
   
-  case _const
+  case _const = 10
   
-  case _documentation
+  case _documentation = 11
   
-  case _dynamicReplacement
+  case _dynamicReplacement = 12
   
-  case _effects
+  case _effects = 13
   
-  case _expose
+  case _expose = 14
   
-  case _forward
+  case _forward = 15
   
-  case _implements
+  case _implements = 16
   
-  case _linear
+  case _linear = 17
   
-  case _local
+  case _local = 18
   
-  case _modify
+  case _modify = 19
   
-  case _move
+  case _move = 20
   
-  case _NativeClass
+  case _NativeClass = 21
   
-  case _NativeRefCountedObject
+  case _NativeRefCountedObject = 22
   
-  case _noMetadata
+  case _noMetadata = 23
   
-  case _nonSendable
+  case _nonSendable = 24
   
-  case _objcImplementation
+  case _objcImplementation = 25
   
-  case _objcRuntimeName
+  case _objcRuntimeName = 26
   
-  case _opaqueReturnTypeOf
+  case _opaqueReturnTypeOf = 27
   
-  case _optimize
+  case _optimize = 28
   
-  case _originallyDefinedIn
+  case _originallyDefinedIn = 29
   
-  case _PackageDescription
+  case _PackageDescription = 30
   
-  case _private
+  case _private = 31
   
-  case _projectedValueProperty
+  case _projectedValueProperty = 32
   
-  case _read
+  case _read = 33
   
-  case _RefCountedObject
+  case _RefCountedObject = 34
   
-  case _semantics
+  case _semantics = 35
   
-  case _silgen_name
+  case _silgen_name = 36
   
-  case _specialize
+  case _specialize = 37
   
-  case _spi
+  case _spi = 38
   
-  case _spi_available
+  case _spi_available = 39
   
-  case _swift_native_objc_runtime_base
+  case _swift_native_objc_runtime_base = 40
   
-  case _Trivial
+  case _Trivial = 41
   
-  case _TrivialAtMost
+  case _TrivialAtMost = 42
   
-  case _typeEraser
+  case _typeEraser = 43
   
-  case _unavailableFromAsync
+  case _unavailableFromAsync = 44
   
-  case _UnknownLayout
+  case _UnknownLayout = 45
   
-  case actor
+  case actor = 46
   
-  case addressWithNativeOwner
+  case addressWithNativeOwner = 47
   
-  case addressWithOwner
+  case addressWithOwner = 48
   
-  case any
+  case any = 49
   
-  case `Any`
+  case `Any` = 50
   
-  case `as`
+  case `as` = 51
   
-  case assignment
+  case assignment = 52
   
-  case `associatedtype`
+  case `associatedtype` = 53
   
-  case associativity
+  case associativity = 54
   
-  case async
+  case async = 55
   
-  case autoclosure
+  case autoclosure = 56
   
-  case availability
+  case availability = 57
   
-  case available
+  case available = 58
   
-  case await
+  case await = 59
   
-  case before
+  case before = 60
   
-  case `break`
+  case `break` = 61
   
-  case `case`
+  case `case` = 62
   
-  case `catch`
+  case `catch` = 63
   
-  case `class`
+  case `class` = 64
   
-  case `continue`
+  case `continue` = 65
   
-  case convenience
+  case convenience = 66
   
-  case convention
+  case convention = 67
   
-  case `default`
+  case `default` = 68
   
-  case `defer`
+  case `defer` = 69
   
-  case `deinit`
+  case `deinit` = 70
   
-  case deprecated
+  case deprecated = 71
   
-  case derivative
+  case derivative = 72
   
-  case didSet
+  case didSet = 73
   
-  case differentiable
+  case differentiable = 74
   
-  case distributed
+  case distributed = 75
   
-  case `do`
+  case `do` = 76
   
-  case dynamic
+  case dynamic = 77
   
-  case each
+  case each = 78
   
-  case `else`
+  case `else` = 79
   
-  case `enum`
+  case `enum` = 80
   
-  case escaping
+  case escaping = 81
   
-  case exclusivity
+  case exclusivity = 82
   
-  case exported
+  case exported = 83
   
-  case `extension`
+  case `extension` = 84
   
-  case `fallthrough`
+  case `fallthrough` = 85
   
-  case `false`
+  case `false` = 86
   
-  case `fileprivate`
+  case `fileprivate` = 87
   
-  case final
+  case final = 88
   
-  case `for`
+  case `for` = 89
   
-  case `func`
+  case `func` = 90
   
-  case get
+  case get = 91
   
-  case `guard`
+  case `guard` = 92
   
-  case higherThan
+  case higherThan = 93
   
-  case `if`
+  case `if` = 94
   
-  case `import`
+  case `import` = 95
   
-  case `in`
+  case `in` = 96
   
-  case indirect
+  case indirect = 97
   
-  case infix
+  case infix = 98
   
-  case `init`
+  case `init` = 99
   
-  case inline
+  case inline = 100
   
-  case `inout`
+  case `inout` = 101
   
-  case `internal`
+  case `internal` = 102
   
-  case introduced
+  case introduced = 103
   
-  case `is`
+  case `is` = 104
   
-  case isolated
+  case isolated = 105
   
-  case kind
+  case kind = 106
   
-  case lazy
+  case lazy = 107
   
-  case `let`
+  case `let` = 108
   
-  case lowerThan
+  case lowerThan = 109
   
-  case macro
+  case macro = 110
   
-  case message
+  case message = 111
   
-  case metadata
+  case metadata = 112
   
-  case module
+  case module = 113
   
-  case mutableAddressWithNativeOwner
+  case mutableAddressWithNativeOwner = 114
   
-  case mutableAddressWithOwner
+  case mutableAddressWithOwner = 115
   
-  case mutating
+  case mutating = 116
   
-  case `nil`
+  case `nil` = 117
   
-  case noasync
+  case noasync = 118
   
-  case noDerivative
+  case noDerivative = 119
   
-  case noescape
+  case noescape = 120
   
-  case nonisolated
+  case nonisolated = 121
   
-  case nonmutating
+  case nonmutating = 122
   
-  case objc
+  case objc = 123
   
-  case obsoleted
+  case obsoleted = 124
   
-  case of
+  case of = 125
   
-  case open
+  case open = 126
   
-  case `operator`
+  case `operator` = 127
   
-  case optional
+  case optional = 128
   
-  case override
+  case override = 129
   
-  case package
+  case package = 130
   
-  case postfix
+  case postfix = 131
   
-  case `precedencegroup`
+  case `precedencegroup` = 132
   
-  case prefix
+  case prefix = 133
   
-  case `private`
+  case `private` = 134
   
-  case `Protocol`
+  case `Protocol` = 135
   
-  case `protocol`
+  case `protocol` = 136
   
-  case `public`
+  case `public` = 137
   
-  case reasync
+  case reasync = 138
   
-  case renamed
+  case renamed = 139
   
-  case `repeat`
+  case `repeat` = 140
   
-  case required
+  case required = 141
   
-  case `rethrows`
+  case `rethrows` = 142
   
-  case `return`
+  case `return` = 143
   
-  case reverse
+  case reverse = 144
   
-  case safe
+  case safe = 145
   
-  case `self`
+  case `self` = 146
   
-  case `Self`
+  case `Self` = 147
   
-  case Sendable
+  case Sendable = 148
   
-  case set
+  case set = 149
   
-  case some
+  case some = 150
   
-  case sourceFile
+  case sourceFile = 151
   
-  case spi
+  case spi = 152
   
-  case spiModule
+  case spiModule = 153
   
-  case `static`
+  case `static` = 154
   
-  case `struct`
+  case `struct` = 155
   
-  case `subscript`
+  case `subscript` = 156
   
-  case `super`
+  case `super` = 157
   
-  case swift
+  case swift = 158
   
-  case `switch`
+  case `switch` = 159
   
-  case target
+  case target = 160
   
-  case `throw`
+  case `throw` = 161
   
-  case `throws`
+  case `throws` = 162
   
-  case transpose
+  case transpose = 163
   
-  case `true`
+  case `true` = 164
   
-  case `try`
+  case `try` = 165
   
-  case `Type`
+  case `Type` = 166
   
-  case `typealias`
+  case `typealias` = 167
   
-  case unavailable
+  case unavailable = 168
   
-  case unchecked
+  case unchecked = 169
   
-  case unowned
+  case unowned = 170
   
-  case unsafe
+  case unsafe = 171
   
-  case unsafeAddress
+  case unsafeAddress = 172
   
-  case unsafeMutableAddress
+  case unsafeMutableAddress = 173
   
-  case `var`
+  case `var` = 174
   
-  case visibility
+  case visibility = 175
   
-  case weak
+  case weak = 176
   
-  case `where`
+  case `where` = 177
   
-  case `while`
+  case `while` = 178
   
-  case willSet
+  case willSet = 179
   
-  case witness_method
+  case witness_method = 180
   
-  case wrt
+  case wrt = 181
   
-  case yield
+  case yield = 182
   
   @_spi(RawSyntax) public init?(_ text: SyntaxText) {
     switch text.count {
@@ -994,7 +994,15 @@ public enum Keyword: StaticString {
     }
   }
   
-  var defaultText: SyntaxText {
-    return SyntaxText(self.rawValue)
+  /// This is really unfortunate. Really, we should have a `switch` in
+  /// `Keyword.defaultText` to return the keyword's kind but the constant lookup
+  /// table is significantly faster. Ideally, we could also get the compiler to
+  /// constant-evaluate `Keyword.spi.defaultText` to a `SyntaxText` but I don't
+  /// see how that's possible right now.
+  private static let keywordTextLookupTable: [SyntaxText] = ["__consuming", "__owned", "__setter_access", "__shared", "_alignment", "_backDeploy", "_borrow", "_cdecl", "_Class", "_compilerInitialized", "_const", "_documentation", "_dynamicReplacement", "_effects", "_expose", "_forward", "_implements", "_linear", "_local", "_modify", "_move", "_NativeClass", "_NativeRefCountedObject", "_noMetadata", "_nonSendable", "_objcImplementation", "_objcRuntimeName", "_opaqueReturnTypeOf", "_optimize", "_originallyDefinedIn", "_PackageDescription", "_private", "_projectedValueProperty", "_read", "_RefCountedObject", "_semantics", "_silgen_name", "_specialize", "_spi", "_spi_available", "_swift_native_objc_runtime_base", "_Trivial", "_TrivialAtMost", "_typeEraser", "_unavailableFromAsync", "_UnknownLayout", "actor", "addressWithNativeOwner", "addressWithOwner", "any", "Any", "as", "assignment", "associatedtype", "associativity", "async", "autoclosure", "availability", "available", "await", "before", "break", "case", "catch", "class", "continue", "convenience", "convention", "default", "defer", "deinit", "deprecated", "derivative", "didSet", "differentiable", "distributed", "do", "dynamic", "each", "else", "enum", "escaping", "exclusivity", "exported", "extension", "fallthrough", "false", "fileprivate", "final", "for", "func", "get", "guard", "higherThan", "if", "import", "in", "indirect", "infix", "init", "inline", "inout", "internal", "introduced", "is", "isolated", "kind", "lazy", "let", "lowerThan", "macro", "message", "metadata", "module", "mutableAddressWithNativeOwner", "mutableAddressWithOwner", "mutating", "nil", "noasync", "noDerivative", "noescape", "nonisolated", "nonmutating", "objc", "obsoleted", "of", "open", "operator", "optional", "override", "package", "postfix", "precedencegroup", "prefix", "private", "Protocol", "protocol", "public", "reasync", "renamed", "repeat", "required", "rethrows", "return", "reverse", "safe", "self", "Self", "Sendable", "set", "some", "sourceFile", "spi", "spiModule", "static", "struct", "subscript", "super", "swift", "switch", "target", "throw", "throws", "transpose", "true", "try", "Type", "typealias", "unavailable", "unchecked", "unowned", "unsafe", "unsafeAddress", "unsafeMutableAddress", "var", "visibility", "weak", "where", "while", "willSet", "witness_method", "wrt", "yield"]
+  
+  @_spi(RawSyntax)
+  public var defaultText: SyntaxText {
+    return Keyword.keywordTextLookupTable[Int(self.rawValue)]
   }
 }

--- a/Sources/SwiftSyntax/generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/generated/TokenKind.swift
@@ -838,9 +838,12 @@ extension TokenKind: Equatable {
   }
 }
 
-/// Plain token kind value, without an associated `String` value.
+// Note: It's important that this enum is marked as having a raw base kind
+// because it significantly improves performance when comparing two
+// `RawTokenBaseKind` for equality. With the raw value, it compiles down to
+// a primitive integer compare, without, it calls into `__derived_enum_equals`.
 @frozen // FIXME: Not actually stable, works around a miscompile
-public enum RawTokenKind: Equatable, Hashable {
+public enum RawTokenBaseKind: UInt8, Equatable, Hashable {
   case eof
   
   case wildcard
@@ -961,15 +964,304 @@ public enum RawTokenKind: Equatable, Hashable {
   
   case dollarIdentifier
   
-  case keyword(Keyword)
+  case keyword
   
   case rawStringDelimiter
   
   case stringSegment
+}
+
+fileprivate extension Keyword {
+  static var rawValueZero: Keyword {
+    return Keyword(rawValue: 0)!
+  }
+}
+
+/// Similar to `TokenKind` but without a `String` associated value.
+/// Technically, this should be an enum like
+/// ```
+/// enum RawTokenKind {
+///   case eof
+///   case associatedtypeKeyword
+///   // remaining case from `RawTokenBaseKind`...
+///   case keyword(Keyword)
+/// }
+/// ```
+///
+/// But modelling it this way has significant performance implications since
+/// comparing two `RawTokenKind` calls into `__derived_enum_equals`. It's more
+/// effient to model the base kind as an enum with a raw value and store the
+/// keyword separately.
+///
+/// Whenever `base` is not `keyword`, `keyword` should have a raw value
+/// of `0`.
+@frozen // FIXME: Not actually stable, works around a miscompile
+public struct RawTokenKind: Equatable, Hashable {
+  public let base: RawTokenBaseKind
+  
+  public let keyword: Keyword
+  
+  public init(base: RawTokenBaseKind, keyword: Keyword) {
+    assert(base == .keyword || keyword.rawValue == 0)
+    self.base = base
+    self.keyword = keyword
+  }
+  
+  public static var eof: RawTokenKind {
+    return RawTokenKind(base: .eof, keyword: .rawValueZero)
+  }
+  
+  public static var wildcard: RawTokenKind {
+    return RawTokenKind(base: .wildcard, keyword: .rawValueZero)
+  }
+  
+  public static var leftParen: RawTokenKind {
+    return RawTokenKind(base: .leftParen, keyword: .rawValueZero)
+  }
+  
+  public static var rightParen: RawTokenKind {
+    return RawTokenKind(base: .rightParen, keyword: .rawValueZero)
+  }
+  
+  public static var leftBrace: RawTokenKind {
+    return RawTokenKind(base: .leftBrace, keyword: .rawValueZero)
+  }
+  
+  public static var rightBrace: RawTokenKind {
+    return RawTokenKind(base: .rightBrace, keyword: .rawValueZero)
+  }
+  
+  public static var leftSquareBracket: RawTokenKind {
+    return RawTokenKind(base: .leftSquareBracket, keyword: .rawValueZero)
+  }
+  
+  public static var rightSquareBracket: RawTokenKind {
+    return RawTokenKind(base: .rightSquareBracket, keyword: .rawValueZero)
+  }
+  
+  public static var leftAngle: RawTokenKind {
+    return RawTokenKind(base: .leftAngle, keyword: .rawValueZero)
+  }
+  
+  public static var rightAngle: RawTokenKind {
+    return RawTokenKind(base: .rightAngle, keyword: .rawValueZero)
+  }
+  
+  public static var period: RawTokenKind {
+    return RawTokenKind(base: .period, keyword: .rawValueZero)
+  }
+  
+  public static var comma: RawTokenKind {
+    return RawTokenKind(base: .comma, keyword: .rawValueZero)
+  }
+  
+  public static var ellipsis: RawTokenKind {
+    return RawTokenKind(base: .ellipsis, keyword: .rawValueZero)
+  }
+  
+  public static var colon: RawTokenKind {
+    return RawTokenKind(base: .colon, keyword: .rawValueZero)
+  }
+  
+  public static var semicolon: RawTokenKind {
+    return RawTokenKind(base: .semicolon, keyword: .rawValueZero)
+  }
+  
+  public static var equal: RawTokenKind {
+    return RawTokenKind(base: .equal, keyword: .rawValueZero)
+  }
+  
+  public static var atSign: RawTokenKind {
+    return RawTokenKind(base: .atSign, keyword: .rawValueZero)
+  }
+  
+  public static var pound: RawTokenKind {
+    return RawTokenKind(base: .pound, keyword: .rawValueZero)
+  }
+  
+  public static var prefixAmpersand: RawTokenKind {
+    return RawTokenKind(base: .prefixAmpersand, keyword: .rawValueZero)
+  }
+  
+  public static var arrow: RawTokenKind {
+    return RawTokenKind(base: .arrow, keyword: .rawValueZero)
+  }
+  
+  public static var backtick: RawTokenKind {
+    return RawTokenKind(base: .backtick, keyword: .rawValueZero)
+  }
+  
+  public static var backslash: RawTokenKind {
+    return RawTokenKind(base: .backslash, keyword: .rawValueZero)
+  }
+  
+  public static var exclamationMark: RawTokenKind {
+    return RawTokenKind(base: .exclamationMark, keyword: .rawValueZero)
+  }
+  
+  public static var postfixQuestionMark: RawTokenKind {
+    return RawTokenKind(base: .postfixQuestionMark, keyword: .rawValueZero)
+  }
+  
+  public static var infixQuestionMark: RawTokenKind {
+    return RawTokenKind(base: .infixQuestionMark, keyword: .rawValueZero)
+  }
+  
+  public static var stringQuote: RawTokenKind {
+    return RawTokenKind(base: .stringQuote, keyword: .rawValueZero)
+  }
+  
+  public static var singleQuote: RawTokenKind {
+    return RawTokenKind(base: .singleQuote, keyword: .rawValueZero)
+  }
+  
+  public static var multilineStringQuote: RawTokenKind {
+    return RawTokenKind(base: .multilineStringQuote, keyword: .rawValueZero)
+  }
+  
+  public static var poundKeyPathKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundKeyPathKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundLineKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundLineKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundSelectorKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundSelectorKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundFileKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundFileKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundFileIDKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundFileIDKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundFilePathKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundFilePathKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundColumnKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundColumnKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundFunctionKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundFunctionKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundDsohandleKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundDsohandleKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundAssertKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundAssertKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundSourceLocationKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundSourceLocationKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundWarningKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundWarningKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundErrorKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundErrorKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundIfKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundIfKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundElseKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundElseKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundElseifKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundElseifKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundEndifKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundEndifKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundAvailableKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundAvailableKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundUnavailableKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundUnavailableKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundFileLiteralKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundFileLiteralKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundImageLiteralKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundImageLiteralKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundColorLiteralKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundColorLiteralKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var poundHasSymbolKeyword: RawTokenKind {
+    return RawTokenKind(base: .poundHasSymbolKeyword, keyword: .rawValueZero)
+  }
+  
+  public static var integerLiteral: RawTokenKind {
+    return RawTokenKind(base: .integerLiteral, keyword: .rawValueZero)
+  }
+  
+  public static var floatingLiteral: RawTokenKind {
+    return RawTokenKind(base: .floatingLiteral, keyword: .rawValueZero)
+  }
+  
+  public static var regexLiteral: RawTokenKind {
+    return RawTokenKind(base: .regexLiteral, keyword: .rawValueZero)
+  }
+  
+  public static var unknown: RawTokenKind {
+    return RawTokenKind(base: .unknown, keyword: .rawValueZero)
+  }
+  
+  public static var identifier: RawTokenKind {
+    return RawTokenKind(base: .identifier, keyword: .rawValueZero)
+  }
+  
+  public static var binaryOperator: RawTokenKind {
+    return RawTokenKind(base: .binaryOperator, keyword: .rawValueZero)
+  }
+  
+  public static var postfixOperator: RawTokenKind {
+    return RawTokenKind(base: .postfixOperator, keyword: .rawValueZero)
+  }
+  
+  public static var prefixOperator: RawTokenKind {
+    return RawTokenKind(base: .prefixOperator, keyword: .rawValueZero)
+  }
+  
+  public static var dollarIdentifier: RawTokenKind {
+    return RawTokenKind(base: .dollarIdentifier, keyword: .rawValueZero)
+  }
+  
+  public static var rawStringDelimiter: RawTokenKind {
+    return RawTokenKind(base: .rawStringDelimiter, keyword: .rawValueZero)
+  }
+  
+  public static var stringSegment: RawTokenKind {
+    return RawTokenKind(base: .stringSegment, keyword: .rawValueZero)
+  }
+  
+  public static func keyword(_ keyword: Keyword) -> RawTokenKind {
+    return RawTokenKind(base: .keyword, keyword: keyword)
+  }
   
   @_spi(RawSyntax) 
   public var defaultText: SyntaxText? {
-    switch self {
+    switch self.base {
     case .eof: 
       return ""
     case .wildcard: 
@@ -1072,15 +1364,15 @@ public enum RawTokenKind: Equatable, Hashable {
       return #"#colorLiteral"#
     case .poundHasSymbolKeyword: 
       return #"#_hasSymbol"#
-    case .keyword(let assoc): 
-      return assoc.defaultText
+    case .keyword: 
+      return self.keyword.defaultText
     default: 
       return nil
     }
   }
   
   public var nameForDiagnostics: String {
-    switch self {
+    switch self.base {
     case .eof: 
       return "end of file"
     case .wildcard: 
@@ -1205,8 +1497,8 @@ public enum RawTokenKind: Equatable, Hashable {
       return #"raw string delimiter"#
     case .stringSegment: 
       return #"string segment"#
-    case .keyword(let keyword): 
-      return String(syntaxText: keyword.defaultText)
+    case .keyword: 
+      return String(syntaxText: self.keyword.defaultText)
     }
   }
   
@@ -1216,7 +1508,7 @@ public enum RawTokenKind: Equatable, Hashable {
   /// appear as identifiers in any position without being escaped. For example,
   /// `class`, `func`, or `import`.
   public var isLexerClassifiedKeyword: Bool {
-    switch self {
+    switch self.base {
     case .eof: 
       return false
     case .wildcard: 
@@ -1341,8 +1633,8 @@ public enum RawTokenKind: Equatable, Hashable {
       return false
     case .stringSegment: 
       return false
-    case .keyword(let keyword): 
-      return keyword.isLexerClassified
+    case .keyword: 
+      return self.keyword.isLexerClassified
     }
   }
   
@@ -1352,7 +1644,7 @@ public enum RawTokenKind: Equatable, Hashable {
   /// example, the '<' and '>' characters in a generic parameter list, or the
   /// quote characters in a string literal.
   public var isPunctuation: Bool {
-    switch self {
+    switch self.base {
     case .eof: 
       return false
     case .wildcard: 
@@ -1596,7 +1888,7 @@ extension TokenKind {
   /// If the `rawKind` has a `defaultText`, `text` can be empty.
   @_spi(RawSyntax)
   public static func fromRaw(kind rawKind: RawTokenKind, text: String) -> TokenKind {
-    switch rawKind {
+    switch rawKind.base {
     case .eof: 
       return .eof
     case .wildcard: 
@@ -1767,9 +2059,9 @@ extension TokenKind {
       return .prefixOperator(text)
     case .dollarIdentifier: 
       return .dollarIdentifier(text)
-    case .keyword(let assoc): 
-      assert(text.isEmpty || String(syntaxText: assoc.defaultText) == text)
-      return .keyword(assoc)
+    case .keyword: 
+      assert(text.isEmpty || String(syntaxText: rawKind.keyword.defaultText) == text)
+      return .keyword(rawKind.keyword)
     case .rawStringDelimiter: 
       return .rawStringDelimiter(text)
     case .stringSegment: 
@@ -1902,8 +2194,8 @@ extension TokenKind {
       return (.prefixOperator, str)
     case .dollarIdentifier(let str): 
       return (.dollarIdentifier, str)
-    case .keyword(let assoc): 
-      return (.keyword(assoc), nil)
+    case .keyword(let keyword): 
+      return (.keyword(keyword), nil)
     case .rawStringDelimiter(let str): 
       return (.rawStringDelimiter, str)
     case .stringSegment(let str): 


### PR DESCRIPTION
This improves parsing performance by ~2.5x. Parsing is still about 1.5x slower compared to before https://github.com/apple/swift-syntax/pull/1173 but given that I introduced quite a bit of necessary state and the fact that we still parse all files in [MovieSwiftUI](https://github.com/Dimillian/MovieSwiftUI) in less than 15ms I hope that’s acceptable. If we want to improve performance further, we just need to do some more investigation.

It’s probably best to review this commit by commit. All commits are standalone and have a description of what they do. I can split any commit that’s controversial to its own PR.