### PR TITLE
[Macros] Use a type parameter conforming to DeclSyntaxProtocol in the PeerMacro protocol requirement.

### DIFF
--- a/Sources/SwiftSyntaxMacros/MacroProtocols/PeerMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/PeerMacro.swift
@@ -16,9 +16,12 @@ public protocol PeerMacro: AttachedMacro {
   ///
   /// The macro expansion can introduce "peer" declarations that sit alongside
   /// the given declaration.
-  static func expansion<Context: MacroExpansionContext>(
+  static func expansion<
+    Context: MacroExpansionContext,
+    Declaration: DeclSyntaxProtocol
+  >(
     of node: AttributeSyntax,
-    providingPeersOf declaration: DeclSyntax,
+    providingPeersOf declaration: Declaration,
     in context: Context
   ) throws -> [DeclSyntax]
 }

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -294,9 +294,12 @@ extension PropertyWrapper: AccessorMacro {
 }
 
 extension PropertyWrapper: PeerMacro {
-  public static func expansion<Context: MacroExpansionContext>(
+  public static func expansion<
+    Context: MacroExpansionContext,
+    Declaration: DeclSyntaxProtocol
+  >(
     of node: AttributeSyntax,
-    providingPeersOf declaration: DeclSyntax,
+    providingPeersOf declaration: Declaration,
     in context: Context
   ) throws -> [SwiftSyntax.DeclSyntax] {
     guard let varDecl = declaration.as(VariableDeclSyntax.self),
@@ -331,9 +334,12 @@ extension PropertyWrapper: PeerMacro {
 }
 
 public struct AddCompletionHandler: PeerMacro {
-  public static func expansion<Context: MacroExpansionContext>(
+  public static func expansion<
+    Context: MacroExpansionContext,
+    Declaration: DeclSyntaxProtocol
+  >(
     of node: AttributeSyntax,
-    providingPeersOf declaration: DeclSyntax,
+    providingPeersOf declaration: Declaration,
     in context: Context
   ) throws -> [DeclSyntax] {
     // Only on functions at the moment. We could handle initializers as well


### PR DESCRIPTION
I believe this is the last step in generalizing all `AttachedMacro` protocol refinements to use type parameters instead of `DeclSyntax` in the `expansion` requirement.