### PR TITLE
Parse attributes in `#if`

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -165,6 +165,11 @@ extension Parser {
   public mutating func parseDeclaration(inMemberDeclList: Bool = false) -> RawDeclSyntax {
     switch self.at(anyIn: PoundDeclarationStart.self) {
     case (.poundIfKeyword, _)?:
+      if self.withLookahead({ $0.consumeIfConfigOfAttributes() }) {
+        // If we are at a `#if` of attributes, the `#if` directive should be
+        // parsed when we're parsing the attributes.
+        break
+      }
       let directive = self.parsePoundIfDirective { parser in
         let parsedDecl = parser.parseDeclaration()
         let semicolon = parser.consume(if: .semicolon)

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -195,7 +195,9 @@ extension Parser {
   /// If we are not at the top level, such a closing brace should close the
   /// wrapping declaration instead of being consumed by lookeahead.
   private mutating func parseItem(isAtTopLevel: Bool = false, allowInitDecl: Bool = true) -> RawCodeBlockItemSyntax.Item {
-    if self.at(.poundIfKeyword) {
+    if self.at(.poundIfKeyword) && !self.withLookahead({ $0.consumeIfConfigOfAttributes() }) {
+      // If config of attributes is parsed as part of declaration parsing as it
+      // doesn't constitute its own code block item.
       let directive = self.parsePoundIfDirective {
         $0.parseCodeBlockItem()
       } addSemicolonIfNeeded: { lastElement, newItemAtStartOfLine, parser in

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1371,6 +1371,17 @@ final class DeclarationTests: XCTestCase {
       )
     )
   }
+
+  func testAttributeInPoundIf() {
+    AssertParse(
+      """
+      #if hasAttribute(foo)
+      @foo
+      #endif
+      struct MyStruct {}
+      """
+    )
+  }
 }
 
 extension Parser.DeclAttributes {

--- a/Tests/SwiftParserTest/DirectiveTests.swift
+++ b/Tests/SwiftParserTest/DirectiveTests.swift
@@ -147,25 +147,20 @@ final class DirectiveTests: XCTestCase {
         public struct S2 { }
 
       #if hasAttribute(foo)
-        @foo1️⃣
+        @foo
       #endif
         @inlinable
         func f1() { }
 
       #if hasAttribute(foo)
-        @foo2️⃣
+        @foo
       #else
         @available(*, deprecated, message: "nope")
-        @frozen3️⃣
+        @frozen
       #endif
         public struct S3 { }
       }
-      """,
-      diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected declaration after attribute in conditional compilation clause"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected declaration after attribute in conditional compilation clause"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected declaration after attribute in conditional compilation clause"),
-      ]
+      """
     )
   }
 


### PR DESCRIPTION
Fixes apple/swift-syntax#1119
rdar://103048943