### PR TITLE
Add substructure test case for unterminated string literal

### DIFF
--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -900,6 +900,27 @@ final class ExpressionTests: XCTestCase {
       ]
     )
   }
+
+  func testFoo() {
+    AssertParse(
+      """
+      "This is unterminated1️⃣
+      x
+      """,
+      substructure: Syntax(
+        StringLiteralExprSyntax(
+          openQuote: .stringQuoteToken(),
+          segments: StringLiteralSegmentsSyntax([
+            .stringSegment(StringSegmentSyntax(content: .stringSegment("This is unterminated")))
+          ]),
+          closeQuote: .stringQuoteToken(presence: .missing)
+        )
+      ),
+      diagnostics: [
+        DiagnosticSpec(message: #"expected '"' to end string literal"#)
+      ]
+    )
+  }
 }
 
 final class MemberExprTests: XCTestCase {


### PR DESCRIPTION
Adds a test case for apple/swift-syntax#778