### PR TITLE
Rename `LexerError` -> `TokenDiagnostic`

### DIFF
--- a/Sources/SwiftParser/Lexer/Lexeme.swift
+++ b/Sources/SwiftParser/Lexer/Lexeme.swift
@@ -40,7 +40,7 @@ extension Lexer {
     @_spi(RawSyntax)
     public var rawTokenKind: RawTokenKind
     public var flags: Lexeme.Flags
-    public var error: LexerError?
+    public var diagnostic: TokenDiagnostic?
     var start: UnsafePointer<UInt8>
     public var leadingTriviaByteLength: Int
     public var textByteLength: Int
@@ -60,7 +60,7 @@ extension Lexer {
     init(
       tokenKind: RawTokenKind,
       flags: Flags,
-      error: LexerError?,
+      diagnostic: TokenDiagnostic?,
       start: UnsafePointer<UInt8>,
       leadingTriviaLength: Int,
       textLength: Int,
@@ -69,7 +69,7 @@ extension Lexer {
     ) {
       self.rawTokenKind = tokenKind
       self.flags = flags
-      self.error = error
+      self.diagnostic = diagnostic
       self.start = start
       self.leadingTriviaByteLength = leadingTriviaLength
       self.textByteLength = textLength

--- a/Sources/SwiftParser/Lexer/LexemeSequence.swift
+++ b/Sources/SwiftParser/Lexer/LexemeSequence.swift
@@ -47,7 +47,7 @@ extension Lexer {
           self.nextToken = Lexeme(
             tokenKind: .eof,
             flags: [],
-            error: nil,
+            diagnostic: nil,
             start: self.cursor.pointer,
             leadingTriviaLength: 0,
             textLength: 0,

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -187,7 +187,7 @@ public struct Parser {
       wholeText: tok.wholeText,
       textRange: tok.textRange,
       presence: .present,
-      lexerError: tok.error,
+      tokenDiagnostic: tok.diagnostic,
       arena: arena
     )
   }
@@ -511,10 +511,10 @@ extension Parser {
     assert(tokenText.hasPrefix(prefix))
 
     let endIndex = current.textRange.lowerBound.advanced(by: prefix.count)
-    var lexerError = current.error
-    if let error = lexerError, error.byteOffset > prefix.count + current.leadingTriviaByteLength {
+    var tokenDiagnostic = current.diagnostic
+    if let error = tokenDiagnostic, error.byteOffset > prefix.count + current.leadingTriviaByteLength {
       // The lexer error isn't in the prefix. Drop it.
-      lexerError = nil
+      tokenDiagnostic = nil
     }
 
     let tok = RawTokenSyntax(
@@ -522,7 +522,7 @@ extension Parser {
       wholeText: SyntaxText(rebasing: current.wholeText[..<endIndex]),
       textRange: current.textRange.lowerBound..<endIndex,
       presence: .present,
-      lexerError: lexerError,
+      tokenDiagnostic: tokenDiagnostic,
       arena: self.arena
     )
 

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -55,13 +55,13 @@ fileprivate class StringLiteralExpressionIndentationChecker {
     if hasSufficientIndentation {
       return nil
     }
-    if token.tokenView.lexerError != nil {
+    if token.tokenView.tokenDiagnostic != nil {
       // Token already has a lexer error, ignore the indentation error until that
       // error is fixed
       return nil
     }
-    return token.tokenView.withLexerError(
-      lexerError: LexerError(.insufficientIndentationInMultilineStringLiteral, byteOffset: 0),
+    return token.tokenView.withTokenDiagnostic(
+      tokenDiagnostic: TokenDiagnostic(.insufficientIndentationInMultilineStringLiteral, byteOffset: 0),
       arena: arena
     )
   }
@@ -136,7 +136,7 @@ extension Parser {
     in token: RawTokenSyntax,
     leading reclassifyLeading: SyntaxText = "",
     trailing reclassifyTrailing: SyntaxText = "",
-    lexerError: LexerError? = nil
+    tokenDiagnostic: TokenDiagnostic? = nil
   ) -> RawTokenSyntax {
     assert(SyntaxText(rebasing: token.tokenText.prefix(reclassifyLeading.count)) == reclassifyLeading)
     assert(SyntaxText(rebasing: token.tokenText.suffix(reclassifyTrailing.count)) == reclassifyTrailing)
@@ -146,7 +146,7 @@ extension Parser {
       leadingTriviaPieces: token.leadingTriviaPieces + TriviaParser.parseTrivia(reclassifyLeading, position: .trailing),
       trailingTriviaPieces: TriviaParser.parseTrivia(reclassifyTrailing, position: .trailing) + token.trailingTriviaPieces,
       presence: token.presence,
-      lexerError: token.tokenView.lexerError ?? lexerError,
+      tokenDiagnostic: token.tokenView.tokenDiagnostic ?? tokenDiagnostic,
       arena: self.arena
     )
   }
@@ -253,8 +253,8 @@ extension Parser {
             // Empty lines don't need to be indented and there's no indentation we need to strip away.
           } else {
             let actualIndentation = SyntaxText(rebasing: segment.content.tokenText.prefix(while: { $0 == UInt8(ascii: " ") || $0 == UInt8(ascii: "\t") }))
-            let lexerError = LexerError(.insufficientIndentationInMultilineStringLiteral, byteOffset: 0)
-            let content = self.reclassifyTrivia(in: segment.content, leading: actualIndentation, lexerError: lexerError)
+            let tokenDiagnostic = TokenDiagnostic(.insufficientIndentationInMultilineStringLiteral, byteOffset: 0)
+            let content = self.reclassifyTrivia(in: segment.content, leading: actualIndentation, tokenDiagnostic: tokenDiagnostic)
             segment = RawStringSegmentSyntax(
               segment.unexpectedBeforeContent,
               content: content,
@@ -372,7 +372,7 @@ extension Parser {
         leadingTriviaPieces: parsedTrivia + closeQuote.leadingTriviaPieces,
         trailingTriviaPieces: closeQuote.trailingTriviaPieces,
         presence: closeQuote.presence,
-        lexerError: closeQuote.tokenView.lexerError,
+        tokenDiagnostic: closeQuote.tokenView.tokenDiagnostic,
         arena: self.arena
       )
     } else {

--- a/Sources/SwiftParserDiagnostics/MultiLineStringLiteralDiagnoticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/MultiLineStringLiteralDiagnoticsGenerator.swift
@@ -144,7 +144,7 @@ final class MultiLineStringLiteralIndentatinDiagnosticsGenerator: SyntaxVisitor 
       return .visitChildren
     }
 
-    if token.lexerError?.kind == .insufficientIndentationInMultilineStringLiteral {
+    if token.tokenDiagnostic?.kind == .insufficientIndentationInMultilineStringLiteral {
       addIncorrectlyIndentedToken(token: token)
     } else {
       finishInProgressDiagnostic()

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -31,7 +31,7 @@ fileprivate extension TokenSyntax {
 }
 
 fileprivate extension DiagnosticSeverity {
-  func matches(_ lexerErorSeverity: SwiftSyntax.LexerError.Severity) -> Bool {
+  func matches(_ lexerErorSeverity: SwiftSyntax.TokenDiagnostic.Severity) -> Bool {
     switch (self, lexerErorSeverity) {
     case (.error, .error):
       return true
@@ -359,14 +359,14 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     if token.presence == .missing {
       handleMissingToken(token)
     } else {
-      if let lexerError = token.lexerError {
-        let message = lexerError.diagnosticMessage(in: token)
-        assert(message.severity.matches(lexerError.severity))
+      if let tokenDiagnostic = token.tokenDiagnostic {
+        let message = tokenDiagnostic.diagnosticMessage(in: token)
+        assert(message.severity.matches(tokenDiagnostic.severity))
         self.addDiagnostic(
           token,
-          position: token.position.advanced(by: Int(lexerError.byteOffset)),
+          position: token.position.advanced(by: Int(tokenDiagnostic.byteOffset)),
           message,
-          fixIts: lexerError.fixIts(in: token)
+          fixIts: tokenDiagnostic.fixIts(in: token)
         )
       }
     }

--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -11,7 +11,6 @@ add_swift_host_library(SwiftSyntax
   BumpPtrAllocator.swift
   CommonAncestor.swift
   IncrementalParseTransition.swift
-  LexerError.swift
   SourceLength.swift
   SourceLocation.swift
   SourcePresence.swift
@@ -22,6 +21,7 @@ add_swift_host_library(SwiftSyntax
   SyntaxOtherNodes.swift
   SyntaxText.swift
   SyntaxTreeViewMode.swift
+  TokenDiagnostic.swift
   Utils.swift
 
   Raw/RawSyntax.swift

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -26,10 +26,10 @@ struct RecursiveRawSyntaxFlags: OptionSet {
   /// Whether the tree contained by this layout has any
   ///  - missing nodes or
   ///  - unexpected nodes or
-  ///  - tokens with a `LexerError` of severity `error`
+  ///  - tokens with a `TokenDiagnostic` of severity `error`
   static let hasError = RecursiveRawSyntaxFlags(rawValue: 1 << 0)
-  /// Whether the tree contained by this layout has any tokens with a `LexerError`
-  /// of severity `warning`.
+  /// Whether the tree contained by this layout has any tokens with a
+  /// `TokenDiagnostic` of severity `warning`.
   static let hasWarning = RecursiveRawSyntaxFlags(rawValue: 1 << 1)
   static let hasSequenceExpr = RecursiveRawSyntaxFlags(rawValue: 1 << 2)
   static let hasMaximumNestingLevelOverflow = RecursiveRawSyntaxFlags(rawValue: 1 << 3)
@@ -61,38 +61,38 @@ internal struct RawSyntaxData {
 
     var presence: SourcePresence
 
-    /// Store the members of `LexerError` individually so the compiler can pack
+    /// Store the members of `TokenDiagnostic` individually so the compiler can pack
     /// `ParsedToken` more efficiently (saving 2 bytes)
-    /// `lexerErrorByteOffset` is ignored if `lexerErrorKind` is `nil`
-    private var lexerErrorKind: LexerError.Kind?
-    private var lexerErrorByteOffset: UInt16
+    /// `tokenDiagnosticByteOffset` is ignored if `tokenDiagnosticKind` is `nil`
+    private var tokenDiagnosticKind: TokenDiagnostic.Kind?
+    private var tokenDiagnosticByteOffset: UInt16
 
-    var lexerError: LexerError? {
+    var tokenDiagnostic: TokenDiagnostic? {
       get {
-        if let kind = lexerErrorKind {
-          return LexerError(kind, byteOffset: lexerErrorByteOffset)
+        if let kind = tokenDiagnosticKind {
+          return TokenDiagnostic(kind, byteOffset: tokenDiagnosticByteOffset)
         } else {
           return nil
         }
       }
       set {
         if let newValue = newValue {
-          self.lexerErrorKind = newValue.kind
-          self.lexerErrorByteOffset = newValue.byteOffset
+          self.tokenDiagnosticKind = newValue.kind
+          self.tokenDiagnosticByteOffset = newValue.byteOffset
         } else {
-          self.lexerErrorKind = nil
-          self.lexerErrorByteOffset = 0
+          self.tokenDiagnosticKind = nil
+          self.tokenDiagnosticByteOffset = 0
         }
       }
     }
 
-    init(tokenKind: RawTokenKind, wholeText: SyntaxText, textRange: Range<SyntaxText.Index>, presence: SourcePresence, lexerError: LexerError?) {
+    init(tokenKind: RawTokenKind, wholeText: SyntaxText, textRange: Range<SyntaxText.Index>, presence: SourcePresence, tokenDiagnostic: TokenDiagnostic?) {
       self.tokenKind = tokenKind
       self.wholeText = wholeText
       self.textRange = textRange
       self.presence = presence
-      self.lexerErrorKind = lexerError?.kind
-      self.lexerErrorByteOffset = lexerError?.byteOffset ?? 0
+      self.tokenDiagnosticKind = tokenDiagnostic?.kind
+      self.tokenDiagnosticByteOffset = tokenDiagnostic?.byteOffset ?? 0
     }
   }
 
@@ -104,38 +104,38 @@ internal struct RawSyntaxData {
     var numLeadingTrivia: UInt32
     var byteLength: UInt32
     var presence: SourcePresence
-    /// Store the members of `LexerError` individually so the compiler can pack
+    /// Store the members of `TokenDiagnostic` individually so the compiler can pack
     /// `ParsedToken` more efficiently (saving 2 bytes)
-    /// `lexerErrorByteOffset` is ignored if `lexerErrorKind` is `nil`
-    private var lexerErrorKind: LexerError.Kind?
-    private var lexerErrorByteOffset: UInt16
+    /// `tokenDiagnosticByteOffset` is ignored if `tokenDiagnosticKind` is `nil`
+    private var tokenDiagnosticKind: TokenDiagnostic.Kind?
+    private var tokenDiagnosticByteOffset: UInt16
 
-    init(tokenKind: RawTokenKind, tokenText: SyntaxText, triviaPieces: RawTriviaPieceBuffer, numLeadingTrivia: UInt32, byteLength: UInt32, presence: SourcePresence, lexerError: LexerError?) {
+    init(tokenKind: RawTokenKind, tokenText: SyntaxText, triviaPieces: RawTriviaPieceBuffer, numLeadingTrivia: UInt32, byteLength: UInt32, presence: SourcePresence, tokenDiagnostic: TokenDiagnostic?) {
       self.tokenKind = tokenKind
       self.tokenText = tokenText
       self.triviaPieces = triviaPieces
       self.numLeadingTrivia = numLeadingTrivia
       self.byteLength = byteLength
       self.presence = presence
-      self.lexerErrorKind = lexerError?.kind
-      self.lexerErrorByteOffset = lexerError?.byteOffset ?? 0
+      self.tokenDiagnosticKind = tokenDiagnostic?.kind
+      self.tokenDiagnosticByteOffset = tokenDiagnostic?.byteOffset ?? 0
     }
 
-    var lexerError: LexerError? {
+    var tokenDiagnostic: TokenDiagnostic? {
       get {
-        if let kind = lexerErrorKind {
-          return LexerError(kind, byteOffset: lexerErrorByteOffset)
+        if let kind = tokenDiagnosticKind {
+          return TokenDiagnostic(kind, byteOffset: tokenDiagnosticByteOffset)
         } else {
           return nil
         }
       }
       set {
         if let newValue = newValue {
-          self.lexerErrorKind = newValue.kind
-          self.lexerErrorByteOffset = newValue.byteOffset
+          self.tokenDiagnosticKind = newValue.kind
+          self.tokenDiagnosticByteOffset = newValue.byteOffset
         } else {
-          self.lexerErrorKind = nil
-          self.lexerErrorByteOffset = 0
+          self.tokenDiagnosticKind = nil
+          self.tokenDiagnosticByteOffset = 0
         }
       }
     }
@@ -236,7 +236,7 @@ extension RawSyntax {
       if tokenView.presence == .missing {
         recursiveFlags.insert(.hasError)
       }
-      switch tokenView.lexerError?.severity {
+      switch tokenView.tokenDiagnostic?.severity {
       case .error:
         recursiveFlags.insert(.hasError)
       case .warning:
@@ -301,7 +301,7 @@ extension RawSyntax {
         leadingTrivia: leadingTrivia,
         trailingTrivia: tokenView.formTrailingTrivia(),
         presence: tokenView.presence,
-        lexerError: tokenView.lexerError,
+        tokenDiagnostic: tokenView.tokenDiagnostic,
         arena: arena
       )
     case .layout(let layoutView):
@@ -327,7 +327,7 @@ extension RawSyntax {
         leadingTrivia: tokenView.formLeadingTrivia(),
         trailingTrivia: trailingTrivia,
         presence: tokenView.presence,
-        lexerError: tokenView.lexerError,
+        tokenDiagnostic: tokenView.tokenDiagnostic,
         arena: arena
       )
     case .layout(let layoutView):
@@ -533,7 +533,7 @@ extension RawSyntax {
     wholeText: SyntaxText,
     textRange: Range<SyntaxText.Index>,
     presence: SourcePresence,
-    lexerError: LexerError?,
+    tokenDiagnostic: TokenDiagnostic?,
     arena: __shared SyntaxArena
   ) -> RawSyntax {
     assert(
@@ -549,7 +549,7 @@ extension RawSyntax {
       wholeText: wholeText,
       textRange: textRange,
       presence: presence,
-      lexerError: lexerError
+      tokenDiagnostic: tokenDiagnostic
     )
     return RawSyntax(arena: arena, payload: .parsedToken(payload))
   }
@@ -575,7 +575,7 @@ extension RawSyntax {
     numLeadingTrivia: UInt32,
     byteLength: UInt32,
     presence: SourcePresence,
-    lexerError: LexerError?,
+    tokenDiagnostic: TokenDiagnostic?,
     arena: __shared SyntaxArena
   ) -> RawSyntax {
     let payload = RawSyntaxData.MaterializedToken(
@@ -585,7 +585,7 @@ extension RawSyntax {
       numLeadingTrivia: numLeadingTrivia,
       byteLength: byteLength,
       presence: presence,
-      lexerError: lexerError
+      tokenDiagnostic: tokenDiagnostic
     )
     return RawSyntax(arena: arena, payload: .materializedToken(payload))
   }
@@ -607,7 +607,7 @@ extension RawSyntax {
     leadingTriviaPieceCount: Int,
     trailingTriviaPieceCount: Int,
     presence: SourcePresence,
-    lexerError: LexerError?,
+    tokenDiagnostic: TokenDiagnostic?,
     arena: __shared SyntaxArena,
     initializingLeadingTriviaWith: (UnsafeMutableBufferPointer<RawTriviaPiece>) -> Void,
     initializingTrailingTriviaWith: (UnsafeMutableBufferPointer<RawTriviaPiece>) -> Void
@@ -630,7 +630,7 @@ extension RawSyntax {
       numLeadingTrivia: numericCast(leadingTriviaPieceCount),
       byteLength: numericCast(byteLength),
       presence: presence,
-      lexerError: lexerError,
+      tokenDiagnostic: tokenDiagnostic,
       arena: arena
     )
   }
@@ -648,7 +648,7 @@ extension RawSyntax {
     leadingTrivia: Trivia,
     trailingTrivia: Trivia,
     presence: SourcePresence,
-    lexerError: LexerError?,
+    tokenDiagnostic: TokenDiagnostic?,
     arena: __shared SyntaxArena
   ) -> RawSyntax {
     let decomposed = kind.decomposeToRaw()
@@ -661,7 +661,7 @@ extension RawSyntax {
       leadingTriviaPieceCount: leadingTrivia.count,
       trailingTriviaPieceCount: trailingTrivia.count,
       presence: presence,
-      lexerError: lexerError,
+      tokenDiagnostic: tokenDiagnostic,
       arena: arena,
       initializingLeadingTriviaWith: { buffer in
         guard var ptr = buffer.baseAddress else { return }
@@ -692,7 +692,7 @@ extension RawSyntax {
       numLeadingTrivia: 0,
       byteLength: 0,
       presence: .missing,
-      lexerError: nil,
+      tokenDiagnostic: nil,
       arena: arena
     )
   }

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -148,7 +148,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
     wholeText: SyntaxText,
     textRange: Range<SyntaxText.Index>,
     presence: SourcePresence,
-    lexerError: LexerError?,
+    tokenDiagnostic: TokenDiagnostic?,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.parsedToken(
@@ -156,7 +156,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
       wholeText: wholeText,
       textRange: textRange,
       presence: presence,
-      lexerError: lexerError,
+      tokenDiagnostic: tokenDiagnostic,
       arena: arena
     )
     self = RawTokenSyntax(raw: raw)
@@ -170,7 +170,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
     leadingTriviaPieces: [RawTriviaPiece] = [],
     trailingTriviaPieces: [RawTriviaPiece] = [],
     presence: SourcePresence,
-    lexerError: LexerError? = nil,
+    tokenDiagnostic: TokenDiagnostic? = nil,
     arena: __shared SyntaxArena
   ) {
     if leadingTriviaPieces.isEmpty && trailingTriviaPieces.isEmpty {
@@ -180,7 +180,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
         wholeText: text,
         textRange: 0..<text.count,
         presence: presence,
-        lexerError: lexerError,
+        tokenDiagnostic: tokenDiagnostic,
         arena: arena
       )
     } else {
@@ -191,7 +191,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
         leadingTriviaPieces: leadingTriviaPieces,
         trailingTriviaPieces: trailingTriviaPieces,
         presence: presence,
-        lexerError: lexerError,
+        tokenDiagnostic: tokenDiagnostic,
         arena: arena
       )
     }
@@ -204,7 +204,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
     leadingTriviaPieces: [RawTriviaPiece],
     trailingTriviaPieces: [RawTriviaPiece],
     presence: SourcePresence,
-    lexerError: LexerError?,
+    tokenDiagnostic: TokenDiagnostic?,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeMaterializedToken(
@@ -213,7 +213,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
       leadingTriviaPieceCount: leadingTriviaPieces.count,
       trailingTriviaPieceCount: trailingTriviaPieces.count,
       presence: presence,
-      lexerError: lexerError,
+      tokenDiagnostic: tokenDiagnostic,
       arena: arena,
       initializingLeadingTriviaWith: { buffer in
         _ = buffer.initialize(from: leadingTriviaPieces)
@@ -245,7 +245,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
       leadingTriviaPieces: leadingTriviaPieces,
       trailingTriviaPieces: trailingTriviaPieces,
       presence: .missing,
-      lexerError: nil,
+      tokenDiagnostic: nil,
       arena: arena
     )
   }

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -182,7 +182,7 @@ public struct RawSyntaxTokenView {
         leadingTrivia: formLeadingTrivia(),
         trailingTrivia: formTrailingTrivia(),
         presence: presence,
-        lexerError: lexerError,
+        tokenDiagnostic: tokenDiagnostic,
         arena: arena
       )
     case .materializedToken(var payload):
@@ -241,28 +241,28 @@ public struct RawSyntaxTokenView {
   }
 
   @_spi(RawSyntax)
-  public var lexerError: LexerError? {
+  public var tokenDiagnostic: TokenDiagnostic? {
     switch raw.rawData.payload {
     case .parsedToken(let dat):
-      return dat.lexerError
+      return dat.tokenDiagnostic
     case .materializedToken(let dat):
-      return dat.lexerError
+      return dat.tokenDiagnostic
     case .layout(_):
-      preconditionFailure("'lexerError' is not available for non-token node")
+      preconditionFailure("'tokenDiagnostic' is not available for non-token node")
     }
   }
 
   @_spi(RawSyntax)
-  public func withLexerError(lexerError: LexerError?, arena: SyntaxArena) -> RawSyntax {
+  public func withTokenDiagnostic(tokenDiagnostic: TokenDiagnostic?, arena: SyntaxArena) -> RawSyntax {
     switch raw.rawData.payload {
     case .parsedToken(var dat):
-      dat.lexerError = lexerError
+      dat.tokenDiagnostic = tokenDiagnostic
       return RawSyntax(arena: arena, payload: .parsedToken(dat))
     case .materializedToken(var dat):
-      dat.lexerError = lexerError
+      dat.tokenDiagnostic = tokenDiagnostic
       return RawSyntax(arena: arena, payload: .materializedToken(dat))
     default:
-      preconditionFailure("'withLexerError' is not available for non-token node")
+      preconditionFailure("'withTokenDiagnostic' is not available for non-token node")
     }
   }
 }

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -281,13 +281,13 @@ public extension SyntaxProtocol {
   /// Whether the tree contained by this layout has any
   ///  - missing nodes or
   ///  - unexpected nodes or
-  ///  - tokens with a `LexerError` of severity `error`
+  ///  - tokens with a `TokenDiagnostic` of severity `error`
   var hasError: Bool {
     return raw.recursiveFlags.contains(.hasError)
   }
 
-  /// Whether the tree contained by this layout has any tokens with a `LexerError`
-  /// of severity `warning`.
+  /// Whether the tree contained by this layout has any tokens with a
+  /// `TokenDiagnostic` of severity `warning`.
   var hasWarning: Bool {
     return raw.recursiveFlags.contains(.hasWarning)
   }

--- a/Sources/SwiftSyntax/SyntaxOtherNodes.swift
+++ b/Sources/SwiftSyntax/SyntaxOtherNodes.swift
@@ -46,7 +46,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
         leadingTrivia: leadingTrivia,
         trailingTrivia: trailingTrivia,
         presence: presence,
-        lexerError: nil,
+        tokenDiagnostic: nil,
         arena: arena
       )
       return SyntaxData.forRoot(raw)
@@ -139,8 +139,8 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   }
 
   /// If the token has a lexical error, the type of the error.
-  public var lexerError: LexerError? {
-    return tokenView.lexerError
+  public var tokenDiagnostic: TokenDiagnostic? {
+    return tokenView.tokenDiagnostic
   }
 }
 

--- a/Sources/SwiftSyntax/TokenDiagnostic.swift
+++ b/Sources/SwiftSyntax/TokenDiagnostic.swift
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// If the token has a lexical error, this defines the type of the error.
-/// `lexerErrorOffset` in the token will specify at which offset the error
-/// occurred.
-public struct LexerError: Hashable {
+/// If the token has an error that's inherent to the token itself and not its
+/// surrounding structure, this defines the type of the error.
+/// `byteOffset` specifies at which offset the error occurred.
+public struct TokenDiagnostic: Hashable {
   public enum Severity {
     case error
     case warning
@@ -40,7 +40,7 @@ public struct LexerError: Hashable {
     case invalidOctalDigitInIntegerLiteral
     case invalidUtf8
     /// The lexer dicovered an error but was not able to represent the offset of the error because it would overflow `LexerErrorOffset`.
-    case lexerErrorOffsetOverflow
+    case tokenDiagnosticOffsetOverflow
     case nonBreakingSpace
     case nulCharacter
     case sourceConflictMarker
@@ -64,7 +64,7 @@ public struct LexerError: Hashable {
     assert(byteOffset >= 0)
     // `type(of: self.byteOffset).max` gets optimized to a constant
     if byteOffset > type(of: self.byteOffset).max {
-      self.kind = .lexerErrorOffsetOverflow
+      self.kind = .tokenDiagnosticOffsetOverflow
       self.byteOffset = 0
     } else {
       self.kind = kind
@@ -91,7 +91,7 @@ public struct LexerError: Hashable {
     case .invalidNumberOfHexDigitsInUnicodeEscape: return .error
     case .invalidOctalDigitInIntegerLiteral: return .error
     case .invalidUtf8: return .error
-    case .lexerErrorOffsetOverflow: return .error
+    case .tokenDiagnosticOffsetOverflow: return .error
     case .nonBreakingSpace: return .warning
     case .nulCharacter: return .warning
     case .sourceConflictMarker: return .error

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -25,7 +25,7 @@ struct LexemeSpec {
   let tokenText: SyntaxText
   let trailingTrivia: SyntaxText
   let errorLocationMarker: String
-  let error: String?
+  let diagnostic: String?
   let flags: Lexer.Lexeme.Flags
 
   /// The file and line at which this `LexemeSpec` was created, so that assertion failures can be reported at its location.
@@ -38,7 +38,7 @@ struct LexemeSpec {
     text: SyntaxText,
     trailing: SyntaxText = "",
     errorLocationMarker: String = "1️⃣",
-    error: String? = nil,
+    diagnostic: String? = nil,
     flags: Lexer.Lexeme.Flags = [],
     file: StaticString = #file,
     line: UInt = #line
@@ -48,7 +48,7 @@ struct LexemeSpec {
     self.tokenText = text
     self.trailingTrivia = trailing
     self.errorLocationMarker = errorLocationMarker
-    self.error = error
+    self.diagnostic = diagnostic
     self.flags = flags
     self.file = file
     self.line = line
@@ -127,7 +127,7 @@ private func AssertTokens(
       )
     }
 
-    switch (actualLexeme.error, expectedLexeme.error) {
+    switch (actualLexeme.diagnostic, expectedLexeme.diagnostic) {
     case (nil, nil): break
     case (nil, .some):
       XCTFail(

--- a/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
@@ -130,7 +130,7 @@ final class RawSyntaxTests: XCTestCase {
         wholeText: arena.intern("\nfoo "),
         textRange: 1..<4,
         presence: .present,
-        lexerError: nil,
+        tokenDiagnostic: nil,
         arena: arena
       )
 

--- a/utils/group.json
+++ b/utils/group.json
@@ -52,7 +52,7 @@
   ],
   "Parse": [
     "IncrementalParseTransition.swift",
-    "LexerError.swift",
+    "TokenDiagnostic.swift",
   ],
   "Internal": [
     "SyntaxArena.swift",


### PR DESCRIPTION
`LexerError` has been the wrong name for this for two reasons:
- It could also contain warnings generated by the lexer
- It also contained errors about insufficient indentation that weren’t generated by the lexer

`TokenDiagnostic` is the best name I have found to describe what this is doing.