### PR TITLE
Update DocC tutorial to follow the latest change

### DIFF
--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step10.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step10.swift
@@ -55,7 +55,7 @@ import Foundation
     }
     return
       sourceFile
-          .with(\.statements, CodeBlockItemSyntax(formattedStatements))
+      .with(\.statements, CodeBlockItemSyntax(formattedStatements))
   }
 
   enum Item {

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step10.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step10.swift
@@ -55,7 +55,7 @@ import Foundation
     }
     return
       sourceFile
-      .withStatements(CodeBlockItemListSyntax(formattedStatements))
+          .with(\.statements, CodeBlockItemSyntax(formattedStatements))
   }
 
   enum Item {

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step11.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step11.swift
@@ -58,7 +58,7 @@ import Foundation
     }
     return
       sourceFile
-      .withStatements(CodeBlockItemListSyntax(formattedStatements))
+          .with(\.statements, CodeBlockItemSyntax(formattedStatements))
   }
 
   enum Item {

--- a/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step11.swift
+++ b/Sources/SwiftSyntax/Documentation.docc/Resources/Formatter.step11.swift
@@ -58,7 +58,7 @@ import Foundation
     }
     return
       sourceFile
-          .with(\.statements, CodeBlockItemSyntax(formattedStatements))
+      .with(\.statements, CodeBlockItemSyntax(formattedStatements))
   }
 
   enum Item {

--- a/Sources/SwiftSyntax/Documentation.docc/Tutorials/SwiftSyntax By Example.tutorial
+++ b/Sources/SwiftSyntax/Documentation.docc/Tutorials/SwiftSyntax By Example.tutorial
@@ -171,7 +171,7 @@
       }
       
       @Step {
-        Then use the `withStatements` method to create a source file
+        Then use the `with*` method to create a source file
         that contains the extracted array of statements.
         
         The syntax tree is immutable. The result of calling `with*` methods is

--- a/Sources/SwiftSyntax/Documentation.docc/Tutorials/SwiftSyntax By Example.tutorial
+++ b/Sources/SwiftSyntax/Documentation.docc/Tutorials/SwiftSyntax By Example.tutorial
@@ -171,7 +171,7 @@
       }
       
       @Step {
-        Then use the `with*` method to create a source file
+        Then use `with(\.statements, <#new statements#>)*` method to create a source file
         that contains the extracted array of statements.
         
         The syntax tree is immutable. The result of calling `with*` methods is

--- a/Sources/SwiftSyntax/Documentation.docc/Tutorials/SwiftSyntax By Example.tutorial
+++ b/Sources/SwiftSyntax/Documentation.docc/Tutorials/SwiftSyntax By Example.tutorial
@@ -174,7 +174,7 @@
         Then use `with(\.statements, <#new statements#>)*` method to create a source file
         that contains the extracted array of statements.
         
-        The syntax tree is immutable. The result of calling `with*` methods is
+        The syntax tree is immutable. The result of calling `with` is
         always a copy of a syntax tree node with the specified child element
         changed.
         


### PR DESCRIPTION
## Changes

I found the diff between latest main branch API and DocC tutorial.

Particularly, in DocC tutorial, `SyntaxProtocol.with` method is not used when copying syntax tree node with `statements` property modified.

