### PR TITLE
Don’t use arrays in `consume` functions

### DIFF
--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -219,7 +219,7 @@ extension Parser {
     }
 
     let version: RawVersionTupleSyntax?
-    if self.at(any: [.integerLiteral, .floatingLiteral]) {
+    if self.at(.integerLiteral, .floatingLiteral) {
       version = self.parseVersionTuple()
     } else {
       version = nil
@@ -242,7 +242,7 @@ extension Parser {
   ///     platform-version → decimal-digits '.' decimal-digits
   ///     platform-version → decimal-digits '.' decimal-digits '.' decimal-digits
   mutating func parseVersionTuple() -> RawVersionTupleSyntax {
-    let (unexpectedBeforeMajorMinor, majorMinor) = self.expectAny([.integerLiteral, .floatingLiteral], default: .integerLiteral)
+    let (unexpectedBeforeMajorMinor, majorMinor) = self.expect(.integerLiteral, .floatingLiteral, default: .integerLiteral)
     let patchPeriod: RawTokenSyntax?
     let unexpectedBeforePatch: RawUnexpectedNodesSyntax?
     let patch: RawTokenSyntax?

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -150,9 +150,35 @@ extension Parser {
   }
 
   mutating func parseAccessLevelModifier() -> RawDeclModifierSyntax {
-    let (unexpectedBeforeName, name) = expectAny(
-      [.keyword(.private), .keyword(.fileprivate), .keyword(.internal), .keyword(.public)],
-      default: .keyword(.internal)
+    enum AccessLevelModifier: RawTokenKindSubset {
+      case `private`
+      case `fileprivate`
+      case `internal`
+      case `public`
+
+      var rawTokenKind: RawTokenKind {
+        switch self {
+        case .private: return .keyword(.private)
+        case .fileprivate: return .keyword(.fileprivate)
+        case .internal: return .keyword(.internal)
+        case .public: return .keyword(.public)
+        }
+      }
+
+      init?(lexeme: Lexer.Lexeme) {
+        switch lexeme {
+        case RawTokenKindMatch(.private): self = .private
+        case RawTokenKindMatch(.fileprivate): self = .fileprivate
+        case RawTokenKindMatch(.internal): self = .internal
+        case RawTokenKindMatch(.public): self = .public
+        default: return nil
+        }
+      }
+    }
+
+    let (unexpectedBeforeName, name) = expect(
+      anyIn: AccessLevelModifier.self,
+      default: .internal
     )
     let details = self.parseAccessModifierDetails()
     return RawDeclModifierSyntax(

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -64,7 +64,7 @@ extension Parser {
   mutating func parseDeclNameRef(_ flags: DeclNameOptions = []) -> (RawTokenSyntax, RawDeclNameArgumentsSyntax?) {
     // Consume the base name.
     let ident: RawTokenSyntax
-    if self.at(.identifier) || self.at(any: [.keyword(.self), .keyword(.Self), .keyword(.`init`)]) {
+    if self.at(.identifier) || self.at(.keyword(.self), .keyword(.Self), .keyword(.`init`)) {
       ident = self.expectIdentifierWithoutRecovery()
     } else if flags.contains(.operators), let (_, _) = self.at(anyIn: Operator.self) {
       ident = self.consumeAnyToken(remapping: .binaryOperator)
@@ -113,7 +113,7 @@ extension Parser {
     var elements = [RawDeclNameArgumentSyntax]()
     do {
       var loopProgress = LoopProgressCondition()
-      while !self.at(any: [.eof, .rightParen]) && loopProgress.evaluate(currentToken) {
+      while !self.at(.eof, .rightParen) && loopProgress.evaluate(currentToken) {
         // Check to see if there is an argument label.
         assert(self.currentToken.canBeArgumentLabel() && self.peek().rawTokenKind == .colon)
         let name = self.consumeAnyToken()
@@ -237,7 +237,7 @@ extension Parser.Lookahead {
     }
 
     var loopProgress = LoopProgressCondition()
-    while !lookahead.at(any: [.eof, .rightParen]) && loopProgress.evaluate(lookahead.currentToken) {
+    while !lookahead.at(.eof, .rightParen) && loopProgress.evaluate(lookahead.currentToken) {
       // Check to see if there is an argument label.
       guard lookahead.currentToken.canBeArgumentLabel() && lookahead.peek().rawTokenKind == .colon else {
         return false

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -210,7 +210,7 @@ extension Parser {
     do {
       var keepGoing = true
       var loopProgress = LoopProgressCondition()
-      while !self.at(any: [.eof, .rightParen]) && keepGoing && loopProgress.evaluate(currentToken) {
+      while !self.at(.eof, .rightParen) && keepGoing && loopProgress.evaluate(currentToken) {
         // If the tuple element has a label, parse it.
         let labelAndColon = self.consume(if: .identifier, followedBy: .colon)
         let (label, colon) = (labelAndColon?.0, labelAndColon?.1)

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -217,13 +217,13 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseConditionElement() -> RawConditionElementSyntax.Condition {
     // Parse a leading #available/#unavailable condition if present.
-    if self.at(any: [.poundAvailableKeyword, .poundUnavailableKeyword]) {
+    if self.at(.poundAvailableKeyword, .poundUnavailableKeyword) {
       return self.parsePoundAvailableConditionElement()
     }
 
     // Parse the basic expression case.  If we have a leading let/var/case
     // keyword or an assignment, then we know this is a binding.
-    guard self.at(any: [.keyword(.let), .keyword(.var), .keyword(.case)]) else {
+    guard self.at(.keyword(.let), .keyword(.var), .keyword(.case)) else {
       // If we lack it, then this is theoretically a boolean condition.
       // However, we also need to handle migrating from Swift 2 syntax, in
       // which a comma followed by an expression could actually be a pattern
@@ -240,7 +240,7 @@ extension Parser {
     }
 
     // We're parsing a conditional binding.
-    assert(self.at(any: [.keyword(.let), .keyword(.var), .keyword(.case)]))
+    assert(self.at(.keyword(.let), .keyword(.var), .keyword(.case)))
     enum BindingKind {
       case pattern(RawTokenSyntax, RawPatternSyntax)
       case optional(RawTokenSyntax, RawPatternSyntax)
@@ -322,7 +322,7 @@ extension Parser {
   ///     availability-condition → '#unavailable' '(' availability-arguments ')'
   @_spi(RawSyntax)
   public mutating func parsePoundAvailableConditionElement() -> RawConditionElementSyntax.Condition {
-    assert(self.at(any: [.poundAvailableKeyword, .poundUnavailableKeyword]))
+    assert(self.at(.poundAvailableKeyword, .poundUnavailableKeyword))
     let keyword = self.consumeAnyToken()
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
     let spec = self.parseAvailabilitySpecList()
@@ -479,7 +479,7 @@ extension Parser {
     // If this is a 'catch' clause and we have "catch {" or "catch where...",
     // then we get an implicit "let error" pattern.
     let pattern: RawPatternSyntax?
-    if self.at(any: [.leftBrace, .keyword(.where)]) {
+    if self.at(.leftBrace, .keyword(.where)) {
       pattern = nil
     } else {
       pattern = self.parseMatchingPattern(context: .matching)
@@ -707,7 +707,7 @@ extension Parser {
         var keepGoing = true
         var elementList = [RawYieldExprListElementSyntax]()
         var loopProgress = LoopProgressCondition()
-        while !self.at(any: [.eof, .rightParen]) && keepGoing && loopProgress.evaluate(currentToken) {
+        while !self.at(.eof, .rightParen) && keepGoing && loopProgress.evaluate(currentToken) {
           let expr = self.parseExpression()
           let comma = self.consume(if: .comma)
           elementList.append(
@@ -959,7 +959,7 @@ extension Parser.Lookahead {
       lookahead.consumeAnyToken()
       // just find the end of the line
       lookahead.skipUntilEndOfLine()
-    } while lookahead.at(any: [.poundIfKeyword, .poundElseifKeyword, .poundElseKeyword]) && loopProgress.evaluate(lookahead.currentToken)
+    } while lookahead.at(.poundIfKeyword, .poundElseifKeyword, .poundElseKeyword) && loopProgress.evaluate(lookahead.currentToken)
     return lookahead.isAtStartOfSwitchCase()
   }
 }

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -465,7 +465,7 @@ extension Parser {
     let openDelimiter = self.consume(if: .rawStringDelimiter)
 
     /// Parse open quote.
-    var (unexpectedBeforeOpenQuote, openQuote) = self.expectAny([.stringQuote, .multilineStringQuote], default: .stringQuote)
+    var (unexpectedBeforeOpenQuote, openQuote) = self.expect(.stringQuote, .multilineStringQuote, default: .stringQuote)
     var openQuoteKind: RawTokenKind = openQuote.tokenKind
     if openQuote.isMissing, let singleQuote = self.consume(if: .singleQuote) {
       unexpectedBeforeOpenQuote = RawUnexpectedNodesSyntax(combining: unexpectedBeforeOpenQuote, singleQuote, arena: self.arena)
@@ -487,7 +487,7 @@ extension Parser {
         // This allows us to skip over extraneous identifiers etc. in an unterminated string interpolation.
         var unexpectedBeforeRightParen: [RawTokenSyntax] = []
         var unexpectedProgress = LoopProgressCondition()
-        while !self.at(any: [.rightParen, .stringSegment, .backslash, openQuoteKind, .eof]) && unexpectedProgress.evaluate(self.currentToken) {
+        while !self.at(.rightParen, .stringSegment, .backslash) && !self.at(openQuoteKind, .eof) && unexpectedProgress.evaluate(self.currentToken) {
           unexpectedBeforeRightParen.append(self.consumeAnyToken())
         }
         let rightParen = self.expectWithoutRecovery(.rightParen)

--- a/Sources/SwiftParser/SyntaxUtils.swift
+++ b/Sources/SwiftParser/SyntaxUtils.swift
@@ -91,8 +91,12 @@ extension SyntaxText {
 }
 
 extension RawTokenKind {
-  func `is`(any kinds: [RawTokenKind]) -> Bool {
-    return kinds.contains(self)
+  func `is`(_ kind1: RawTokenKind, _ kind2: RawTokenKind) -> Bool {
+    return self == kind1 || self == kind2
+  }
+
+  func `is`(_ kind1: RawTokenKind, _ kind2: RawTokenKind, _ kind3: RawTokenKind) -> Bool {
+    return self == kind1 || self == kind2 || self == kind3
   }
 }
 

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -157,7 +157,7 @@ extension Parser {
         arena: self.arena
       )
     }
-    if self.at(any: [.keyword(.case), .keyword(.default)]) {
+    if self.at(.keyword(.case), .keyword(.default)) {
       // 'case' and 'default' are invalid in code block items.
       // Parse them and put them in their own CodeBlockItem but as an unexpected node.
       let switchCase = self.parseSwitchCase()


### PR DESCRIPTION
Creating arrays for `consume(ifAny:)` and friends incurs memory allocations and reference counting costs. Stamp out copies of `consume(if:)` for up to three different kinds and start using `RawTokenKindSubset` if more kinds need to be checked.

This improves performance of parsing MovieSwiftUI by 5%.

rdar://103774645