### PR TITLE
[Macros] Parse top-level macro expansion declarations

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -192,14 +192,12 @@ extension Parser {
       return RawDeclSyntax(directive)
     case (.poundWarningKeyword, _)?, (.poundErrorKeyword, _)?:
       return self.parsePoundDiagnosticDeclaration()
-    case nil:
-      break
-    }
-
-    if (self.at(.pound)) {
+    case (.pound, _)?:
       // FIXME: If we can have attributes for macro expansions, handle this
       // via DeclarationStart.
       return RawDeclSyntax(self.parseMacroExpansionDeclaration())
+    case nil:
+      break
     }
 
     let attrs = DeclAttributes(

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -32,9 +32,16 @@ extension TokenConsumer {
   mutating func atStartOfDeclaration(
     isAtTopLevel: Bool = false,
     allowInitDecl: Bool = true,
-    allowRecovery: Bool = false
+    allowRecovery: Bool = false,
+    preferPoundAsExpression: Bool = false
   ) -> Bool {
     if self.at(anyIn: PoundDeclarationStart.self) != nil {
+      // If we are in a context where we prefer # to be an expression,
+      // treat it as one if it's not at the start of the line.
+      if preferPoundAsExpression && self.at(.pound) && !self.currentToken.isAtStartOfLine {
+        return false
+      }
+
       return true
     }
 

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -476,12 +476,14 @@ enum PoundDeclarationStart: RawTokenKindSubset {
   case poundIfKeyword
   case poundWarningKeyword
   case poundErrorKeyword
+  case pound
 
   init?(lexeme: Lexer.Lexeme) {
     switch lexeme.rawTokenKind {
     case .poundIfKeyword: self = .poundIfKeyword
     case .poundWarningKeyword: self = .poundWarningKeyword
     case .poundErrorKeyword: self = .poundErrorKeyword
+    case .pound: self = .pound
     default: return nil
     }
   }
@@ -491,6 +493,7 @@ enum PoundDeclarationStart: RawTokenKindSubset {
     case .poundIfKeyword: return .poundIfKeyword
     case .poundWarningKeyword: return .poundWarningKeyword
     case .poundErrorKeyword: return .poundErrorKeyword
+    case .pound: return .pound
     }
   }
 }

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -985,8 +985,7 @@ extension Parser {
       .poundIfKeyword, .poundErrorKeyword, .poundWarningKeyword,
       .poundEndifKeyword, .poundElseKeyword, .poundElseifKeyword,
     ])
-      && !self.atStartOfStatement() &&
-        !self.atStartOfDeclaration(preferPoundAsExpression: true)
+      && !self.atStartOfStatement() && !self.atStartOfDeclaration(preferPoundAsExpression: true)
     {
       let parsedExpr = self.parseExpression()
       if hasMisplacedTry && !parsedExpr.is(RawTryExprSyntax.self) {

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -985,7 +985,8 @@ extension Parser {
       .poundIfKeyword, .poundErrorKeyword, .poundWarningKeyword,
       .poundEndifKeyword, .poundElseKeyword, .poundElseifKeyword,
     ])
-      && !self.atStartOfStatement() && !self.atStartOfDeclaration()
+      && !self.atStartOfStatement() &&
+        !self.atStartOfDeclaration(preferPoundAsExpression: true)
     {
       let parsedExpr = self.parseExpression()
       if hasMisplacedTry && !parsedExpr.is(RawTryExprSyntax.self) {

--- a/Sources/_SwiftSyntaxMacros/Syntax+MacroEvaluation.swift
+++ b/Sources/_SwiftSyntaxMacros/Syntax+MacroEvaluation.swift
@@ -24,11 +24,11 @@ struct ThrownErrorDiagnostic: DiagnosticMessage {
   }
 }
 
-extension MacroExpansionExprSyntax {
+extension MacroExpansionDeclSyntax {
   /// Macro expansion declarations are parsed in some positions where an
   /// expression is also warranted, so
-  func asMacroExpansionDecl() -> MacroExpansionDeclSyntax {
-    MacroExpansionDeclSyntax(
+  public func asMacroExpansionExpr() -> MacroExpansionExprSyntax {
+    MacroExpansionExprSyntax(
       unexpectedBeforePoundToken,
       poundToken: poundToken,
       unexpectedBetweenPoundTokenAndMacro,
@@ -47,7 +47,9 @@ extension MacroExpansionExprSyntax {
       unexpectedAfterAdditionalTrailingClosures
     )
   }
+}
 
+extension MacroExpansionExprSyntax {
   /// Evaluate the given macro for this syntax node, producing the expanded
   /// result and (possibly) some diagnostics.
   func evaluateMacro(

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1176,6 +1176,18 @@ final class DeclarationTests: XCTestCase {
       }
       """
     )
+    AssertParse(
+      """
+      #expand
+      """,
+      substructure: Syntax(
+        SourceFileSyntax(
+          CodeBlockItemListSyntax {
+            MacroExpansionDeclSyntax(macro: "expand")
+          }
+        )
+      )
+    )
   }
 
   func testVariableDeclWithGetSetButNoBrace() {

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -726,7 +726,7 @@ final class ExpressionTests: XCTestCase {
       "#keyPath((b:1️⃣)2️⃣",
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected value in tuple"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end pound literal expression"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end pound literal declaration"),
       ]
     )
   }


### PR DESCRIPTION
Parse freestanding macro expansions as declarations rather than expressions when it's not part of a statement or expression (i.e. "top-level").