### PR TITLE
[SE-0376] Rename `@_backDeploy(before:)` to `@backDeployed(before:)`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -97,6 +97,7 @@ public let KEYWORDS: [KeywordSpec] = [
   KeywordSpec("availability"),
   KeywordSpec("available"),
   KeywordSpec("await"),
+  KeywordSpec("backDeployed"),
   KeywordSpec("before"),
   KeywordSpec("block"),
   KeywordSpec("break", isLexerClassified: true, requiresTrailingSpace: true),

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/AttributeNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/AttributeNodes.swift
@@ -50,8 +50,8 @@ public let ATTRIBUTE_NODES: [Node] = [
                        kind: .node(kind: "DifferentiableAttributeArguments")),
                  Child(name: "DerivativeRegistrationArguments",
                        kind: .node(kind: "DerivativeRegistrationAttributeArguments")),
-                 Child(name: "BackDeployArguments",
-                       kind: .node(kind: "BackDeployAttributeSpecList")),
+                 Child(name: "BackDeployedArguments",
+                       kind: .node(kind: "BackDeployedAttributeSpecList")),
                  Child(name: "ConventionArguments",
                        kind: .node(kind: "ConventionAttributeArguments")),
                  Child(name: "ConventionWitnessMethodArguments",
@@ -340,9 +340,9 @@ public let ATTRIBUTE_NODES: [Node] = [
                isOptional: true)
        ]),
 
-  Node(name: "BackDeployAttributeSpecList",
-       nameForDiagnostics: "'@_backDeploy' arguments",
-       description: "A collection of arguments for the `@_backDeploy` attribute",
+  Node(name: "BackDeployedAttributeSpecList",
+       nameForDiagnostics: "'@backDeployed' arguments",
+       description: "A collection of arguments for the `@backDeployed` attribute",
        kind: "Syntax",
        children: [
          Child(name: "BeforeLabel",

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -32,7 +32,6 @@ extension Parser {
   /// Compiler-known attributes that take arguments.
   enum DeclarationAttributeWithSpecialSyntax: RawTokenKindSubset {
     case _alignment
-    case _backDeploy
     case _cdecl
     case _documentation
     case _dynamicReplacement
@@ -56,6 +55,7 @@ extension Parser {
     case _unavailableFromAsync
     case `rethrows`
     case available
+    case backDeployed
     case derivative
     case differentiable
     case exclusivity
@@ -66,7 +66,7 @@ extension Parser {
     init?(lexeme: Lexer.Lexeme) {
       switch lexeme {
       case RawTokenKindMatch(._alignment): self = ._alignment
-      case RawTokenKindMatch(._backDeploy): self = ._backDeploy
+      case RawTokenKindMatch(._backDeploy): self = .backDeployed
       case RawTokenKindMatch(._cdecl): self = ._cdecl
       case RawTokenKindMatch(._documentation): self = ._documentation
       case RawTokenKindMatch(._dynamicReplacement): self = ._dynamicReplacement
@@ -90,6 +90,7 @@ extension Parser {
       case RawTokenKindMatch(._unavailableFromAsync): self = ._unavailableFromAsync
       case RawTokenKindMatch(.`rethrows`): self = .rethrows
       case RawTokenKindMatch(.available): self = .available
+      case RawTokenKindMatch(.backDeployed): self = .backDeployed
       case RawTokenKindMatch(.derivative): self = .derivative
       case RawTokenKindMatch(.differentiable): self = .differentiable
       case RawTokenKindMatch(.exclusivity): self = .exclusivity
@@ -104,7 +105,6 @@ extension Parser {
     var rawTokenKind: RawTokenKind {
       switch self {
       case ._alignment: return .keyword(._alignment)
-      case ._backDeploy: return .keyword(._backDeploy)
       case ._cdecl: return .keyword(._cdecl)
       case ._documentation: return .keyword(._documentation)
       case ._dynamicReplacement: return .keyword(._dynamicReplacement)
@@ -128,6 +128,7 @@ extension Parser {
       case ._unavailableFromAsync: return .keyword(._unavailableFromAsync)
       case .`rethrows`: return .keyword(.rethrows)
       case .available: return .keyword(.available)
+      case .backDeployed: return .keyword(.backDeployed)
       case .derivative: return .keyword(.derivative)
       case .differentiable: return .keyword(.differentiable)
       case .exclusivity: return .keyword(.exclusivity)
@@ -222,6 +223,10 @@ extension Parser {
       return parseAttribute(argumentMode: .required) { parser in
         return .availability(parser.parseAvailabilityArgumentSpecList())
       }
+    case .backDeployed:
+      return parseAttribute(argumentMode: .required) { parser in
+        return .backDeployedArguments(parser.parseBackDeployedArguments())
+      }
     case .differentiable:
       return parseAttribute(argumentMode: .required) { parser in
         return .differentiableArguments(parser.parseDifferentiableAttributeArguments())
@@ -293,10 +298,6 @@ extension Parser {
     case ._semantics:
       return parseAttribute(argumentMode: .required) { parser in
         return .string(parser.parseStringLiteral())
-      }
-    case ._backDeploy:
-      return parseAttribute(argumentMode: .required) { parser in
-        return .backDeployArguments(parser.parseBackDeployArguments())
       }
     case ._expose:
       return parseAttribute(argumentMode: .required) { parser in
@@ -920,7 +921,7 @@ extension Parser {
 }
 
 extension Parser {
-  mutating func parseBackDeployArguments() -> RawBackDeployAttributeSpecListSyntax {
+  mutating func parseBackDeployedArguments() -> RawBackDeployedAttributeSpecListSyntax {
     let (unexpectedBeforeLabel, label) = self.expect(.keyword(.before))
     let (unexpectedBeforeColon, colon) = self.expect(.colon)
     var elements: [RawAvailabilityVersionRestrictionListEntrySyntax] = []
@@ -936,7 +937,7 @@ extension Parser {
         )
       )
     } while keepGoing != nil
-    return RawBackDeployAttributeSpecListSyntax(
+    return RawBackDeployedAttributeSpecListSyntax(
       unexpectedBeforeLabel,
       beforeLabel: label,
       unexpectedBeforeColon,

--- a/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
@@ -355,7 +355,7 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/DifferentiabilityParamSyntax>
 - <doc:SwiftSyntax/DerivativeRegistrationAttributeArgumentsSyntax>
 - <doc:SwiftSyntax/QualifiedDeclNameSyntax>
-- <doc:SwiftSyntax/BackDeployAttributeSpecListSyntax>
+- <doc:SwiftSyntax/BackDeployedAttributeSpecListSyntax>
 - <doc:SwiftSyntax/AvailabilityVersionRestrictionListSyntax>
 - <doc:SwiftSyntax/AvailabilityVersionRestrictionListEntrySyntax>
 - <doc:SwiftSyntax/OpaqueReturnTypeOfAttributeArgumentsSyntax>

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -10573,7 +10573,7 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
     case `implementsArguments`(RawImplementsAttributeArgumentsSyntax)
     case `differentiableArguments`(RawDifferentiableAttributeArgumentsSyntax)
     case `derivativeRegistrationArguments`(RawDerivativeRegistrationAttributeArgumentsSyntax)
-    case `backDeployArguments`(RawBackDeployAttributeSpecListSyntax)
+    case `backDeployedArguments`(RawBackDeployedAttributeSpecListSyntax)
     case `conventionArguments`(RawConventionAttributeArgumentsSyntax)
     case `conventionWitnessMethodArguments`(RawConventionWitnessMethodAttributeArgumentsSyntax)
     case `opaqueReturnTypeOfAttributeArguments`(RawOpaqueReturnTypeOfAttributeArgumentsSyntax)
@@ -10586,7 +10586,7 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
     case `documentationArguments`(RawDocumentationAttributeArgumentsSyntax)
 
     public static func isKindOf(_ raw: RawSyntax) -> Bool {
-      return RawTupleExprElementListSyntax.isKindOf(raw) || RawTokenSyntax.isKindOf(raw) || RawStringLiteralExprSyntax.isKindOf(raw) || RawAvailabilitySpecListSyntax.isKindOf(raw) || RawSpecializeAttributeSpecListSyntax.isKindOf(raw) || RawObjCSelectorSyntax.isKindOf(raw) || RawImplementsAttributeArgumentsSyntax.isKindOf(raw) || RawDifferentiableAttributeArgumentsSyntax.isKindOf(raw) || RawDerivativeRegistrationAttributeArgumentsSyntax.isKindOf(raw) || RawBackDeployAttributeSpecListSyntax.isKindOf(raw) || RawConventionAttributeArgumentsSyntax.isKindOf(raw) || RawConventionWitnessMethodAttributeArgumentsSyntax.isKindOf(raw) || RawOpaqueReturnTypeOfAttributeArgumentsSyntax.isKindOf(raw) || RawExposeAttributeArgumentsSyntax.isKindOf(raw) || RawOriginallyDefinedInArgumentsSyntax.isKindOf(raw) || RawUnderscorePrivateAttributeArgumentsSyntax.isKindOf(raw) || RawDynamicReplacementArgumentsSyntax.isKindOf(raw) || RawUnavailableFromAsyncArgumentsSyntax.isKindOf(raw) || RawEffectsArgumentsSyntax.isKindOf(raw) || RawDocumentationAttributeArgumentsSyntax.isKindOf(raw)
+      return RawTupleExprElementListSyntax.isKindOf(raw) || RawTokenSyntax.isKindOf(raw) || RawStringLiteralExprSyntax.isKindOf(raw) || RawAvailabilitySpecListSyntax.isKindOf(raw) || RawSpecializeAttributeSpecListSyntax.isKindOf(raw) || RawObjCSelectorSyntax.isKindOf(raw) || RawImplementsAttributeArgumentsSyntax.isKindOf(raw) || RawDifferentiableAttributeArgumentsSyntax.isKindOf(raw) || RawDerivativeRegistrationAttributeArgumentsSyntax.isKindOf(raw) || RawBackDeployedAttributeSpecListSyntax.isKindOf(raw) || RawConventionAttributeArgumentsSyntax.isKindOf(raw) || RawConventionWitnessMethodAttributeArgumentsSyntax.isKindOf(raw) || RawOpaqueReturnTypeOfAttributeArgumentsSyntax.isKindOf(raw) || RawExposeAttributeArgumentsSyntax.isKindOf(raw) || RawOriginallyDefinedInArgumentsSyntax.isKindOf(raw) || RawUnderscorePrivateAttributeArgumentsSyntax.isKindOf(raw) || RawDynamicReplacementArgumentsSyntax.isKindOf(raw) || RawUnavailableFromAsyncArgumentsSyntax.isKindOf(raw) || RawEffectsArgumentsSyntax.isKindOf(raw) || RawDocumentationAttributeArgumentsSyntax.isKindOf(raw)
     }
 
     public var raw: RawSyntax {
@@ -10600,7 +10600,7 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
       case .implementsArguments(let node): return node.raw
       case .differentiableArguments(let node): return node.raw
       case .derivativeRegistrationArguments(let node): return node.raw
-      case .backDeployArguments(let node): return node.raw
+      case .backDeployedArguments(let node): return node.raw
       case .conventionArguments(let node): return node.raw
       case .conventionWitnessMethodArguments(let node): return node.raw
       case .opaqueReturnTypeOfAttributeArguments(let node): return node.raw
@@ -10651,8 +10651,8 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
         self = .derivativeRegistrationArguments(node)
         return
       }
-      if let node = RawBackDeployAttributeSpecListSyntax(other) {
-        self = .backDeployArguments(node)
+      if let node = RawBackDeployedAttributeSpecListSyntax(other) {
+        self = .backDeployedArguments(node)
         return
       }
       if let node = RawConventionAttributeArgumentsSyntax(other) {
@@ -11999,7 +11999,7 @@ public struct RawQualifiedDeclNameSyntax: RawSyntaxNodeProtocol {
 }
 
 @_spi(RawSyntax)
-public struct RawBackDeployAttributeSpecListSyntax: RawSyntaxNodeProtocol {
+public struct RawBackDeployedAttributeSpecListSyntax: RawSyntaxNodeProtocol {
 
   @_spi(RawSyntax)
   public var layoutView: RawSyntaxLayoutView {
@@ -12007,7 +12007,7 @@ public struct RawBackDeployAttributeSpecListSyntax: RawSyntaxNodeProtocol {
   }
 
   public static func isKindOf(_ raw: RawSyntax) -> Bool {
-    return raw.kind == .backDeployAttributeSpecList
+    return raw.kind == .backDeployedAttributeSpecList
   }
 
   public var raw: RawSyntax
@@ -12034,7 +12034,7 @@ public struct RawBackDeployAttributeSpecListSyntax: RawSyntaxNodeProtocol {
     assert(beforeLabel.tokenKind == .keyword(.before), "Received \(beforeLabel.tokenKind)")
     assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
     let raw = RawSyntax.makeLayout(
-      kind: .backDeployAttributeSpecList, uninitializedCount: 7, arena: arena) { layout in
+      kind: .backDeployedAttributeSpecList, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeBeforeLabel?.raw
       layout[1] = beforeLabel.raw

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
@@ -1736,7 +1736,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 7, verify(layout[7], as: RawDeclNameArgumentsSyntax?.self))
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
     break
-  case .backDeployAttributeSpecList:
+  case .backDeployedAttributeSpecList:
     assert(layout.count == 7)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self))

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -145,6 +145,8 @@ public enum Keyword: UInt8, Hashable {
   
   case await
   
+  case backDeployed
+  
   case before
   
   case block
@@ -789,6 +791,8 @@ public enum Keyword: UInt8, Hashable {
         self = ._silgen_name
       case "availability": 
         self = .availability
+      case "backDeployed": 
+        self = .backDeployed
       case "noDerivative": 
         self = .noDerivative
       default: 
@@ -1096,6 +1100,7 @@ public enum Keyword: UInt8, Hashable {
     "availability", 
     "available", 
     "await", 
+    "backDeployed", 
     "before", 
     "block", 
     "break", 

--- a/Sources/SwiftSyntax/generated/Misc.swift
+++ b/Sources/SwiftSyntax/generated/Misc.swift
@@ -46,7 +46,7 @@ extension Syntax {
         .node(AvailabilityVersionRestrictionListSyntax.self), 
         .node(AvailabilityVersionRestrictionSyntax.self), 
         .node(AwaitExprSyntax.self), 
-        .node(BackDeployAttributeSpecListSyntax.self), 
+        .node(BackDeployedAttributeSpecListSyntax.self), 
         .node(BinaryOperatorExprSyntax.self), 
         .node(BooleanLiteralExprSyntax.self), 
         .node(BorrowExprSyntax.self), 
@@ -340,8 +340,8 @@ extension SyntaxKind {
       return AvailabilityVersionRestrictionSyntax.self
     case .awaitExpr: 
       return AwaitExprSyntax.self
-    case .backDeployAttributeSpecList: 
-      return BackDeployAttributeSpecListSyntax.self
+    case .backDeployedAttributeSpecList: 
+      return BackDeployedAttributeSpecListSyntax.self
     case .binaryOperatorExpr: 
       return BinaryOperatorExprSyntax.self
     case .booleanLiteralExpr: 
@@ -865,8 +865,8 @@ extension SyntaxKind {
       return "version restriction"
     case .awaitExpr: 
       return "'await' expression"
-    case .backDeployAttributeSpecList: 
-      return "'@_backDeploy' arguments"
+    case .backDeployedAttributeSpecList: 
+      return "'@backDeployed' arguments"
     case .binaryOperatorExpr: 
       return "operator"
     case .booleanLiteralExpr: 

--- a/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
@@ -273,11 +273,11 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
   
-  override open func visit(_ node: BackDeployAttributeSpecListSyntax) -> SyntaxVisitorContinueKind {
+  override open func visit(_ node: BackDeployedAttributeSpecListSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
   
-  override open func visitPost(_ node: BackDeployAttributeSpecListSyntax) {
+  override open func visitPost(_ node: BackDeployedAttributeSpecListSyntax) {
     visitAnyPost(node._syntaxNode)
   }
   

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -73,7 +73,7 @@ public enum SyntaxEnum {
   
   case awaitExpr(AwaitExprSyntax)
   
-  case backDeployAttributeSpecList(BackDeployAttributeSpecListSyntax)
+  case backDeployedAttributeSpecList(BackDeployedAttributeSpecListSyntax)
   
   case binaryOperatorExpr(BinaryOperatorExprSyntax)
   
@@ -598,8 +598,8 @@ public extension Syntax {
       return .availabilityVersionRestriction(AvailabilityVersionRestrictionSyntax(self)!)
     case .awaitExpr: 
       return .awaitExpr(AwaitExprSyntax(self)!)
-    case .backDeployAttributeSpecList: 
-      return .backDeployAttributeSpecList(BackDeployAttributeSpecListSyntax(self)!)
+    case .backDeployedAttributeSpecList: 
+      return .backDeployedAttributeSpecList(BackDeployedAttributeSpecListSyntax(self)!)
     case .binaryOperatorExpr: 
       return .binaryOperatorExpr(BinaryOperatorExprSyntax(self)!)
     case .booleanLiteralExpr: 

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -73,7 +73,7 @@ public enum SyntaxKind {
   
   case awaitExpr
   
-  case backDeployAttributeSpecList
+  case backDeployedAttributeSpecList
   
   case binaryOperatorExpr
   

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -216,11 +216,11 @@ open class SyntaxRewriter {
     return ExprSyntax(visitChildren(node))
   }
   
-  /// Visit a `BackDeployAttributeSpecListSyntax`.
+  /// Visit a `BackDeployedAttributeSpecListSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
-  open func visit(_ node: BackDeployAttributeSpecListSyntax) -> BackDeployAttributeSpecListSyntax {
-    return Syntax(visitChildren(node)).cast(BackDeployAttributeSpecListSyntax.self)
+  open func visit(_ node: BackDeployedAttributeSpecListSyntax) -> BackDeployedAttributeSpecListSyntax {
+    return Syntax(visitChildren(node)).cast(BackDeployedAttributeSpecListSyntax.self)
   }
   
   /// Visit a `BinaryOperatorExprSyntax`.
@@ -2293,8 +2293,8 @@ open class SyntaxRewriter {
   }
   
   /// Implementation detail of visit(_:). Do not call directly.
-  private func visitImplBackDeployAttributeSpecListSyntax(_ data: SyntaxData) -> Syntax {
-    let node = BackDeployAttributeSpecListSyntax(data)
+  private func visitImplBackDeployedAttributeSpecListSyntax(_ data: SyntaxData) -> Syntax {
+    let node = BackDeployedAttributeSpecListSyntax(data)
     // Accessing _syntaxNode directly is faster than calling Syntax(node)
     visitPre(node._syntaxNode)
     defer { 
@@ -5636,8 +5636,8 @@ open class SyntaxRewriter {
       return visitImplAvailabilityVersionRestrictionSyntax
     case .awaitExpr: 
       return visitImplAwaitExprSyntax
-    case .backDeployAttributeSpecList: 
-      return visitImplBackDeployAttributeSpecListSyntax
+    case .backDeployedAttributeSpecList: 
+      return visitImplBackDeployedAttributeSpecListSyntax
     case .binaryOperatorExpr: 
       return visitImplBinaryOperatorExprSyntax
     case .booleanLiteralExpr: 
@@ -6164,8 +6164,8 @@ open class SyntaxRewriter {
       return visitImplAvailabilityVersionRestrictionSyntax(data)
     case .awaitExpr: 
       return visitImplAwaitExprSyntax(data)
-    case .backDeployAttributeSpecList: 
-      return visitImplBackDeployAttributeSpecListSyntax(data)
+    case .backDeployedAttributeSpecList: 
+      return visitImplBackDeployedAttributeSpecListSyntax(data)
     case .binaryOperatorExpr: 
       return visitImplBinaryOperatorExprSyntax(data)
     case .booleanLiteralExpr: 

--- a/Sources/SwiftSyntax/generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTransform.swift
@@ -156,10 +156,10 @@ public protocol SyntaxTransformVisitor {
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: AwaitExprSyntax) -> ResultType
   
-  /// Visiting `BackDeployAttributeSpecListSyntax` specifically.
+  /// Visiting `BackDeployedAttributeSpecListSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
-  func visit(_ node: BackDeployAttributeSpecListSyntax) -> ResultType
+  func visit(_ node: BackDeployedAttributeSpecListSyntax) -> ResultType
   
   /// Visiting `BinaryOperatorExprSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
@@ -1511,10 +1511,10 @@ extension SyntaxTransformVisitor {
     visitAny(Syntax(node))
   }
   
-  /// Visiting `BackDeployAttributeSpecListSyntax` specifically.
+  /// Visiting `BackDeployedAttributeSpecListSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
-  public func visit(_ node: BackDeployAttributeSpecListSyntax) -> ResultType {
+  public func visit(_ node: BackDeployedAttributeSpecListSyntax) -> ResultType {
     visitAny(Syntax(node))
   }
   
@@ -3193,7 +3193,7 @@ extension SyntaxTransformVisitor {
       return visit(derived)
     case .awaitExpr(let derived): 
       return visit(derived)
-    case .backDeployAttributeSpecList(let derived): 
+    case .backDeployedAttributeSpecList(let derived): 
       return visit(derived)
     case .binaryOperatorExpr(let derived): 
       return visit(derived)

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -352,16 +352,16 @@ open class SyntaxVisitor {
   open func visitPost(_ node: AwaitExprSyntax) {
   }
   
-  /// Visiting `BackDeployAttributeSpecListSyntax` specifically.
+  /// Visiting `BackDeployedAttributeSpecListSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
-  open func visit(_ node: BackDeployAttributeSpecListSyntax) -> SyntaxVisitorContinueKind {
+  open func visit(_ node: BackDeployedAttributeSpecListSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
   
-  /// The function called after visiting `BackDeployAttributeSpecListSyntax` and its descendents.
+  /// The function called after visiting `BackDeployedAttributeSpecListSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
-  open func visitPost(_ node: BackDeployAttributeSpecListSyntax) {
+  open func visitPost(_ node: BackDeployedAttributeSpecListSyntax) {
   }
   
   /// Visiting `BinaryOperatorExprSyntax` specifically.
@@ -3446,8 +3446,8 @@ open class SyntaxVisitor {
   }
   
   /// Implementation detail of doVisit(_:_:). Do not call directly.
-  private func visitImplBackDeployAttributeSpecListSyntax(_ data: SyntaxData) {
-    let node = BackDeployAttributeSpecListSyntax(data)
+  private func visitImplBackDeployedAttributeSpecListSyntax(_ data: SyntaxData) {
+    let node = BackDeployedAttributeSpecListSyntax(data)
     let needsChildren = (visit(node) == .visitChildren)
     // Avoid calling into visitChildren if possible.
     if needsChildren && !node.raw.layoutView!.children.isEmpty {
@@ -6058,8 +6058,8 @@ open class SyntaxVisitor {
       visitImplAvailabilityVersionRestrictionSyntax(data)
     case .awaitExpr: 
       visitImplAwaitExprSyntax(data)
-    case .backDeployAttributeSpecList: 
-      visitImplBackDeployAttributeSpecListSyntax(data)
+    case .backDeployedAttributeSpecList: 
+      visitImplBackDeployedAttributeSpecListSyntax(data)
     case .binaryOperatorExpr: 
       visitImplBinaryOperatorExprSyntax(data)
     case .booleanLiteralExpr: 

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -5518,8 +5518,8 @@ public enum SyntaxFactory {
       return QualifiedDeclNameSyntax(data)
     }
   }
-  @available(*, deprecated, message: "Use initializer on BackDeployAttributeSpecListSyntax")
-  public static func makeBackDeployAttributeSpecList(_ unexpectedBeforeBeforeLabel: UnexpectedNodesSyntax? = nil, beforeLabel: TokenSyntax, _ unexpectedBetweenBeforeLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndVersionList: UnexpectedNodesSyntax? = nil, versionList: AvailabilityVersionRestrictionListSyntax, _ unexpectedAfterVersionList: UnexpectedNodesSyntax? = nil) -> BackDeployAttributeSpecListSyntax {
+  @available(*, deprecated, message: "Use initializer on BackDeployedAttributeSpecListSyntax")
+  public static func makeBackDeployedAttributeSpecList(_ unexpectedBeforeBeforeLabel: UnexpectedNodesSyntax? = nil, beforeLabel: TokenSyntax, _ unexpectedBetweenBeforeLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndVersionList: UnexpectedNodesSyntax? = nil, versionList: AvailabilityVersionRestrictionListSyntax, _ unexpectedAfterVersionList: UnexpectedNodesSyntax? = nil) -> BackDeployedAttributeSpecListSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBeforeLabel?.raw,
       beforeLabel.raw,
@@ -5530,17 +5530,17 @@ public enum SyntaxFactory {
       unexpectedAfterVersionList?.raw,
     ]
     return withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployAttributeSpecList,
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployedAttributeSpecList,
         from: layout, arena: arena)
       let data = SyntaxData.forRoot(raw)
-      return BackDeployAttributeSpecListSyntax(data)
+      return BackDeployedAttributeSpecListSyntax(data)
     }
   }
 
-  @available(*, deprecated, message: "Use initializer on BackDeployAttributeSpecListSyntax")
-  public static func makeBlankBackDeployAttributeSpecList(presence: SourcePresence = .present) -> BackDeployAttributeSpecListSyntax {
+  @available(*, deprecated, message: "Use initializer on BackDeployedAttributeSpecListSyntax")
+  public static func makeBlankBackDeployedAttributeSpecList(presence: SourcePresence = .present) -> BackDeployedAttributeSpecListSyntax {
     return withExtendedLifetime(SyntaxArena()) { arena in
-      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .backDeployAttributeSpecList,
+      let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .backDeployedAttributeSpecList,
         from: [
         nil,
         RawSyntax.makeMissingToken(kind: TokenKind.keyword(.before), arena: arena),
@@ -5550,7 +5550,7 @@ public enum SyntaxFactory {
         RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilityVersionRestrictionList, arena: arena),
         nil,
       ], arena: arena))
-      return BackDeployAttributeSpecListSyntax(data)
+      return BackDeployedAttributeSpecListSyntax(data)
     }
   }
   @available(*, deprecated, message: "Use initializer on AvailabilityVersionRestrictionListSyntax")

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -8454,7 +8454,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
     case `implementsArguments`(ImplementsAttributeArgumentsSyntax)
     case `differentiableArguments`(DifferentiableAttributeArgumentsSyntax)
     case `derivativeRegistrationArguments`(DerivativeRegistrationAttributeArgumentsSyntax)
-    case `backDeployArguments`(BackDeployAttributeSpecListSyntax)
+    case `backDeployedArguments`(BackDeployedAttributeSpecListSyntax)
     case `conventionArguments`(ConventionAttributeArgumentsSyntax)
     case `conventionWitnessMethodArguments`(ConventionWitnessMethodAttributeArgumentsSyntax)
     case `opaqueReturnTypeOfAttributeArguments`(OpaqueReturnTypeOfAttributeArgumentsSyntax)
@@ -8476,7 +8476,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       case .implementsArguments(let node): return node._syntaxNode
       case .differentiableArguments(let node): return node._syntaxNode
       case .derivativeRegistrationArguments(let node): return node._syntaxNode
-      case .backDeployArguments(let node): return node._syntaxNode
+      case .backDeployedArguments(let node): return node._syntaxNode
       case .conventionArguments(let node): return node._syntaxNode
       case .conventionWitnessMethodArguments(let node): return node._syntaxNode
       case .opaqueReturnTypeOfAttributeArguments(let node): return node._syntaxNode
@@ -8517,8 +8517,8 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
     public init(_ node: DerivativeRegistrationAttributeArgumentsSyntax) {
       self = .derivativeRegistrationArguments(node)
     }
-    public init(_ node: BackDeployAttributeSpecListSyntax) {
-      self = .backDeployArguments(node)
+    public init(_ node: BackDeployedAttributeSpecListSyntax) {
+      self = .backDeployedArguments(node)
     }
     public init(_ node: ConventionAttributeArgumentsSyntax) {
       self = .conventionArguments(node)
@@ -8587,8 +8587,8 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
         self = .derivativeRegistrationArguments(node)
         return
       }
-      if let node = node.as(BackDeployAttributeSpecListSyntax.self) {
-        self = .backDeployArguments(node)
+      if let node = node.as(BackDeployedAttributeSpecListSyntax.self) {
+        self = .backDeployedArguments(node)
         return
       }
       if let node = node.as(ConventionAttributeArgumentsSyntax.self) {
@@ -8645,7 +8645,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
         .node(ImplementsAttributeArgumentsSyntax.self),
         .node(DifferentiableAttributeArgumentsSyntax.self),
         .node(DerivativeRegistrationAttributeArgumentsSyntax.self),
-        .node(BackDeployAttributeSpecListSyntax.self),
+        .node(BackDeployedAttributeSpecListSyntax.self),
         .node(ConventionAttributeArgumentsSyntax.self),
         .node(ConventionWitnessMethodAttributeArgumentsSyntax.self),
         .node(OpaqueReturnTypeOfAttributeArgumentsSyntax.self),
@@ -11271,24 +11271,24 @@ extension QualifiedDeclNameSyntax: CustomReflectable {
   }
 }
 
-// MARK: - BackDeployAttributeSpecListSyntax
+// MARK: - BackDeployedAttributeSpecListSyntax
 
 /// 
-/// A collection of arguments for the `@_backDeploy` attribute
+/// A collection of arguments for the `@backDeployed` attribute
 /// 
-public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable {
+public struct BackDeployedAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   public init?<S: SyntaxProtocol>(_ node: S) {
-    guard node.raw.kind == .backDeployAttributeSpecList else { return nil }
+    guard node.raw.kind == .backDeployedAttributeSpecList else { return nil }
     self._syntaxNode = node._syntaxNode
   }
 
-  /// Creates a `BackDeployAttributeSpecListSyntax` node from the given `SyntaxData`. This assumes
+  /// Creates a `BackDeployedAttributeSpecListSyntax` node from the given `SyntaxData`. This assumes
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .backDeployAttributeSpecList)
+    assert(data.raw.kind == .backDeployedAttributeSpecList)
     self._syntaxNode = Syntax(data)
   }
 
@@ -11316,7 +11316,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
         unexpectedAfterVersionList?.raw,
       ]
       let raw = RawSyntax.makeLayout(
-        kind: SyntaxKind.backDeployAttributeSpecList, from: layout, arena: arena,
+        kind: SyntaxKind.backDeployedAttributeSpecList, from: layout, arena: arena,
         leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
       return SyntaxData.forRoot(raw)
     }
@@ -11328,7 +11328,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
     set(value) {
-      self = BackDeployAttributeSpecListSyntax(data.replacingChild(at: 0, with: value?.raw, arena: SyntaxArena()))
+      self = BackDeployedAttributeSpecListSyntax(data.replacingChild(at: 0, with: value?.raw, arena: SyntaxArena()))
     }
   }
 
@@ -11338,7 +11338,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)
     }
     set(value) {
-      self = BackDeployAttributeSpecListSyntax(data.replacingChild(at: 1, with: value.raw, arena: SyntaxArena()))
+      self = BackDeployedAttributeSpecListSyntax(data.replacingChild(at: 1, with: value.raw, arena: SyntaxArena()))
     }
   }
 
@@ -11347,7 +11347,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       return data.child(at: 2, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
     set(value) {
-      self = BackDeployAttributeSpecListSyntax(data.replacingChild(at: 2, with: value?.raw, arena: SyntaxArena()))
+      self = BackDeployedAttributeSpecListSyntax(data.replacingChild(at: 2, with: value?.raw, arena: SyntaxArena()))
     }
   }
 
@@ -11359,7 +11359,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       return TokenSyntax(data.child(at: 3, parent: Syntax(self))!)
     }
     set(value) {
-      self = BackDeployAttributeSpecListSyntax(data.replacingChild(at: 3, with: value.raw, arena: SyntaxArena()))
+      self = BackDeployedAttributeSpecListSyntax(data.replacingChild(at: 3, with: value.raw, arena: SyntaxArena()))
     }
   }
 
@@ -11368,7 +11368,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
     set(value) {
-      self = BackDeployAttributeSpecListSyntax(data.replacingChild(at: 4, with: value?.raw, arena: SyntaxArena()))
+      self = BackDeployedAttributeSpecListSyntax(data.replacingChild(at: 4, with: value?.raw, arena: SyntaxArena()))
     }
   }
 
@@ -11381,7 +11381,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       return AvailabilityVersionRestrictionListSyntax(data.child(at: 5, parent: Syntax(self))!)
     }
     set(value) {
-      self = BackDeployAttributeSpecListSyntax(data.replacingChild(at: 5, with: value.raw, arena: SyntaxArena()))
+      self = BackDeployedAttributeSpecListSyntax(data.replacingChild(at: 5, with: value.raw, arena: SyntaxArena()))
     }
   }
 
@@ -11391,7 +11391,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   ///                  `versionList` collection.
   /// - returns: A copy of the receiver with the provided `Availability`
   ///            appended to its `versionList` collection.
-  public func addAvailability(_ element: AvailabilityVersionRestrictionListEntrySyntax) -> BackDeployAttributeSpecListSyntax {
+  public func addAvailability(_ element: AvailabilityVersionRestrictionListEntrySyntax) -> BackDeployedAttributeSpecListSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
     if let col = raw.layoutView!.children[5] {
@@ -11401,7 +11401,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
         from: [element.raw], arena: arena)
     }
     let newData = data.replacingChild(at: 5, with: collection, arena: arena)
-    return BackDeployAttributeSpecListSyntax(newData)
+    return BackDeployedAttributeSpecListSyntax(newData)
   }
 
   public var unexpectedAfterVersionList: UnexpectedNodesSyntax? {
@@ -11409,7 +11409,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       return data.child(at: 6, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
     set(value) {
-      self = BackDeployAttributeSpecListSyntax(data.replacingChild(at: 6, with: value?.raw, arena: SyntaxArena()))
+      self = BackDeployedAttributeSpecListSyntax(data.replacingChild(at: 6, with: value?.raw, arena: SyntaxArena()))
     }
   }
 
@@ -11447,7 +11447,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   }
 }
 
-extension BackDeployAttributeSpecListSyntax: CustomReflectable {
+extension BackDeployedAttributeSpecListSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
       "unexpectedBeforeBeforeLabel": unexpectedBeforeBeforeLabel.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -348,7 +348,30 @@ final class AttributeTests: XCTestCase {
     )
   }
 
-  func testBackDeploy() {
+  func testBackDeployed() {
+    AssertParse(
+      """
+      @backDeployed(before: macOS 12.0)
+      struct Foo {}
+      """
+    )
+
+    AssertParse(
+      """
+      @backDeployed(before: macos 12.0, iOS 15.0)
+      struct Foo {}
+      """
+    )
+
+    AssertParse(
+      """
+      @available(macOS 11.0, *)
+      @backDeployed(before: _macOS12_1)
+      public func backDeployTopLevelFunc2() -> Int { return 48 }
+      """
+    )
+
+    // Legacy spelling @_backDeploy(before:)
     AssertParse(
       """
       @_backDeploy(before: macOS 12.0)

--- a/gyb_syntax_support/AttributeKinds.py
+++ b/gyb_syntax_support/AttributeKinds.py
@@ -656,11 +656,12 @@ DECL_ATTR_KINDS = [
                   ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
                   code=128),
 
-    DeclAttribute('_backDeploy', 'BackDeploy',
+    DeclAttribute('backDeployed', 'BackDeployed',
                   OnAbstractFunction,  OnAccessor,  OnSubscript,  OnVar,
                     AllowMultipleAttributes,  LongAttribute,  UserInaccessible,
                   ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIBreakingToRemove,
                   code=129),
+    DeclAttributeAlias('_backDeploy', 'BackDeployed'),
 
     SimpleDeclAttribute('_moveOnly', 'MoveOnly',
                         OnNominalType,

--- a/gyb_syntax_support/AttributeNodes.py
+++ b/gyb_syntax_support/AttributeNodes.py
@@ -42,8 +42,8 @@ ATTRIBUTE_NODES = [
                              kind='DifferentiableAttributeArguments'),
                        Child('DerivativeRegistrationArguments',
                              kind='DerivativeRegistrationAttributeArguments'),
-                       Child('BackDeployArguments',
-                             kind='BackDeployAttributeSpecList'),
+                       Child('BackDeployedArguments',
+                             kind='BackDeployedAttributeSpecList'),
                        Child('ConventionArguments',
                              kind='ConventionAttributeArguments'),
                        Child('ConventionWitnessMethodArguments',
@@ -367,12 +367,12 @@ ATTRIBUTE_NODES = [
                    '''),
          ]),
 
-    # The arguments of '@_backDeploy(...)'
-    # back-deploy-attr-spec-list -> 'before' ':' back-deploy-version-list
-    Node('BackDeployAttributeSpecList', kind='Syntax',
-         name_for_diagnostics="'@_backDeploy' arguments",
+    # The arguments of '@backDeployed(...)'
+    # back-deployed-attr-spec-list -> 'before' ':' back-deployed-version-list
+    Node('BackDeployedAttributeSpecList', kind='Syntax',
+         name_for_diagnostics="'@backDeployed' arguments",
          description='''
-         A collection of arguments for the `@_backDeploy` attribute
+         A collection of arguments for the `@backDeployed` attribute
          ''',
          children=[
              Child('BeforeLabel', kind='KeywordToken',


### PR DESCRIPTION
Corresponding Swift compiler PR: https://github.com/apple/swift/pull/63357

Resolves rdar://102792909