### PR TITLE
Store lexer error offset relative to leading trivia start

### DIFF
--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -512,7 +512,7 @@ extension Parser {
 
     let endIndex = current.textRange.lowerBound.advanced(by: prefix.count)
     var lexerError = current.error
-    if let error = lexerError, error.byteOffset > prefix.count {
+    if let error = lexerError, error.byteOffset > prefix.count + current.leadingTriviaByteLength {
       // The lexer error isn't in the prefix. Drop it.
       lexerError = nil
     }

--- a/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
@@ -98,9 +98,9 @@ public extension SwiftSyntax.LexerError {
   /// `tokenText` is the entire text of the token in which the `LexerError`
   /// occurred, including trivia.
   @_spi(RawSyntax)
-  func diagnostic(tokenText: SyntaxText) -> DiagnosticMessage {
+  func diagnostic(wholeText: SyntaxText) -> DiagnosticMessage {
     var scalarAtErrorOffset: UnicodeScalar {
-      Unicode.Scalar(tokenText[Int(self.byteOffset)])
+      Unicode.Scalar(wholeText[Int(self.byteOffset)])
     }
 
     switch self.kind {
@@ -130,6 +130,8 @@ public extension SwiftSyntax.LexerError {
   }
 
   func diagnostic(in token: TokenSyntax) -> DiagnosticMessage {
-    return self.diagnostic(tokenText: token.tokenView.rawText)
+    return token.tokenView.wholeText { wholeText in
+      return self.diagnostic(wholeText: token.tokenView.rawText)
+    }
   }
 }

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -338,7 +338,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
       handleMissingToken(token)
     } else {
       if let lexerError = token.lexerError {
-        self.addDiagnostic(token, position: token.positionAfterSkippingLeadingTrivia.advanced(by: Int(lexerError.byteOffset)), lexerError.diagnostic(in: token))
+        self.addDiagnostic(token, position: token.position.advanced(by: Int(lexerError.byteOffset)), lexerError.diagnostic(in: token))
       }
     }
 

--- a/Sources/SwiftSyntax/LexerError.swift
+++ b/Sources/SwiftSyntax/LexerError.swift
@@ -33,8 +33,8 @@ public struct LexerError: Hashable {
 
   public let kind: Kind
 
-  /// The offset at which the error is, in bytes relative to the token's content
-  /// start (i.e. relative to the tokens `positionAfterSkippingLeadingTrivia`)
+  /// The offset at which the error is, in bytes relative to the token's leading
+  /// trivia start (i.e. relative to the token's `position`)
   public let byteOffset: UInt16
 
   public init(_ kind: Kind, byteOffset: UInt16) {
@@ -43,6 +43,7 @@ public struct LexerError: Hashable {
   }
 
   public init(_ kind: Kind, byteOffset: Int) {
+    assert(byteOffset >= 0)
     // `type(of: self.byteOffset).max` gets optimized to a constant
     if byteOffset > type(of: self.byteOffset).max {
       self.kind = .lexerErrorOffsetOverflow

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -65,29 +65,6 @@ public struct RawSyntaxTokenView {
     }
   }
 
-  @_spi(RawSyntax)
-  public func wholeText<T>(_ body: (SyntaxText) -> T) -> T {
-    switch raw.rawData.payload {
-    case .parsedToken(let dat):
-      return body(dat.wholeText)
-    case .materializedToken(let dat):
-      var wholeText: [UInt8] = []
-      wholeText.reserveCapacity(leadingTriviaByteLength + textByteLength + trailingTriviaByteLength)
-      for leadingTriviaPiece in dat.leadingTrivia {
-        leadingTriviaPiece.withSyntaxText { wholeText.append(contentsOf: $0) }
-      }
-      wholeText.append(contentsOf: self.rawText)
-      for trailingTriviaPiece in dat.trailingTrivia {
-        trailingTriviaPiece.withSyntaxText { wholeText.append(contentsOf: $0) }
-      }
-      return wholeText.withUnsafeBufferPointer { buffer in
-        return body(SyntaxText(buffer: buffer))
-      }
-    case .layout(_):
-      preconditionFailure("'wholeText' is not available for non-token node")
-    }
-  }
-
   /// The UTF-8 byte length of the leading trivia.
   @_spi(RawSyntax)
   public var leadingTriviaByteLength: Int {

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -143,7 +143,7 @@ private func AssertTokens(
       )
     case (let actualError?, let expectedError?):
       AssertStringsEqualWithDiff(
-        actualError.diagnostic(tokenText: actualLexeme.tokenText).message,
+        actualError.diagnostic(wholeText: actualLexeme.wholeText).message,
         expectedError,
         file: expectedLexeme.file,
         line: expectedLexeme.line
@@ -151,7 +151,7 @@ private func AssertTokens(
       if let location = markerLocations[expectedLexeme.errorLocationMarker] {
         XCTAssertEqual(
           Int(actualError.byteOffset),
-          location - lexemeStartOffset - actualLexeme.leadingTriviaByteLength,
+          location - lexemeStartOffset,
           "Expected location did not match",
           file: expectedLexeme.file,
           line: expectedLexeme.line

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -143,7 +143,7 @@ private func AssertTokens(
       )
     case (let actualError?, let expectedError?):
       AssertStringsEqualWithDiff(
-        actualError.diagnostic(wholeText: actualLexeme.wholeText).message,
+        actualError.diagnostic(wholeTextBytes: Array(actualLexeme.wholeText)).message,
         expectedError,
         file: expectedLexeme.file,
         line: expectedLexeme.line

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -718,6 +718,15 @@ public class LexerTests: XCTestCase {
     )
   }
 
+  func testInvalidCharacterSpanningMultipleBytes() {
+    AssertLexemes(
+      "121️⃣😡",
+      lexemes: [
+        LexemeSpec(.integerLiteral, text: "12😡", error: "'😡' is not a valid digit in integer literal")
+      ]
+    )
+  }
+
   func testBadNumericLiteralDigits() {
     AssertLexemes(
       "01️⃣a1234567",


### PR DESCRIPTION
We need this so we can diagnose invalid UTF-8 in a token’s leading trivia. Also, it seems cleaner in general to store the lexer error relative to the token’s leading trivia start instead of the token’s text start.