### PR TITLE
Add FreestandingMacroExpansionSyntax trait for freestanding macro expansions

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
@@ -1635,6 +1635,9 @@ public let DECL_NODES: [Node] = [
   Node(name: "MacroExpansionDecl",
        nameForDiagnostics: "pound literal declaration",
        kind: "Decl",
+       traits: [
+         "FreestandingMacroExpansion"
+       ],
        children: [
          Child(name: "PoundToken",
                kind: "PoundToken",

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
@@ -1186,6 +1186,9 @@ public let EXPR_NODES: [Node] = [
   Node(name: "MacroExpansionExpr",
        nameForDiagnostics: "pound literal expression",
        kind: "Expr",
+       traits: [
+         "FreestandingMacroExpansion"
+       ],
        children: [
          Child(name: "PoundToken",
                kind: "PoundToken",

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/Traits.swift
@@ -59,6 +59,18 @@ public let TRAITS: [Trait] = [
           Child(name: "RightParen", kind: "RightParenToken"),
         ]
   ),
+  Trait(traitName: "FreestandingMacroExpansion",
+        children: [
+          Child(name: "PoundToken", kind: "PoundToken"),
+          Child(name: "Macro", kind: "IdentifierToken"),
+          Child(name: "GenericArguments", kind: "GenericArgumentClause", isOptional: true),
+          Child(name: "LeftParen", kind: "LeftParenToken", isOptional: true),
+          Child(name: "ArgumentList", kind: "TupleExprElementList"),
+          Child(name: "RightParen", kind: "RightParenToken", isOptional: true),
+          Child(name: "TrailingClosure", kind: "ClosureExpr", isOptional: true),
+          Child(name: "AdditionalTrailingClosures", kind: "MultipleTrailingClosureElementList", isOptional: true),
+        ]
+  ),
   Trait(traitName: "WithTrailingComma",
         children: [
           Child(name: "TrailingComma", kind: "CommaToken", isOptional: true),

--- a/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
@@ -433,6 +433,7 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/IdentifiedDeclSyntax>
 - <doc:SwiftSyntax/WithCodeBlockSyntax>
 - <doc:SwiftSyntax/ParenthesizedSyntax>
+- <doc:SwiftSyntax/FreestandingMacroExpansionSyntax>
 - <doc:SwiftSyntax/WithTrailingCommaSyntax>
 - <doc:SwiftSyntax/WithStatementsSyntax>
 

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -180,6 +180,74 @@ public extension SyntaxProtocol {
   }
 }
 
+// MARK: - FreestandingMacroExpansionSyntax
+
+public protocol FreestandingMacroExpansionSyntax: SyntaxProtocol {
+  var poundToken: TokenSyntax { 
+    get 
+  }
+  
+  func withPoundToken(_ newChild: TokenSyntax) -> Self
+  
+  var macro: TokenSyntax { 
+    get 
+  }
+  
+  func withMacro(_ newChild: TokenSyntax) -> Self
+  
+  var genericArguments: GenericArgumentClauseSyntax? { 
+    get 
+  }
+  
+  func withGenericArguments(_ newChild: GenericArgumentClauseSyntax?) -> Self
+  
+  var leftParen: TokenSyntax? { 
+    get 
+  }
+  
+  func withLeftParen(_ newChild: TokenSyntax?) -> Self
+  
+  var argumentList: TupleExprElementListSyntax { 
+    get 
+  }
+  
+  func withArgumentList(_ newChild: TupleExprElementListSyntax) -> Self
+  
+  var rightParen: TokenSyntax? { 
+    get 
+  }
+  
+  func withRightParen(_ newChild: TokenSyntax?) -> Self
+  
+  var trailingClosure: ClosureExprSyntax? { 
+    get 
+  }
+  
+  func withTrailingClosure(_ newChild: ClosureExprSyntax?) -> Self
+  
+  var additionalTrailingClosures: MultipleTrailingClosureElementListSyntax? { 
+    get 
+  }
+  
+  func withAdditionalTrailingClosures(_ newChild: MultipleTrailingClosureElementListSyntax?) -> Self
+}
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to
+  /// `FreestandingMacroExpansionSyntax`.
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: FreestandingMacroExpansionSyntax.Protocol) -> Bool {
+    return self.asProtocol(FreestandingMacroExpansionSyntax.self) != nil
+  }
+  
+  /// Return the non-type erased version of this syntax node if it conforms to
+  /// `FreestandingMacroExpansionSyntax`. Otherwise return `nil`.
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: FreestandingMacroExpansionSyntax.Protocol) -> FreestandingMacroExpansionSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? FreestandingMacroExpansionSyntax
+  }
+}
+
 // MARK: - WithTrailingCommaSyntax
 
 public protocol WithTrailingCommaSyntax: SyntaxProtocol {
@@ -362,6 +430,12 @@ extension LabeledSpecializeEntrySyntax: WithTrailingCommaSyntax {
 }
 
 extension MacroDeclSyntax: IdentifiedDeclSyntax, AttributedSyntax {
+}
+
+extension MacroExpansionDeclSyntax: FreestandingMacroExpansionSyntax {
+}
+
+extension MacroExpansionExprSyntax: FreestandingMacroExpansionSyntax {
 }
 
 extension MemberDeclBlockSyntax: BracedSyntax {

--- a/gyb_syntax_support/DeclNodes.py
+++ b/gyb_syntax_support/DeclNodes.py
@@ -924,6 +924,7 @@ DECL_NODES = [
     # e.g., "#embed("filename.txt")"
     Node('MacroExpansionDecl',
          name_for_diagnostics="pound literal declaration", kind='Decl',
+         traits=['FreestandingMacroExpansion'],
          children=[
              Child('PoundToken', kind='PoundToken',
                    description='The `#` sign.'),

--- a/gyb_syntax_support/ExprNodes.py
+++ b/gyb_syntax_support/ExprNodes.py
@@ -653,6 +653,7 @@ EXPR_NODES = [
     # e.g., "#embed("filename.txt")"
     Node('MacroExpansionExpr',
          name_for_diagnostics="pound literal expression", kind='Expr',
+         traits=['FreestandingMacroExpansion'],
          children=[
              Child('PoundToken', kind='PoundToken',
                    description='The `#` sign.'),

--- a/gyb_syntax_support/Traits.py
+++ b/gyb_syntax_support/Traits.py
@@ -43,6 +43,26 @@ TRAITS = [
               Child('RightParen', kind='RightParenToken'),
           ]),
 
+    Trait('FreestandingMacroExpansion',
+          children=[
+             Child('PoundToken', kind='PoundToken'),
+             Child('Macro', kind='IdentifierToken'),
+             Child('GenericArguments', kind='GenericArgumentClause',
+                   is_optional=True),
+             Child('LeftParen', kind='LeftParenToken',
+                   is_optional=True),
+             Child('ArgumentList', kind='TupleExprElementList',
+                   collection_element_name='Argument'),
+             Child('RightParen', kind='RightParenToken',
+                   is_optional=True),
+             Child('TrailingClosure', kind='ClosureExpr',
+                   is_optional=True),
+             Child('AdditionalTrailingClosures',
+                   kind='MultipleTrailingClosureElementList',
+                   collection_element_name='AdditionalTrailingClosure',
+                   is_optional=True),
+          ]),
+
     Trait('WithTrailingComma',
           children=[
               Child('TrailingComma', kind='CommaToken', is_optional=True),


### PR DESCRIPTION
We need this to abstract over `MacroExpansionDeclSyntax` and `MacroExpansionExprSyntax`. 