### PR TITLE
Implement support for automatically coloring output in DiagnosticsFormatter

### DIFF
--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -139,10 +139,11 @@ public struct DiagnosticsFormatter {
     switch message.severity {
     case .error:
       let annotation = ANSIAnnotation(color: .red, trait: .bold)
-      return annotation.applied(to: message.message)
+      return annotation.applied(to: "error: \(message.message)")
     case .warning:
-      let annotation = ANSIAnnotation(color: .yellow)
-      return annotation.applied(to: message.message)
+      let color = ANSIAnnotation(color: .yellow)
+      let prefix = color.withTrait(.bold).applied(to: "warning: ")
+      return prefix + color.applied(to: message.message)
     case .note:
       return message.message
     }
@@ -179,6 +180,10 @@ struct ANSIAnnotation {
   init(color: Color, trait: Trait = .normal) {
     self.color = color
     self.trait = trait
+  }
+
+  func withTrait(_ trait: Trait) -> Self {
+    return ANSIAnnotation(color: self.color, trait: trait)
   }
 
   func applied(to message: String) -> String {

--- a/Sources/swift-parser-cli/TerminalUtils.swift
+++ b/Sources/swift-parser-cli/TerminalUtils.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Glibc)
+import Glibc
+#elseif os(Windows)
+import CRT
+#else
+import Darwin.C
+#endif
+
+#if os(Android)
+typealias FILEPointer = OpaquePointer
+#else
+typealias FILEPointer = UnsafeMutablePointer<FILE>
+#endif
+
+enum TerminalHelper {
+  static var isConnectedToTerminal: Bool {
+    return isTTY(stderr)
+  }
+
+  /// Checks if passed file pointer is a tty.
+  static func isTTY(_ filePointer: FILEPointer) -> Bool {
+    return terminalType(filePointer) == .tty
+  }
+
+  /// The type of terminal.
+  enum TerminalType {
+    /// The terminal is a TTY.
+    case tty
+
+    /// The terminal is a file stream.
+    case file
+  }
+
+  /// Computes the terminal type of the stream.
+  static func terminalType(_ filePointer: FILEPointer) -> TerminalType {
+    let isTTY = isatty(fileno(filePointer)) != 0
+    return isTTY ? .tty : .file
+  }
+}

--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -198,7 +198,7 @@ class PrintDiags: ParsableCommand {
   @Flag(name: .long, help: "Perform sequence folding with the standard operators")
   var foldSequences: Bool = false
 
-  @Flag(name: .long, help: "Colorize output with ANSI color codes")
+  @Flag(name: .long, help: "Force output coloring with ANSI color codes")
   var colorize: Bool = false
 
   func run() throws {
@@ -206,9 +206,14 @@ class PrintDiags: ParsableCommand {
 
     source.withUnsafeBufferPointer { sourceBuffer in
       let tree = Parser.parse(source: sourceBuffer)
-
       var diags = ParseDiagnosticsGenerator.diagnostics(for: tree)
-      print(DiagnosticsFormatter.annotatedSource(tree: tree, diags: diags, colorize: colorize))
+      let annotatedSource = DiagnosticsFormatter.annotatedSource(
+        tree: tree,
+        diags: diags,
+        colorize: colorize || TerminalHelper.isConnectedToTerminal
+      )
+
+      print(annotatedSource)
 
       if foldSequences {
         diags += foldAllSequences(tree).1

--- a/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
@@ -101,7 +101,7 @@ final class DiagnosticsFormatterTests: XCTestCase {
 
     let expectedOutput = """
       1 │ var foo = bar +
-        ∣                ╰─ \u{001B}[1;31mexpected expression in variable\u{001B}[0;0m
+        ∣                ╰─ \u{001B}[1;31merror: expected expression in variable\u{001B}[0;0m
 
       """
     AssertStringsEqualWithDiff(expectedOutput, annotate(source: source, colorize: true))
@@ -113,9 +113,9 @@ final class DiagnosticsFormatterTests: XCTestCase {
       """
     let expectedOutput = """
       1 │ foo.[].[].[]
-        ∣     │  │  ╰─ \u{001B}[1;31mexpected name in member access\u{001B}[0;0m
-        ∣     │  ╰─ \u{001B}[1;31mexpected name in member access\u{001B}[0;0m
-        ∣     ╰─ \u{001B}[1;31mexpected name in member access\u{001B}[0;0m
+        ∣     │  │  ╰─ \u{001B}[1;31merror: expected name in member access\u{001B}[0;0m
+        ∣     │  ╰─ \u{001B}[1;31merror: expected name in member access\u{001B}[0;0m
+        ∣     ╰─ \u{001B}[1;31merror: expected name in member access\u{001B}[0;0m
 
       """
     AssertStringsEqualWithDiff(expectedOutput, annotate(source: source, colorize: true))


### PR DESCRIPTION
This builds on the work in #1256 to add support for automatically enabling output coloring as suggested by @ahoppen. As of this change when invoking `$ swift-parser-cli print-diags` in a terminal it will enable output coloring by default. The `--colorize` flag introduced in #1256 is still supported to force output colors, if desired.

API-wise this should be a non-breaking change since it only adds overloads to instantiate a `DiagnosticsFormatter` with a new `ColorMode` parameter (shamelessly stolen from swift-format).

Some notes:
 - This implementation only copies the absolutely minimum required components from swift-format and swift-tools-support-core to enable the feature. I'm happy to discuss moving more things over from TSC / laying the groundwork for further development if that improves the end result.
   - In particular, TSC wraps `stderr` with a few wrapper types to simplify reading/writing to it. This doesn't seem to be used for detecting a TTY environment which is why I left it out for now.
 - I noticed that swift-tools-support-core exposes a `TSCLibc` module that re-exports symbols from C standard libraries on the various platforms (Glibc for Linux, CRT on Windows and Darwin.C on Apple platforms) but opted to "inline" the use of `stderr` for now. Don't have the resources at the moment to test this cross platform and so would more than appreciate any pointers here.
 - The implementation in TSCBasic uses a `ProcessEnv` type to read properties from the environment (relevant in this case is the `ProcessEnv.vars["TERM"]` call to check whether it's set to `"dumb"`) on non-Windows platforms. I've opted to remove support for detecting this case for now since copying `ProcessEnv` into swift-syntax seems out of scope but please do let me know if there's anything I'm missing here.

Additionally, I've taken the liberty of adding "error:" and "warning:" prefixes to formatted output when coloring is enabled to help with accessibility, as suggested by @DougGregor in #1256. I realize it's slightly out of scope but it's a nice addition in my opinion, let me know if this is better suited for a separate PR.