### PR TITLE
[Macros] Rename macros to match recent pitches

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -406,9 +406,13 @@ public extension SyntaxProtocol {
     }
 
     // Otherwise, it must be one of our children.
-    return children(viewMode: .sourceAccurate).lazy.compactMap { child in
-      child.token(at: position)
-    }.first
+    for child in children(viewMode: .sourceAccurate) {
+      if let token = child.token(at: position) {
+        return token
+      }
+    }
+
+    fatalError("Children of syntax node do not cover all positions in it")
   }
 
   /// The absolute position of the starting point of this node. If the first token

--- a/Sources/_SwiftSyntaxMacros/AccessorMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/AccessorMacro.swift
@@ -10,7 +10,7 @@
 import SwiftSyntax
 
 /// Describes a macro that adds accessors to a given declaration.
-public protocol AccessorDeclarationMacro: DeclarationMacro {
+public protocol AccessorMacro: AttachedMacro {
   /// Expand a macro that's expressed as a custom attribute attached to
   /// the given declaration. The result is a set of accessors for the
   /// declaration.
@@ -20,3 +20,6 @@ public protocol AccessorDeclarationMacro: DeclarationMacro {
     in context: inout MacroExpansionContext
   ) throws -> [AccessorDeclSyntax]
 }
+
+@available(*, deprecated, renamed: "AccessorMacro")
+public typealias AccessorDeclarationMacro = AccessorMacro

--- a/Sources/_SwiftSyntaxMacros/AttachedMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/AttachedMacro.swift
@@ -1,0 +1,13 @@
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Describes a macro that is attached, meaning that it is used with
+/// custom attribute syntax and attached to another entity.
+public protocol AttachedMacro: Macro {
+}

--- a/Sources/_SwiftSyntaxMacros/CMakeLists.txt
+++ b/Sources/_SwiftSyntaxMacros/CMakeLists.txt
@@ -7,16 +7,18 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_swift_host_library(_SwiftSyntaxMacros
-  AccessorDeclarationMacro.swift
+  AccessorMacro.swift
+  AttachedMacro.swift
+  CodeItemMacro.swift
   DeclarationMacro.swift
   ExpressionMacro.swift
-  FreestandingDeclarationMacro.swift
+  FreestandingMacro.swift
   Macro.swift
   MacroExpansionContext.swift
   MacroSystem.swift
   MemberAttributeMacro.swift
-  MemberDeclarationMacro.swift
-  PeerDeclarationMacro.swift
+  MemberMacro.swift
+  PeerMacro.swift
   Syntax+MacroEvaluation.swift
 )
 

--- a/Sources/_SwiftSyntaxMacros/CodeItemMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/CodeItemMacro.swift
@@ -9,12 +9,12 @@
 
 import SwiftSyntax
 
-/// Describes a macro that forms declarations.
-public protocol FreestandingDeclarationMacro: DeclarationMacro {
+/// Describes a macro that forms code items in a function or closure body.
+public protocol CodeItemMacro: FreestandingMacro {
   /// Expand a macro described by the given freestanding macro expansion
   /// declaration within the given context to produce a set of declarations.
   static func expansion(
     of node: MacroExpansionDeclSyntax,
     in context: inout MacroExpansionContext
-  ) throws -> [DeclSyntax]
+  ) throws -> [CodeBlockItemSyntax]
 }

--- a/Sources/_SwiftSyntaxMacros/DeclarationMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/DeclarationMacro.swift
@@ -7,6 +7,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftSyntax
+
 /// Describes a macro that forms declarations.
-public protocol DeclarationMacro: Macro {
+public protocol DeclarationMacro: FreestandingMacro {
+  /// Expand a macro described by the given freestanding macro expansion
+  /// declaration within the given context to produce a set of declarations.
+  static func expansion(
+    of node: MacroExpansionDeclSyntax,
+    in context: inout MacroExpansionContext
+  ) throws -> [DeclSyntax]
 }
+
+@available(*, deprecated, renamed: "DeclarationMacro")
+public typealias FreestandingDeclarationMacro = DeclarationMacro

--- a/Sources/_SwiftSyntaxMacros/ExpressionMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/ExpressionMacro.swift
@@ -13,7 +13,7 @@
 import SwiftSyntax
 
 /// Describes a macro that is explicitly expanded as an expression.
-public protocol ExpressionMacro: Macro {
+public protocol ExpressionMacro: FreestandingMacro {
   /// Expand a macro described by the given macro expansion expression
   /// within the given context to produce a replacement expression.
   static func expansion(

--- a/Sources/_SwiftSyntaxMacros/FreestandingMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/FreestandingMacro.swift
@@ -1,0 +1,13 @@
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Describes a macro that is freestanding, meaning that it is used with the
+/// `#` syntax.
+public protocol FreestandingMacro: Macro {
+}

--- a/Sources/_SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem.swift
@@ -130,7 +130,7 @@ class MacroApplication: SyntaxRewriter {
       if case let .expr(exprItem) = item.item,
         let exprExpansion = exprItem.as(MacroExpansionExprSyntax.self),
         let macro = macroSystem.macros[exprExpansion.macro.text],
-         let freestandingMacro = macro as? DeclarationMacro.Type
+        let freestandingMacro = macro as? DeclarationMacro.Type
       {
         do {
           let expandedDecls = try freestandingMacro.expansion(
@@ -180,7 +180,7 @@ class MacroApplication: SyntaxRewriter {
       // Expand declaration macros, which produce zero or more declarations.
       if let declExpansion = item.decl.as(MacroExpansionDeclSyntax.self),
         let macro = macroSystem.macros[declExpansion.macro.text],
-         let freestandingMacro = macro as? DeclarationMacro.Type
+        let freestandingMacro = macro as? DeclarationMacro.Type
       {
         do {
           let expandedDecls = try freestandingMacro.expansion(

--- a/Sources/_SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/_SwiftSyntaxMacros/MacroSystem.swift
@@ -109,7 +109,7 @@ class MacroApplication: SyntaxRewriter {
           return true
         }
 
-        return !(macro is PeerDeclarationMacro.Type || macro is MemberDeclarationMacro.Type || macro is AccessorDeclarationMacro.Type || macro is MemberAttributeMacro.Type)
+        return !(macro is PeerMacro.Type || macro is MemberMacro.Type || macro is AccessorMacro.Type || macro is MemberAttributeMacro.Type)
       }
 
       if newAttributes.isEmpty {
@@ -130,7 +130,7 @@ class MacroApplication: SyntaxRewriter {
       if case let .expr(exprItem) = item.item,
         let exprExpansion = exprItem.as(MacroExpansionExprSyntax.self),
         let macro = macroSystem.macros[exprExpansion.macro.text],
-        let freestandingMacro = macro as? FreestandingDeclarationMacro.Type
+         let freestandingMacro = macro as? DeclarationMacro.Type
       {
         do {
           let expandedDecls = try freestandingMacro.expansion(
@@ -180,7 +180,7 @@ class MacroApplication: SyntaxRewriter {
       // Expand declaration macros, which produce zero or more declarations.
       if let declExpansion = item.decl.as(MacroExpansionDeclSyntax.self),
         let macro = macroSystem.macros[declExpansion.macro.text],
-        let freestandingMacro = macro as? FreestandingDeclarationMacro.Type
+         let freestandingMacro = macro as? DeclarationMacro.Type
       {
         do {
           let expandedDecls = try freestandingMacro.expansion(
@@ -293,7 +293,7 @@ class MacroApplication: SyntaxRewriter {
 
     var accessors: [AccessorDeclSyntax] = []
 
-    let accessorMacroAttributes = getMacroAttributes(attachedTo: DeclSyntax(node), ofType: AccessorDeclarationMacro.Type.self)
+    let accessorMacroAttributes = getMacroAttributes(attachedTo: DeclSyntax(node), ofType: AccessorMacro.Type.self)
     for (accessorAttr, accessorMacro) in accessorMacroAttributes {
       do {
         let newAccessors = try accessorMacro.expansion(
@@ -362,7 +362,7 @@ extension MacroApplication {
   // set of peer declarations.
   private func expandPeers(of decl: DeclSyntax) -> [DeclSyntax] {
     var peers: [DeclSyntax] = []
-    let macroAttributes = getMacroAttributes(attachedTo: decl, ofType: PeerDeclarationMacro.Type.self)
+    let macroAttributes = getMacroAttributes(attachedTo: decl, ofType: PeerMacro.Type.self)
     for (attribute, peerMacro) in macroAttributes {
       do {
         let newPeers = try peerMacro.expansion(of: attribute, attachedTo: decl, in: &context)
@@ -387,7 +387,7 @@ extension MacroApplication {
     of decl: Decl
   ) -> Decl {
     var newMembers: [DeclSyntax] = []
-    let macroAttributes = getMacroAttributes(attachedTo: DeclSyntax(decl), ofType: MemberDeclarationMacro.Type.self)
+    let macroAttributes = getMacroAttributes(attachedTo: DeclSyntax(decl), ofType: MemberMacro.Type.self)
     for (attribute, memberMacro) in macroAttributes {
       do {
         try newMembers.append(

--- a/Sources/_SwiftSyntaxMacros/MemberAttributeMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/MemberAttributeMacro.swift
@@ -14,7 +14,7 @@ import SwiftSyntax
 
 /// Describes a macro that can add attributes to the members inside the
 /// declaration it's attached to.
-public protocol MemberAttributeMacro: DeclarationMacro {
+public protocol MemberAttributeMacro: AttachedMacro {
   /// Expand an attached declaration macro to produce an attribute list for
   /// a given member.
   ///

--- a/Sources/_SwiftSyntaxMacros/MemberMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/MemberMacro.swift
@@ -13,7 +13,7 @@
 import SwiftSyntax
 
 /// Describes a macro that can add members to the declaration it's attached to.
-public protocol MemberDeclarationMacro: DeclarationMacro {
+public protocol MemberMacro: AttachedMacro {
   /// Expand an attached declaration macro to produce a set of members.
   ///
   /// - Parameters:
@@ -29,3 +29,6 @@ public protocol MemberDeclarationMacro: DeclarationMacro {
     in context: inout MacroExpansionContext
   ) throws -> [DeclSyntax]
 }
+
+@available(*, deprecated, renamed: "MemberMacro")
+public typealias MemberDeclarationMacro = MemberMacro

--- a/Sources/_SwiftSyntaxMacros/PeerMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/PeerMacro.swift
@@ -9,7 +9,7 @@
 
 import SwiftSyntax
 
-public protocol PeerDeclarationMacro: DeclarationMacro {
+public protocol PeerMacro: AttachedMacro {
   /// Expand a macro described by the given custom attribute and
   /// attached to the given declaration and evaluated within a
   /// particular expansion context.
@@ -22,3 +22,6 @@ public protocol PeerDeclarationMacro: DeclarationMacro {
     in context: inout MacroExpansionContext
   ) throws -> [DeclSyntax]
 }
+
+@available(*, deprecated, renamed: "PeerMacro")
+public typealias PeerDeclarationMacro = PeerMacro

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -154,7 +154,7 @@ extension SimpleDiagnosticMessage: FixItMessage {
   var fixItID: MessageID { diagnosticID }
 }
 
-public struct ErrorMacro: FreestandingDeclarationMacro {
+public struct ErrorMacro: DeclarationMacro {
   public static func expansion(
     of node: MacroExpansionDeclSyntax,
     in context: inout MacroExpansionContext
@@ -183,7 +183,7 @@ public struct ErrorMacro: FreestandingDeclarationMacro {
   }
 }
 
-struct DefineBitwidthNumberedStructsMacro: FreestandingDeclarationMacro {
+struct DefineBitwidthNumberedStructsMacro: DeclarationMacro {
   static func expansion(
     of node: MacroExpansionDeclSyntax,
     in context: inout MacroExpansionContext
@@ -210,7 +210,7 @@ struct DefineBitwidthNumberedStructsMacro: FreestandingDeclarationMacro {
 
 public struct PropertyWrapper {}
 
-extension PropertyWrapper: AccessorDeclarationMacro {
+extension PropertyWrapper: AccessorMacro {
   public static func expansion(
     of node: AttributeSyntax,
     attachedTo declaration: DeclSyntax,
@@ -241,7 +241,7 @@ extension PropertyWrapper: AccessorDeclarationMacro {
   }
 }
 
-extension PropertyWrapper: PeerDeclarationMacro {
+extension PropertyWrapper: PeerMacro {
   public static func expansion(
     of node: AttributeSyntax,
     attachedTo declaration: DeclSyntax,
@@ -278,7 +278,7 @@ extension PropertyWrapper: PeerDeclarationMacro {
   }
 }
 
-public struct AddCompletionHandler: PeerDeclarationMacro {
+public struct AddCompletionHandler: PeerMacro {
   public static func expansion(
     of node: AttributeSyntax,
     attachedTo declaration: DeclSyntax,
@@ -389,7 +389,7 @@ public struct AddCompletionHandler: PeerDeclarationMacro {
   }
 }
 
-public struct AddBackingStorage: MemberDeclarationMacro {
+public struct AddBackingStorage: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     attachedTo decl: DeclSyntax,
@@ -470,7 +470,7 @@ public struct WrapStoredProperties: MemberAttributeMacro {
 
 struct CustomTypeWrapperMacro {}
 
-extension CustomTypeWrapperMacro: MemberDeclarationMacro {
+extension CustomTypeWrapperMacro: MemberMacro {
   static func expansion(
     of node: AttributeSyntax,
     attachedTo declaration: DeclSyntax,
@@ -503,7 +503,7 @@ extension CustomTypeWrapperMacro: MemberAttributeMacro {
   }
 }
 
-extension CustomTypeWrapperMacro: AccessorDeclarationMacro {
+extension CustomTypeWrapperMacro: AccessorMacro {
   static func expansion(
     of node: AttributeSyntax,
     attachedTo declaration: DeclSyntax,


### PR DESCRIPTION
Bringing things up to date with the pitches, at least for macro names. There's still more to do here for argument labels and `async`indication. rdar://104567818