### PR TITLE
Disable assertions that check TokenKind

### DIFF
--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodes.swift.gyb
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodes.swift.gyb
@@ -149,9 +149,15 @@ public struct Raw${node.name}: Raw${node.name if node.is_base() else node.base_t
 %             end
 %           end
 %           if child.is_optional:
-    assert(${child.swift_name} == nil || ${' || '.join([f'{child.swift_name}?.tokenKind{base} == {choice}' for (base, choice) in choices])}, "Received \(String(describing: ${child.swift_name}?.tokenKind))")
+%{
+    # FIXME: Assert disabled because normal CI doesn't have assertions enabled and debug CI seems to fail in a variety of places with this assertion
+    # assert(${child.swift_name} == nil || ${' || '.join([f'{child.swift_name}?.tokenKind{base} == {choice}' for (base, choice) in choices])}, "Received \(String(describing: ${child.swift_name}?.tokenKind))")
+}%
 %           else:
-    assert(${' || '.join([f'{child.swift_name}.tokenKind{base} == {choice}' for (base, choice) in choices])}, "Received \(${child.swift_name}.tokenKind)")
+%{
+    # FIXME: Assert disabled because normal CI doesn't have assertions enabled and debug CI seems to fail in a variety of places with this assertion
+    # assert(${' || '.join([f'{child.swift_name}.tokenKind{base} == {choice}' for (base, choice) in choices])}, "Received \(${child.swift_name}.tokenKind)")
+}%
 %           end
 %         end
 %       end

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -505,7 +505,6 @@ public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterSemicolon: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(semicolon == nil || semicolon?.tokenKind.base == .semicolon, "Received \(String(describing: semicolon?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .codeBlockItem, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -608,8 +607,6 @@ public struct RawCodeBlockSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftBrace.tokenKind.base == .leftBrace, "Received \(leftBrace.tokenKind)")
-    assert(rightBrace.tokenKind.base == .rightBrace, "Received \(rightBrace.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .codeBlock, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -838,7 +835,6 @@ public struct RawInOutExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(ampersand.tokenKind.base == .prefixAmpersand, "Received \(ampersand.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .inOutExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -1090,8 +1086,6 @@ public struct RawTryExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(tryKeyword.tokenKind == .keyword(.try), "Received \(tryKeyword.tokenKind)")
-    assert(questionOrExclamationMark == nil || questionOrExclamationMark?.tokenKind.base == .postfixQuestionMark || questionOrExclamationMark?.tokenKind.base == .exclamationMark, "Received \(String(describing: questionOrExclamationMark?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .tryExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -1160,7 +1154,6 @@ public struct RawAwaitExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(awaitKeyword.tokenKind == .keyword(.await), "Received \(awaitKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .awaitExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -1221,7 +1214,6 @@ public struct RawMoveExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(moveKeyword.tokenKind == .keyword(._move), "Received \(moveKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .moveExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -1282,7 +1274,6 @@ public struct RawBorrowExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(borrowKeyword.tokenKind == .keyword(._borrow), "Received \(borrowKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .borrowExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -1343,7 +1334,6 @@ public struct RawDeclNameArgumentSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterColon: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .declNameArgument, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -1446,8 +1436,6 @@ public struct RawDeclNameArgumentsSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftParen.tokenKind.base == .leftParen, "Received \(leftParen.tokenKind)")
-    assert(rightParen.tokenKind.base == .rightParen, "Received \(rightParen.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .declNameArguments, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -1516,7 +1504,6 @@ public struct RawIdentifierExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(identifier.tokenKind.base == .identifier || identifier.tokenKind.base == .keyword || identifier.tokenKind.base == .dollarIdentifier || identifier.tokenKind.base == .binaryOperator, "Received \(identifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .identifierExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -1575,7 +1562,6 @@ public struct RawSuperRefExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterSuperKeyword: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(superKeyword.tokenKind == .keyword(.super), "Received \(superKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .superRefExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -1626,7 +1612,6 @@ public struct RawNilLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterNilKeyword: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(nilKeyword.tokenKind == .keyword(.nil), "Received \(nilKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .nilLiteralExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -1677,7 +1662,6 @@ public struct RawDiscardAssignmentExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterWildcard: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(wildcard.tokenKind.base == .wildcard, "Received \(wildcard.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .discardAssignmentExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -1728,7 +1712,6 @@ public struct RawAssignmentExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterAssignToken: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(assignToken.tokenKind.base == .equal, "Received \(assignToken.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .assignmentExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -1781,7 +1764,6 @@ public struct RawPackExpansionExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterPatternExpr: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(repeatKeyword.tokenKind == .keyword(.repeat), "Received \(repeatKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .packExpansionExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -1842,7 +1824,6 @@ public struct RawPackElementExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterPackRefExpr: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(eachKeyword.tokenKind == .keyword(.each), "Received \(eachKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .packElementExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -1993,7 +1974,6 @@ public struct RawPrefixOperatorExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterPostfixExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(operatorToken == nil || operatorToken?.tokenKind.base == .prefixOperator, "Received \(String(describing: operatorToken?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .prefixOperatorExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -2052,7 +2032,6 @@ public struct RawBinaryOperatorExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterOperatorToken: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(operatorToken.tokenKind.base == .binaryOperator, "Received \(operatorToken.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .binaryOperatorExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -2105,7 +2084,6 @@ public struct RawArrowExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterArrowToken: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(arrowToken.tokenKind.base == .arrow, "Received \(arrowToken.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .arrowExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -2234,7 +2212,6 @@ public struct RawFloatLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterFloatingDigits: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(floatingDigits.tokenKind.base == .floatingLiteral, "Received \(floatingDigits.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .floatLiteralExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -2289,8 +2266,6 @@ public struct RawTupleExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftParen.tokenKind.base == .leftParen, "Received \(leftParen.tokenKind)")
-    assert(rightParen.tokenKind.base == .rightParen, "Received \(rightParen.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .tupleExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -2361,8 +2336,6 @@ public struct RawArrayExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterRightSquare: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftSquare.tokenKind.base == .leftSquareBracket, "Received \(leftSquare.tokenKind)")
-    assert(rightSquare.tokenKind.base == .rightSquareBracket, "Received \(rightSquare.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .arrayExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -2462,8 +2435,6 @@ public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterRightSquare: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftSquare.tokenKind.base == .leftSquareBracket, "Received \(leftSquare.tokenKind)")
-    assert(rightSquare.tokenKind.base == .rightSquareBracket, "Received \(rightSquare.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .dictionaryExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -2536,9 +2507,6 @@ public struct RawTupleExprElementSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(label == nil || label?.tokenKind.base == .identifier || label?.tokenKind.base == .wildcard, "Received \(String(describing: label?.tokenKind))")
-    assert(colon == nil || colon?.tokenKind.base == .colon, "Received \(String(describing: colon?.tokenKind))")
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .tupleExprElement, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -2615,7 +2583,6 @@ public struct RawArrayElementSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .arrayElement, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -2680,8 +2647,6 @@ public struct RawDictionaryElementSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .dictionaryElement, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -2756,7 +2721,6 @@ public struct RawIntegerLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterDigits: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(digits.tokenKind.base == .integerLiteral, "Received \(digits.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .integerLiteralExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -2807,7 +2771,6 @@ public struct RawBooleanLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterBooleanLiteral: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(booleanLiteral.tokenKind == .keyword(.true) || booleanLiteral.tokenKind == .keyword(.false), "Received \(booleanLiteral.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .booleanLiteralExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -2895,7 +2858,6 @@ public struct RawIfExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterElseBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(ifKeyword.tokenKind == .keyword(.if), "Received \(ifKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .ifExpr, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -2986,9 +2948,6 @@ public struct RawSwitchExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(switchKeyword.tokenKind == .keyword(.switch), "Received \(switchKeyword.tokenKind)")
-    assert(leftBrace.tokenKind.base == .leftBrace, "Received \(leftBrace.tokenKind)")
-    assert(rightBrace.tokenKind.base == .rightBrace, "Received \(rightBrace.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .switchExpr, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -3243,8 +3202,6 @@ public struct RawSwitchCaseLabelSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterColon: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(caseKeyword.tokenKind == .keyword(.case), "Received \(caseKeyword.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .switchCaseLabel, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -3313,8 +3270,6 @@ public struct RawSwitchDefaultLabelSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterColon: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(defaultKeyword.tokenKind == .keyword(.default), "Received \(defaultKeyword.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .switchDefaultLabel, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -3377,7 +3332,6 @@ public struct RawCaseItemSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .caseItem, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -3448,8 +3402,6 @@ public struct RawUnresolvedTernaryExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterColonMark: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(questionMark.tokenKind.base == .infixQuestionMark, "Received \(questionMark.tokenKind)")
-    assert(colonMark.tokenKind.base == .colon, "Received \(colonMark.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .unresolvedTernaryExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -3524,8 +3476,6 @@ public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterSecondChoice: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(questionMark.tokenKind.base == .infixQuestionMark, "Received \(questionMark.tokenKind)")
-    assert(colonMark.tokenKind.base == .colon, "Received \(colonMark.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .ternaryExpr, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -3614,7 +3564,6 @@ public struct RawMemberAccessExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(dot.tokenKind.base == .period, "Received \(dot.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .memberAccessExpr, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -3689,7 +3638,6 @@ public struct RawUnresolvedIsExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterIsTok: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(isTok.tokenKind == .keyword(.is), "Received \(isTok.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .unresolvedIsExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -3744,7 +3692,6 @@ public struct RawIsExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterTypeName: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(isTok.tokenKind == .keyword(.is), "Received \(isTok.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .isExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -3813,8 +3760,6 @@ public struct RawUnresolvedAsExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterQuestionOrExclamationMark: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(asTok.tokenKind == .keyword(.as), "Received \(asTok.tokenKind)")
-    assert(questionOrExclamationMark == nil || questionOrExclamationMark?.tokenKind.base == .postfixQuestionMark || questionOrExclamationMark?.tokenKind.base == .exclamationMark, "Received \(String(describing: questionOrExclamationMark?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .unresolvedAsExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -3879,8 +3824,6 @@ public struct RawAsExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterTypeName: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(asTok.tokenKind == .keyword(.as), "Received \(asTok.tokenKind)")
-    assert(questionOrExclamationMark == nil || questionOrExclamationMark?.tokenKind.base == .postfixQuestionMark || questionOrExclamationMark?.tokenKind.base == .exclamationMark, "Received \(String(describing: questionOrExclamationMark?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .asExpr, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -4011,10 +3954,6 @@ public struct RawClosureCaptureItemSpecifierSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(specifier.tokenKind == .keyword(.weak) || specifier.tokenKind == .keyword(.unowned), "Received \(specifier.tokenKind)")
-    assert(leftParen == nil || leftParen?.tokenKind.base == .leftParen, "Received \(String(describing: leftParen?.tokenKind))")
-    assert(detail == nil || detail?.tokenKind == .keyword(.safe) || detail?.tokenKind == .keyword(.unsafe), "Received \(String(describing: detail?.tokenKind))")
-    assert(rightParen == nil || rightParen?.tokenKind.base == .rightParen, "Received \(String(describing: rightParen?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .closureCaptureItemSpecifier, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -4097,9 +4036,6 @@ public struct RawClosureCaptureItemSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(name == nil || name?.tokenKind.base == .identifier, "Received \(String(describing: name?.tokenKind))")
-    assert(assignToken == nil || assignToken?.tokenKind.base == .equal, "Received \(String(describing: assignToken?.tokenKind))")
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .closureCaptureItem, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -4226,8 +4162,6 @@ public struct RawClosureCaptureSignatureSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightSquare: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftSquare.tokenKind.base == .leftSquareBracket, "Received \(leftSquare.tokenKind)")
-    assert(rightSquare.tokenKind.base == .rightSquareBracket, "Received \(rightSquare.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .closureCaptureSignature, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -4296,8 +4230,6 @@ public struct RawClosureParamSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(name.tokenKind.base == .identifier || name.tokenKind.base == .wildcard, "Received \(name.tokenKind)")
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .closureParam, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -4435,7 +4367,6 @@ public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterInTok: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(inTok.tokenKind == .keyword(.in), "Received \(inTok.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .closureSignature, uninitializedCount: 13, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -4532,8 +4463,6 @@ public struct RawClosureExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftBrace.tokenKind.base == .leftBrace, "Received \(leftBrace.tokenKind)")
-    assert(rightBrace.tokenKind.base == .rightBrace, "Received \(rightBrace.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .closureExpr, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -4662,8 +4591,6 @@ public struct RawMultipleTrailingClosureElementSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterClosure: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(label.tokenKind.base == .identifier || label.tokenKind.base == .wildcard, "Received \(label.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .multipleTrailingClosureElement, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -4780,8 +4707,6 @@ public struct RawFunctionCallExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterAdditionalTrailingClosures: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftParen == nil || leftParen?.tokenKind.base == .leftParen, "Received \(String(describing: leftParen?.tokenKind))")
-    assert(rightParen == nil || rightParen?.tokenKind.base == .rightParen, "Received \(String(describing: rightParen?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .functionCallExpr, uninitializedCount: 13, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -4882,8 +4807,6 @@ public struct RawSubscriptExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterAdditionalTrailingClosures: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftBracket.tokenKind.base == .leftSquareBracket, "Received \(leftBracket.tokenKind)")
-    assert(rightBracket.tokenKind.base == .rightSquareBracket, "Received \(rightBracket.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .subscriptExpr, uninitializedCount: 13, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -4976,7 +4899,6 @@ public struct RawOptionalChainingExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterQuestionMark: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(questionMark.tokenKind.base == .postfixQuestionMark, "Received \(questionMark.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .optionalChainingExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -5037,7 +4959,6 @@ public struct RawForcedValueExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterExclamationMark: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(exclamationMark.tokenKind.base == .exclamationMark, "Received \(exclamationMark.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .forcedValueExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -5098,7 +5019,6 @@ public struct RawPostfixUnaryExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterOperatorToken: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(operatorToken.tokenKind.base == .postfixOperator, "Received \(operatorToken.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .postfixUnaryExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -5217,7 +5137,6 @@ public struct RawStringSegmentSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterContent: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(content.tokenKind.base == .stringSegment, "Received \(content.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .stringSegment, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -5276,10 +5195,6 @@ public struct RawExpressionSegmentSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(backslash.tokenKind.base == .backslash, "Received \(backslash.tokenKind)")
-    assert(delimiter == nil || delimiter?.tokenKind.base == .rawStringDelimiter, "Received \(String(describing: delimiter?.tokenKind))")
-    assert(leftParen.tokenKind.base == .leftParen, "Received \(leftParen.tokenKind)")
-    assert(rightParen.tokenKind.base == .rightParen, "Received \(rightParen.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .expressionSegment, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -5370,10 +5285,6 @@ public struct RawStringLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterCloseDelimiter: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(openDelimiter == nil || openDelimiter?.tokenKind.base == .rawStringDelimiter, "Received \(String(describing: openDelimiter?.tokenKind))")
-    assert(openQuote.tokenKind.base == .stringQuote || openQuote.tokenKind.base == .multilineStringQuote || openQuote.tokenKind.base == .singleQuote, "Received \(openQuote.tokenKind)")
-    assert(closeQuote.tokenKind.base == .stringQuote || closeQuote.tokenKind.base == .multilineStringQuote || closeQuote.tokenKind.base == .singleQuote, "Received \(closeQuote.tokenKind)")
-    assert(closeDelimiter == nil || closeDelimiter?.tokenKind.base == .rawStringDelimiter, "Received \(String(describing: closeDelimiter?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .stringLiteralExpr, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -5456,7 +5367,6 @@ public struct RawRegexLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterRegex: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(regex.tokenKind.base == .regexLiteral, "Received \(regex.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .regexLiteralExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -5511,7 +5421,6 @@ public struct RawKeyPathExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterComponents: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(backslash.tokenKind.base == .backslash, "Received \(backslash.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .keyPathExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -5655,7 +5564,6 @@ public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterComponent: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(period == nil || period?.tokenKind.base == .period, "Received \(String(describing: period?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .keyPathComponent, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -5718,7 +5626,6 @@ public struct RawKeyPathPropertyComponentSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(identifier.tokenKind.base == .identifier || identifier.tokenKind.base == .keyword || identifier.tokenKind.base == .dollarIdentifier || identifier.tokenKind.base == .binaryOperator || identifier.tokenKind.base == .integerLiteral, "Received \(identifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .keyPathPropertyComponent, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -5789,8 +5696,6 @@ public struct RawKeyPathSubscriptComponentSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightBracket: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftBracket.tokenKind.base == .leftSquareBracket, "Received \(leftBracket.tokenKind)")
-    assert(rightBracket.tokenKind.base == .rightSquareBracket, "Received \(rightBracket.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .keyPathSubscriptComponent, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -5857,7 +5762,6 @@ public struct RawKeyPathOptionalComponentSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterQuestionOrExclamationMark: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(questionOrExclamationMark.tokenKind.base == .postfixQuestionMark || questionOrExclamationMark.tokenKind.base == .exclamationMark, "Received \(questionOrExclamationMark.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .keyPathOptionalComponent, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -5922,10 +5826,6 @@ public struct RawMacroExpansionExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterAdditionalTrailingClosures: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(poundToken.tokenKind.base == .pound, "Received \(poundToken.tokenKind)")
-    assert(macro.tokenKind.base == .identifier, "Received \(macro.tokenKind)")
-    assert(leftParen == nil || leftParen?.tokenKind.base == .leftParen, "Received \(String(describing: leftParen?.tokenKind))")
-    assert(rightParen == nil || rightParen?.tokenKind.base == .rightParen, "Received \(String(describing: rightParen?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .macroExpansionExpr, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -6092,7 +5992,6 @@ public struct RawEditorPlaceholderExprSyntax: RawExprSyntaxNodeProtocol {
     _ unexpectedAfterIdentifier: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(identifier.tokenKind.base == .identifier, "Received \(identifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .editorPlaceholderExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -6185,7 +6084,6 @@ public struct RawYieldExprListElementSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(comma == nil || comma?.tokenKind.base == .comma, "Received \(String(describing: comma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .yieldExprListElement, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -6246,7 +6144,6 @@ public struct RawTypeInitializerClauseSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterValue: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(equal.tokenKind.base == .equal, "Received \(equal.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .typeInitializerClause, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -6317,8 +6214,6 @@ public struct RawTypealiasDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterGenericWhereClause: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(typealiasKeyword.tokenKind == .keyword(.typealias), "Received \(typealiasKeyword.tokenKind)")
-    assert(identifier.tokenKind.base == .identifier, "Received \(identifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .typealiasDecl, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -6429,8 +6324,6 @@ public struct RawAssociatedtypeDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterGenericWhereClause: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(associatedtypeKeyword.tokenKind == .keyword(.associatedtype), "Received \(associatedtypeKeyword.tokenKind)")
-    assert(identifier.tokenKind.base == .identifier, "Received \(identifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .associatedtypeDecl, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -6573,8 +6466,6 @@ public struct RawParameterClauseSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftParen.tokenKind.base == .leftParen, "Received \(leftParen.tokenKind)")
-    assert(rightParen.tokenKind.base == .rightParen, "Received \(rightParen.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .parameterClause, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -6643,7 +6534,6 @@ public struct RawReturnClauseSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterReturnType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(arrow.tokenKind.base == .arrow, "Received \(arrow.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .returnClause, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -6823,7 +6713,6 @@ public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterElements: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(poundKeyword.tokenKind.base == .poundIfKeyword || poundKeyword.tokenKind.base == .poundElseifKeyword || poundKeyword.tokenKind.base == .poundElseKeyword, "Received \(poundKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .ifConfigClause, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -6932,7 +6821,6 @@ public struct RawIfConfigDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterPoundEndif: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(poundEndif.tokenKind.base == .poundEndifKeyword, "Received \(poundEndif.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .ifConfigDecl, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -6997,9 +6885,6 @@ public struct RawPoundSourceLocationSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(poundSourceLocation.tokenKind.base == .poundSourceLocationKeyword, "Received \(poundSourceLocation.tokenKind)")
-    assert(leftParen.tokenKind.base == .leftParen, "Received \(leftParen.tokenKind)")
-    assert(rightParen.tokenKind.base == .rightParen, "Received \(rightParen.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .poundSourceLocation, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -7086,12 +6971,6 @@ public struct RawPoundSourceLocationArgsSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterLineNumber: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(fileArgLabel.tokenKind == .keyword(.file), "Received \(fileArgLabel.tokenKind)")
-    assert(fileArgColon.tokenKind.base == .colon, "Received \(fileArgColon.tokenKind)")
-    assert(comma.tokenKind.base == .comma, "Received \(comma.tokenKind)")
-    assert(lineArgLabel.tokenKind == .keyword(.line), "Received \(lineArgLabel.tokenKind)")
-    assert(lineArgColon.tokenKind.base == .colon, "Received \(lineArgColon.tokenKind)")
-    assert(lineNumber.tokenKind.base == .integerLiteral, "Received \(lineNumber.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .poundSourceLocationArgs, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -7194,9 +7073,6 @@ public struct RawDeclModifierDetailSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftParen.tokenKind.base == .leftParen, "Received \(leftParen.tokenKind)")
-    assert(detail.tokenKind.base == .identifier || detail.tokenKind == .keyword(.set), "Received \(detail.tokenKind)")
-    assert(rightParen.tokenKind.base == .rightParen, "Received \(rightParen.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .declModifierDetail, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -7265,7 +7141,6 @@ public struct RawDeclModifierSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterDetail: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(name.tokenKind == .keyword(.class) || name.tokenKind == .keyword(.convenience) || name.tokenKind == .keyword(.dynamic) || name.tokenKind == .keyword(.final) || name.tokenKind == .keyword(.infix) || name.tokenKind == .keyword(.lazy) || name.tokenKind == .keyword(.optional) || name.tokenKind == .keyword(.override) || name.tokenKind == .keyword(.postfix) || name.tokenKind == .keyword(.prefix) || name.tokenKind == .keyword(.required) || name.tokenKind == .keyword(.static) || name.tokenKind == .keyword(.unowned) || name.tokenKind == .keyword(.weak) || name.tokenKind == .keyword(.private) || name.tokenKind == .keyword(.fileprivate) || name.tokenKind == .keyword(.internal) || name.tokenKind == .keyword(.public) || name.tokenKind == .keyword(.open) || name.tokenKind == .keyword(.mutating) || name.tokenKind == .keyword(.nonmutating) || name.tokenKind == .keyword(.indirect) || name.tokenKind == .keyword(.__consuming) || name.tokenKind == .keyword(.actor) || name.tokenKind == .keyword(.async) || name.tokenKind == .keyword(.distributed) || name.tokenKind == .keyword(.isolated) || name.tokenKind == .keyword(.nonisolated) || name.tokenKind == .keyword(._const) || name.tokenKind == .keyword(._local) || name.tokenKind == .keyword(.package), "Received \(name.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .declModifier, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -7326,7 +7201,6 @@ public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .inheritedType, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -7427,7 +7301,6 @@ public struct RawTypeInheritanceClauseSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterInheritedTypeCollection: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .typeInheritanceClause, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -7500,8 +7373,6 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(classKeyword.tokenKind == .keyword(.class), "Received \(classKeyword.tokenKind)")
-    assert(identifier.tokenKind.base == .identifier, "Received \(identifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .classDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -7622,8 +7493,6 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(actorKeyword.tokenKind == .keyword(.actor), "Received \(actorKeyword.tokenKind)")
-    assert(identifier.tokenKind.base == .identifier, "Received \(identifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .actorDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -7744,8 +7613,6 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(structKeyword.tokenKind == .keyword(.struct), "Received \(structKeyword.tokenKind)")
-    assert(identifier.tokenKind.base == .identifier, "Received \(identifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .structDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -7866,8 +7733,6 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(protocolKeyword.tokenKind == .keyword(.protocol), "Received \(protocolKeyword.tokenKind)")
-    assert(identifier.tokenKind.base == .identifier, "Received \(identifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .protocolDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -7986,7 +7851,6 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(extensionKeyword.tokenKind == .keyword(.extension), "Received \(extensionKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .extensionDecl, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -8089,8 +7953,6 @@ public struct RawMemberDeclBlockSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftBrace.tokenKind.base == .leftBrace, "Received \(leftBrace.tokenKind)")
-    assert(rightBrace.tokenKind.base == .rightBrace, "Received \(rightBrace.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .memberDeclBlock, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -8199,7 +8061,6 @@ public struct RawMemberDeclListItemSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterSemicolon: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(semicolon == nil || semicolon?.tokenKind.base == .semicolon, "Received \(String(describing: semicolon?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .memberDeclListItem, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -8320,7 +8181,6 @@ public struct RawInitializerClauseSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterValue: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(equal.tokenKind.base == .equal, "Received \(equal.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .initializerClause, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -8395,11 +8255,6 @@ public struct RawFunctionParameterSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(firstName == nil || firstName?.tokenKind.base == .identifier || firstName?.tokenKind.base == .wildcard, "Received \(String(describing: firstName?.tokenKind))")
-    assert(secondName == nil || secondName?.tokenKind.base == .identifier || secondName?.tokenKind.base == .wildcard, "Received \(String(describing: secondName?.tokenKind))")
-    assert(colon == nil || colon?.tokenKind.base == .colon, "Received \(String(describing: colon?.tokenKind))")
-    assert(ellipsis == nil || ellipsis?.tokenKind.base == .ellipsis, "Received \(String(describing: ellipsis?.tokenKind))")
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .functionParameter, uninitializedCount: 19, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -8568,8 +8423,6 @@ public struct RawFunctionDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(funcKeyword.tokenKind == .keyword(.func), "Received \(funcKeyword.tokenKind)")
-    assert(identifier.tokenKind.base == .identifier || identifier.tokenKind.base == .binaryOperator || identifier.tokenKind.base == .prefixOperator || identifier.tokenKind.base == .postfixOperator, "Received \(identifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .functionDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -8690,8 +8543,6 @@ public struct RawInitializerDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(initKeyword.tokenKind == .keyword(.`init`), "Received \(initKeyword.tokenKind)")
-    assert(optionalMark == nil || optionalMark?.tokenKind.base == .postfixQuestionMark || optionalMark?.tokenKind.base == .infixQuestionMark || optionalMark?.tokenKind.base == .exclamationMark, "Received \(String(describing: optionalMark?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .initializerDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -8804,7 +8655,6 @@ public struct RawDeinitializerDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(deinitKeyword.tokenKind == .keyword(.deinit), "Received \(deinitKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .deinitializerDecl, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -8922,7 +8772,6 @@ public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterAccessor: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(subscriptKeyword.tokenKind == .keyword(.subscript), "Received \(subscriptKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .subscriptDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -9031,8 +8880,6 @@ public struct RawAccessPathComponentSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingDot: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(name.tokenKind.base == .identifier, "Received \(name.tokenKind)")
-    assert(trailingDot == nil || trailingDot?.tokenKind.base == .period, "Received \(String(describing: trailingDot?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .accessPathComponent, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -9139,8 +8986,6 @@ public struct RawImportDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterPath: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(importTok.tokenKind == .keyword(.import), "Received \(importTok.tokenKind)")
-    assert(importKind == nil || importKind?.tokenKind == .keyword(.typealias) || importKind?.tokenKind == .keyword(.struct) || importKind?.tokenKind == .keyword(.class) || importKind?.tokenKind == .keyword(.enum) || importKind?.tokenKind == .keyword(.protocol) || importKind?.tokenKind == .keyword(.var) || importKind?.tokenKind == .keyword(.let) || importKind?.tokenKind == .keyword(.func), "Received \(String(describing: importKind?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .importDecl, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -9227,9 +9072,6 @@ public struct RawAccessorParameterSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftParen.tokenKind.base == .leftParen, "Received \(leftParen.tokenKind)")
-    assert(name.tokenKind.base == .identifier, "Received \(name.tokenKind)")
-    assert(rightParen.tokenKind.base == .rightParen, "Received \(rightParen.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .accessorParameter, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -9306,7 +9148,6 @@ public struct RawAccessorDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(accessorKind.tokenKind == .keyword(.get) || accessorKind.tokenKind == .keyword(.set) || accessorKind.tokenKind == .keyword(.didSet) || accessorKind.tokenKind == .keyword(.willSet) || accessorKind.tokenKind == .keyword(.unsafeAddress) || accessorKind.tokenKind == .keyword(.addressWithOwner) || accessorKind.tokenKind == .keyword(.addressWithNativeOwner) || accessorKind.tokenKind == .keyword(.unsafeMutableAddress) || accessorKind.tokenKind == .keyword(.mutableAddressWithOwner) || accessorKind.tokenKind == .keyword(.mutableAddressWithNativeOwner) || accessorKind.tokenKind == .keyword(._read) || accessorKind.tokenKind == .keyword(._modify), "Received \(accessorKind.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .accessorDecl, uninitializedCount: 13, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -9441,8 +9282,6 @@ public struct RawAccessorBlockSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftBrace.tokenKind.base == .leftBrace, "Received \(leftBrace.tokenKind)")
-    assert(rightBrace.tokenKind.base == .rightBrace, "Received \(rightBrace.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .accessorBlock, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -9546,7 +9385,6 @@ public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .patternBinding, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -9675,7 +9513,6 @@ public struct RawVariableDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterBindings: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(letOrVarKeyword.tokenKind == .keyword(.let) || letOrVarKeyword.tokenKind == .keyword(.var), "Received \(letOrVarKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .variableDecl, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -9756,8 +9593,6 @@ public struct RawEnumCaseElementSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(identifier.tokenKind.base == .identifier, "Received \(identifier.tokenKind)")
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .enumCaseElement, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -9878,7 +9713,6 @@ public struct RawEnumCaseDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterElements: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(caseKeyword.tokenKind == .keyword(.case), "Received \(caseKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .enumCaseDecl, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -9967,8 +9801,6 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(enumKeyword.tokenKind == .keyword(.enum), "Received \(enumKeyword.tokenKind)")
-    assert(identifier.tokenKind.base == .identifier, "Received \(identifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .enumDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -10083,8 +9915,6 @@ public struct RawOperatorDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterOperatorPrecedenceAndTypes: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(operatorKeyword.tokenKind == .keyword(.operator), "Received \(operatorKeyword.tokenKind)")
-    assert(identifier.tokenKind.base == .binaryOperator || identifier.tokenKind.base == .prefixOperator || identifier.tokenKind.base == .postfixOperator, "Received \(identifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .operatorDecl, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -10209,7 +10039,6 @@ public struct RawDesignatedTypeElementSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterName: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leadingComma.tokenKind.base == .comma, "Received \(leadingComma.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .designatedTypeElement, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -10272,8 +10101,6 @@ public struct RawOperatorPrecedenceAndTypesSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterDesignatedTypes: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
-    assert(precedenceGroup.tokenKind.base == .identifier, "Received \(precedenceGroup.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .operatorPrecedenceAndTypes, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -10352,10 +10179,6 @@ public struct RawPrecedenceGroupDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(precedencegroupKeyword.tokenKind == .keyword(.precedencegroup), "Received \(precedencegroupKeyword.tokenKind)")
-    assert(identifier.tokenKind.base == .identifier, "Received \(identifier.tokenKind)")
-    assert(leftBrace.tokenKind.base == .leftBrace, "Received \(leftBrace.tokenKind)")
-    assert(rightBrace.tokenKind.base == .rightBrace, "Received \(rightBrace.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .precedenceGroupDecl, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -10533,8 +10356,6 @@ public struct RawPrecedenceGroupRelationSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterOtherNames: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(higherThanOrLowerThan.tokenKind == .keyword(.higherThan) || higherThanOrLowerThan.tokenKind == .keyword(.lowerThan), "Received \(higherThanOrLowerThan.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .precedenceGroupRelation, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -10643,8 +10464,6 @@ public struct RawPrecedenceGroupNameElementSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(name.tokenKind.base == .identifier, "Received \(name.tokenKind)")
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .precedenceGroupNameElement, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -10707,9 +10526,6 @@ public struct RawPrecedenceGroupAssignmentSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterFlag: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(assignmentKeyword.tokenKind == .keyword(.assignment), "Received \(assignmentKeyword.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
-    assert(flag.tokenKind == .keyword(.true) || flag.tokenKind == .keyword(.false), "Received \(flag.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .precedenceGroupAssignment, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -10780,9 +10596,6 @@ public struct RawPrecedenceGroupAssociativitySyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterValue: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(associativityKeyword.tokenKind == .keyword(.associativity), "Received \(associativityKeyword.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
-    assert(value.tokenKind == .keyword(.left) || value.tokenKind == .keyword(.right) || value.tokenKind == .keyword(.none), "Received \(value.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .precedenceGroupAssociativity, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -10892,8 +10705,6 @@ public struct RawMacroDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterGenericWhereClause: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(macroKeyword.tokenKind == .keyword(.macro), "Received \(macroKeyword.tokenKind)")
-    assert(identifier.tokenKind.base == .identifier, "Received \(identifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .macroDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -11014,10 +10825,6 @@ public struct RawMacroExpansionDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterAdditionalTrailingClosures: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(poundToken.tokenKind.base == .pound, "Received \(poundToken.tokenKind)")
-    assert(macro.tokenKind.base == .identifier, "Received \(macro.tokenKind)")
-    assert(leftParen == nil || leftParen?.tokenKind.base == .leftParen, "Received \(String(describing: leftParen?.tokenKind))")
-    assert(rightParen == nil || rightParen?.tokenKind.base == .rightParen, "Received \(String(describing: rightParen?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .macroExpansionDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -11124,7 +10931,6 @@ public struct RawEditorPlaceholderDeclSyntax: RawDeclSyntaxNodeProtocol {
     _ unexpectedAfterIdentifier: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(identifier.tokenKind.base == .identifier, "Received \(identifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .editorPlaceholderDecl, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -11320,9 +11126,6 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(atSignToken.tokenKind.base == .atSign, "Received \(atSignToken.tokenKind)")
-    assert(leftParen == nil || leftParen?.tokenKind.base == .leftParen, "Received \(String(describing: leftParen?.tokenKind))")
-    assert(rightParen == nil || rightParen?.tokenKind.base == .rightParen, "Received \(String(describing: rightParen?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .attribute, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -11561,9 +11364,6 @@ public struct RawAvailabilityEntrySyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterSemicolon: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(label.tokenKind == .keyword(.availability), "Received \(label.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
-    assert(semicolon.tokenKind.base == .semicolon, "Received \(semicolon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .availabilityEntry, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -11644,9 +11444,6 @@ public struct RawLabeledSpecializeEntrySyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(label.tokenKind == .keyword(.available) || label.tokenKind == .keyword(.exported) || label.tokenKind == .keyword(.kind) || label.tokenKind == .keyword(.spi) || label.tokenKind == .keyword(.spiModule) || label.tokenKind.base == .identifier, "Received \(label.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .labeledSpecializeEntry, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -11727,9 +11524,6 @@ public struct RawTargetFunctionEntrySyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(label.tokenKind == .keyword(.target), "Received \(label.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .targetFunctionEntry, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -11806,7 +11600,6 @@ public struct RawDeclNameSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(declBaseName.tokenKind.base == .identifier || declBaseName.tokenKind.base == .prefixOperator || declBaseName.tokenKind == .keyword(.`init`), "Received \(declBaseName.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .declName, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -11871,7 +11664,6 @@ public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(comma.tokenKind.base == .comma, "Received \(comma.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .implementsAttributeArguments, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -11948,8 +11740,6 @@ public struct RawObjCSelectorPieceSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterColon: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(name == nil || name?.tokenKind.base == .identifier, "Received \(String(describing: name?.tokenKind))")
-    assert(colon == nil || colon?.tokenKind.base == .colon, "Received \(String(describing: colon?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .objCSelectorPiece, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -12056,9 +11846,6 @@ public struct RawDifferentiableAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterWhereClause: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(diffKind == nil || diffKind?.tokenKind == .keyword(.forward) || diffKind?.tokenKind == .keyword(.reverse) || diffKind?.tokenKind == .keyword(.linear), "Received \(String(describing: diffKind?.tokenKind))")
-    assert(diffKindComma == nil || diffKindComma?.tokenKind.base == .comma, "Received \(String(describing: diffKindComma?.tokenKind))")
-    assert(diffParamsComma == nil || diffParamsComma?.tokenKind.base == .comma, "Received \(String(describing: diffParamsComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .differentiableAttributeArguments, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -12174,8 +11961,6 @@ public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterParameters: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(wrtLabel.tokenKind == .keyword(.wrt), "Received \(wrtLabel.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .differentiabilityParamsClause, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -12246,8 +12031,6 @@ public struct RawDifferentiabilityParamsSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftParen.tokenKind.base == .leftParen, "Received \(leftParen.tokenKind)")
-    assert(rightParen.tokenKind.base == .rightParen, "Received \(rightParen.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .differentiabilityParams, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -12356,8 +12139,6 @@ public struct RawDifferentiabilityParamSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(parameter.tokenKind.base == .identifier || parameter.tokenKind.base == .integerLiteral || parameter.tokenKind.base == .keyword, "Received \(parameter.tokenKind)")
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .differentiabilityParam, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -12428,11 +12209,6 @@ public struct RawDerivativeRegistrationAttributeArgumentsSyntax: RawSyntaxNodePr
     _ unexpectedAfterDiffParams: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(ofLabel.tokenKind == .keyword(.of), "Received \(ofLabel.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
-    assert(period == nil || period?.tokenKind.base == .period, "Received \(String(describing: period?.tokenKind))")
-    assert(accessorKind == nil || accessorKind?.tokenKind == .keyword(.get) || accessorKind?.tokenKind == .keyword(.set), "Received \(String(describing: accessorKind?.tokenKind))")
-    assert(comma == nil || comma?.tokenKind.base == .comma, "Received \(String(describing: comma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .derivativeRegistrationAttributeArguments, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -12537,8 +12313,6 @@ public struct RawQualifiedDeclNameSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterArguments: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(dot == nil || dot?.tokenKind.base == .period, "Received \(String(describing: dot?.tokenKind))")
-    assert(name.tokenKind.base == .identifier || name.tokenKind.base == .binaryOperator || name.tokenKind.base == .prefixOperator || name.tokenKind.base == .postfixOperator, "Received \(name.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .qualifiedDeclName, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -12617,8 +12391,6 @@ public struct RawBackDeployedAttributeSpecListSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterVersionList: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(beforeLabel.tokenKind == .keyword(.before), "Received \(beforeLabel.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .backDeployedAttributeSpecList, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -12727,7 +12499,6 @@ public struct RawAvailabilityVersionRestrictionListEntrySyntax: RawSyntaxNodePro
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .availabilityVersionRestrictionListEntry, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -12790,8 +12561,6 @@ public struct RawOpaqueReturnTypeOfAttributeArgumentsSyntax: RawSyntaxNodeProtoc
     _ unexpectedAfterOrdinal: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(comma.tokenKind.base == .comma, "Received \(comma.tokenKind)")
-    assert(ordinal.tokenKind.base == .integerLiteral, "Received \(ordinal.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .opaqueReturnTypeOfAttributeArguments, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -12866,10 +12635,6 @@ public struct RawConventionAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterCTypeString: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(conventionLabel.tokenKind.base == .identifier, "Received \(conventionLabel.tokenKind)")
-    assert(comma == nil || comma?.tokenKind.base == .comma, "Received \(String(describing: comma?.tokenKind))")
-    assert(cTypeLabel == nil || cTypeLabel?.tokenKind == .keyword(.cType), "Received \(String(describing: cTypeLabel?.tokenKind))")
-    assert(colon == nil || colon?.tokenKind.base == .colon, "Received \(String(describing: colon?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .conventionAttributeArguments, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -12956,9 +12721,6 @@ public struct RawConventionWitnessMethodAttributeArgumentsSyntax: RawSyntaxNodeP
     _ unexpectedAfterProtocolName: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(witnessMethodLabel.tokenKind == .keyword(.witness_method), "Received \(witnessMethodLabel.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
-    assert(protocolName.tokenKind.base == .identifier, "Received \(protocolName.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .conventionWitnessMethodAttributeArguments, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -13029,7 +12791,6 @@ public struct RawExposeAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterCxxName: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(comma == nil || comma?.tokenKind.base == .comma, "Received \(String(describing: comma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .exposeAttributeArguments, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -13104,9 +12865,6 @@ public struct RawOriginallyDefinedInArgumentsSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterPlatforms: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(moduleLabel.tokenKind == .keyword(.module), "Received \(moduleLabel.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
-    assert(comma.tokenKind.base == .comma, "Received \(comma.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .originallyDefinedInArguments, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -13193,8 +12951,6 @@ public struct RawUnderscorePrivateAttributeArgumentsSyntax: RawSyntaxNodeProtoco
     _ unexpectedAfterFilename: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(sourceFileLabel.tokenKind == .keyword(.sourceFile), "Received \(sourceFileLabel.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .underscorePrivateAttributeArguments, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -13265,8 +13021,6 @@ public struct RawDynamicReplacementArgumentsSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterDeclname: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(forLabel.tokenKind == .keyword(.for), "Received \(forLabel.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .dynamicReplacementArguments, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -13337,8 +13091,6 @@ public struct RawUnavailableFromAsyncArgumentsSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterMessage: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(messageLabel.tokenKind == .keyword(.message), "Received \(messageLabel.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .unavailableFromAsyncArguments, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -13480,9 +13232,6 @@ public struct RawDocumentationAttributeArgumentSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(label.tokenKind == .keyword(.visibility) || label.tokenKind == .keyword(.metadata), "Received \(label.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .documentationAttributeArgument, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -13601,8 +13350,6 @@ public struct RawLabeledStmtSyntax: RawStmtSyntaxNodeProtocol {
     _ unexpectedAfterStatement: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(labelName.tokenKind.base == .identifier, "Received \(labelName.tokenKind)")
-    assert(labelColon.tokenKind.base == .colon, "Received \(labelColon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .labeledStmt, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -13721,8 +13468,6 @@ public struct RawContinueStmtSyntax: RawStmtSyntaxNodeProtocol {
     _ unexpectedAfterLabel: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(continueKeyword.tokenKind == .keyword(.continue), "Received \(continueKeyword.tokenKind)")
-    assert(label == nil || label?.tokenKind.base == .identifier, "Received \(String(describing: label?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .continueStmt, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -13785,7 +13530,6 @@ public struct RawWhileStmtSyntax: RawStmtSyntaxNodeProtocol {
     _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(whileKeyword.tokenKind == .keyword(.while), "Received \(whileKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .whileStmt, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -13854,7 +13598,6 @@ public struct RawDeferStmtSyntax: RawStmtSyntaxNodeProtocol {
     _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(deferKeyword.tokenKind == .keyword(.defer), "Received \(deferKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .deferStmt, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -13919,8 +13662,6 @@ public struct RawRepeatWhileStmtSyntax: RawStmtSyntaxNodeProtocol {
     _ unexpectedAfterCondition: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(repeatKeyword.tokenKind == .keyword(.repeat), "Received \(repeatKeyword.tokenKind)")
-    assert(whileKeyword.tokenKind == .keyword(.while), "Received \(whileKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .repeatWhileStmt, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -14001,8 +13742,6 @@ public struct RawGuardStmtSyntax: RawStmtSyntaxNodeProtocol {
     _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(guardKeyword.tokenKind == .keyword(.guard), "Received \(guardKeyword.tokenKind)")
-    assert(elseKeyword.tokenKind == .keyword(.else), "Received \(elseKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .guardStmt, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -14079,7 +13818,6 @@ public struct RawWhereClauseSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterGuardResult: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(whereKeyword.tokenKind == .keyword(.where), "Received \(whereKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .whereClause, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -14156,9 +13894,6 @@ public struct RawForInStmtSyntax: RawStmtSyntaxNodeProtocol {
     _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(forKeyword.tokenKind == .keyword(.for), "Received \(forKeyword.tokenKind)")
-    assert(awaitKeyword == nil || awaitKeyword?.tokenKind == .keyword(.await), "Received \(String(describing: awaitKeyword?.tokenKind))")
-    assert(inKeyword.tokenKind == .keyword(.in), "Received \(inKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .forInStmt, uninitializedCount: 21, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -14325,7 +14060,6 @@ public struct RawDoStmtSyntax: RawStmtSyntaxNodeProtocol {
     _ unexpectedAfterCatchClauses: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(doKeyword.tokenKind == .keyword(.do), "Received \(doKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .doStmt, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -14394,7 +14128,6 @@ public struct RawReturnStmtSyntax: RawStmtSyntaxNodeProtocol {
     _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(returnKeyword.tokenKind == .keyword(.return), "Received \(returnKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .returnStmt, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -14484,7 +14217,6 @@ public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol {
     _ unexpectedAfterYields: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(yieldKeyword.tokenKind == .keyword(.yield), "Received \(yieldKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .yieldStmt, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -14547,8 +14279,6 @@ public struct RawYieldListSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftParen.tokenKind.base == .leftParen, "Received \(leftParen.tokenKind)")
-    assert(rightParen.tokenKind.base == .rightParen, "Received \(rightParen.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .yieldList, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -14615,7 +14345,6 @@ public struct RawFallthroughStmtSyntax: RawStmtSyntaxNodeProtocol {
     _ unexpectedAfterFallthroughKeyword: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(fallthroughKeyword.tokenKind == .keyword(.fallthrough), "Received \(fallthroughKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .fallthroughStmt, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -14668,8 +14397,6 @@ public struct RawBreakStmtSyntax: RawStmtSyntaxNodeProtocol {
     _ unexpectedAfterLabel: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(breakKeyword.tokenKind == .keyword(.break), "Received \(breakKeyword.tokenKind)")
-    assert(label == nil || label?.tokenKind.base == .identifier, "Received \(String(describing: label?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .breakStmt, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -14851,7 +14578,6 @@ public struct RawConditionElementSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .conditionElement, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -14916,9 +14642,6 @@ public struct RawAvailabilityConditionSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(availabilityKeyword.tokenKind.base == .poundAvailableKeyword || availabilityKeyword.tokenKind.base == .poundUnavailableKeyword, "Received \(availabilityKeyword.tokenKind)")
-    assert(leftParen.tokenKind.base == .leftParen, "Received \(leftParen.tokenKind)")
-    assert(rightParen.tokenKind.base == .rightParen, "Received \(rightParen.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .availabilityCondition, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -14999,7 +14722,6 @@ public struct RawMatchingPatternConditionSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterInitializer: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(caseKeyword.tokenKind == .keyword(.case), "Received \(caseKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .matchingPatternCondition, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -15080,7 +14802,6 @@ public struct RawOptionalBindingConditionSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterInitializer: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(letOrVarKeyword.tokenKind == .keyword(.let) || letOrVarKeyword.tokenKind == .keyword(.var), "Received \(letOrVarKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .optionalBindingCondition, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -15259,7 +14980,6 @@ public struct RawCatchItemSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .catchItem, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -15330,7 +15050,6 @@ public struct RawCatchClauseSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(catchKeyword.tokenKind == .keyword(.catch), "Received \(catchKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .catchClause, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -15399,7 +15118,6 @@ public struct RawGenericWhereClauseSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRequirementList: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(whereKeyword.tokenKind == .keyword(.where), "Received \(whereKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .genericWhereClause, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -15535,7 +15253,6 @@ public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .genericRequirement, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -15598,7 +15315,6 @@ public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightTypeIdentifier: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(equalityToken.tokenKind.base == .binaryOperator || equalityToken.tokenKind.base == .prefixOperator || equalityToken.tokenKind.base == .postfixOperator, "Received \(equalityToken.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .sameTypeRequirement, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -15679,13 +15395,6 @@ public struct RawLayoutRequirementSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
-    assert(layoutConstraint.tokenKind == .keyword(._Trivial) || layoutConstraint.tokenKind == .keyword(._TrivialAtMost) || layoutConstraint.tokenKind == .keyword(._UnknownLayout) || layoutConstraint.tokenKind == .keyword(._RefCountedObject) || layoutConstraint.tokenKind == .keyword(._NativeRefCountedObject) || layoutConstraint.tokenKind == .keyword(._Class) || layoutConstraint.tokenKind == .keyword(._NativeClass), "Received \(layoutConstraint.tokenKind)")
-    assert(leftParen == nil || leftParen?.tokenKind.base == .leftParen, "Received \(String(describing: leftParen?.tokenKind))")
-    assert(size == nil || size?.tokenKind.base == .integerLiteral, "Received \(String(describing: size?.tokenKind))")
-    assert(comma == nil || comma?.tokenKind.base == .comma, "Received \(String(describing: comma?.tokenKind))")
-    assert(alignment == nil || alignment?.tokenKind.base == .integerLiteral, "Received \(String(describing: alignment?.tokenKind))")
-    assert(rightParen == nil || rightParen?.tokenKind.base == .rightParen, "Received \(String(describing: rightParen?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .layoutRequirement, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -15842,10 +15551,6 @@ public struct RawGenericParameterSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(name.tokenKind.base == .identifier, "Received \(name.tokenKind)")
-    assert(ellipsis == nil || ellipsis?.tokenKind.base == .ellipsis, "Received \(String(describing: ellipsis?.tokenKind))")
-    assert(colon == nil || colon?.tokenKind.base == .colon, "Received \(String(describing: colon?.tokenKind))")
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .genericParameter, uninitializedCount: 13, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -15978,8 +15683,6 @@ public struct RawPrimaryAssociatedTypeSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(name.tokenKind.base == .identifier, "Received \(name.tokenKind)")
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .primaryAssociatedType, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -16044,8 +15747,6 @@ public struct RawGenericParameterClauseSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightAngleBracket: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftAngleBracket.tokenKind.base == .leftAngle, "Received \(leftAngleBracket.tokenKind)")
-    assert(rightAngleBracket.tokenKind.base == .rightAngle, "Received \(rightAngleBracket.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .genericParameterClause, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -16124,7 +15825,6 @@ public struct RawConformanceRequirementSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightTypeIdentifier: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .conformanceRequirement, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -16195,8 +15895,6 @@ public struct RawPrimaryAssociatedTypeClauseSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightAngleBracket: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftAngleBracket.tokenKind.base == .leftAngle, "Received \(leftAngleBracket.tokenKind)")
-    assert(rightAngleBracket.tokenKind.base == .rightAngle, "Received \(rightAngleBracket.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .primaryAssociatedTypeClause, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -16265,7 +15963,6 @@ public struct RawSimpleTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol {
     _ unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(name.tokenKind.base == .identifier || name.tokenKind.base == .keyword || name.tokenKind.base == .wildcard, "Received \(name.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .simpleTypeIdentifier, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -16330,8 +16027,6 @@ public struct RawMemberTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol {
     _ unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(period.tokenKind.base == .period, "Received \(period.tokenKind)")
-    assert(name.tokenKind.base == .identifier || name.tokenKind.base == .keyword, "Received \(name.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .memberTypeIdentifier, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -16406,7 +16101,6 @@ public struct RawClassRestrictionTypeSyntax: RawTypeSyntaxNodeProtocol {
     _ unexpectedAfterClassKeyword: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(classKeyword.tokenKind == .keyword(.class), "Received \(classKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .classRestrictionType, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -16461,8 +16155,6 @@ public struct RawArrayTypeSyntax: RawTypeSyntaxNodeProtocol {
     _ unexpectedAfterRightSquareBracket: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftSquareBracket.tokenKind.base == .leftSquareBracket, "Received \(leftSquareBracket.tokenKind)")
-    assert(rightSquareBracket.tokenKind.base == .rightSquareBracket, "Received \(rightSquareBracket.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .arrayType, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -16537,9 +16229,6 @@ public struct RawDictionaryTypeSyntax: RawTypeSyntaxNodeProtocol {
     _ unexpectedAfterRightSquareBracket: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftSquareBracket.tokenKind.base == .leftSquareBracket, "Received \(leftSquareBracket.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
-    assert(rightSquareBracket.tokenKind.base == .rightSquareBracket, "Received \(rightSquareBracket.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .dictionaryType, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -16626,8 +16315,6 @@ public struct RawMetatypeTypeSyntax: RawTypeSyntaxNodeProtocol {
     _ unexpectedAfterTypeOrProtocol: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(period.tokenKind.base == .period, "Received \(period.tokenKind)")
-    assert(typeOrProtocol.tokenKind == .keyword(.Type) || typeOrProtocol.tokenKind == .keyword(.Protocol), "Received \(typeOrProtocol.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .metatypeType, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -16696,7 +16383,6 @@ public struct RawOptionalTypeSyntax: RawTypeSyntaxNodeProtocol {
     _ unexpectedAfterQuestionMark: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(questionMark.tokenKind.base == .postfixQuestionMark, "Received \(questionMark.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .optionalType, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -16757,7 +16443,6 @@ public struct RawConstrainedSugarTypeSyntax: RawTypeSyntaxNodeProtocol {
     _ unexpectedAfterBaseType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(someOrAnySpecifier.tokenKind == .keyword(.some) || someOrAnySpecifier.tokenKind == .keyword(.any), "Received \(someOrAnySpecifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .constrainedSugarType, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -16818,7 +16503,6 @@ public struct RawImplicitlyUnwrappedOptionalTypeSyntax: RawTypeSyntaxNodeProtoco
     _ unexpectedAfterExclamationMark: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(exclamationMark.tokenKind.base == .exclamationMark, "Received \(exclamationMark.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .implicitlyUnwrappedOptionalType, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -17029,7 +16713,6 @@ public struct RawPackExpansionTypeSyntax: RawTypeSyntaxNodeProtocol {
     _ unexpectedAfterPatternType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(repeatKeyword.tokenKind == .keyword(.repeat), "Received \(repeatKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .packExpansionType, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -17090,7 +16773,6 @@ public struct RawPackReferenceTypeSyntax: RawTypeSyntaxNodeProtocol {
     _ unexpectedAfterPackType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(eachKeyword.tokenKind == .keyword(.each), "Received \(eachKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .packReferenceType, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -17163,11 +16845,6 @@ public struct RawTupleTypeElementSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(name == nil || name?.tokenKind.base == .identifier || name?.tokenKind.base == .wildcard, "Received \(String(describing: name?.tokenKind))")
-    assert(secondName == nil || secondName?.tokenKind.base == .identifier || secondName?.tokenKind.base == .wildcard, "Received \(String(describing: secondName?.tokenKind))")
-    assert(colon == nil || colon?.tokenKind.base == .colon, "Received \(String(describing: colon?.tokenKind))")
-    assert(ellipsis == nil || ellipsis?.tokenKind.base == .ellipsis, "Received \(String(describing: ellipsis?.tokenKind))")
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .tupleTypeElement, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -17318,8 +16995,6 @@ public struct RawTupleTypeSyntax: RawTypeSyntaxNodeProtocol {
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftParen.tokenKind.base == .leftParen, "Received \(leftParen.tokenKind)")
-    assert(rightParen.tokenKind.base == .rightParen, "Received \(rightParen.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .tupleType, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -17394,8 +17069,6 @@ public struct RawFunctionTypeSyntax: RawTypeSyntaxNodeProtocol {
     _ unexpectedAfterOutput: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftParen.tokenKind.base == .leftParen, "Received \(leftParen.tokenKind)")
-    assert(rightParen.tokenKind.base == .rightParen, "Received \(rightParen.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .functionType, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -17482,7 +17155,6 @@ public struct RawAttributedTypeSyntax: RawTypeSyntaxNodeProtocol {
     _ unexpectedAfterBaseType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(specifier == nil || specifier?.tokenKind == .keyword(.inout) || specifier?.tokenKind == .keyword(.__shared) || specifier?.tokenKind == .keyword(.__owned) || specifier?.tokenKind == .keyword(.isolated) || specifier?.tokenKind == .keyword(._const), "Received \(String(describing: specifier?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .attributedType, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -17591,7 +17263,6 @@ public struct RawGenericArgumentSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .genericArgument, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -17654,8 +17325,6 @@ public struct RawGenericArgumentClauseSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterRightAngleBracket: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftAngleBracket.tokenKind.base == .leftAngle, "Received \(leftAngleBracket.tokenKind)")
-    assert(rightAngleBracket.tokenKind.base == .rightAngle, "Received \(rightAngleBracket.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .genericArgumentClause, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -17784,7 +17453,6 @@ public struct RawTypeAnnotationSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .typeAnnotation, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -17845,7 +17513,6 @@ public struct RawIsTypePatternSyntax: RawPatternSyntaxNodeProtocol {
     _ unexpectedAfterType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(isKeyword.tokenKind == .keyword(.is), "Received \(isKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .isTypePattern, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -17904,7 +17571,6 @@ public struct RawIdentifierPatternSyntax: RawPatternSyntaxNodeProtocol {
     _ unexpectedAfterIdentifier: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(identifier.tokenKind.base == .identifier || identifier.tokenKind.base == .keyword, "Received \(identifier.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .identifierPattern, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -17959,8 +17625,6 @@ public struct RawTuplePatternSyntax: RawPatternSyntaxNodeProtocol {
     _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(leftParen.tokenKind.base == .leftParen, "Received \(leftParen.tokenKind)")
-    assert(rightParen.tokenKind.base == .rightParen, "Received \(rightParen.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .tuplePattern, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -18029,7 +17693,6 @@ public struct RawWildcardPatternSyntax: RawPatternSyntaxNodeProtocol {
     _ unexpectedAfterTypeAnnotation: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(wildcard.tokenKind.base == .wildcard, "Received \(wildcard.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .wildcardPattern, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -18094,9 +17757,6 @@ public struct RawTuplePatternElementSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(labelName == nil || labelName?.tokenKind.base == .identifier, "Received \(String(describing: labelName?.tokenKind))")
-    assert(labelColon == nil || labelColon?.tokenKind.base == .colon, "Received \(String(describing: labelColon?.tokenKind))")
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .tuplePatternElement, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -18263,7 +17923,6 @@ public struct RawValueBindingPatternSyntax: RawPatternSyntaxNodeProtocol {
     _ unexpectedAfterValuePattern: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(letOrVarKeyword.tokenKind == .keyword(.let) || letOrVarKeyword.tokenKind == .keyword(.var), "Received \(letOrVarKeyword.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .valueBindingPattern, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -18399,7 +18058,6 @@ public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(trailingComma == nil || trailingComma?.tokenKind.base == .comma, "Received \(String(describing: trailingComma?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .availabilityArgument, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -18491,8 +18149,6 @@ public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterValue: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(label.tokenKind == .keyword(.message) || label.tokenKind == .keyword(.renamed) || label.tokenKind == .keyword(.introduced) || label.tokenKind == .keyword(.obsoleted) || label.tokenKind == .keyword(.deprecated), "Received \(label.tokenKind)")
-    assert(colon.tokenKind.base == .colon, "Received \(colon.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .availabilityLabeledArgument, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -18561,7 +18217,6 @@ public struct RawAvailabilityVersionRestrictionSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterVersion: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(platform.tokenKind.base == .identifier, "Received \(platform.tokenKind)")
     let raw = RawSyntax.makeLayout(
       kind: .availabilityVersionRestriction, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
@@ -18624,9 +18279,6 @@ public struct RawVersionTupleSyntax: RawSyntaxNodeProtocol {
     _ unexpectedAfterPatchVersion: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
-    assert(majorMinor.tokenKind.base == .integerLiteral || majorMinor.tokenKind.base == .floatingLiteral, "Received \(majorMinor.tokenKind)")
-    assert(patchPeriod == nil || patchPeriod?.tokenKind.base == .period, "Received \(String(describing: patchPeriod?.tokenKind))")
-    assert(patchVersion == nil || patchVersion?.tokenKind.base == .integerLiteral, "Received \(String(describing: patchVersion?.tokenKind))")
     let raw = RawSyntax.makeLayout(
       kind: .versionTuple, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)


### PR DESCRIPTION
I only now noticed that normal CI doesn't have assertions enabled and debug CI seems to fail in a variety of places with this assertion.

Disable the assertion for now. The path forward is to enable assertions in SwiftSyntax for Release+Assert builds and then re-apply this fix, fixing any issues that CI now discovers.