### PR TITLE
[Macros] generate diagnostics from thrown error

### DIFF
--- a/Sources/SwiftDiagnostics/Diagnostic.swift
+++ b/Sources/SwiftDiagnostics/Diagnostic.swift
@@ -71,3 +71,9 @@ public struct Diagnostic: CustomDebugStringConvertible {
     return "\(location): \(message)"
   }
 }
+
+public protocol DiagnosticsProviding: Error {
+  /// The diagnostics provided by this error.
+  /// At least one diagnostic should have `severity == .error`.
+  var diagnostics: [Diagnostic] { get }
+}

--- a/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
@@ -88,12 +88,12 @@ extension MacroExpansionContext {
       )
       return
     }
-    
+
     let providedDiagnostics = diagnosticsProvider.diagnostics
     for diagnostic in providedDiagnostics {
       diagnose(diagnostic)
     }
-    
+
     // handle possibility that none of the diagnostics was an error
     if !providedDiagnostics.contains(
       where: { $0.diagMessage.severity == .error }

--- a/Sources/SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacros/MacroSystem.swift
@@ -150,13 +150,7 @@ class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
             newItems.append(CodeBlockItemSyntax(item: .init(expandedExpr)))
           }
         } catch {
-          // Record the error
-          context.diagnose(
-            Diagnostic(
-              node: Syntax(node),
-              message: ThrownErrorDiagnostic(message: String(describing: error))
-            )
-          )
+          context.addDiagnostics(from: error, node: node)
         }
 
         continue
@@ -200,13 +194,7 @@ class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
             }
           )
         } catch {
-          // Record the error
-          context.diagnose(
-            Diagnostic(
-              node: Syntax(node),
-              message: ThrownErrorDiagnostic(message: String(describing: error))
-            )
-          )
+          context.addDiagnostics(from: error, node: node)
         }
 
         continue
@@ -376,13 +364,7 @@ extension MacroApplication {
         let newPeers = try peerMacro.expansion(of: attribute, providingPeersOf: decl, in: context)
         peers.append(contentsOf: newPeers)
       } catch {
-        // Record the error
-        context.diagnose(
-          Diagnostic(
-            node: Syntax(attribute),
-            message: ThrownErrorDiagnostic(message: String(describing: error))
-          )
-        )
+        context.addDiagnostics(from: error, node: attribute)
       }
     }
 
@@ -406,13 +388,7 @@ extension MacroApplication {
           )
         )
       } catch {
-        // Record the error
-        context.diagnose(
-          Diagnostic(
-            node: Syntax(attribute),
-            message: ThrownErrorDiagnostic(message: String(describing: error))
-          )
-        )
+        context.addDiagnostics(from: error, node: attribute)
       }
     }
 
@@ -473,13 +449,7 @@ extension MacroApplication {
           contentsOf: try _openExistential(typedDecl, do: expand)
         )
       } catch {
-        // Record the error
-        context.diagnose(
-          Diagnostic(
-            node: Syntax(attribute),
-            message: ThrownErrorDiagnostic(message: String(describing: error))
-          )
-        )
+        context.addDiagnostics(from: error, node: attribute)
       }
     }
 

--- a/Sources/SwiftSyntaxMacros/Syntax+MacroEvaluation.swift
+++ b/Sources/SwiftSyntaxMacros/Syntax+MacroEvaluation.swift
@@ -13,17 +13,6 @@
 import SwiftDiagnostics
 import SwiftSyntax
 
-/// Diagnostic message used for thrown errors.
-struct ThrownErrorDiagnostic: DiagnosticMessage {
-  let message: String
-
-  var severity: DiagnosticSeverity { .error }
-
-  var diagnosticID: MessageID {
-    .init(domain: "SwiftSyntaxMacros", id: "ThrownErrorDiagnostic")
-  }
-}
-
 extension SyntaxProtocol {
   /// Detach the current node and inform the macro expansion context,
   /// if it needs to know.
@@ -51,14 +40,7 @@ extension MacroExpansionExprSyntax {
     do {
       return try exprMacro.expansion(of: detach(in: context), in: context)
     } catch {
-      // Record the error
-      context.diagnose(
-        Diagnostic(
-          node: Syntax(self),
-          message: ThrownErrorDiagnostic(message: String(describing: error))
-        )
-      )
-
+      context.addDiagnostics(from: error, node: self)
       return ExprSyntax(self)
     }
   }


### PR DESCRIPTION
Macro expansion methods throw an error to indicate that the expansion failed. This patch allows the error thrown to add full-fledged diagnostics, rather than autogenerating a diagnostic based on the error's description.

It adds an error protocol:
```swift
public protocol DiagnosticsProviding: Error {
  var diagnostics: [Diagnostic] { get }
}
```

...and a utility method on `MacroExpansionContext` to add diagnostics from an error. The implementation of this method checks if the error is diagnostic providing; if not, it generates the same diagnostic as before. If so, it adds all the provided diagnostics.