### PR TITLE
Fix two assertion failures related to invalid UTF-8

### DIFF
--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -2102,7 +2102,7 @@ extension Lexer.Cursor {
   /// valid operator start, advance the cursor by what can be considered a
   /// lexeme.
   mutating func lexUnknown() -> UnknownCharactersClassification {
-    assert(self.peekScalar()?.isValidIdentifierStartCodePoint == false && self.peekScalar()?.isOperatorStartCodePoint == false)
+    assert(!(self.peekScalar()?.isValidIdentifierStartCodePoint ?? false) && !(self.peekScalar()?.isOperatorStartCodePoint ?? false))
     var tmp = self
     if tmp.advance(if: { Unicode.Scalar($0).isValidIdentifierContinuationCodePoint }) {
       // If this is a valid identifier continuation, but not a valid identifier

--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -134,14 +134,18 @@ class VerifyRoundTrip: ParsableCommand {
   ) throws {
     let tree = Parser.parse(source: source)
 
-    _ = ParseDiagnosticsGenerator.diagnostics(for: tree)
+    var diags = ParseDiagnosticsGenerator.diagnostics(for: tree)
 
     let resultTree: Syntax
     if foldSequences {
-      resultTree = foldAllSequences(tree).0
+      let folded = foldAllSequences(tree)
+      resultTree = folded.0
+      diags += folded.1
     } else {
       resultTree = Syntax(tree)
     }
+
+    _ = DiagnosticsFormatter.annotatedSource(tree: tree, diags: diags)
 
     if resultTree.syntaxTextBytes != [UInt8](source) {
       throw Error.roundTripFailed

--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -207,6 +207,9 @@ class PrintDiags: ParsableCommand {
     source.withUnsafeBufferPointer { sourceBuffer in
       let tree = Parser.parse(source: sourceBuffer)
       var diags = ParseDiagnosticsGenerator.diagnostics(for: tree)
+      if foldSequences {
+        diags += foldAllSequences(tree).1
+      }
       let annotatedSource = DiagnosticsFormatter.annotatedSource(
         tree: tree,
         diags: diags,
@@ -214,10 +217,6 @@ class PrintDiags: ParsableCommand {
       )
 
       print(annotatedSource)
-
-      if foldSequences {
-        diags += foldAllSequences(tree).1
-      }
 
       if diags.isEmpty {
         print("No diagnostics produced")

--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -427,7 +427,7 @@ class Reduce: ParsableCommand {
     if verbose {
       printerr("Reduced from \(source.count) to \(reduced.count) characters in \(checks) iterations")
     }
-    let reducedString = String(decoding: reduced, as: UTF8.self)
-    print(reducedString)
+
+    FileHandle.standardOutput.write(Data(reduced))
   }
 }

--- a/Tests/SwiftSyntaxTest/SourceLocationConverterTests.swift
+++ b/Tests/SwiftSyntaxTest/SourceLocationConverterTests.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@_spi(RawSyntax) import SwiftSyntax
+
+final class SourceLocationConverterTests: XCTestCase {
+  func testInvalidUtf8() {
+    let eofToken = withExtendedLifetime(SyntaxArena()) { arena in
+      let leadingTriviaText = [UInt8(0xfd)].withUnsafeBufferPointer { buf in
+        arena.intern(SyntaxText(buffer: buf))
+      }
+
+      let nodeWithInvalidUtf8 = RawTokenSyntax(
+        kind: .eof,
+        text: "",
+        leadingTriviaPieces: [
+          .unexpectedText(leadingTriviaText)
+        ],
+        presence: .present,
+        arena: arena
+      )
+
+      return Syntax(raw: nodeWithInvalidUtf8.raw).cast(TokenSyntax.self)
+    }
+
+    let tree = SourceFileSyntax(statements: [], eofToken: eofToken)
+
+    // This used to violate the following assertion in the SourceLocationConverter's
+    // initializer, because we were using `String` which was lossy when handling the
+    // invalid UTF-8:
+    // ```
+    // assert(tree.byteSize == endOfFile.utf8Offset)
+    // ```
+    _ = SourceLocationConverter(file: "", tree: tree)
+  }
+}


### PR DESCRIPTION
- Fix an incorrect assertion in Cursor.swift
  - This assertion returned `false` if we reached the end of the file, while it should return `true`.
- Make SourceLocationConverter handle invalid UTF-8
  - The `SourceLocationConverter` previously worked on `String`, which is lossy if the source contains invalid UTF-8. Make it work on `SyntaxText` and `RawTriviaPiece` so it’s source accurate.


While at it, also fix a few things in `swift-parser-cli`:
- Show diagnostics from operator folding when running `swift-parser-cli print-diags`
- Run the diagnostic formatter during round-trip testing
  - This allows us to reduce crashes in the diagnostic formatter.
- Output reduced test case as bytes instead of a string
  - This allows us to reduce invalid UTF-8, which were lossily converted when creating a `String`.