### PR TITLE
Fix an assertion failure if a string literal inside string interpolation is unterminated

### DIFF
--- a/Tests/SwiftParserTest/translated/UnclosedStringInterpolationTests.swift
+++ b/Tests/SwiftParserTest/translated/UnclosedStringInterpolationTests.swift
@@ -119,4 +119,17 @@ final class UnclosedStringInterpolationTests: XCTestCase {
       ]
     )
   }
+
+  func testUnterminatedStringLiteralInInterpolation() {
+    AssertParse(
+      #"""
+      "\("1️⃣
+      """#,
+      diagnostics: [
+        DiagnosticSpec(message: #"expected '"' to end string literal"#),
+        DiagnosticSpec(message: #"expected ')' in string literal"#),
+        DiagnosticSpec(message: #"expected '"' to end string literal"#),
+      ]
+    )
+  }
 }


### PR DESCRIPTION
We don't eat newlines as leading trivia in string interpolation of single line strings but  `lexNormal` expects newlines to already be eaten. If we reach a newline inside string interpolation of a single-line string, emit an empty string segment to indicate to the parser that the string has ended and pop out of string interpolation.