### PR TITLE
[Macros] Freestanding macros expand to CodeBlockItemList; parse top-level macro expansion decls

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -192,14 +192,12 @@ extension Parser {
       return RawDeclSyntax(directive)
     case (.poundWarningKeyword, _)?, (.poundErrorKeyword, _)?:
       return self.parsePoundDiagnosticDeclaration()
-    case nil:
-      break
-    }
-
-    if (self.at(.pound)) {
+    case (.pound, _)?:
       // FIXME: If we can have attributes for macro expansions, handle this
       // via DeclarationStart.
       return RawDeclSyntax(self.parseMacroExpansionDeclaration())
+    case nil:
+      break
     }
 
     let attrs = DeclAttributes(

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -32,9 +32,16 @@ extension TokenConsumer {
   mutating func atStartOfDeclaration(
     isAtTopLevel: Bool = false,
     allowInitDecl: Bool = true,
-    allowRecovery: Bool = false
+    allowRecovery: Bool = false,
+    preferPoundAsExpression: Bool = false
   ) -> Bool {
     if self.at(anyIn: PoundDeclarationStart.self) != nil {
+      // If we are in a context where we prefer # to be an expression,
+      // treat it as one if it's not at the start of the line.
+      if preferPoundAsExpression && self.at(.pound) && !self.currentToken.isAtStartOfLine {
+        return false
+      }
+
       return true
     }
 

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -513,12 +513,14 @@ enum PoundDeclarationStart: RawTokenKindSubset {
   case poundIfKeyword
   case poundWarningKeyword
   case poundErrorKeyword
+  case pound
 
   init?(lexeme: Lexer.Lexeme) {
     switch lexeme.rawTokenKind {
     case .poundIfKeyword: self = .poundIfKeyword
     case .poundWarningKeyword: self = .poundWarningKeyword
     case .poundErrorKeyword: self = .poundErrorKeyword
+    case .pound: self = .pound
     default: return nil
     }
   }
@@ -528,6 +530,7 @@ enum PoundDeclarationStart: RawTokenKindSubset {
     case .poundIfKeyword: return .poundIfKeyword
     case .poundWarningKeyword: return .poundWarningKeyword
     case .poundErrorKeyword: return .poundErrorKeyword
+    case .pound: return .pound
     }
   }
 }

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -985,7 +985,8 @@ extension Parser {
       .poundIfKeyword, .poundErrorKeyword, .poundWarningKeyword,
       .poundEndifKeyword, .poundElseKeyword, .poundElseifKeyword,
     ])
-      && !self.atStartOfStatement() && !self.atStartOfDeclaration()
+      && !self.atStartOfStatement() &&
+        !self.atStartOfDeclaration(preferPoundAsExpression: true)
     {
       let parsedExpr = self.parseExpression()
       if hasMisplacedTry && !parsedExpr.is(RawTryExprSyntax.self) {

--- a/Sources/_SwiftSyntaxMacros/CodeItemMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/CodeItemMacro.swift
@@ -16,5 +16,5 @@ public protocol CodeItemMacro: FreestandingMacro {
   static func expansion(
     of node: MacroExpansionDeclSyntax,
     in context: inout MacroExpansionContext
-  ) throws -> [CodeBlockItemSyntax]
+  ) throws -> CodeBlockItemListSyntax
 }

--- a/Sources/_SwiftSyntaxMacros/DeclarationMacro.swift
+++ b/Sources/_SwiftSyntaxMacros/DeclarationMacro.swift
@@ -16,7 +16,7 @@ public protocol DeclarationMacro: FreestandingMacro {
   static func expansion(
     of node: MacroExpansionDeclSyntax,
     in context: inout MacroExpansionContext
-  ) throws -> [DeclSyntax]
+  ) throws -> CodeBlockItemListSyntax
 }
 
 @available(*, deprecated, renamed: "DeclarationMacro")

--- a/Sources/_SwiftSyntaxMacros/Syntax+MacroEvaluation.swift
+++ b/Sources/_SwiftSyntaxMacros/Syntax+MacroEvaluation.swift
@@ -24,11 +24,11 @@ struct ThrownErrorDiagnostic: DiagnosticMessage {
   }
 }
 
-extension MacroExpansionExprSyntax {
+extension MacroExpansionDeclSyntax {
   /// Macro expansion declarations are parsed in some positions where an
   /// expression is also warranted, so
-  func asMacroExpansionDecl() -> MacroExpansionDeclSyntax {
-    MacroExpansionDeclSyntax(
+  public func asMacroExpansionExpr() -> MacroExpansionExprSyntax {
+    MacroExpansionExprSyntax(
       unexpectedBeforePoundToken,
       poundToken: poundToken,
       unexpectedBetweenPoundTokenAndMacro,
@@ -47,7 +47,9 @@ extension MacroExpansionExprSyntax {
       unexpectedAfterAdditionalTrailingClosures
     )
   }
+}
 
+extension MacroExpansionExprSyntax {
   /// Evaluate the given macro for this syntax node, producing the expanded
   /// result and (possibly) some diagnostics.
   func evaluateMacro(

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1162,6 +1162,18 @@ final class DeclarationTests: XCTestCase {
       }
       """
     )
+    AssertParse(
+      """
+      #expand
+      """,
+      substructure: Syntax(
+        SourceFileSyntax(
+          CodeBlockItemListSyntax {
+            MacroExpansionDeclSyntax(macro: "expand")
+          }
+        )
+      )
+    )
   }
 
   func testVariableDeclWithGetSetButNoBrace() {

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -726,7 +726,7 @@ final class ExpressionTests: XCTestCase {
       "#keyPath((b:1️⃣)2️⃣",
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected value in tuple"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end pound literal expression"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end pound literal declaration"),
       ]
     )
   }

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -158,7 +158,7 @@ public struct ErrorMacro: DeclarationMacro {
   public static func expansion(
     of node: MacroExpansionDeclSyntax,
     in context: inout MacroExpansionContext
-  ) throws -> [DeclSyntax] {
+  ) throws -> CodeBlockItemListSyntax {
     guard let firstElement = node.argumentList.first,
       let stringLiteral = firstElement.expression
         .as(StringLiteralExprSyntax.self),
@@ -187,7 +187,7 @@ struct DefineBitwidthNumberedStructsMacro: DeclarationMacro {
   static func expansion(
     of node: MacroExpansionDeclSyntax,
     in context: inout MacroExpansionContext
-  ) throws -> [DeclSyntax] {
+  ) throws -> CodeBlockItemListSyntax {
     guard let firstElement = node.argumentList.first,
       let stringLiteral = firstElement.expression
         .as(StringLiteralExprSyntax.self),
@@ -199,12 +199,17 @@ struct DefineBitwidthNumberedStructsMacro: DeclarationMacro {
       )
     }
 
-    return [8, 16, 32, 64].map { bitwidth in
+    let decls: [DeclSyntax] = [8, 16, 32, 64].map { bitwidth in
       """
 
       struct \(raw: prefix)\(raw: String(bitwidth)) { }
       """
     }
+    // TODO: Interpolate to `CodeBlockItemList` directly when it supports
+    // string interpolation.
+    return CodeBlockItemListSyntax(decls.map {
+      CodeBlockItemSyntax(item: .init($0))
+    })
   }
 }
 


### PR DESCRIPTION
- Change the return type of `FreestandingDeclarationMacro.expanion(of:in:)` to ``CodeBlockItemListSyntax` to allow expressions, statements, and declarations.
- Parse freestanding macro expansions as declarations rather than expressions when it's not part of a statement or expression (i.e. "top-level").