### PR TITLE
Produce meaningful diagnostic for '#else if' typo

### DIFF
--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -197,6 +197,9 @@ extension DiagnosticMessage where Self == StaticParserError {
   public static var tryOnInitialValueExpression: Self {
     .init("'try' must be placed on the initial value expression")
   }
+  public static var unexpectedPoundElseSpaceIf: Self {
+    .init("unexpected 'if' keyword following '#else' conditional compilation directive; did you mean '#elseif'?")
+  }
   public static var unexpectedSemicolon: Self {
     .init("unexpected ';' separator")
   }

--- a/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
+++ b/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
@@ -428,6 +428,35 @@ final class IfconfigExprTests: XCTestCase {
     )
   }
 
+  func testIfconfigExpr31() {
+    AssertParse(
+      """
+      #if arch(x86_64)
+        debugPrint("x86_64")
+      1️⃣#else if arch(arm64)
+        debugPrint("arm64")
+      #else
+        debugPrint("Some other architecture.")
+      #endif
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "unexpected 'if' keyword following '#else' conditional compilation directive; did you mean '#elseif'?",
+          fixIts: ["replace '#else if' with '#elseif'"]
+        )
+      ],
+      fixedSource: """
+        #if arch(x86_64)
+          debugPrint("x86_64")
+        #elseif arch(arm64)
+          debugPrint("arm64")
+        #else
+          debugPrint("Some other architecture.")
+        #endif
+        """
+    )
+  }
+
   func testUnknownPlatform1() {
     AssertParse(
       """


### PR DESCRIPTION
The purpose of this PR is to fix the first part of issue https://github.com/apple/swift-syntax/issues/1221: produce a meaningful diagnostic for the common `#else if` typo.

I've followed the tips given by @bnbarham and the ones from the [fixingBugs document](https://github.com/apple/swift-syntax/blob/main/Sources/SwiftParser/SwiftParser.docc/FixingBugs.md). Here's what I did so far:
1. Added a test inside `ifconfigExprTests` (it's currently failing because the diagnostics include more errors than the one I'm expecting, I must be doing something wrong)
2. Generated an unexpected token for the `#else if` typo, and a missing one for `#elseif`, in `parsePoundIfDirective`, inside `Directives.swift` (I'm not sure if I'm using the right methods)
3. Added code to generate correct diagnostics for `IfConfigDeclSyntax`, in `ParseDiagnosticsGenerator.swift`

Any tip or help to get this right is really appreciated. Thank you in advance.