### PR TITLE
Fix a crash when string interpolation creates a MissingStmtSyntax

### DIFF
--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -203,12 +203,20 @@ public struct RawMissingSyntax: RawSyntaxNodeProtocol {
   }
 
   public init(
+    _ unexpected: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    let raw = RawSyntax.makeEmptyLayout(kind: .missing, arena: arena)
+    let raw = RawSyntax.makeLayout(
+      kind: .missing, uninitializedCount: 1, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpected?.raw
+    }
     self.init(raw: raw)
   }
 
+  public var unexpected: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -295,12 +303,20 @@ public struct RawMissingExprSyntax: RawExprSyntaxNodeProtocol {
   }
 
   public init(
+    _ unexpected: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    let raw = RawSyntax.makeEmptyLayout(kind: .missingExpr, arena: arena)
+    let raw = RawSyntax.makeLayout(
+      kind: .missingExpr, uninitializedCount: 1, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpected?.raw
+    }
     self.init(raw: raw)
   }
 
+  public var unexpected: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -327,12 +343,20 @@ public struct RawMissingStmtSyntax: RawStmtSyntaxNodeProtocol {
   }
 
   public init(
+    _ unexpected: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    let raw = RawSyntax.makeEmptyLayout(kind: .missingStmt, arena: arena)
+    let raw = RawSyntax.makeLayout(
+      kind: .missingStmt, uninitializedCount: 1, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpected?.raw
+    }
     self.init(raw: raw)
   }
 
+  public var unexpected: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -359,12 +383,20 @@ public struct RawMissingTypeSyntax: RawTypeSyntaxNodeProtocol {
   }
 
   public init(
+    _ unexpected: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    let raw = RawSyntax.makeEmptyLayout(kind: .missingType, arena: arena)
+    let raw = RawSyntax.makeLayout(
+      kind: .missingType, uninitializedCount: 1, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpected?.raw
+    }
     self.init(raw: raw)
   }
 
+  public var unexpected: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -391,12 +423,20 @@ public struct RawMissingPatternSyntax: RawPatternSyntaxNodeProtocol {
   }
 
   public init(
+    _ unexpected: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    let raw = RawSyntax.makeEmptyLayout(kind: .missingPattern, arena: arena)
+    let raw = RawSyntax.makeLayout(
+      kind: .missingPattern, uninitializedCount: 1, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpected?.raw
+    }
     self.init(raw: raw)
   }
 
+  public var unexpected: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
@@ -88,7 +88,8 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .token:
     assertionFailure("validateLayout for .token kind is not supported")
   case .missing:
-    assert(layout.count == 0)
+    assert(layout.count == 1)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
     break
   case .missingDecl:
     assert(layout.count == 5)
@@ -99,16 +100,20 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
     break
   case .missingExpr:
-    assert(layout.count == 0)
+    assert(layout.count == 1)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
     break
   case .missingStmt:
-    assert(layout.count == 0)
+    assert(layout.count == 1)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
     break
   case .missingType:
-    assert(layout.count == 0)
+    assert(layout.count == 1)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
     break
   case .missingPattern:
-    assert(layout.count == 0)
+    assert(layout.count == 1)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
     break
   case .codeBlockItem:
     assert(layout.count == 5)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -41,12 +41,25 @@ public enum SyntaxFactory {
 
 
 
+  @available(*, deprecated, message: "Use initializer on MissingSyntax")
+  public static func makeMissing(_ unexpected: UnexpectedNodesSyntax? = nil) -> MissingSyntax {
+    let layout: [RawSyntax?] = [
+      unexpected?.raw,
+    ]
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missing,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MissingSyntax(data)
+    }
+  }
 
   @available(*, deprecated, message: "Use initializer on MissingSyntax")
   public static func makeBlankMissing(presence: SourcePresence = .missing) -> MissingSyntax {
     return withExtendedLifetime(SyntaxArena()) { arena in
       let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missing,
         from: [
+        nil,
       ], arena: arena))
       return MissingSyntax(data)
     }
@@ -82,14 +95,39 @@ public enum SyntaxFactory {
       return MissingDeclSyntax(data)
     }
   }
+  @available(*, deprecated, message: "Use initializer on MissingExprSyntax")
+  public static func makeMissingExpr(_ unexpected: UnexpectedNodesSyntax? = nil) -> MissingExprSyntax {
+    let layout: [RawSyntax?] = [
+      unexpected?.raw,
+    ]
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingExpr,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MissingExprSyntax(data)
+    }
+  }
 
   @available(*, deprecated, message: "Use initializer on MissingExprSyntax")
   public static func makeBlankMissingExpr(presence: SourcePresence = .missing) -> MissingExprSyntax {
     return withExtendedLifetime(SyntaxArena()) { arena in
       let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missingExpr,
         from: [
+        nil,
       ], arena: arena))
       return MissingExprSyntax(data)
+    }
+  }
+  @available(*, deprecated, message: "Use initializer on MissingStmtSyntax")
+  public static func makeMissingStmt(_ unexpected: UnexpectedNodesSyntax? = nil) -> MissingStmtSyntax {
+    let layout: [RawSyntax?] = [
+      unexpected?.raw,
+    ]
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingStmt,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MissingStmtSyntax(data)
     }
   }
 
@@ -98,8 +136,21 @@ public enum SyntaxFactory {
     return withExtendedLifetime(SyntaxArena()) { arena in
       let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missingStmt,
         from: [
+        nil,
       ], arena: arena))
       return MissingStmtSyntax(data)
+    }
+  }
+  @available(*, deprecated, message: "Use initializer on MissingTypeSyntax")
+  public static func makeMissingType(_ unexpected: UnexpectedNodesSyntax? = nil) -> MissingTypeSyntax {
+    let layout: [RawSyntax?] = [
+      unexpected?.raw,
+    ]
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingType,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MissingTypeSyntax(data)
     }
   }
 
@@ -108,8 +159,21 @@ public enum SyntaxFactory {
     return withExtendedLifetime(SyntaxArena()) { arena in
       let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missingType,
         from: [
+        nil,
       ], arena: arena))
       return MissingTypeSyntax(data)
+    }
+  }
+  @available(*, deprecated, message: "Use initializer on MissingPatternSyntax")
+  public static func makeMissingPattern(_ unexpected: UnexpectedNodesSyntax? = nil) -> MissingPatternSyntax {
+    let layout: [RawSyntax?] = [
+      unexpected?.raw,
+    ]
+    return withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingPattern,
+        from: layout, arena: arena)
+      let data = SyntaxData.forRoot(raw)
+      return MissingPatternSyntax(data)
     }
   }
 
@@ -118,6 +182,7 @@ public enum SyntaxFactory {
     return withExtendedLifetime(SyntaxArena()) { arena in
       let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missingPattern,
         from: [
+        nil,
       ], arena: arena))
       return MissingPatternSyntax(data)
     }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -31,23 +31,44 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init() {
+  public init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpected: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed 
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), ())) { (arena, _) in
-      let raw = RawSyntax.makeEmptyLayout(kind: SyntaxKind.missing, arena: arena)
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpected))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpected?.raw,
+      ]
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.missing, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
   }
 
+  public var unexpected: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = MissingSyntax(data.replacingChild(at: 0, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+
   public static var structure: SyntaxNodeStructure {
     return .layout([
+      \Self.unexpected,
     ])
   }
 
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
+    case 0:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -57,6 +78,7 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
 extension MissingSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
+      "unexpected": unexpected.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
@@ -31,23 +31,44 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init() {
+  public init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpected: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed 
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), ())) { (arena, _) in
-      let raw = RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: arena)
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpected))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpected?.raw,
+      ]
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.missingPattern, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
   }
 
+  public var unexpected: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = MissingPatternSyntax(data.replacingChild(at: 0, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+
   public static var structure: SyntaxNodeStructure {
     return .layout([
+      \Self.unexpected,
     ])
   }
 
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
+    case 0:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -57,6 +78,7 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension MissingPatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
+      "unexpected": unexpected.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -31,23 +31,44 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init() {
+  public init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpected: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed 
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), ())) { (arena, _) in
-      let raw = RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingStmt, arena: arena)
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpected))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpected?.raw,
+      ]
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.missingStmt, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
   }
 
+  public var unexpected: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = MissingStmtSyntax(data.replacingChild(at: 0, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+
   public static var structure: SyntaxNodeStructure {
     return .layout([
+      \Self.unexpected,
     ])
   }
 
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
+    case 0:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -57,6 +78,7 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension MissingStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
+      "unexpected": unexpected.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -31,23 +31,44 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
-  public init() {
+  public init(
+    leadingTrivia: Trivia? = nil,
+    _ unexpected: UnexpectedNodesSyntax? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed 
     // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), ())) { (arena, _) in
-      let raw = RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: arena)
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (unexpected))) { (arena, _) in
+      let layout: [RawSyntax?] = [
+        unexpected?.raw,
+      ]
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.missingType, from: layout, arena: arena,
+        leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
   }
 
+  public var unexpected: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = MissingTypeSyntax(data.replacingChild(at: 0, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+
   public static var structure: SyntaxNodeStructure {
     return .layout([
+      \Self.unexpected,
     ])
   }
 
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
+    case 0:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -57,6 +78,7 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension MissingTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
+      "unexpected": unexpected.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -504,4 +504,22 @@ final class StringInterpolationTests: XCTestCase {
       )
     }
   }
+
+  func testInvalidSyntax2() {
+    let invalid = StmtSyntax("struct Foo {}")
+    XCTAssert(invalid.hasError)
+
+    XCTAssertThrowsError(try StmtSyntax(validating: "struct Foo {}")) { error in
+      AssertStringsEqualWithDiff(
+        String(describing: error),
+        """
+
+        1 │ struct Foo {}
+          ∣ │            ╰─ expected statement
+          ∣ ╰─ unexpected code 'struct Foo {}' before statement
+
+        """
+      )
+    }
+  }
 }

--- a/gyb_syntax_support/Node.py
+++ b/gyb_syntax_support/Node.py
@@ -46,6 +46,13 @@ class Node(object):
                     ))
                 else:
                     self.children.append(children[int((i - 1) / 2)])
+        elif kind != 'SyntaxCollection' and len(children) == 0:
+          self.children.append(Child(
+              'Unexpected',
+              kind='UnexpectedNodes',
+              collection_element_name='Unexpected',
+              is_optional=True
+          ))
 
         self.non_unexpected_children = \
             [child for child in children if not child.is_unexpected_nodes()]


### PR DESCRIPTION
We were crashing here because string interpolation created a `MissingStmtSyntax`, which doesn’t have any children. It then tried to assign the remaining tokens as unexpected tokens to the last child of the `MissingStmtSyntax`, which failed (because there are no children).

The fix here is to just add an `unexpected` child to the missing nodes. I’ve got a gut feeling that that might be useful anyway.