### PR TITLE
Remove trailing whitespace in multi-line string literals of tests

### DIFF
--- a/Tests/SwiftParserTest/translated/AsyncTests.swift
+++ b/Tests/SwiftParserTest/translated/AsyncTests.swift
@@ -112,7 +112,7 @@ final class AsyncTests: XCTestCase {
           get {
             return 0
           }
-          set async { 
+          set async {
           }
         }
       }

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
@@ -61,7 +61,7 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery5a() {
     AssertParse(
       """
-      if !1️⃣#available(OSX 10.52, *) { 
+      if !1️⃣#available(OSX 10.52, *) {
       }
       """,
       diagnostics: [
@@ -89,7 +89,7 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery6() {
     AssertParse(
       """
-      if #available(OSX 10.51, *) 1️⃣&& #available(OSX 10.52, *) { 
+      if #available(OSX 10.51, *) 1️⃣&& #available(OSX 10.52, *) {
       }
       """,
       diagnostics: [
@@ -105,7 +105,7 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery7() {
     AssertParse(
       """
-      if #available 1️⃣{ 
+      if #available 1️⃣{
       }
       """,
       diagnostics: [
@@ -160,7 +160,7 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery11() {
     AssertParse(
       """
-      if #available(OSX) { 
+      if #available(OSX) {
       }
       """,
       diagnostics: [
@@ -190,7 +190,7 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery13() {
     AssertParse(
       """
-      if #available(iDishwasherOS 10.51) { 
+      if #available(iDishwasherOS 10.51) {
       }
       """
     )
@@ -199,7 +199,7 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery14() {
     AssertParse(
       """
-      if #available(iDishwasherOS 10.51, *) { 
+      if #available(iDishwasherOS 10.51, *) {
       }
       """
     )
@@ -208,7 +208,7 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery15() {
     AssertParse(
       """
-      if #available(macos 10.51, *) { 
+      if #available(macos 10.51, *) {
       }
       """
     )
@@ -217,7 +217,7 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery16() {
     AssertParse(
       """
-      if #available(mscos 10.51, *) { 
+      if #available(mscos 10.51, *) {
       }
       """
     )
@@ -226,7 +226,7 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery17() {
     AssertParse(
       """
-      if #available(macoss 10.51, *) { 
+      if #available(macoss 10.51, *) {
       }
       """
     )
@@ -235,7 +235,7 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery18() {
     AssertParse(
       """
-      if #available(mac 10.51, *) { 
+      if #available(mac 10.51, *) {
       }
       """
     )
@@ -244,7 +244,7 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery19() {
     AssertParse(
       """
-      if #available(OSX 10.51, OSX 10.52, *) {  
+      if #available(OSX 10.51, OSX 10.52, *) {
       }
       """
     )
@@ -367,7 +367,7 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery30() {
     AssertParse(
       """
-      if #available(OSX 10.51, iOS 8.0, iDishwasherOS 10.51) { 
+      if #available(OSX 10.51, iOS 8.0, iDishwasherOS 10.51) {
       }
       """
     )
@@ -376,7 +376,7 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery31() {
     AssertParse(
       """
-      if #available(iDishwasherOS 10.51, OSX 10.51) { 
+      if #available(iDishwasherOS 10.51, OSX 10.51) {
       }
       """
     )
@@ -409,7 +409,7 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery34() {
     AssertParse(
       """
-      if #available(OSX 1️⃣>= 10.51, *) { 
+      if #available(OSX 1️⃣>= 10.51, *) {
       }
       """,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -29,7 +29,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
     AssertParse(
       """
       // Disallow explicit wildcards.
-      if #unavailable(OSX 10.51, *) {} 
+      if #unavailable(OSX 10.51, *) {}
       // Disallow use as an expression.
       if (1️⃣#unavailable(OSX 10.51)) {}
       let x = 2️⃣#unavailable(OSX 10.51)
@@ -74,7 +74,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability3() {
     AssertParse(
       """
-      if #unavailable(OSX 10.51) 1️⃣&& #unavailable(OSX 10.52) { 
+      if #unavailable(OSX 10.51) 1️⃣&& #unavailable(OSX 10.52) {
       }
       """,
       diagnostics: [
@@ -141,7 +141,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability8() {
     AssertParse(
       """
-      if #unavailable(OSX) { 
+      if #unavailable(OSX) {
       }
       """,
       diagnostics: [
@@ -170,7 +170,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability10() {
     AssertParse(
       """
-      if #unavailable(iDishwasherOS 10.51) { 
+      if #unavailable(iDishwasherOS 10.51) {
       }
       """
     )
@@ -179,7 +179,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability11() {
     AssertParse(
       """
-      if #unavailable(iDishwasherOS 10.51) { 
+      if #unavailable(iDishwasherOS 10.51) {
       }
       """
     )
@@ -188,7 +188,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability12() {
     AssertParse(
       """
-      if #unavailable(macos 10.51) { 
+      if #unavailable(macos 10.51) {
       }
       """
     )
@@ -197,7 +197,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability13() {
     AssertParse(
       """
-      if #unavailable(mscos 10.51) { 
+      if #unavailable(mscos 10.51) {
       }
       """
     )
@@ -206,7 +206,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability14() {
     AssertParse(
       """
-      if #unavailable(macoss 10.51) { 
+      if #unavailable(macoss 10.51) {
       }
       """
     )
@@ -215,7 +215,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability15() {
     AssertParse(
       """
-      if #unavailable(mac 10.51) { 
+      if #unavailable(mac 10.51) {
       }
       """
     )
@@ -224,7 +224,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability16() {
     AssertParse(
       """
-      if #unavailable(OSX 10.51, OSX 10.52) {  
+      if #unavailable(OSX 10.51, OSX 10.52) {
       }
       """
     )
@@ -233,7 +233,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability17() {
     AssertParse(
       """
-      if #unavailable(OSX 10.51, iOS 8.0, *) { }  
+      if #unavailable(OSX 10.51, iOS 8.0, *) { }
       if #unavailable(iOS 8.0) {
       }
       """
@@ -335,7 +335,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability25() {
     AssertParse(
       """
-      if #unavailable(OSX 10.51, iOS 8.0, iDishwasherOS 10.51) { 
+      if #unavailable(OSX 10.51, iOS 8.0, iDishwasherOS 10.51) {
       }
       """
     )
@@ -344,7 +344,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability26() {
     AssertParse(
       """
-      if #unavailable(iDishwasherOS 10.51, OSX 10.51) { 
+      if #unavailable(iDishwasherOS 10.51, OSX 10.51) {
       }
       """,
       diagnostics: [
@@ -369,7 +369,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
     AssertParse(
       """
       // Emit Fix-It removing un-needed >=, for the moment.
-      if #unavailable(OSX 1️⃣>= 10.51) { 
+      if #unavailable(OSX 1️⃣>= 10.51) {
       }
       """,
       diagnostics: [
@@ -412,17 +412,17 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
     AssertParse(
       """
       // Prevent availability and unavailability being present in the same statement.
-      if #unavailable(macOS 10.51), #available(macOS 10.52, *) { 
+      if #unavailable(macOS 10.51), #available(macOS 10.52, *) {
       }
-      if #available(macOS 10.51, *), #unavailable(macOS 10.52) { 
+      if #available(macOS 10.51, *), #unavailable(macOS 10.52) {
       }
-      if #available(macOS 10.51, *), #available(macOS 10.55, *), #unavailable(macOS 10.53) { 
+      if #available(macOS 10.51, *), #available(macOS 10.55, *), #unavailable(macOS 10.53) {
       }
-      if #unavailable(macOS 10.51), #unavailable(macOS 10.55), #available(macOS 10.53, *) { 
+      if #unavailable(macOS 10.51), #unavailable(macOS 10.55), #available(macOS 10.53, *) {
       }
-      if case 42 = 42, #available(macOS 10.51, *), #unavailable(macOS 10.52) { 
+      if case 42 = 42, #available(macOS 10.51, *), #unavailable(macOS 10.52) {
       }
-      if #available(macOS 10.51, *), case 42 = 42, #unavailable(macOS 10.52) { 
+      if #available(macOS 10.51, *), case 42 = 42, #unavailable(macOS 10.52) {
       }
       """,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/BuiltinWordTests.swift
+++ b/Tests/SwiftParserTest/translated/BuiltinWordTests.swift
@@ -49,7 +49,7 @@ final class BuiltinWordTests: XCTestCase {
       """
       word = Builtin.truncOrBitCast_Int128_Word(i128)
       word = Builtin.truncOrBitCast_Int64_Word(i64)
-      word = Builtin.truncOrBitCast_Int32_Word(i32) 
+      word = Builtin.truncOrBitCast_Int32_Word(i32)
       word = Builtin.truncOrBitCast_Int16_Word(i16)
       """
     )
@@ -60,7 +60,7 @@ final class BuiltinWordTests: XCTestCase {
       """
       i16 = Builtin.truncOrBitCast_Word_Int16(word)
       i32 = Builtin.truncOrBitCast_Word_Int32(word)
-      i64 = Builtin.truncOrBitCast_Word_Int64(word) 
+      i64 = Builtin.truncOrBitCast_Word_Int64(word)
       i128 = Builtin.truncOrBitCast_Word_Int128(word)
       """
     )
@@ -69,8 +69,8 @@ final class BuiltinWordTests: XCTestCase {
   func testBuiltinWord6() {
     AssertParse(
       """
-      word = Builtin.zextOrBitCast_Int128_Word(i128) 
-      word = Builtin.zextOrBitCast_Int64_Word(i64) 
+      word = Builtin.zextOrBitCast_Int128_Word(i128)
+      word = Builtin.zextOrBitCast_Int64_Word(i64)
       word = Builtin.zextOrBitCast_Int32_Word(i32)
       word = Builtin.zextOrBitCast_Int16_Word(i16)
       """
@@ -80,8 +80,8 @@ final class BuiltinWordTests: XCTestCase {
   func testBuiltinWord7() {
     AssertParse(
       """
-      i16 = Builtin.zextOrBitCast_Word_Int16(word) 
-      i32 = Builtin.zextOrBitCast_Word_Int32(word) 
+      i16 = Builtin.zextOrBitCast_Word_Int16(word)
+      i32 = Builtin.zextOrBitCast_Word_Int32(word)
       i64 = Builtin.zextOrBitCast_Word_Int64(word)
       i128 = Builtin.zextOrBitCast_Word_Int128(word)
       """
@@ -92,8 +92,8 @@ final class BuiltinWordTests: XCTestCase {
     AssertParse(
       """
       word = Builtin.trunc_Int128_Word(i128)
-      word = Builtin.trunc_Int64_Word(i64) 
-      word = Builtin.trunc_Int32_Word(i32) 
+      word = Builtin.trunc_Int64_Word(i64)
+      word = Builtin.trunc_Int32_Word(i32)
       word = Builtin.trunc_Int16_Word(i16)
       """
     )
@@ -103,8 +103,8 @@ final class BuiltinWordTests: XCTestCase {
     AssertParse(
       """
       i16 = Builtin.trunc_Word_Int16(word)
-      i32 = Builtin.trunc_Word_Int32(word) 
-      i64 = Builtin.trunc_Word_Int64(word) 
+      i32 = Builtin.trunc_Word_Int32(word)
+      i64 = Builtin.trunc_Word_Int64(word)
       i128 = Builtin.trunc_Word_Int128(word)
       """
     )
@@ -113,9 +113,9 @@ final class BuiltinWordTests: XCTestCase {
   func testBuiltinWord10() {
     AssertParse(
       """
-      word = Builtin.zext_Int128_Word(i128) 
-      word = Builtin.zext_Int64_Word(i64) 
-      word = Builtin.zext_Int32_Word(i32) 
+      word = Builtin.zext_Int128_Word(i128)
+      word = Builtin.zext_Int64_Word(i64)
+      word = Builtin.zext_Int32_Word(i32)
       word = Builtin.zext_Int16_Word(i16)
       """
     )
@@ -124,9 +124,9 @@ final class BuiltinWordTests: XCTestCase {
   func testBuiltinWord11() {
     AssertParse(
       """
-      i16 = Builtin.zext_Word_Int16(word) 
-      i32 = Builtin.zext_Word_Int32(word) 
-      i64 = Builtin.zext_Word_Int64(word) 
+      i16 = Builtin.zext_Word_Int16(word)
+      i32 = Builtin.zext_Word_Int32(word)
+      i64 = Builtin.zext_Word_Int64(word)
       i128 = Builtin.zext_Word_Int128(word)
       """
     )

--- a/Tests/SwiftParserTest/translated/ConflictMarkersTests.swift
+++ b/Tests/SwiftParserTest/translated/ConflictMarkersTests.swift
@@ -70,7 +70,7 @@ final class ConflictMarkersTests: XCTestCase {
   func testConflictMarkers7() {
     AssertParse(
       #"""
-      1️⃣<<<<<<< HEAD:conflict_markers.swift 
+      1️⃣<<<<<<< HEAD:conflict_markers.swift
       var a : String = "A"
       var b : String = "b"
       =======
@@ -88,8 +88,8 @@ final class ConflictMarkersTests: XCTestCase {
   func testConflictMarkers8() {
     AssertParse(
       #"""
-      1️⃣<<<<<<< HEAD:conflict_markers.swift 
-      ======= 
+      1️⃣<<<<<<< HEAD:conflict_markers.swift
+      =======
       var d : String = "D"
       >>>>>>> 18844bc65229786b96b89a9fc7739c0fc897905e:conflict_markers.swift
       print(d)
@@ -143,7 +143,7 @@ final class ConflictMarkersTests: XCTestCase {
       _ = {
       // Conflict marker.
       let a = "a", b = "b"
-      a 
+      a
       1️⃣<<<<<<< b
       a
       >>>>>>> b
@@ -171,7 +171,7 @@ final class ConflictMarkersTests: XCTestCase {
   func testConflictMarkers14() {
     AssertParse(
       #"""
-      1️⃣>>>> ORIGINAL 
+      1️⃣>>>> ORIGINAL
       var a : String = "A"
       var b : String = "B"
       ==== THEIRS
@@ -192,7 +192,7 @@ final class ConflictMarkersTests: XCTestCase {
   func testConflictMarkers15() {
     AssertParse(
       #"""
-      1️⃣>>>> ORIGINAL 
+      1️⃣>>>> ORIGINAL
       ==== THEIRS
       ==== YOURS
       var d : String = "D"

--- a/Tests/SwiftParserTest/translated/ConsecutiveStatementsTests.swift
+++ b/Tests/SwiftParserTest/translated/ConsecutiveStatementsTests.swift
@@ -33,13 +33,13 @@ final class ConsecutiveStatementsTests: XCTestCase {
         f = { (x : Int) -> () in }
         f(0)
         f (0)
-        f 
-        (0) 
+        f
+        (0)
         var a = [1,2,3]
         a[0] = 1
         a [0] = 1
-        a 
-        [0, 1, 2] 
+        a
+        [0, 1, 2]
       }
       """
     )

--- a/Tests/SwiftParserTest/translated/DelayedExtensionTests.swift
+++ b/Tests/SwiftParserTest/translated/DelayedExtensionTests.swift
@@ -18,7 +18,7 @@ final class DelayedExtensionTests: XCTestCase {
   func testDelayedExtension1() {
     AssertParse(
       """
-      extension X { } 
+      extension X { }
       _ = 1
       f()
       """

--- a/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
+++ b/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
@@ -40,7 +40,7 @@ final class DeprecatedWhereTests: XCTestCase {
       // 1: Inherited constraint
       func f2<T: Mashable>(x: T) {} // no-warning
       // 2: Non-trailing where
-      func f3<T where T: Womparable>(x: T) {} 
+      func f3<T where T: Womparable>(x: T) {}
       // 3: Has return type
       func f4<T>(x: T) -> Int { return 2 } // no-warning
       // 4: Trailing where
@@ -57,15 +57,15 @@ final class DeprecatedWhereTests: XCTestCase {
       """
       // FuncDecl: Choose 2
       // 1,2
-      func f12<T: Mashable where T: Womparable>(x: T) {} 
+      func f12<T: Mashable where T: Womparable>(x: T) {}
       // 1,3
       func f13<T: Mashable>(x: T) -> Int { return 2 } // no-warning
       // 1,4
       func f14<T: Mashable>(x: T) where T: Equatable {} // no-warning
       // 2,3
-      func f23<T where T: Womparable>(x: T) -> Int { return 2 } 
+      func f23<T where T: Womparable>(x: T) -> Int { return 2 }
       // 2,4
-      func f24<T where T: Womparable>(x: T) where T: Equatable {} 
+      func f24<T where T: Womparable>(x: T) where T: Equatable {}
       // 3,4
       func f34<T>(x: T) -> Int where T: Equatable { return 2 } // no-warning
       """,
@@ -82,9 +82,9 @@ final class DeprecatedWhereTests: XCTestCase {
       """
       // FuncDecl: Choose 3
       // 1,2,3
-      func f123<T: Mashable where T: Womparable>(x: T) -> Int { return 2 } 
+      func f123<T: Mashable where T: Womparable>(x: T) -> Int { return 2 }
       // 1,2,4
-      func f124<T: Mashable where T: Womparable>(x: T) where T: Equatable {} 
+      func f124<T: Mashable where T: Womparable>(x: T) where T: Equatable {}
       // 2,3,4
       func f234<T where T: Womparable>(x: T) -> Int where T: Equatable { return 2 }
       """,
@@ -125,7 +125,7 @@ final class DeprecatedWhereTests: XCTestCase {
       // 1: Inherited constraint
       struct S1<T: Mashable> {} // no-warning
       // 2: Non-trailing where
-      struct S2<T where T: Womparable> {} 
+      struct S2<T where T: Womparable> {}
       // 3: Trailing where
       struct S3<T> where T : Equatable {} // no-warning
       """,
@@ -140,7 +140,7 @@ final class DeprecatedWhereTests: XCTestCase {
       """
       // NominalTypeDecl: Choose 2
       // 1,2
-      struct S12<T: Mashable where T: Womparable> {} 
+      struct S12<T: Mashable where T: Womparable> {}
       // 1,3
       struct S13<T: Mashable> where T: Equatable {} // no-warning
       // 2,3
@@ -173,7 +173,7 @@ final class DeprecatedWhereTests: XCTestCase {
       protocol ProtoB {}
       protocol ProtoC {}
       protocol ProtoD {}
-      func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) {} 
+      func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) {}
       func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) where T: ProtoD {}
       """,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/DiagnosticMissingFuncKeywordTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnosticMissingFuncKeywordTests.swift
@@ -267,7 +267,7 @@ final class DiagnosticMissingFuncKeywordTests: XCTestCase {
     AssertParse(
       """
       class C1 {
-        class classMethod1️⃣() {} 
+        class classMethod1️⃣() {}
       }
       """,
       diagnostics: [
@@ -280,7 +280,7 @@ final class DiagnosticMissingFuncKeywordTests: XCTestCase {
     AssertParse(
       """
       class C2 {
-        class classProperty: Int { 1️⃣0 } 
+        class classProperty: Int { 1️⃣0 }
       }
       """,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
+++ b/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
@@ -163,7 +163,7 @@ final class DollarIdentifierTests: XCTestCase {
       """
       func escapedDollarAnd() {
         // FIXME: Bad diagnostics.
-        1️⃣`$0` = 1 
+        1️⃣`$0` = 1
         `$$` = 2
         `$abc` = 3
       }
@@ -187,40 +187,40 @@ final class DollarIdentifierTests: XCTestCase {
   func testDollarIdentifier8() {
     AssertParse(
       """
-      func $declareWithDollar() { 
-        var $foo: Int { 
+      func $declareWithDollar() {
+        var $foo: Int {
           get { 0 }
-          set($value) {} 
+          set($value) {}
         }
-        func $bar() { } 
+        func $bar() { }
         func wibble(
-          $a: Int, 
-          $b c: Int) { } 
+          $a: Int,
+          $b c: Int) { }
         let _: (Int) -> Int = {
-          [$capture = 0] 
-          $a in 
+          [$capture = 0]
+          $a in
           $capture
         }
-        let ($a: _, _) = (0, 0) 
-        $label: if true { 
+        let ($a: _, _) = (0, 0)
+        $label: if true {
           break $label
         }
         switch 0 {
-        @$dollar case _: 
+        @$dollar case _:
           break
         }
-        if #available($Dummy 9999, *) {} 
+        if #available($Dummy 9999, *) {}
         @_swift_native_objc_runtime_base($Dollar)
-        class $Class {} 
-        enum $Enum {} 
-        struct $Struct { 
+        class $Class {}
+        enum $Enum {}
+        struct $Struct {
           @_projectedValueProperty($dummy)
           let property: Never
         }
       }
-      protocol $Protocol {} 
-      precedencegroup $Precedence { 
-        higherThan: $Precedence 
+      protocol $Protocol {}
+      precedencegroup $Precedence {
+        higherThan: $Precedence
       }
       infix operator **: $Precedence
       #$UnknownDirective()

--- a/Tests/SwiftParserTest/translated/EffectfulPropertiesTests.swift
+++ b/Tests/SwiftParserTest/translated/EffectfulPropertiesTests.swift
@@ -84,7 +84,7 @@ final class EffectfulPropertiesTests: XCTestCase {
       struct BadSubscript1 {
         subscript(_ i : Int) -> Int {
             get async throws {}
-            set {} 
+            set {}
           }
       }
       """,
@@ -117,7 +117,7 @@ final class EffectfulPropertiesTests: XCTestCase {
       struct S {
         var prop2 : Int {
           mutating get async throws { 0 }
-          nonmutating set {} 
+          nonmutating set {}
         }
       }
       """,
@@ -134,8 +134,8 @@ final class EffectfulPropertiesTests: XCTestCase {
         _read { yield prop3 }
         // expected-note@+1 2 {{previous definition of getter here}}
         get throws { false }
-        get async { true } 
-        get {} 
+        get async { true }
+        get {}
       }
       """,
       diagnostics: [
@@ -153,7 +153,7 @@ final class EffectfulPropertiesTests: XCTestCase {
       """
       enum E {
         private(set) var prop4 : Double {
-          set {} 
+          set {}
           get async throws { 1.1 }
           _modify { yield &prop4 }
         }
@@ -172,12 +172,12 @@ final class EffectfulPropertiesTests: XCTestCase {
       protocol P {
         associatedtype T
         var prop1 : T { get async throws }
-        var prop2 : T { get async throws set } 
-        var prop3 : T { get throws set } 
+        var prop2 : T { get async throws set }
+        var prop3 : T { get throws set }
         var prop4 : T { get async }
         var prop5 : T { mutating get async throws }
         var prop6 : T { mutating get throws }
-        var prop7 : T { mutating get async nonmutating set } 
+        var prop7 : T { mutating get async nonmutating set }
       }
       """,
       diagnostics: [
@@ -201,8 +201,8 @@ final class EffectfulPropertiesTests: XCTestCase {
     AssertParse(
       """
       var bad1 : Int {
-        get rethrows { 0 }  
-        set rethrows { }   
+        get rethrows { 0 }
+        set rethrows { }
       }
       """,
       diagnostics: [
@@ -217,7 +217,7 @@ final class EffectfulPropertiesTests: XCTestCase {
     AssertParse(
       """
       var bad2 : Int {
-        get reasync { 0 }  
+        get reasync { 0 }
         set reasync { }
       }
       """,
@@ -273,7 +273,7 @@ final class EffectfulPropertiesTests: XCTestCase {
     AssertParse(
       """
       var bad5 : Int {
-        get 1️⃣bogus rethrows {} 
+        get 1️⃣bogus rethrows {}
       }
       """,
       diagnostics: [
@@ -301,7 +301,7 @@ final class EffectfulPropertiesTests: XCTestCase {
     AssertParse(
       """
       var bad7 : Double {
-        get throws 1️⃣async { 3.14 } 
+        get throws 1️⃣async { 3.14 }
       }
       """,
       diagnostics: [
@@ -328,10 +328,10 @@ final class EffectfulPropertiesTests: XCTestCase {
     AssertParse(
       """
       protocol BadP {
-        var prop2 : Int { get 1️⃣bogus rethrows set } 
+        var prop2 : Int { get 1️⃣bogus rethrows set }
         var prop3 : Int { get rethrows 2️⃣bogus set }
         var prop4 : Int { get reasync 3️⃣bogus set }
-        var prop5 : Int { get throws 4️⃣async } 
+        var prop5 : Int { get throws 4️⃣async }
       }
       """,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/EnumElementPatternSwift4Tests.swift
+++ b/Tests/SwiftParserTest/translated/EnumElementPatternSwift4Tests.swift
@@ -32,9 +32,9 @@ final class EnumElementPatternSwift4Tests: XCTestCase {
         case A, B, C, D
         static func testE(e: E) {
           switch e {
-          case A<UndefinedTy>(): 
+          case A<UndefinedTy>():
             break
-          case B<Int>(): 
+          case B<Int>():
             break
           default:
             break;
@@ -50,21 +50,21 @@ final class EnumElementPatternSwift4Tests: XCTestCase {
       """
       func testE(e: E) {
         switch e {
-        case E.A<UndefinedTy>(): 
+        case E.A<UndefinedTy>():
           break
-        case E.B<Int>(): 
+        case E.B<Int>():
           break
-        case .C(): 
+        case .C():
           break
-        case .D(let payload): 
+        case .D(let payload):
           let _: () = payload
           break
         default:
           break
         }
         guard
-          case .C() = e, 
-          case .D(let payload) = e 
+          case .C() = e,
+          case .D(let payload) = e
         else { return }
       }
       """
@@ -87,9 +87,9 @@ final class EnumElementPatternSwift4Tests: XCTestCase {
       """
       do {
         try canThrow()
-      } catch E.A() { 
+      } catch E.A() {
         // ..
-      } catch E.B(let payload) { 
+      } catch E.B(let payload) {
         let _: () = payload
       }
       """

--- a/Tests/SwiftParserTest/translated/EnumTests.swift
+++ b/Tests/SwiftParserTest/translated/EnumTests.swift
@@ -125,7 +125,7 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       struct SomeStruct {
-        case StructCase 
+        case StructCase
       }
       """
     )
@@ -135,7 +135,7 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       class SomeClass {
-        case ClassCase 
+        case ClassCase
       }
       """
     )
@@ -148,7 +148,7 @@ final class EnumTests: XCTestCase {
         case A1
       }
       extension EnumWithExtension1 {
-        case A2 
+        case A2
       }
       """
     )
@@ -166,7 +166,7 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum EnumCaseAttributes {
-        @xyz case EmptyAttributes  
+        @xyz case EmptyAttributes
       }
       """
     )
@@ -327,7 +327,7 @@ final class EnumTests: XCTestCase {
       enum ImproperlyHasIVars {
         case Flopsy
         case Mopsy
-        var ivar : Int 
+        var ivar : Int
       }
       """
     )
@@ -339,7 +339,7 @@ final class EnumTests: XCTestCase {
       // We used to crash on this.  rdar://14678675
       enum rdar14678675 {
         case U1, 1️⃣
-        case U2 
+        case U2
         case U3
       }
       """,
@@ -353,7 +353,7 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum Recovery1 {
-        case1️⃣: 
+        case1️⃣:
       }
       """,
       diagnostics: [
@@ -457,7 +457,7 @@ final class EnumTests: XCTestCase {
   func testEnum24() {
     AssertParse(
       """
-      enum MultiRawType : Int64, Int32 { 
+      enum MultiRawType : Int64, Int32 {
         case Couch, Davis
       }
       """
@@ -468,7 +468,7 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       protocol RawTypeNotFirstProtocol {}
-      enum RawTypeNotFirst : RawTypeNotFirstProtocol, Int { 
+      enum RawTypeNotFirst : RawTypeNotFirstProtocol, Int {
         case E
       }
       """
@@ -478,7 +478,7 @@ final class EnumTests: XCTestCase {
   func testEnum26() {
     AssertParse(
       """
-      enum ExpressibleByRawTypeNotLiteral : Array<Int> { 
+      enum ExpressibleByRawTypeNotLiteral : Array<Int> {
         case Ladd, Elliott, Sixteenth, Harrison
       }
       """
@@ -488,7 +488,7 @@ final class EnumTests: XCTestCase {
   func testEnum27() {
     AssertParse(
       """
-      enum RawTypeCircularityA : RawTypeCircularityB, ExpressibleByIntegerLiteral { 
+      enum RawTypeCircularityA : RawTypeCircularityB, ExpressibleByIntegerLiteral {
         case Morrison, Belmont, Madison, Hawthorne
         init(integerLiteral value: Int) {
           self = .Morrison
@@ -501,9 +501,9 @@ final class EnumTests: XCTestCase {
   func testEnum28() {
     AssertParse(
       """
-      enum RawTypeCircularityB : RawTypeCircularityA, ExpressibleByIntegerLiteral { 
+      enum RawTypeCircularityB : RawTypeCircularityA, ExpressibleByIntegerLiteral {
         case Willamette, Columbia, Sandy, Multnomah
-        init(integerLiteral value: Int) { 
+        init(integerLiteral value: Int) {
           self = .Willamette
         }
       }
@@ -517,8 +517,8 @@ final class EnumTests: XCTestCase {
       struct ExpressibleByFloatLiteralOnly : ExpressibleByFloatLiteral {
           init(floatLiteral: Double) {}
       }
-      enum ExpressibleByRawTypeNotIntegerLiteral : ExpressibleByFloatLiteralOnly { 
-        case Everett 
+      enum ExpressibleByRawTypeNotIntegerLiteral : ExpressibleByFloatLiteralOnly {
+        case Everett
         case Flanders
       }
       """
@@ -549,9 +549,9 @@ final class EnumTests: XCTestCase {
   func testEnum32() {
     AssertParse(
       #"""
-      enum RawTypeWithUnicodeScalarValues : UnicodeScalar { 
+      enum RawTypeWithUnicodeScalarValues : UnicodeScalar {
         case Kearney = "K"
-        case Lovejoy 
+        case Lovejoy
         case Marshall = "M"
       }
       """#
@@ -561,9 +561,9 @@ final class EnumTests: XCTestCase {
   func testEnum33() {
     AssertParse(
       #"""
-      enum RawTypeWithCharacterValues : Character { 
+      enum RawTypeWithCharacterValues : Character {
         case First = "い"
-        case Second 
+        case Second
         case Third = "は"
       }
       """#
@@ -586,8 +586,8 @@ final class EnumTests: XCTestCase {
   func testEnum35() {
     AssertParse(
       #"""
-      enum RawTypeWithCharacterValues_Error1 : Character { 
-        case First = "abc" 
+      enum RawTypeWithCharacterValues_Error1 : Character {
+        case First = "abc"
       }
       """#
     )
@@ -596,9 +596,9 @@ final class EnumTests: XCTestCase {
   func testEnum36() {
     AssertParse(
       """
-      enum RawTypeWithFloatValues : Float { 
+      enum RawTypeWithFloatValues : Float {
         case Northrup = 1.5
-        case Overton 
+        case Overton
         case Pettygrove = 2.25
       }
       """
@@ -622,7 +622,7 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum RawValuesWithoutRawType {
-        case Upshur = 22 
+        case Upshur = 22
       }
       """
     )
@@ -632,8 +632,8 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum RawTypeWithRepeatValues : Int {
-        case Vaughn = 22 
-        case Wilson = 22 
+        case Vaughn = 22
+        case Wilson = 22
       }
       """
     )
@@ -643,8 +643,8 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum RawTypeWithRepeatValues2 : Double {
-        case Vaughn = 22   
-        case Wilson = 22.0 
+        case Vaughn = 22
+        case Wilson = 22.0
       }
       """
     )
@@ -655,8 +655,8 @@ final class EnumTests: XCTestCase {
       """
       enum RawTypeWithRepeatValues3 : Double {
         // 2^63-1
-        case Vaughn = 9223372036854775807   
-        case Wilson = 9223372036854775807.0 
+        case Vaughn = 9223372036854775807
+        case Wilson = 9223372036854775807.0
       }
       """
     )
@@ -667,8 +667,8 @@ final class EnumTests: XCTestCase {
       """
       enum RawTypeWithRepeatValues4 : Double {
         // 2^64-1
-        case Vaughn = 18446744073709551615   
-        case Wilson = 18446744073709551615.0 
+        case Vaughn = 18446744073709551615
+        case Wilson = 18446744073709551615.0
       }
       """
     )
@@ -717,8 +717,8 @@ final class EnumTests: XCTestCase {
     AssertParse(
       #"""
       enum RawTypeWithRepeatValues8 : String {
-        case Vaughn = "XYZ" 
-        case Wilson = "XYZ" 
+        case Vaughn = "XYZ"
+        case Wilson = "XYZ"
       }
       """#
     )
@@ -741,9 +741,9 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum RawTypeWithRepeatValuesAutoInc : Double {
-        case Vaughn = 22 
-        case Wilson    
-        case Yeon = 23 
+        case Vaughn = 22
+        case Wilson
+        case Yeon = 23
       }
       """
     )
@@ -753,9 +753,9 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum RawTypeWithRepeatValuesAutoInc2 : Double {
-        case Vaughn = 23 
-        case Wilson = 22 
-        case Yeon 
+        case Vaughn = 23
+        case Wilson = 22
+        case Yeon
       }
       """
     )
@@ -765,9 +765,9 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum RawTypeWithRepeatValuesAutoInc3 : Double {
-        case Vaughn 
-        case Wilson 
-        case Yeon = 1 
+        case Vaughn
+        case Wilson
+        case Yeon = 1
       }
       """
     )
@@ -777,8 +777,8 @@ final class EnumTests: XCTestCase {
     AssertParse(
       #"""
       enum RawTypeWithRepeatValuesAutoInc4 : String {
-        case A = "B" 
-        case B 
+        case A = "B"
+        case B
       }
       """#
     )
@@ -788,8 +788,8 @@ final class EnumTests: XCTestCase {
     AssertParse(
       #"""
       enum RawTypeWithRepeatValuesAutoInc5 : String {
-        case A 
-        case B = "A" 
+        case A
+        case B = "A"
       }
       """#
     )
@@ -800,8 +800,8 @@ final class EnumTests: XCTestCase {
       #"""
       enum RawTypeWithRepeatValuesAutoInc6 : String {
         case A
-        case B 
-        case C = "B" 
+        case B
+        case C = "B"
       }
       """#
     )
@@ -811,7 +811,7 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum NonliteralRawValue : Int {
-        case Yeon = 100 + 20 + 3 
+        case Yeon = 100 + 20 + 3
       }
       """
     )
@@ -820,9 +820,9 @@ final class EnumTests: XCTestCase {
   func testEnum55() {
     AssertParse(
       """
-      enum RawTypeWithPayload : Int { 
-        case Powell(Int) 
-        case Terwilliger(Int) = 17 
+      enum RawTypeWithPayload : Int {
+        case Powell(Int)
+        case Terwilliger(Int) = 17
       }
       """
     )
@@ -831,8 +831,8 @@ final class EnumTests: XCTestCase {
   func testEnum56() {
     AssertParse(
       #"""
-      enum RawTypeMismatch : Int { 
-        case Barbur = "foo" 
+      enum RawTypeMismatch : Int {
+        case Barbur = "foo"
       }
       """#
     )
@@ -842,8 +842,8 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum DuplicateMembers1 {
-        case Foo 
-        case Foo 
+        case Foo
+        case Foo
       }
       """
     )
@@ -853,9 +853,9 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum DuplicateMembers2 {
-        case Foo, Bar 
-        case Foo 
-        case Bar 
+        case Foo, Bar
+        case Foo
+        case Bar
       }
       """
     )
@@ -865,8 +865,8 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum DuplicateMembers3 {
-        case Foo 
-        case Foo(Int) 
+        case Foo
+        case Foo(Int)
       }
       """
     )
@@ -875,9 +875,9 @@ final class EnumTests: XCTestCase {
   func testEnum60() {
     AssertParse(
       """
-      enum DuplicateMembers4 : Int { 
-        case Foo = 1 
-        case Foo = 2 
+      enum DuplicateMembers4 : Int {
+        case Foo = 1
+        case Foo = 2
       }
       """
     )
@@ -886,9 +886,9 @@ final class EnumTests: XCTestCase {
   func testEnum61() {
     AssertParse(
       """
-      enum DuplicateMembers5 : Int { 
-        case Foo = 1 
-        case Foo = 1 + 1 
+      enum DuplicateMembers5 : Int {
+        case Foo = 1
+        case Foo = 1 + 1
       }
       """
     )
@@ -899,8 +899,8 @@ final class EnumTests: XCTestCase {
       """
       enum DuplicateMembers6 {
         case Foo // expected-note 2{{'Foo' previously declared here}}
-        case Foo 
-        case Foo 
+        case Foo
+        case Foo
       }
       """
     )
@@ -909,9 +909,9 @@ final class EnumTests: XCTestCase {
   func testEnum63() {
     AssertParse(
       #"""
-      enum DuplicateMembers7 : String { 
-        case Foo 
-        case Foo = "Bar" 
+      enum DuplicateMembers7 : String {
+        case Foo
+        case Foo = "Bar"
       }
       """#
     )
@@ -923,7 +923,7 @@ final class EnumTests: XCTestCase {
       // Refs to duplicated enum cases shouldn't crash the compiler.
       // rdar://problem/20922401
       func check20922401() -> String {
-        let x: DuplicateMembers1 = .Foo 
+        let x: DuplicateMembers1 = .Foo
         switch x {
           case .Foo:
             return "Foo"
@@ -979,8 +979,8 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum ManyLiteralA : ManyLiteralable {
-        case A 
-        case B = 0 
+        case A
+        case B = 0
       }
       """
     )
@@ -989,9 +989,9 @@ final class EnumTests: XCTestCase {
   func testEnum68() {
     AssertParse(
       #"""
-      enum ManyLiteralB : ManyLiteralable { 
+      enum ManyLiteralB : ManyLiteralable {
         case A = "abc"
-        case B 
+        case B
       }
       """#
     )
@@ -1054,8 +1054,8 @@ final class EnumTests: XCTestCase {
   func testEnum74() {
     AssertParse(
       """
-      enum foo : String { 
-        case bar = nil 
+      enum foo : String {
+        case bar = nil
       }
       """
     )
@@ -1083,7 +1083,7 @@ final class EnumTests: XCTestCase {
       enum EnumWithStaticMember {
         static let staticVar = EmptyStruct()
         func foo() {
-          let _ = staticVar 
+          let _ = staticVar
         }
       }
       """
@@ -1119,8 +1119,8 @@ final class EnumTests: XCTestCase {
           _ = SE0036.A
         }
         func staticReferenceInInstanceMethod() {
-          _ = A 
-          _ = self.A 
+          _ = A
+          _ = self.A
           _ = SE0036.A
         }
         static func staticReferenceInSwitchInStaticMethod() {
@@ -1132,9 +1132,9 @@ final class EnumTests: XCTestCase {
         }
         func staticReferenceInSwitchInInstanceMethod() {
           switch self {
-          case A: break 
-          case B(_): break 
-          case C(let x): _ = x; break 
+          case A: break
+          case B(_): break
+          case C(let x): _ = x; break
           }
         }
         func explicitReferenceInSwitch() {
@@ -1160,10 +1160,10 @@ final class EnumTests: XCTestCase {
         }
         init() {
           self = .A
-          self = A 
+          self = A
           self = SE0036.A
           self = .B(SE0036_Auxiliary())
-          self = B(SE0036_Auxiliary()) 
+          self = B(SE0036_Auxiliary())
           self = SE0036.B(SE0036_Auxiliary())
         }
       }
@@ -1178,7 +1178,7 @@ final class EnumTests: XCTestCase {
         case A(x: T)
         func foo() {
           switch self {
-          case A(_): break 
+          case A(_): break
           }
           switch self {
           case .A(let a): print(a)
@@ -1217,7 +1217,7 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum SE0155 {
-        case emptyArgs() 
+        case emptyArgs()
       }
       """
     )
@@ -1236,7 +1236,7 @@ final class EnumTests: XCTestCase {
       """
       enum E_53662 {
         case identifier
-        case 1️⃣operator 
+        case 1️⃣operator
         case identifier2
       }
       """,
@@ -1266,7 +1266,7 @@ final class EnumTests: XCTestCase {
       """
       enum E_53662_underscore {
         case identifier
-        case 1️⃣_ 
+        case 1️⃣_
         case identifier2
       }
       """,
@@ -1296,7 +1296,7 @@ final class EnumTests: XCTestCase {
         case identifier1
         case identifier2
         case 1️⃣
-        case identifier 
+        case identifier
       }
       """,
       diagnostics: [
@@ -1310,7 +1310,7 @@ final class EnumTests: XCTestCase {
       """
       enum E_53662_Newline2 {
         case 1️⃣
-        func foo() {} 
+        func foo() {}
       }
       """,
       diagnostics: [
@@ -1323,7 +1323,7 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum E_53662_PatternMatching {
-        case 1️⃣let 2️⃣.foo(x, y): 
+        case 1️⃣let 2️⃣.foo(x, y):
       }
       """,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/ErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/ErrorsTests.swift
@@ -47,7 +47,7 @@ final class ErrorsTests: XCTestCase {
         } catch _ {
         }
         do {
-        } catch { 
+        } catch {
           let error2 = error
         }
         do {
@@ -58,12 +58,12 @@ final class ErrorsTests: XCTestCase {
         // <rdar://problem/20985280> QoI: improve diagnostic on improper pattern match on type
         do {
           throw opaque_error()
-        } catch MSV { 
+        } catch MSV {
         } catch {
         }
         do {
           throw opaque_error()
-        } catch is Error {  
+        } catch is Error {
         }
         func foo() throws {}
         do {
@@ -80,7 +80,7 @@ final class ErrorsTests: XCTestCase {
         }
         do {
           throw opaque_error()
-        } catch MSV.Foo, MSV.CarriesInt(let num) { 
+        } catch MSV.Foo, MSV.CarriesInt(let num) {
         } catch {
         }
       }
@@ -114,17 +114,17 @@ final class ErrorsTests: XCTestCase {
     AssertParse(
       """
       func testAutoclosures() throws {
-        takesAutoclosure(genError()) 
+        takesAutoclosure(genError())
         takesAutoclosure(genNoError())
-        try takesAutoclosure(genError()) 
-        try takesAutoclosure(genNoError()) 
-        takesAutoclosure(try genError()) 
-        takesAutoclosure(try genNoError()) 
+        try takesAutoclosure(genError())
+        try takesAutoclosure(genNoError())
+        takesAutoclosure(try genError())
+        takesAutoclosure(try genNoError())
         takesThrowingAutoclosure(try genError())
-        takesThrowingAutoclosure(try genNoError()) 
+        takesThrowingAutoclosure(try genNoError())
         try takesThrowingAutoclosure(genError())
-        try takesThrowingAutoclosure(genNoError()) 
-        takesThrowingAutoclosure(genError()) 
+        try takesThrowingAutoclosure(genNoError())
+        takesThrowingAutoclosure(genError())
         takesThrowingAutoclosure(genNoError())
       }
       """
@@ -137,7 +137,7 @@ final class ErrorsTests: XCTestCase {
       func illformed() throws {
           do {
             _ = try genError()
-          } catch MSV.CarriesInt(let i) where i == genError()1️⃣) { 
+          } catch MSV.CarriesInt(let i) where i == genError()1️⃣) {
           }
       }
       """,
@@ -151,7 +151,7 @@ final class ErrorsTests: XCTestCase {
   func testErrors8() {
     AssertParse(
       """
-      func postThrows() -> Int 1️⃣throws { 
+      func postThrows() -> Int 1️⃣throws {
         return 5
       }
       """,
@@ -169,7 +169,7 @@ final class ErrorsTests: XCTestCase {
   func testErrors9() {
     AssertParse(
       """
-      func postThrows2() -> 1️⃣throws Int { 
+      func postThrows2() -> 1️⃣throws Int {
         return try postThrows()
       }
       """,
@@ -182,7 +182,7 @@ final class ErrorsTests: XCTestCase {
   func testErrors10() {
     AssertParse(
       """
-      func postRethrows(_ f: () throws -> Int) -> Int 1️⃣rethrows { 
+      func postRethrows(_ f: () throws -> Int) -> Int 1️⃣rethrows {
         return try f()
       }
       """,
@@ -214,7 +214,7 @@ final class ErrorsTests: XCTestCase {
     AssertParse(
       """
       func postThrows3() {
-        _ = { () -> Int 1️⃣throws in } 
+        _ = { () -> Int 1️⃣throws in }
       }
       """,
       diagnostics: [
@@ -351,7 +351,7 @@ final class ErrorsTests: XCTestCase {
       func fixitThrow2() throws {
         var _: (Int)
         throw MSV.Foo
-        var _: (Int) 1️⃣throw -> Int 
+        var _: (Int) 1️⃣throw -> Int
       }
       """,
       diagnostics: [
@@ -361,7 +361,7 @@ final class ErrorsTests: XCTestCase {
         func fixitThrow2() throws {
           var _: (Int)
           throw MSV.Foo
-          var _: (Int) throws -> Int 
+          var _: (Int) throws -> Int
         }
         """
     )

--- a/Tests/SwiftParserTest/translated/ForeachAsyncTests.swift
+++ b/Tests/SwiftParserTest/translated/ForeachAsyncTests.swift
@@ -54,14 +54,14 @@ final class ForeachAsyncTests: XCTestCase {
   func testForeachAsync4() {
     AssertParse(
       """
-      func for_each(r: AsyncRange<Int>, iir: AsyncIntRange<Int>) async { 
+      func for_each(r: AsyncRange<Int>, iir: AsyncIntRange<Int>) async {
         var sum = 0
         // Simple foreach loop, using the variable in the body
         for await i in r {
           sum = sum + i
         }
         // Check scoping of variable introduced with foreach loop
-        i = 0 
+        i = 0
         // For-each loops with two variables and varying degrees of typedness
         for await (i, j) in iir {
           sum = sum + i + j
@@ -73,8 +73,8 @@ final class ForeachAsyncTests: XCTestCase {
           sum = sum + i + j
         }
         // Parse errors
-        for await i 1️⃣r { 
-        }         
+        for await i 1️⃣r {
+        }
         for await i in r 2️⃣sum = sum + i;3️⃣
       }
       """,

--- a/Tests/SwiftParserTest/translated/ForeachTests.swift
+++ b/Tests/SwiftParserTest/translated/ForeachTests.swift
@@ -31,14 +31,14 @@ final class ForeachTests: XCTestCase {
   func testForeach2() {
     AssertParse(
       """
-      func for_each(r: Range<Int>, iir: IntRange<Int>) { 
+      func for_each(r: Range<Int>, iir: IntRange<Int>) {
         var sum = 0
         // Simple foreach loop, using the variable in the body
         for i in r {
           sum = sum + i
         }
         // Check scoping of variable introduced with foreach loop
-        i = 0 
+        i = 0
         // For-each loops with two variables and varying degrees of typedness
         for (i, j) in iir {
           sum = sum + i + j
@@ -50,8 +50,8 @@ final class ForeachTests: XCTestCase {
           sum = sum + i + j
         }
         // Parse errors
-        for i 1️⃣r { 
-        }         
+        for i 1️⃣r {
+        }
         for i in r 2️⃣sum = sum + i;3️⃣
       }
       """,

--- a/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
+++ b/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
@@ -20,7 +20,7 @@ final class GenericDisambiguationTests: XCTestCase {
   func testGenericDisambiguation1() {
     AssertParse(
       """
-      struct A<B> { 
+      struct A<B> {
         init(x:Int) {}
         static func c() {}
         struct C<D> {
@@ -244,7 +244,7 @@ final class GenericDisambiguationTests: XCTestCase {
   func testGenericDisambiguation17() {
     AssertParse(
       """
-      A<B?>(x: 0) // parses as type 
+      A<B?>(x: 0) // parses as type
       _ = a < b ? c : d
       """
     )

--- a/Tests/SwiftParserTest/translated/HashbangMainTests.swift
+++ b/Tests/SwiftParserTest/translated/HashbangMainTests.swift
@@ -20,7 +20,7 @@ final class HashbangMainTests: XCTestCase {
       """
       #!/usr/bin/swift
       let x = 42
-      x + x 
+      x + x
       // Check that we skip the hashbang at the beginning of the file.
       """
     )

--- a/Tests/SwiftParserTest/translated/IdentifiersTests.swift
+++ b/Tests/SwiftParserTest/translated/IdentifiersTests.swift
@@ -167,14 +167,14 @@ final class IdentifiersTests: XCTestCase {
     AssertParse(
       """
       // SIL keywords are tokenized as normal identifiers in non-SIL mode.
-      _ = undef 
-      _ = sil 
-      _ = sil_stage 
-      _ = sil_vtable 
-      _ = sil_global 
-      _ = sil_witness_table 
-      _ = sil_default_witness_table 
-      _ = sil_coverage_map 
+      _ = undef
+      _ = sil
+      _ = sil_stage
+      _ = sil_vtable
+      _ = sil_global
+      _ = sil_witness_table
+      _ = sil_default_witness_table
+      _ = sil_coverage_map
       _ = sil_scope
       """
     )
@@ -192,7 +192,7 @@ final class IdentifiersTests: XCTestCase {
   func testIdentifiers11() {
     AssertParse(
       """
-      @propertyWrapper 
+      @propertyWrapper
       struct Wrapper {
         var wrappedValue = 0
       }

--- a/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
+++ b/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
@@ -63,7 +63,7 @@ final class IfconfigExprTests: XCTestCase {
       func testBasic(baseExpr: MyStruct) {
           baseExpr
       #if CONDITION_1
-            .methodOne() 
+            .methodOne()
       #else
             .methodTwo()
       #endif
@@ -77,7 +77,7 @@ final class IfconfigExprTests: XCTestCase {
       """
       MyStruct()
       #if CONDITION_1
-        .methodOne() 
+        .methodOne()
       #else
         .methodTwo()
       #endif
@@ -89,18 +89,18 @@ final class IfconfigExprTests: XCTestCase {
     AssertParse(
       #"""
       func testInvalidContent(baseExpr: MyStruct, otherExpr: Int) {
-        baseExpr      
+        baseExpr
       #if CONDITION_1
-          { $0 + 1  } 
-      #endif
-        baseExpr      
-      #if CONDITION_1
-          1️⃣+ otherExpr 
+          { $0 + 1  }
       #endif
         baseExpr
       #if CONDITION_1
-          .methodOne() 
-        2️⃣print("debug") 
+          1️⃣+ otherExpr
+      #endif
+        baseExpr
+      #if CONDITION_1
+          .methodOne()
+        2️⃣print("debug")
       #endif
       }
       """#,
@@ -117,7 +117,7 @@ final class IfconfigExprTests: XCTestCase {
       func testExprKind(baseExpr: MyStruct, idx: Int) {
         baseExpr
       #if CONDITION_1
-        .optionalMember?.optionalMethod()![idx]++ 
+        .optionalMember?.optionalMethod()![idx]++
       #else
         .otherMethod(arg) {
           //...
@@ -125,7 +125,7 @@ final class IfconfigExprTests: XCTestCase {
       #endif
         baseExpr
       #if CONDITION_1
-        .methodOne() 1️⃣+ 12 
+        .methodOne() 1️⃣+ 12
       #endif
       }
       """,
@@ -141,13 +141,13 @@ final class IfconfigExprTests: XCTestCase {
       func emptyElse(baseExpr: MyStruct) {
         baseExpr
       #if CONDITION_1
-          .methodOne() 
+          .methodOne()
       #elseif CONDITION_2
           // OK. Do nothing.
       #endif
         baseExpr
       #if CONDITION_1
-          .methodOne() 
+          .methodOne()
       #elseif CONDITION_2
         1️⃣return
       #endif
@@ -170,7 +170,7 @@ final class IfconfigExprTests: XCTestCase {
       #if CONDITION_2
         .methodTwo()
       #endif
-        .unknownMethod() 
+        .unknownMethod()
       }
       """
     )
@@ -186,7 +186,7 @@ final class IfconfigExprTests: XCTestCase {
           .methodOne()
         #endif
         #if CONDITION_1
-          .methodTwo() 
+          .methodTwo()
         #endif
       #else
         .unknownMethod1()
@@ -203,7 +203,7 @@ final class IfconfigExprTests: XCTestCase {
     AssertParse(
       """
       func ifconfigExprInExpr(baseExpr: MyStruct) {
-        globalFunc( 
+        globalFunc(
           baseExpr
       #if CONDITION_1
             .methodOne()

--- a/Tests/SwiftParserTest/translated/ImplicitGetterIncompleteTests.swift
+++ b/Tests/SwiftParserTest/translated/ImplicitGetterIncompleteTests.swift
@@ -35,9 +35,9 @@ final class ImplicitGetterIncompleteTests: XCTestCase {
     AssertParse(
       #"""
       // Would trigger assertion when AST verifier checks source ranges ("child source range not contained within its parent")
-      func test2() { 
-        var a : Int { 
-          switch i { 
+      func test2() {
+        var a : Int {
+          switch i {
       }1️⃣
       """#,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/InitDeinitTests.swift
+++ b/Tests/SwiftParserTest/translated/InitDeinitTests.swift
@@ -34,7 +34,7 @@ final class InitDeinitTests: XCTestCase {
     AssertParse(
       """
       struct FooStructConstructorB {
-        init() 
+        init()
       }
       """
     )
@@ -44,7 +44,7 @@ final class InitDeinitTests: XCTestCase {
     AssertParse(
       """
       struct FooStructConstructorC {
-        init 1️⃣{} 
+        init 1️⃣{}
       }
       """,
       diagnostics: [
@@ -143,7 +143,7 @@ final class InitDeinitTests: XCTestCase {
     AssertParse(
       """
       struct FooStructDeinitializerB {
-        deinit 
+        deinit
       }
       """
     )
@@ -153,7 +153,7 @@ final class InitDeinitTests: XCTestCase {
     AssertParse(
       """
       struct FooStructDeinitializerC {
-        deinit {} 
+        deinit {}
       }
       """
     )
@@ -163,7 +163,7 @@ final class InitDeinitTests: XCTestCase {
     AssertParse(
       """
       class FooClassDeinitializerA {
-        deinit1️⃣(a : Int) {} 
+        deinit1️⃣(a : Int) {}
       }
       """,
       diagnostics: [
@@ -209,8 +209,8 @@ final class InitDeinitTests: XCTestCase {
   func testInitDeinit11() {
     AssertParse(
       """
-      init 1️⃣{} 
-      init() 
+      init 1️⃣{}
+      init()
       init() {}
       """,
       diagnostics: [
@@ -222,8 +222,8 @@ final class InitDeinitTests: XCTestCase {
   func testInitDeinit12() {
     AssertParse(
       """
-      deinit {} 
-      deinit 
+      deinit {}
+      deinit
       deinit {}
       """
     )
@@ -234,7 +234,7 @@ final class InitDeinitTests: XCTestCase {
       """
       struct BarStruct {
         init() {}
-        deinit {} 
+        deinit {}
       }
       """
     )
@@ -246,7 +246,7 @@ final class InitDeinitTests: XCTestCase {
       extension BarStruct {
         init(x : Int) {}
         // When/if we allow 'var' in extensions, then we should also allow dtors
-        deinit {} 
+        deinit {}
       }
       """
     )
@@ -257,7 +257,7 @@ final class InitDeinitTests: XCTestCase {
       """
       enum BarUnion {
         init() {}
-        deinit {} 
+        deinit {}
       }
       """
     )
@@ -268,7 +268,7 @@ final class InitDeinitTests: XCTestCase {
       """
       extension BarUnion {
         init(x : Int) {}
-        deinit {} 
+        deinit {}
       }
       """
     )
@@ -290,7 +290,7 @@ final class InitDeinitTests: XCTestCase {
       """
       extension BarClass {
         convenience init(x : Int) { self.init() }
-        deinit {} 
+        deinit {}
       }
       """
     )
@@ -300,8 +300,8 @@ final class InitDeinitTests: XCTestCase {
     AssertParse(
       """
       protocol BarProtocol {
-        init() {} 
-        deinit {} 
+        init() {}
+        deinit {}
       }
       """
     )
@@ -312,7 +312,7 @@ final class InitDeinitTests: XCTestCase {
       """
       extension BarProtocol {
         init(x : Int) {}
-        deinit {} 
+        deinit {}
       }
       """
     )
@@ -322,8 +322,8 @@ final class InitDeinitTests: XCTestCase {
     AssertParse(
       """
       func fooFunc() {
-        init() {} 
-        deinit {} 
+        init() {}
+        deinit {}
       }
       """
     )
@@ -334,11 +334,11 @@ final class InitDeinitTests: XCTestCase {
       """
       func barFunc() {
         var x : () = { () -> () in
-          init() {} 
+          init() {}
           return
         } ()
         var y : () = { () -> () in
-          deinit {} 
+          deinit {}
           return
         } ()
       }

--- a/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
+++ b/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
@@ -76,18 +76,18 @@ final class MatchingPatternsTests: XCTestCase {
       case var a:
         a = 1
       case let a:
-        a = 1         
-      case var var a: 
+        a = 1
+      case var var a:
         a += 1
-      case var let a: 
+      case var let a:
         print(a, terminator: "")
-      case var (var b): 
+      case var (var b):
         b += 1
       // 'Any' pattern.
       case _:
         ()
       // patterns are resolved in expression-only positions are errors.
-      case 1 + (_): 
+      case 1 + (_):
         ()
       }
       """#
@@ -98,9 +98,9 @@ final class MatchingPatternsTests: XCTestCase {
     AssertParse(
       """
       switch (x,x) {
-      case (var a, var a): 
+      case (var a, var a):
         fallthrough
-      case _: 
+      case _:
         ()
       }
       """
@@ -118,7 +118,7 @@ final class MatchingPatternsTests: XCTestCase {
   func testMatchingPatterns9() {
     AssertParse(
       """
-      switch e { 
+      switch e {
       // 'is' pattern.
       case is Int,
            is A<Int>,
@@ -160,23 +160,23 @@ final class MatchingPatternsTests: XCTestCase {
           case other:
             ()
           case .Naught,
-               .Naught(), 
-               .Naught(_), 
-               .Naught(_, _): 
+               .Naught(),
+               .Naught(_),
+               .Naught(_, _):
             ()
           case .Mere,
-               .Mere(), 
+               .Mere(),
                .Mere(_),
-               .Mere(_, _): 
+               .Mere(_, _):
             ()
-          case .Twain(), 
-               .Twain(_), 
+          case .Twain(),
+               .Twain(_),
                .Twain(_, _),
-               .Twain(_, _, _): 
+               .Twain(_, _, _):
             ()
           }
           switch foo {
-          case .Naught: 
+          case .Naught:
             ()
           case .A, .B, .C:
             ()
@@ -191,7 +191,7 @@ final class MatchingPatternsTests: XCTestCase {
     AssertParse(
       """
       var n : Voluntary<Int> = .Naught
-      if case let .Naught(value) = n {} 
+      if case let .Naught(value) = n {}
       if case let .Naught(value1, value2, value3) = n {}
       """
     )
@@ -201,26 +201,26 @@ final class MatchingPatternsTests: XCTestCase {
     AssertParse(
       """
       switch n {
-      case Foo.A: 
+      case Foo.A:
         ()
       case Voluntary<Int>.Naught,
-           Voluntary<Int>.Naught(), 
-           Voluntary<Int>.Naught(_, _), 
+           Voluntary<Int>.Naught(),
+           Voluntary<Int>.Naught(_, _),
            Voluntary.Naught,
            .Naught:
         ()
       case Voluntary<Int>.Mere,
            Voluntary<Int>.Mere(_),
-           Voluntary<Int>.Mere(_, _), 
+           Voluntary<Int>.Mere(_, _),
            Voluntary.Mere,
            Voluntary.Mere(_),
            .Mere,
            .Mere(_):
         ()
       case .Twain,
-           .Twain(_), 
+           .Twain(_),
            .Twain(_, _),
-           .Twain(_, _, _): 
+           .Twain(_, _, _):
         ()
       }
       """
@@ -239,7 +239,7 @@ final class MatchingPatternsTests: XCTestCase {
     AssertParse(
       """
       switch notAnEnum {
-      case .Foo: 
+      case .Foo:
         ()
       }
       """
@@ -256,12 +256,12 @@ final class MatchingPatternsTests: XCTestCase {
           case Twain(T, T)
         }
         func member(_ n: Possible<Int>) {
-          switch n { 
+          switch n {
           case ContainsEnum.Possible<Int>.Naught,
-               ContainsEnum.Possible.Naught, 
-               Possible<Int>.Naught, 
-               Possible.Naught, 
-               .Naught: 
+               ContainsEnum.Possible.Naught,
+               Possible<Int>.Naught,
+               Possible.Naught,
+               .Naught:
             ()
           }
         }
@@ -274,9 +274,9 @@ final class MatchingPatternsTests: XCTestCase {
     AssertParse(
       """
       func nonmemberAccessesMemberType(_ n: ContainsEnum.Possible<Int>) {
-        switch n { 
+        switch n {
         case ContainsEnum.Possible<Int>.Naught,
-             .Naught: 
+             .Naught:
           ()
         }
       }
@@ -297,15 +297,15 @@ final class MatchingPatternsTests: XCTestCase {
       """
       switch m {
       case imported_enums.ImportedEnum.Simple,
-           ImportedEnum.Simple, 
-           .Simple: 
+           ImportedEnum.Simple,
+           .Simple:
         ()
       case imported_enums.ImportedEnum.Compound,
-           imported_enums.ImportedEnum.Compound(_), 
-           ImportedEnum.Compound, 
-           ImportedEnum.Compound(_), 
-           .Compound, 
-           .Compound(_): 
+           imported_enums.ImportedEnum.Compound(_),
+           ImportedEnum.Compound,
+           ImportedEnum.Compound(_),
+           .Compound,
+           .Compound(_):
         ()
       }
       """
@@ -351,22 +351,22 @@ final class MatchingPatternsTests: XCTestCase {
       case let .Payload(x):
         acceptInt(x)
         acceptString("\(x)")
-      case let .Payload(name: x): 
+      case let .Payload(name: x):
         acceptInt(x)
         acceptString("\(x)")
-      case let .Payload((name: x)): 
+      case let .Payload((name: x)):
         acceptInt(x)
         acceptString("\(x)")
-      case .Payload(let (name: x)): 
+      case .Payload(let (name: x)):
         acceptInt(x)
         acceptString("\(x)")
-      case .Payload(let (name: x)): 
+      case .Payload(let (name: x)):
         acceptInt(x)
         acceptString("\(x)")
-      case .Payload(let x): 
+      case .Payload(let x):
         acceptInt(x)
         acceptString("\(x)")
-      case .Payload((let x)): 
+      case .Payload((let x)):
         acceptInt(x)
         acceptString("\(x)")
       }
@@ -434,7 +434,7 @@ final class MatchingPatternsTests: XCTestCase {
         a += 1
       case var (_, b, 3):
         b += 1
-      case var (_, var c, 3): 
+      case var (_, var c, 3):
         c += 1
       case (1, 2, 3):
         ()
@@ -465,9 +465,9 @@ final class MatchingPatternsTests: XCTestCase {
     AssertParse(
       """
       switch [Derived(), Derived(), Base()] {
-      case let ds as [Derived]: 
+      case let ds as [Derived]:
         ()
-      case is [Derived]: 
+      case is [Derived]:
         ()
       default:
         ()
@@ -505,7 +505,7 @@ final class MatchingPatternsTests: XCTestCase {
       case nil: break
       case _?: break
       case (1?)?: break
-      case (_?)?: break 
+      case (_?)?: break
       }
       """
     )

--- a/Tests/SwiftParserTest/translated/MetatypeObjectConversionTests.swift
+++ b/Tests/SwiftParserTest/translated/MetatypeObjectConversionTests.swift
@@ -45,9 +45,9 @@ final class MetatypeObjectConversionTests: XCTestCase {
     AssertParse(
       """
       func concreteTypes() {
-        takesAnyObject(C.self) 
-        takesAnyObject(S.self) 
-        takesAnyObject(ClassConstrainedProto.self) 
+        takesAnyObject(C.self)
+        takesAnyObject(S.self)
+        takesAnyObject(ClassConstrainedProto.self)
       }
       """
     )
@@ -59,7 +59,7 @@ final class MetatypeObjectConversionTests: XCTestCase {
       func existentialMetatypes(nonClass: NonClassProto.Type,
                                 classConstrained: ClassConstrainedProto.Type,
                                 compo: (NonClassProto & ClassConstrainedProto).Type) {
-        takesAnyObject(nonClass) 
+        takesAnyObject(nonClass)
         takesAnyObject(classConstrained)
         takesAnyObject(compo)
       }

--- a/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
@@ -171,7 +171,7 @@ final class MultilineErrorsTests: XCTestCase {
       _ = """
           Foo
       1️⃣\
-          Bar 
+          Bar
           """
       """#,
       diagnostics: [
@@ -511,7 +511,7 @@ final class MultilineErrorsTests: XCTestCase {
     AssertParseWithAllNewlineEndings(
       #"""
       _ = """
-        \\1️⃣\	   
+        \\1️⃣\	  \#u{20}
         """
       """#,
       diagnostics: [
@@ -529,7 +529,7 @@ final class MultilineErrorsTests: XCTestCase {
     AssertParseWithAllNewlineEndings(
       #"""
       _ = """
-        \(42)1️⃣\		
+        \(42)1️⃣\	\#t
         """
       """#,
       diagnostics: [
@@ -604,7 +604,7 @@ final class MultilineErrorsTests: XCTestCase {
       ],
       fixedSource: #"""
         _ = """
-          
+         \#u{20}
           """
         """#
     )
@@ -622,7 +622,7 @@ final class MultilineErrorsTests: XCTestCase {
       ],
       fixedSource: #"""
         _ = """
-          
+         \#u{20}
           """
         """#
     )

--- a/Tests/SwiftParserTest/translated/MultilineStringTests.swift
+++ b/Tests/SwiftParserTest/translated/MultilineStringTests.swift
@@ -245,7 +245,7 @@ final class MultilineStringTests: XCTestCase {
         \("""
           substring1 \
           \("""
-            substring2 \          
+            substring2 \         \#u{20}
             substring3
             """)
           """) \
@@ -260,7 +260,7 @@ final class MultilineStringTests: XCTestCase {
     AssertParse(
       #"""
       _ = """
-          foo\ 
+          foo
 
           bar
           """
@@ -273,8 +273,8 @@ final class MultilineStringTests: XCTestCase {
     AssertParse(
       #"""
       _ = """
-          foo\ 
-          
+          foo\\#u{20}
+         \#u{20}
           bar
           """
       """#

--- a/Tests/SwiftParserTest/translated/ObjcEnumTests.swift
+++ b/Tests/SwiftParserTest/translated/ObjcEnumTests.swift
@@ -28,7 +28,7 @@ final class ObjcEnumTests: XCTestCase {
   func testObjcEnum2() {
     AssertParse(
       """
-      @objc enum Generic<T>: Int32 { 
+      @objc enum Generic<T>: Int32 {
         case Zim, Zang, Zung
       }
       """
@@ -48,7 +48,7 @@ final class ObjcEnumTests: XCTestCase {
   func testObjcEnum4() {
     AssertParse(
       """
-      @objc enum NoRawType { 
+      @objc enum NoRawType {
         case Zim, Zang, Zung
       }
       """
@@ -58,7 +58,7 @@ final class ObjcEnumTests: XCTestCase {
   func testObjcEnum5() {
     AssertParse(
       """
-      @objc enum NonIntegerRawType: Float { 
+      @objc enum NonIntegerRawType: Float {
         case Zim = 1.0, Zang = 1.5, Zung = 2.0
       }
       """
@@ -80,7 +80,7 @@ final class ObjcEnumTests: XCTestCase {
       """
       class Bar {
         @objc func foo(x: Foo) {}
-        @objc func nonObjC(x: NonObjCEnum) {} 
+        @objc func nonObjC(x: NonObjCEnum) {}
       }
       """
     )
@@ -90,8 +90,8 @@ final class ObjcEnumTests: XCTestCase {
     AssertParse(
       """
       // <rdar://problem/23681566> @objc enums with payloads rejected with no source location info
-      @objc enum r23681566 : Int32 {  
-        case Foo(progress: Int)     
+      @objc enum r23681566 : Int32 {
+        case Foo(progress: Int)
       }
       """
     )

--- a/Tests/SwiftParserTest/translated/OperatorDeclDesignatedTypesTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorDeclDesignatedTypesTests.swift
@@ -200,7 +200,7 @@ final class OperatorDeclDesignatedTypesTests: XCTestCase {
   func testOperatorDeclDesignatedTypes17() {
     AssertParse(
       """
-      infix operator **^^ : MediumPrecedence 
+      infix operator **^^ : MediumPrecedence
       infix operator **^^ : InfixMagicOperatorProtocol
       """,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
@@ -326,7 +326,7 @@ final class OperatorDeclTests: XCTestCase {
   func testOperatorDecl15a() {
     AssertParse(
       """
-      precedencegroup 1️⃣{ 
+      precedencegroup 1️⃣{
         associativity: right
       }
       """,
@@ -416,7 +416,7 @@ final class OperatorDeclTests: XCTestCase {
       """
       precedencegroup BangBangBang {
         associativity: none
-        associativity: left 
+        associativity: left
       }
       """
     )
@@ -426,8 +426,8 @@ final class OperatorDeclTests: XCTestCase {
     AssertParse(
       """
       precedencegroup CaretCaretCaret {
-        assignment: true 
-        assignment: false 
+        assignment: true
+        assignment: false
       }
       """
     )
@@ -437,7 +437,7 @@ final class OperatorDeclTests: XCTestCase {
     AssertParse(
       """
       class Foo {
-        infix operator ||| 
+        infix operator |||
       }
       """
     )

--- a/Tests/SwiftParserTest/translated/OptionalChainLvaluesTests.swift
+++ b/Tests/SwiftParserTest/translated/OptionalChainLvaluesTests.swift
@@ -72,9 +72,9 @@ final class OptionalChainLvaluesTests: XCTestCase {
     AssertParse(
       """
       mutT?.mutateT()
-      immT?.mutateT() 
+      immT?.mutateT()
       mutT?.mutS?.mutateS()
-      mutT?.immS?.mutateS() 
+      mutT?.immS?.mutateS()
       mutT?.mutS?.x += 1
       mutT?.mutS?.y++
       """
@@ -85,7 +85,7 @@ final class OptionalChainLvaluesTests: XCTestCase {
     AssertParse(
       """
       // Prefix operators don't chain
-      ++mutT?.mutS?.x 
+      ++mutT?.mutS?.x
       ++mutT?.mutS?.y
       """
     )
@@ -98,11 +98,11 @@ final class OptionalChainLvaluesTests: XCTestCase {
       mutT?.mutS = S()
       mutT?.mutS? = S()
       mutT?.mutS?.x += 0
-      _ = mutT?.mutS?.x + 0 
-      mutT?.mutS?.y -= 0 
-      mutT?.immS = S() 
-      mutT?.immS? = S() 
-      mutT?.immS?.x += 0 
+      _ = mutT?.mutS?.x + 0
+      mutT?.mutS?.y -= 0
+      mutT?.immS = S()
+      mutT?.immS? = S()
+      mutT?.immS?.x += 0
       mutT?.immS?.y -= 0
       """
     )

--- a/Tests/SwiftParserTest/translated/OptionalLvaluesTests.swift
+++ b/Tests/SwiftParserTest/translated/OptionalLvaluesTests.swift
@@ -63,10 +63,10 @@ final class OptionalLvaluesTests: XCTestCase {
       mutT!.mutS = S()
       mutT!.mutS! = S()
       mutT!.mutS!.x = 0
-      mutT!.mutS!.y = 0 
-      mutT!.immS = S() 
-      mutT!.immS! = S() 
-      mutT!.immS!.x = 0 
+      mutT!.mutS!.y = 0
+      mutT!.immS = S()
+      mutT!.immS! = S()
+      mutT!.immS!.x = 0
       mutT!.immS!.y = 0
       """
     )
@@ -75,14 +75,14 @@ final class OptionalLvaluesTests: XCTestCase {
   func testOptionalLvalues6() {
     AssertParse(
       """
-      immT! = T() 
-      immT!.mutS = S() 
-      immT!.mutS! = S() 
-      immT!.mutS!.x = 0 
-      immT!.mutS!.y = 0 
-      immT!.immS = S() 
-      immT!.immS! = S() 
-      immT!.immS!.x = 0 
+      immT! = T()
+      immT!.mutS = S()
+      immT!.mutS! = S()
+      immT!.mutS!.x = 0
+      immT!.mutS!.y = 0
+      immT!.immS = S()
+      immT!.immS! = S()
+      immT!.immS!.x = 0
       immT!.immS!.y = 0
       """
     )
@@ -101,8 +101,8 @@ final class OptionalLvaluesTests: XCTestCase {
     AssertParse(
       """
       mutIUO!.mutS = S()
-      mutIUO!.immS = S() 
-      immIUO!.mutS = S() 
+      mutIUO!.immS = S()
+      immIUO!.mutS = S()
       immIUO!.immS = S()
       """
     )
@@ -112,8 +112,8 @@ final class OptionalLvaluesTests: XCTestCase {
     AssertParse(
       """
       mutIUO.mutS = S()
-      mutIUO.immS = S() 
-      immIUO.mutS = S() 
+      mutIUO.immS = S()
+      immIUO.mutS = S()
       immIUO.immS = S()
       """
     )
@@ -131,7 +131,7 @@ final class OptionalLvaluesTests: XCTestCase {
     AssertParse(
       """
       var nonOptional: S = S()
-      _ = nonOptional! 
+      _ = nonOptional!
       _ = nonOptional!.x
       """
     )

--- a/Tests/SwiftParserTest/translated/OptionalTests.swift
+++ b/Tests/SwiftParserTest/translated/OptionalTests.swift
@@ -41,7 +41,7 @@ final class OptionalTests: XCTestCase {
   func testOptional3a() {
     AssertParse(
       """
-      var c = a?  
+      var c = a?
       """,
       substructure: Syntax(
         OptionalChainingExprSyntax(

--- a/Tests/SwiftParserTest/translated/OriginalDefinedInAttrTests.swift
+++ b/Tests/SwiftParserTest/translated/OriginalDefinedInAttrTests.swift
@@ -18,7 +18,7 @@ final class OriginalDefinedInAttrTests: XCTestCase {
   func testOriginalDefinedInAttr1() {
     AssertParse(
       #"""
-      @_originallyDefinedIn(module: "foo", OSX 13.13) 
+      @_originallyDefinedIn(module: "foo", OSX 13.13)
       public func foo() {}
       """#,
       diagnostics: [
@@ -43,7 +43,7 @@ final class OriginalDefinedInAttrTests: XCTestCase {
   func testOriginalDefinedInAttr3() {
     AssertParse(
       #"""
-      @_originallyDefinedIn(module: "foo", OSX 13.13.3) 
+      @_originallyDefinedIn(module: "foo", OSX 13.13.3)
       public class ToplevelClass {}
       """#,
       diagnostics: [
@@ -94,7 +94,7 @@ final class OriginalDefinedInAttrTests: XCTestCase {
     AssertParse(
       #"""
       @available(OSX 13.10, *)
-      @_originallyDefinedIn(module: "foo", * 13.13) 
+      @_originallyDefinedIn(module: "foo", * 13.13)
       public class ToplevelClass4 {}
       """#
     )
@@ -132,7 +132,7 @@ final class OriginalDefinedInAttrTests: XCTestCase {
     AssertParse(
       #"""
       @available(OSX 13.10, *)
-      @_originallyDefinedIn(module: "foo", OSX 13.13) 
+      @_originallyDefinedIn(module: "foo", OSX 13.13)
       @_originallyDefinedIn(module: "foo", iOS 7.0)
       internal class ToplevelClass5 {}
       """#,
@@ -146,7 +146,7 @@ final class OriginalDefinedInAttrTests: XCTestCase {
     AssertParse(
       #"""
       @available(OSX 13.10, *)
-      @_originallyDefinedIn(module: "foo", OSX 13.13) 
+      @_originallyDefinedIn(module: "foo", OSX 13.13)
       @_originallyDefinedIn(module: "foo", iOS 7.0)
       private class ToplevelClass6 {}
       """#,
@@ -160,7 +160,7 @@ final class OriginalDefinedInAttrTests: XCTestCase {
     AssertParse(
       #"""
       @available(OSX 13.10, *)
-      @_originallyDefinedIn(module: "foo", OSX 13.13) 
+      @_originallyDefinedIn(module: "foo", OSX 13.13)
       @_originallyDefinedIn(module: "foo", iOS 7.0)
       fileprivate class ToplevelClass7 {}
       """#,
@@ -174,7 +174,7 @@ final class OriginalDefinedInAttrTests: XCTestCase {
     AssertParse(
       #"""
       @available(OSX 13.10, *)
-      @_originallyDefinedIn(module: "foo", OSX 13.13, iOS 7.0) 
+      @_originallyDefinedIn(module: "foo", OSX 13.13, iOS 7.0)
       internal class ToplevelClass8 {}
       """#,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
+++ b/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
@@ -37,8 +37,8 @@ final class PatternWithoutVariablesTests: XCTestCase {
     AssertParse(
       """
       struct Foo {
-        let _ = 1 
-        var (_, _) = (1, 2) 
+        let _ = 1
+        var (_, _) = (1, 2)
         func foo() {
           let _ = 1 // OK
         }
@@ -61,18 +61,18 @@ final class PatternWithoutVariablesTests: XCTestCase {
       #"""
       func testVarLetPattern(a : SimpleEnum) {
         switch a {
-        case let .Bar: break      
+        case let .Bar: break
         }
         switch a {
         case let x: _ = x; break         // Ok.
         }
         switch a {
-        case let _: break         
+        case let _: break
         }
         switch (a, 42) {
         case let (_, x): _ = x; break    // ok
         }
-        if case let _ = "str" {}  
+        if case let _ = "str" {}
       }
       """#
     )
@@ -83,7 +83,7 @@ final class PatternWithoutVariablesTests: XCTestCase {
       """
       // https://github.com/apple/swift/issues/53293
       class C_53293 {
-        static var _: Int { 0 } 
+        static var _: Int { 0 }
       }
       """
     )

--- a/Tests/SwiftParserTest/translated/RecoveryLibraryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryLibraryTests.swift
@@ -19,17 +19,17 @@ final class RecoveryLibraryTests: XCTestCase {
     AssertParse(
       """
       // Check that we handle multiple consecutive right braces.
-      1️⃣} 
-      } 
+      1️⃣}
+      }
       func foo() {}
       // Check that we handle multiple consecutive right braces.
-      2️⃣} 
-      } 
+      2️⃣}
+      }
       func bar() {}
       //===--- Recovery for extra braces at top level.
       //===--- Keep this test the last one in the file.
       // Check that we handle multiple consecutive right braces.
-      3️⃣} 
+      3️⃣}
       }
       """,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -32,8 +32,8 @@ final class RecoveryTests: XCTestCase {
       #"""
       func garbage() -> () {
         var a : Int
-        1️⃣) this line is invalid, but we will stop at the keyword below... 
-        return a + "a" 
+        1️⃣) this line is invalid, but we will stop at the keyword below...
+        return a + "a"
       }
       """#,
       diagnostics: [
@@ -46,9 +46,9 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       #"""
       func moreGarbage() -> () {
-        1️⃣) this line is invalid, but we will stop at the declaration... 
+        1️⃣) this line is invalid, but we will stop at the declaration...
         func a() -> Int { return 4 }
-        return a() + "a" 
+        return a() + "a"
       }
       """#,
       diagnostics: [
@@ -71,7 +71,7 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       func useContainer() -> () {
-        var a : Container<not 1️⃣a2️⃣ type [skip 3️⃣this greater: >] >4️⃣, b : Int 
+        var a : Container<not 1️⃣a2️⃣ type [skip 3️⃣this greater: >] >4️⃣, b : Int
         b = 5 // no-warning
         a.exists()
       }
@@ -89,7 +89,7 @@ final class RecoveryTests: XCTestCase {
   func testRecovery8() {
     AssertParse(
       """
-      @xyz class BadAttributes { 
+      @xyz class BadAttributes {
         func exists() -> Bool { return true }
       }
       """
@@ -137,8 +137,8 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       func braceStmt3() {
-        {  
-          undefinedIdentifier {} 
+        {
+          undefinedIdentifier {}
         }
       }
       """
@@ -149,13 +149,13 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       //===--- Recovery for misplaced 'static'.
-      static func toplevelStaticFunc() {} 
-      static struct StaticStruct {} 
-      static class StaticClass {} 
-      static protocol StaticProtocol {} 
-      static typealias StaticTypealias = Int 
+      static func toplevelStaticFunc() {}
+      static struct StaticStruct {}
+      static class StaticClass {}
+      static protocol StaticProtocol {}
+      static typealias StaticTypealias = Int
       class ClassWithStaticDecls {
-        class var a = 42 
+        class var a = 42
       }
       """
     )
@@ -175,7 +175,7 @@ final class RecoveryTests: XCTestCase {
   func testRecovery14() {
     AssertParse(
       """
-      if { 
+      if {
         }1️⃣
       """,
       diagnostics: [
@@ -188,7 +188,7 @@ final class RecoveryTests: XCTestCase {
   func testRecovery15() {
     AssertParse(
       """
-      if 
+      if
         {
         }1️⃣
       """,
@@ -203,7 +203,7 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       if true {
-        } else if { 
+        } else if {
         }1️⃣
       """,
       diagnostics: [
@@ -218,7 +218,7 @@ final class RecoveryTests: XCTestCase {
       """
       // It is debatable if we should do recovery here and parse { true } as the
         // body, but the error message should be sensible.
-        if { true } { 
+        if { true } {
         }
       """,
       diagnostics: [
@@ -272,7 +272,7 @@ final class RecoveryTests: XCTestCase {
   func testRecovery21() {
     AssertParse(
       """
-      while { 
+      while {
         }1️⃣
       """,
       diagnostics: [
@@ -285,7 +285,7 @@ final class RecoveryTests: XCTestCase {
   func testRecovery22() {
     AssertParse(
       """
-      while 
+      while
         {
         }1️⃣
       """,
@@ -356,7 +356,7 @@ final class RecoveryTests: XCTestCase {
   func testRecovery27() {
     AssertParse(
       """
-      { 
+      {
         missingControllingExprInRepeatWhile();
       }
       """,
@@ -410,8 +410,8 @@ final class RecoveryTests: XCTestCase {
   func testRecovery31() {
     AssertParse(
       """
-      for 1️⃣; 
-        { 
+      for 1️⃣;
+        {
         }
       """,
       diagnostics: [
@@ -424,7 +424,7 @@ final class RecoveryTests: XCTestCase {
   func testRecovery32() {
     AssertParse(
       """
-      for 1️⃣; true { 
+      for 1️⃣; true {
       }
       """,
       diagnostics: [
@@ -437,7 +437,7 @@ final class RecoveryTests: XCTestCase {
   func testRecovery33() {
     AssertParse(
       """
-      for var i 1️⃣= 0; true { 
+      for var i 1️⃣= 0; true {
         i += 1
       }
       """,
@@ -562,7 +562,7 @@ final class RecoveryTests: XCTestCase {
   func testRecovery42() {
     AssertParse(
       """
-      for i in { 
+      for i in {
       }1️⃣
       """,
       diagnostics: [
@@ -601,7 +601,7 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       for 1️⃣
-        2️⃣; 
+        2️⃣;
       }
       """,
       diagnostics: [
@@ -626,7 +626,7 @@ final class RecoveryTests: XCTestCase {
   func testRecovery46() {
     AssertParse(
       """
-      switch { 
+      switch {
       }1️⃣
       """,
       diagnostics: [
@@ -640,7 +640,7 @@ final class RecoveryTests: XCTestCase {
   func testRecovery47() {
     AssertParse(
       """
-      switch 
+      switch
       {
       }1️⃣
       """,
@@ -655,7 +655,7 @@ final class RecoveryTests: XCTestCase {
   func testRecovery48() {
     AssertParse(
       """
-      switch { 
+      switch {
         1️⃣case _: return
       }2️⃣
       """,
@@ -670,7 +670,7 @@ final class RecoveryTests: XCTestCase {
   func testRecovery49() {
     AssertParse(
       """
-      switch { 
+      switch {
         1️⃣case Int: return
         2️⃣case _: return
       }3️⃣
@@ -688,7 +688,7 @@ final class RecoveryTests: XCTestCase {
   func testRecovery50() {
     AssertParse(
       """
-      switch { 42 } { 
+      switch { 42 } {
         case _: return
       }
       """
@@ -720,9 +720,9 @@ final class RecoveryTests: XCTestCase {
   func testRecovery55() {
     AssertParse(
       """
-      enum NoBracesUnion11️⃣() 
-      class NoBracesClass12️⃣() 
-      protocol NoBracesProtocol13️⃣() 
+      enum NoBracesUnion11️⃣()
+      class NoBracesClass12️⃣()
+      protocol NoBracesProtocol13️⃣()
       extension NoBracesStruct14️⃣()
       """,
       diagnostics: [
@@ -899,7 +899,7 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       struct ErrorTypeInVarDecl4 {
-        var v1 : Int<1️⃣, 
+        var v1 : Int<1️⃣,
         var v2 : Int
       }
       """,
@@ -970,8 +970,8 @@ final class RecoveryTests: XCTestCase {
   func testRecovery84() {
     AssertParse(
       """
-      struct ErrorTypeInVarDecl13 { 
-        var v1 : 1️⃣& FooProtocol 
+      struct ErrorTypeInVarDecl13 {
+        var v1 : 1️⃣& FooProtocol
         var v2 : Int
       }
       """,
@@ -1191,10 +1191,10 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       struct ErrorTypeInVarDeclDictionaryType {
-        let a1: String1️⃣: 
-        let a2: String2️⃣: Int] 
-        let a3: String3️⃣: [Int] 
-        let a4: String4️⃣: Int 
+        let a1: String1️⃣:
+        let a2: String2️⃣: Int]
+        let a3: String3️⃣: [Int]
+        let a4: String4️⃣: Int
       }
       """,
       diagnostics: [
@@ -1216,10 +1216,10 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       struct ErrorInFunctionSignatureResultArrayType1 {
-        func foo() -> Int1️⃣[ { 
+        func foo() -> Int1️⃣[ {
           return [0]
         }  2️⃣
-        func bar() -> Int3️⃣] { 
+        func bar() -> Int3️⃣] {
           return [0]
         }
       }
@@ -1240,8 +1240,8 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       struct ErrorInFunctionSignatureResultArrayType2 {
-        func foo() -> Int1️⃣[0 { 
-          return [0]  
+        func foo() -> Int1️⃣[0 {
+          return [0]
         }2️⃣
       3️⃣}
       """,
@@ -1259,7 +1259,7 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       struct ErrorInFunctionSignatureResultArrayType3 {
-        func foo() -> Int1️⃣[0] { 
+        func foo() -> Int1️⃣[0] {
           return [0]
         }
       }
@@ -1275,7 +1275,7 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       struct ErrorInFunctionSignatureResultArrayType4 {
-        func foo() -> Int1️⃣[0_1] { 
+        func foo() -> Int1️⃣[0_1] {
           return [0]
         }
       }
@@ -1291,7 +1291,7 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       struct ErrorInFunctionSignatureResultArrayType5 {
-        func foo() -> Int1️⃣[0b1] { 
+        func foo() -> Int1️⃣[0b1] {
           return [0]
         }
       }
@@ -1306,8 +1306,8 @@ final class RecoveryTests: XCTestCase {
   func testRecovery105() {
     AssertParse(
       """
-      struct ErrorInFunctionSignatureResultArrayType11 { 
-        func foo() -> Int1️⃣[(a){a++}] { 
+      struct ErrorInFunctionSignatureResultArrayType11 {
+        func foo() -> Int1️⃣[(a){a++}] {
         }
       2️⃣}
       """,
@@ -1371,7 +1371,7 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       func exprPostfix2() {
-        _ = .1️⃣42 
+        _ = .1️⃣42
       }
       """,
       diagnostics: [
@@ -1402,7 +1402,7 @@ final class RecoveryTests: XCTestCase {
       """
       class ExprSuper1 {
         init() {
-          super 
+          super
         }
       }
       """
@@ -1435,8 +1435,8 @@ final class RecoveryTests: XCTestCase {
   func testRecovery116() {
     AssertParse(
       """
-      struct BracesInsideNominalDecl1 { 
-        1️⃣{ 
+      struct BracesInsideNominalDecl1 {
+        1️⃣{
           aaa
         }
         typealias A = Int
@@ -1464,7 +1464,7 @@ final class RecoveryTests: XCTestCase {
       #"""
       // https://github.com/apple/swift/issues/43383
       class С_43383 {
-          1️⃣print(2️⃣"No one else was in the room where it happened") 
+          1️⃣print(2️⃣"No one else was in the room where it happened")
       }
       """#,
       diagnostics: [
@@ -1504,7 +1504,7 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       class WrongDeclIntroducerKeyword1 {
-        1️⃣notAKeyword() {} 
+        1️⃣notAKeyword() {}
         func foo() {}
         class func bar() {}
       }
@@ -1649,7 +1649,7 @@ final class RecoveryTests: XCTestCase {
       #"""
       // <rdar://problem/18634543> Parser hangs at swift::Parser::parseType
       public enum TestA {
-        public static func convertFromExtenndition( 
+        public static func convertFromExtenndition(
           s._core.count 1️⃣!= 0, "Can't form a Character from an empty String")
       }
       """#,
@@ -1666,7 +1666,7 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       #"""
       public enum TestB {
-        public static func convertFromExtenndition( 
+        public static func convertFromExtenndition(
           s._core.count 1️⃣?= 0, "Can't form a Character from an empty String")
       }
       """#,
@@ -1736,7 +1736,7 @@ final class RecoveryTests: XCTestCase {
       #if true
       // rdar://19605164
       struct Foo19605164 {
-      func a(s: S1️⃣[{{g2️⃣) -> Int {} 
+      func a(s: S1️⃣[{{g2️⃣) -> Int {}
       }}3️⃣}
       #endif
       """,
@@ -1871,7 +1871,7 @@ final class RecoveryTests: XCTestCase {
   func testRecovery153() {
     AssertParse(
       """
-      if var y = x, z = x { 
+      if var y = x, z = x {
         z = y; y = z
       }
       """,
@@ -1896,7 +1896,7 @@ final class RecoveryTests: XCTestCase {
       // rdar://20866942
       func testRefutableLet() {
         var e : Int?
-        let x1️⃣? = e  
+        let x1️⃣? = e
       }
       """,
       diagnostics: [
@@ -1964,9 +1964,9 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       // <rdar://problem/21369926> Malformed Swift Enums crash playground service
-      enum Rank: Int {  
+      enum Rank: Int {
         case Ace = 1
-        case Two = 2.1  
+        case Two = 2.1
       }
       """
     )
@@ -1978,7 +1978,7 @@ final class RecoveryTests: XCTestCase {
       // rdar://22240342 - Crash in diagRecursivePropertyAccess
       class r22240342 {
         lazy var xx: Int = {
-          foo {  
+          foo {
             let issueView = 42
             issueView.delegate = 12
           }
@@ -1994,8 +1994,8 @@ final class RecoveryTests: XCTestCase {
       """
       // <rdar://problem/22387625> QoI: Common errors: 'let x= 5' and 'let x =5' could use Fix-its
       func r22387625() {
-        let _= 5 
-        let _ =5 
+        let _= 5
+        let _ =5
       }
       """,
       diagnostics: [
@@ -2010,8 +2010,8 @@ final class RecoveryTests: XCTestCase {
       """
       // https://github.com/apple/swift/issues/45723
       do {
-        let _: Int= 5 
-        let _: Array<Int>= [] 
+        let _: Int= 5
+        let _: Array<Int>= []
       }
       """,
       diagnostics: [
@@ -2060,7 +2060,7 @@ final class RecoveryTests: XCTestCase {
       // and `ss + s` becomes ambiguous. Disambiguation is provided with the unavailable overload
       // in order to produce a meaningful diagnostics. (Related: <rdar://problem/31763930>)
       func test23550816(ss: [String], s: String) {
-        print(ss + s)  
+        print(ss + s)
       }
       """#
     )
@@ -2072,7 +2072,7 @@ final class RecoveryTests: XCTestCase {
       // <rdar://problem/23719432> [practicalswift] Compiler crashes on &(Int:_)
       func test23719432() {
         var x = 42
-          &(Int:x) 
+          &(Int:x)
       }
       """,
       diagnostics: [
@@ -2130,7 +2130,7 @@ final class RecoveryTests: XCTestCase {
         let a = s.startIndex..<s.startIndex
         _ = a
         // The specific errors produced don't actually matter, but we need to reject this.
-        return "\(s[a1️⃣)"  
+        return "\(s[a1️⃣)"
       }
       """#,
       diagnostics: [
@@ -2203,7 +2203,7 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       func testSkipUnbalancedParen() {1️⃣
-        2️⃣?( 
+        2️⃣?(
       }
       """,
       diagnostics: [
@@ -2232,7 +2232,7 @@ final class RecoveryTests: XCTestCase {
     AssertParse(
       """
       func testSkipToFindOpenBrace2() {
-        do { if true {} else 1️⃣false } 
+        do { if true {} else 1️⃣false }
       }2️⃣
       """,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/SelfRebindingTests.swift
+++ b/Tests/SwiftParserTest/translated/SelfRebindingTests.swift
@@ -105,13 +105,13 @@ final class SelfRebindingTests: XCTestCase {
     AssertParse(
       """
       struct TypeWithSelfMethod {
-          let property = self 
+          let property = self
           // Existing warning expected, not confusable
-          let property2 = self() 
+          let property2 = self()
           let propertyFromClosure: () = {
-              print(self) 
+              print(self)
           }()
-          let propertyFromFunc = funcThatReturnsSomething(self) 
+          let propertyFromFunc = funcThatReturnsSomething(self)
           let propertyFromFunc2 = funcThatReturnsSomething(TypeWithSelfMethod.self) // OK
           func `self`() {
           }
@@ -126,11 +126,11 @@ final class SelfRebindingTests: XCTestCase {
       /// Test fix_unqualified_access_member_named_self doesn't appear for computed var called `self`
       /// it can't currently be referenced as a static member -- unlike a method with the same name
       struct TypeWithSelfComputedVar {
-          let property = self 
+          let property = self
           let propertyFromClosure: () = {
-              print(self) 
+              print(self)
           }()
-          let propertyFromFunc = funcThatReturnsSomething(self) 
+          let propertyFromFunc = funcThatReturnsSomething(self)
           var `self`: () {
               ()
           }
@@ -145,11 +145,11 @@ final class SelfRebindingTests: XCTestCase {
       /// Test fix_unqualified_access_member_named_self doesn't appear for property called `self`
       /// it can't currently be referenced as a static member -- unlike a method with the same name
       struct TypeWithSelfProperty {
-          let property = self 
+          let property = self
           let propertyFromClosure: () = {
-              print(self) 
+              print(self)
           }()
-          let propertyFromFunc = funcThatReturnsSomething(self) 
+          let propertyFromFunc = funcThatReturnsSomething(self)
           let `self`: () = ()
       }
       """

--- a/Tests/SwiftParserTest/translated/SubscriptingTests.swift
+++ b/Tests/SwiftParserTest/translated/SubscriptingTests.swift
@@ -139,7 +139,7 @@ final class SubscriptingTests: XCTestCase {
       """
       struct Y1 {
         var stored: Int
-        subscript(_: i, j: Int) -> Int { 
+        subscript(_: i, j: Int) -> Int {
           get {
             return stored + j
           }
@@ -177,7 +177,7 @@ final class SubscriptingTests: XCTestCase {
     AssertParse(
       """
       // FIXME: This test case does not belong in Parse/
-      let y2 = Y2() 
+      let y2 = Y2()
       _ = y2[0]
       """
     )
@@ -246,7 +246,7 @@ final class SubscriptingTests: XCTestCase {
         subscript (i : Int) 1️⃣
            Int {
           get {
-            return stored 
+            return stored
           }
           set {
             stored = newValue
@@ -270,7 +270,7 @@ final class SubscriptingTests: XCTestCase {
             return stored
           }
           set {
-            stored = newValue 
+            stored = newValue
           }
         }
       }
@@ -303,7 +303,7 @@ final class SubscriptingTests: XCTestCase {
     AssertParse(
       """
       struct A4 {
-        subscript(i : Int) 1️⃣{ 
+        subscript(i : Int) 1️⃣{
           get {
             return i
           }
@@ -320,7 +320,7 @@ final class SubscriptingTests: XCTestCase {
     AssertParse(
       """
       struct A5 {
-        subscript(i : Int) -> Int 
+        subscript(i : Int) -> Int
       }
       """
     )
@@ -330,9 +330,9 @@ final class SubscriptingTests: XCTestCase {
     AssertParse(
       """
       struct A6 {
-        subscript(i: Int)1️⃣(j: Int) -> Int { 
+        subscript(i: Int)1️⃣(j: Int) -> Int {
           get {
-            return i + j 
+            return i + j
           }
         }
       }
@@ -347,7 +347,7 @@ final class SubscriptingTests: XCTestCase {
     AssertParse(
       """
       struct A7 {
-        class subscript(a: Float) -> Int { 
+        class subscript(a: Float) -> Int {
           get {
             return 42
           }
@@ -361,7 +361,7 @@ final class SubscriptingTests: XCTestCase {
     AssertParse(
       """
       class A7b {
-        class static subscript(a: Float) -> Int { 
+        class static subscript(a: Float) -> Int {
           get {
             return 42
           }
@@ -395,7 +395,7 @@ final class SubscriptingTests: XCTestCase {
     AssertParse(
       """
       struct A9 {
-        subscript 1️⃣x() -> Int { 
+        subscript 1️⃣x() -> Int {
           return 0
         }
       }
@@ -418,10 +418,10 @@ final class SubscriptingTests: XCTestCase {
     AssertParse(
       """
       struct A10 {
-        subscript 1️⃣x(i: Int) -> Int { 
+        subscript 1️⃣x(i: Int) -> Int {
           return 0
         }
-        subscript 2️⃣x<T>(i: T) -> Int { 
+        subscript 2️⃣x<T>(i: T) -> Int {
           return 0
         }
       }

--- a/Tests/SwiftParserTest/translated/SuperTests.swift
+++ b/Tests/SwiftParserTest/translated/SuperTests.swift
@@ -22,8 +22,8 @@ final class SuperTests: XCTestCase {
       class B {
         var foo: Int
         func bar() {}
-        init() {} 
-        init(x: Int) {} 
+        init() {}
+        init(x: Int) {}
         subscript(x: Int) -> Int {
           get {}
           set {}
@@ -174,21 +174,21 @@ final class SuperTests: XCTestCase {
       class Closures : B {
         func captureWeak() {
           let g = { [weak self] () -> Void in // expected-note * {{'self' explicitly captured here}}
-            super.foo() 
+            super.foo()
           }
           g()
         }
         func captureUnowned() {
           let g = { [unowned self] () -> Void in // expected-note * {{'self' explicitly captured here}}
-            super.foo() 
+            super.foo()
           }
           g()
         }
         func nestedInner() {
           let g = { () -> Void in
             let h = { [weak self] () -> Void in // expected-note * {{'self' explicitly captured here}}
-              super.foo() 
-              nil ?? super.foo() 
+              super.foo()
+              nil ?? super.foo()
             }
             h()
           }
@@ -197,8 +197,8 @@ final class SuperTests: XCTestCase {
         func nestedOuter() {
           let g = { [weak self] () -> Void in // expected-note * {{'self' explicitly captured here}}
             let h = { () -> Void in
-              super.foo() 
-              nil ?? super.foo() 
+              super.foo()
+              nil ?? super.foo()
             }
             h()
           }

--- a/Tests/SwiftParserTest/translated/SwitchIncompleteTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchIncompleteTests.swift
@@ -20,7 +20,7 @@ final class SwitchIncompleteTests: XCTestCase {
       """
       // <rdar://problem/15971438> Incomplete switch was parsing to an AST that
       // triggered an assertion failure.
-      switch 1 ℹ️{ 
+      switch 1 ℹ️{
       case 1:1️⃣
       """,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/SwitchTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchTests.swift
@@ -154,7 +154,7 @@ final class SwitchTests: XCTestCase {
         x = 1
       case var y where y % 2 == 0:
         x = y + 1
-      case _ where 0: 
+      case _ where 0:
         x = 0
       default:
         x = 1
@@ -167,8 +167,8 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       // Multiple cases per case block
-      switch x { 
-      case 0: 
+      switch x {
+      case 0:
       case 1:
         x = 0
       }
@@ -180,7 +180,7 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       switch x {
-      case 0: 
+      case 0:
       default:
         x = 0
       }
@@ -191,10 +191,10 @@ final class SwitchTests: XCTestCase {
   func testSwitch13() {
     AssertParse(
       """
-      switch x { 
+      switch x {
       case 0:
         x = 0
-      case 1: 
+      case 1:
       }
       """
     )
@@ -206,7 +206,7 @@ final class SwitchTests: XCTestCase {
       switch x {
       case 0:
         x = 0
-      default: 
+      default:
       }
       """
     )
@@ -243,7 +243,7 @@ final class SwitchTests: XCTestCase {
         1️⃣x = 1
       default:
         x = 0
-      case 0: 
+      case 0:
         x = 0
       case 1:
         x = 0
@@ -284,7 +284,7 @@ final class SwitchTests: XCTestCase {
       switch x {
       default:
         x = 0
-      default: 
+      default:
         x = 0
       }
       """
@@ -294,8 +294,8 @@ final class SwitchTests: XCTestCase {
   func testSwitch18() {
     AssertParse(
       """
-      switch x { 
-        1️⃣x = 1 
+      switch x {
+        1️⃣x = 1
       }
       """,
       diagnostics: [
@@ -307,8 +307,8 @@ final class SwitchTests: XCTestCase {
   func testSwitch19() {
     AssertParse(
       """
-      switch x { 
-        1️⃣x = 1 
+      switch x {
+        1️⃣x = 1
         x = 2
       }
       """,
@@ -322,8 +322,8 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       switch x {
-      default: 
-      case 0: 
+      default:
+      case 0:
         x = 0
       }
       """
@@ -334,8 +334,8 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       switch x {
-      default: 
-      default: 
+      default:
+      default:
         x = 0
       }
       """
@@ -345,8 +345,8 @@ final class SwitchTests: XCTestCase {
   func testSwitch22() {
     AssertParse(
       """
-      switch x { 
-      default 1️⃣where x == 0: 
+      switch x {
+      default 1️⃣where x == 0:
         x = 0
       }
       """,
@@ -359,8 +359,8 @@ final class SwitchTests: XCTestCase {
   func testSwitch23() {
     AssertParse(
       """
-      switch x { 
-      case 0: 
+      switch x {
+      case 0:
       }
       """
     )
@@ -369,8 +369,8 @@ final class SwitchTests: XCTestCase {
   func testSwitch24() {
     AssertParse(
       """
-      switch x { 
-      case 0: 
+      switch x {
+      case 0:
       case 1:
         x = 0
       }
@@ -381,10 +381,10 @@ final class SwitchTests: XCTestCase {
   func testSwitch25() {
     AssertParse(
       """
-      switch x { 
+      switch x {
       case 0:
         x = 0
-      case 1: 
+      case 1:
       }
       """
     )
@@ -393,7 +393,7 @@ final class SwitchTests: XCTestCase {
   func testSwitch26() {
     AssertParse(
       """
-      1️⃣case 0: 
+      1️⃣case 0:
       var y = 0
       2️⃣default:
       var z = 1
@@ -422,7 +422,7 @@ final class SwitchTests: XCTestCase {
       case 1:
         fallthrough
       default:
-        fallthrough 
+        fallthrough
       }
       """
     )
@@ -466,33 +466,33 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       switch t {
-      case (var a, 2), (1, _): 
+      case (var a, 2), (1, _):
         ()
-      case (_, 2), (var a, _): 
+      case (_, 2), (var a, _):
         ()
-      case (var a, 2), (1, var b): 
+      case (var a, 2), (1, var b):
         ()
-      case (var a, 2): 
+      case (var a, 2):
       case (1, _):
         ()
-      case (_, 2): 
-      case (1, var a): 
+      case (_, 2):
+      case (1, var a):
         ()
-      case (var a, 2): 
-      case (1, var b): 
+      case (var a, 2):
+      case (1, var b):
         ()
       case (1, let b): // let bindings expected-warning {{immutable value 'b' was never used; consider replacing with '_' or removing it}}
         ()
-      case (_, 2), (let a, _): 
+      case (_, 2), (let a, _):
         ()
       // OK
       case (_, 2), (1, _):
         ()
-      case (_, var a), (_, var a): 
+      case (_, var a), (_, var a):
         ()
-      case (var a, var b), (var b, var a): 
+      case (var a, var b), (var b, var a):
         ()
-      case (_, 2): 
+      case (_, 2):
       case (1, _):
         ()
       }
@@ -505,8 +505,8 @@ final class SwitchTests: XCTestCase {
       """
       func patternVarUsedInAnotherPattern(x: Int) {
         switch x {
-        case let a, 
-             value: 
+        case let a,
+             value:
           break
         }
       }
@@ -520,8 +520,8 @@ final class SwitchTests: XCTestCase {
       // Fallthroughs can only transfer control into a case label with bindings if the previous case binds a superset of those vars.
       switch t {
       case (1, 2):
-        fallthrough 
-      case (var a, var b): 
+        fallthrough
+      case (var a, var b):
         t = (b, a)
       }
       """
@@ -532,7 +532,7 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       switch t { // specifically notice on next line that we shouldn't complain that a is unused - just never mutated
-      case (var a, let b): 
+      case (var a, let b):
         t = (b, b)
         fallthrough // ok - notice that subset of bound variables falling through is fine
       case (2, let a):
@@ -547,7 +547,7 @@ final class SwitchTests: XCTestCase {
       """
       func patternVarDiffType(x: Int, y: Double) {
         switch (x, y) {
-        case (1, let a): 
+        case (1, let a):
           fallthrough
         case (let a, _):
           break
@@ -562,7 +562,7 @@ final class SwitchTests: XCTestCase {
       """
       func patternVarDiffMutability(x: Int, y: Double) {
         switch x {
-        case let a where a < 5, var a where a > 10: 
+        case let a where a < 5, var a where a > 10:
           break
         default:
           break
@@ -571,7 +571,7 @@ final class SwitchTests: XCTestCase {
         // Would be nice to have a fixit in the following line if we detect that all bindings in the same pattern have the same problem.
         case let (a, b) where a < 5, var (a, b) where a > 10: // expected-error 2{{'var' pattern binding must match previous 'let' pattern binding}}{{none}}
           break
-        case (let a, var b) where a < 5, (let a, let b) where a > 10: 
+        case (let a, var b) where a < 5, (let a, let b) where a > 10:
           break
         case (let a, let b) where a < 5, (var a, let b) where a > 10, (let a, var b) where a == 8:
           break
@@ -587,7 +587,7 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       func test_label(x : Int) {
-      Gronk: 
+      Gronk:
         switch x {
         case 42: return
         }
@@ -601,7 +601,7 @@ final class SwitchTests: XCTestCase {
       """
       func enumElementSyntaxOnTuple() {
         switch (1, 1) {
-        case .Bar: 
+        case .Bar:
           break
         default:
           break
@@ -616,8 +616,8 @@ final class SwitchTests: XCTestCase {
       """
       // https://github.com/apple/swift/issues/42798
       enum Whatever { case Thing }
-      func f0(values: [Whatever]) { 
-          switch value { 
+      func f0(values: [Whatever]) {
+          switch value {
           case .Thing: // Ok. Don't emit diagnostics about enum case not found in type <<error type>>.
               break
           }
@@ -640,9 +640,9 @@ final class SwitchTests: XCTestCase {
         switch x {
           case Whichever.title: // Ok. Don't emit diagnostics for static member of enum.
               break
-          case Whichever.buzz: 
+          case Whichever.buzz:
               break
-          case Whichever.alias: 
+          case Whichever.alias:
           default:
             break
         }
@@ -651,7 +651,7 @@ final class SwitchTests: XCTestCase {
               break
           case Whichever.alias: // Ok. Don't emit diagnostics for static member of enum.
               break
-          case Whichever.title: 
+          case Whichever.title:
               break
         }
         switch y {
@@ -669,7 +669,7 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       switch Whatever.Thing {
-      case .Thing: 
+      case .Thing:
       @unknown case _:
         x = 0
       }
@@ -681,7 +681,7 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       switch Whatever.Thing {
-      case .Thing: 
+      case .Thing:
       @unknown default:
         x = 0
       }
@@ -695,7 +695,7 @@ final class SwitchTests: XCTestCase {
       switch Whatever.Thing {
       case .Thing:
         x = 0
-      @unknown case _: 
+      @unknown case _:
       }
       """
     )
@@ -707,7 +707,7 @@ final class SwitchTests: XCTestCase {
       switch Whatever.Thing {
       case .Thing:
         x = 0
-      @unknown default: 
+      @unknown default:
       }
       """
     )
@@ -719,7 +719,7 @@ final class SwitchTests: XCTestCase {
       switch Whatever.Thing {
       @unknown default:
         x = 0
-      default: 
+      default:
         x = 0
       case .Thing:
         x = 0
@@ -734,7 +734,7 @@ final class SwitchTests: XCTestCase {
       switch Whatever.Thing {
       default:
         x = 0
-      @unknown case _: 
+      @unknown case _:
         x = 0
       case .Thing:
         x = 0
@@ -749,7 +749,7 @@ final class SwitchTests: XCTestCase {
       switch Whatever.Thing {
       default:
         x = 0
-      @unknown default: 
+      @unknown default:
         x = 0
       case .Thing:
         x = 0
@@ -761,8 +761,8 @@ final class SwitchTests: XCTestCase {
   func testSwitch49() {
     AssertParse(
       """
-      switch Whatever.Thing { 
-      @unknown default 1️⃣where x == 0: 
+      switch Whatever.Thing {
+      @unknown default 1️⃣where x == 0:
         x = 0
       }
       """,
@@ -775,9 +775,9 @@ final class SwitchTests: XCTestCase {
   func testSwitch50() {
     AssertParse(
       """
-      switch Whatever.Thing { 
+      switch Whatever.Thing {
       @unknown case _:
-        fallthrough 
+        fallthrough
       }
       """
     )
@@ -787,7 +787,7 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       switch Whatever.Thing {
-      @unknown case _: 
+      @unknown case _:
         fallthrough
       case .Thing:
         break
@@ -802,7 +802,7 @@ final class SwitchTests: XCTestCase {
       switch Whatever.Thing {
       @unknown default:
         fallthrough
-      case .Thing: 
+      case .Thing:
         break
       }
       """
@@ -813,7 +813,7 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       switch Whatever.Thing {
-      @unknown case _, _: 
+      @unknown case _, _:
         break
       }
       """
@@ -824,7 +824,7 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       switch Whatever.Thing {
-      @unknown case _, _, _: 
+      @unknown case _, _, _:
         break
       }
       """
@@ -834,8 +834,8 @@ final class SwitchTests: XCTestCase {
   func testSwitch55() {
     AssertParse(
       """
-      switch Whatever.Thing { 
-      @unknown case let value: 
+      switch Whatever.Thing {
+      @unknown case let value:
         _ = value
       }
       """
@@ -845,8 +845,8 @@ final class SwitchTests: XCTestCase {
   func testSwitch56() {
     AssertParse(
       """
-      switch (Whatever.Thing, Whatever.Thing) { 
-      @unknown case (_, _): 
+      switch (Whatever.Thing, Whatever.Thing) {
+      @unknown case (_, _):
         break
       }
       """
@@ -856,8 +856,8 @@ final class SwitchTests: XCTestCase {
   func testSwitch57() {
     AssertParse(
       """
-      switch Whatever.Thing { 
-      @unknown case is Whatever: 
+      switch Whatever.Thing {
+      @unknown case is Whatever:
         break
       }
       """
@@ -867,8 +867,8 @@ final class SwitchTests: XCTestCase {
   func testSwitch58() {
     AssertParse(
       """
-      switch Whatever.Thing { 
-      @unknown case .Thing: 
+      switch Whatever.Thing {
+      @unknown case .Thing:
         break
       }
       """
@@ -878,7 +878,7 @@ final class SwitchTests: XCTestCase {
   func testSwitch59() {
     AssertParse(
       """
-      switch Whatever.Thing { 
+      switch Whatever.Thing {
       @unknown case (_): // okay
         break
       }
@@ -889,8 +889,8 @@ final class SwitchTests: XCTestCase {
   func testSwitch60() {
     AssertParse(
       """
-      switch Whatever.Thing { 
-      @unknown case _ where x == 0: 
+      switch Whatever.Thing {
+      @unknown case _ where x == 0:
         break
       }
       """
@@ -900,8 +900,8 @@ final class SwitchTests: XCTestCase {
   func testSwitch61() {
     AssertParse(
       """
-      switch Whatever.Thing { 
-      @unknown default 1️⃣where x == 0: 
+      switch Whatever.Thing {
+      @unknown default 1️⃣where x == 0:
         break
       }
       """,
@@ -932,7 +932,7 @@ final class SwitchTests: XCTestCase {
       switch x {
       case 0:
         break
-      @garbage case _: 
+      @garbage case _:
         break
       }
       """
@@ -968,7 +968,7 @@ final class SwitchTests: XCTestCase {
       """
       switch x {
       case _:
-        @unknown let _ = 1 
+        @unknown let _ = 1
       }
       """
     )
@@ -980,7 +980,7 @@ final class SwitchTests: XCTestCase {
       switch Whatever.Thing {
       case .Thing:
         break
-      @unknown1️⃣(garbage) case _: 
+      @unknown1️⃣(garbage) case _:
         break
       }
       switch Whatever.Thing {
@@ -991,7 +991,7 @@ final class SwitchTests: XCTestCase {
       case _:
         break
       }
-      switch Whatever.Thing { 
+      switch Whatever.Thing {
       @unknown 3️⃣@garbage(foobar)
       case _:
         break
@@ -1008,10 +1008,10 @@ final class SwitchTests: XCTestCase {
   func testSwitch68() {
     AssertParse(
       """
-      switch x { 
+      switch x {
       case 1:
         break
-      @unknown case _: 
+      @unknown case _:
         break
       }
       """
@@ -1021,8 +1021,8 @@ final class SwitchTests: XCTestCase {
   func testSwitch69() {
     AssertParse(
       """
-      switch x { 
-      @unknown case _: 
+      switch x {
+      @unknown case _:
         break
       }
       """
@@ -1032,8 +1032,8 @@ final class SwitchTests: XCTestCase {
   func testSwitch70() {
     AssertParse(
       """
-      switch x { 
-      @unknown default: 
+      switch x {
+      @unknown default:
         break
       }
       """
@@ -1046,7 +1046,7 @@ final class SwitchTests: XCTestCase {
       switch Whatever.Thing {
       case .Thing:
         break
-      @unknown case _: 
+      @unknown case _:
         break
       @unknown case _:
         break
@@ -1061,7 +1061,7 @@ final class SwitchTests: XCTestCase {
       switch Whatever.Thing {
       case .Thing:
         break
-      @unknown case _: 
+      @unknown case _:
         break
       @unknown default:
         break
@@ -1078,7 +1078,7 @@ final class SwitchTests: XCTestCase {
         break
       @unknown default:
         break
-      @unknown default: 
+      @unknown default:
         break
       }
       """
@@ -1089,7 +1089,7 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       switch Whatever.Thing {
-      @unknown case _: 
+      @unknown case _:
         break
       @unknown case _:
         break
@@ -1102,7 +1102,7 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       switch Whatever.Thing {
-      @unknown case _: 
+      @unknown case _:
         break
       @unknown default:
         break
@@ -1117,7 +1117,7 @@ final class SwitchTests: XCTestCase {
       switch Whatever.Thing {
       @unknown default:
         break
-      @unknown default: 
+      @unknown default:
         break
       }
       """
@@ -1128,7 +1128,7 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       switch x {
-      @unknown case _: 
+      @unknown case _:
         break
       @unknown case _:
         break
@@ -1141,7 +1141,7 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       switch x {
-      @unknown case _: 
+      @unknown case _:
         break
       @unknown default:
         break
@@ -1156,7 +1156,7 @@ final class SwitchTests: XCTestCase {
       switch x {
       @unknown default:
         break
-      @unknown default: 
+      @unknown default:
         break
       }
       """
@@ -1167,10 +1167,10 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       func testReturnBeforeUnknownDefault() {
-        switch x { 
+        switch x {
         case 1:
           return
-        @unknown default: 
+        @unknown default:
           break
         }
       }
@@ -1182,7 +1182,7 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       func testReturnBeforeIncompleteUnknownDefault() {
-        switch x { 
+        switch x {
         case 1:
           return
         @unknown default 1️⃣
@@ -1199,11 +1199,11 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       func testReturnBeforeIncompleteUnknownDefault2() {
-        switch x { 
+        switch x {
         case 1:
           return
         @unknown 1️⃣
-        } 
+        }
       }
       """,
       diagnostics: [
@@ -1216,10 +1216,10 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       func testIncompleteArrayLiteral() {
-        switch x { 
+        switch x {
         case 1:
           _ = ℹ️[1 1️⃣
-        @unknown default: 
+        @unknown default:
           ()
         }
       }

--- a/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
+++ b/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
@@ -134,7 +134,7 @@ final class TrailingClosuresTests: XCTestCase {
   func testTrailingClosures10() {
     AssertParse(
       """
-      func multiple_trailing_with_defaults( 
+      func multiple_trailing_with_defaults(
         duration: Int,
         animations: (() -> Void)? = nil,
         completion: (() -> Void)? = nil) {}
@@ -202,7 +202,7 @@ final class TrailingClosuresTests: XCTestCase {
   func testTrailingClosures14() {
     AssertParse(
       """
-      func produce(fn: () -> Int?, default d: () -> Int) -> Int { 
+      func produce(fn: () -> Int?, default d: () -> Int) -> Int {
         return fn() ?? d()
       }
       // TODO: The diagnostics here are perhaps a little overboard.
@@ -227,10 +227,10 @@ final class TrailingClosuresTests: XCTestCase {
   func testTrailingClosures16() {
     AssertParse(
       """
-      // This should be interpreted as a trailing closure, instead of being 
+      // This should be interpreted as a trailing closure, instead of being
       // interpreted as a computed property with undesired initial value.
       struct TrickyTest {
-          var x : Int = f () { 
+          var x : Int = f () {
               3
           }
       }

--- a/Tests/SwiftParserTest/translated/TryTests.swift
+++ b/Tests/SwiftParserTest/translated/TryTests.swift
@@ -59,7 +59,7 @@ final class TryTests: XCTestCase {
       var x = try foo() + bar()
       x = try foo() + bar()
       x += try foo() + bar()
-      x += try foo() %%%% bar() 
+      x += try foo() %%%% bar()
       x += try foo() %%% bar()
       x = foo() + try bar()
       """
@@ -81,7 +81,7 @@ final class TryTests: XCTestCase {
       var a = try! foo() + bar()
       a = try! foo() + bar()
       a += try! foo() + bar()
-      a += try! foo() %%%% bar() 
+      a += try! foo() %%%% bar()
       a += try! foo() %%% bar()
       a = foo() + try! bar()
       """
@@ -112,14 +112,14 @@ final class TryTests: XCTestCase {
     AssertParse(
       """
       var i = try? foo() + bar()
-      let _: Double = i 
+      let _: Double = i
       i = try? foo() + bar()
       i ?+= try? foo() + bar()
-      i ?+= try? foo() %%%% bar() 
+      i ?+= try? foo() %%%% bar()
       i ?+= try? foo() %%% bar()
-      _ = foo() == try? bar() 
-      _ = (try? foo()) == bar() 
-      _ = foo() == (try? bar()) 
+      _ = foo() == try? bar()
+      _ = (try? foo()) == bar()
+      _ = foo() == (try? bar())
       _ = (try? foo()) == (try? bar())
       """
     )
@@ -332,7 +332,7 @@ final class TryTests: XCTestCase {
       // Test operators.
       func *(a : String, b : String) throws -> Int { return 42 }
       let _ = "foo"
-              *  
+              *
               "bar"
       let _ = try! "foo"*"bar"
       let _ = try? "foo"*"bar"
@@ -347,7 +347,7 @@ final class TryTests: XCTestCase {
       // <rdar://problem/21414023> Assertion failure when compiling function that takes throwing functions and rethrows
       func rethrowsDispatchError(handleError: ((Error) throws -> ()), body: () throws -> ()) rethrows {
         do {
-          body()   
+          body()
         } catch {
         }
       }
@@ -362,7 +362,7 @@ final class TryTests: XCTestCase {
       struct r21432429 {
         func x(_ f: () throws -> ()) rethrows {}
         func y(_ f: () throws -> ()) rethrows {
-          x(f)  
+          x(f)
         }
       }
       """
@@ -374,7 +374,7 @@ final class TryTests: XCTestCase {
       """
       // <rdar://problem/21427855> Swift 2: Omitting try from call to throwing closure in rethrowing function crashes compiler
       func callThrowingClosureWithoutTry(closure: (Int) throws -> Int) rethrows {
-        closure(0)  
+        closure(0)
       }
       """
     )
@@ -430,7 +430,7 @@ final class TryTests: XCTestCase {
   func testTry22() {
     AssertParse(
       """
-      if try? maybeThrow() { 
+      if try? maybeThrow() {
       }
       let _: Int = try? foo()
       """
@@ -472,7 +472,7 @@ final class TryTests: XCTestCase {
     AssertParse(
       #"""
       _ = try "a\()b"
-      _ = "a\()b" 
+      _ = "a\()b"
       _ = try "\() \(1)"
       """#
     )
@@ -482,7 +482,7 @@ final class TryTests: XCTestCase {
     AssertParse(
       """
       func testGenericOptionalTry<T>(_ call: () throws -> T ) {
-        let _: String = try? call() 
+        let _: String = try? call()
       }
       """
     )
@@ -530,9 +530,9 @@ final class TryTests: XCTestCase {
   func testTry32() {
     AssertParse(
       """
-      let _: Int? = try? produceAny() as? Int 
+      let _: Int? = try? produceAny() as? Int
       let _: Int?? = (try? produceAny()) as? Int // good
-      let _: String = try? produceAny() as? Int 
+      let _: String = try? produceAny() as? Int
       let _: String = (try? produceAny()) as? Int
       """
     )
@@ -556,9 +556,9 @@ final class TryTests: XCTestCase {
     AssertParse(
       """
       let optProducer: ThingProducer? = ThingProducer()
-      let _: Int? = try? optProducer?.produceInt() 
-      let _: Int = try? optProducer?.produceInt() 
-      let _: String = try? optProducer?.produceInt() 
+      let _: Int? = try? optProducer?.produceInt()
+      let _: Int = try? optProducer?.produceInt()
+      let _: String = try? optProducer?.produceInt()
       let _: Int?? = try? optProducer?.produceInt() // good
       """
     )
@@ -567,7 +567,7 @@ final class TryTests: XCTestCase {
   func testTry35() {
     AssertParse(
       """
-      let _: Int? = try? optProducer?.produceIntNoThrowing() 
+      let _: Int? = try? optProducer?.produceIntNoThrowing()
       let _: Int?? = try? optProducer?.produceIntNoThrowing()
       """
     )
@@ -577,7 +577,7 @@ final class TryTests: XCTestCase {
     AssertParse(
       """
       let _: Int? = (try? optProducer?.produceAny()) as? Int // good
-      let _: Int? = try? optProducer?.produceAny() as? Int 
+      let _: Int? = try? optProducer?.produceAny() as? Int
       let _: Int?? = try? optProducer?.produceAny() as? Int // good
       let _: String = try? optProducer?.produceAny() as? Int
       """
@@ -603,9 +603,9 @@ final class TryTests: XCTestCase {
   func testTry39() {
     AssertParse(
       """
-      let _: Int = try? producer.produceDoubleOptionalInt() 
-      let _: Int? = try? producer.produceDoubleOptionalInt() 
-      let _: Int?? = try? producer.produceDoubleOptionalInt() 
+      let _: Int = try? producer.produceDoubleOptionalInt()
+      let _: Int? = try? producer.produceDoubleOptionalInt()
+      let _: Int?? = try? producer.produceDoubleOptionalInt()
       let _: Int??? = try? producer.produceDoubleOptionalInt() // good
       let _: String = try? producer.produceDoubleOptionalInt()
       """

--- a/Tests/SwiftParserTest/translated/TypeExprTests.swift
+++ b/Tests/SwiftParserTest/translated/TypeExprTests.swift
@@ -44,8 +44,8 @@ final class TypeExprTests: XCTestCase {
         associatedtype Zang
         init()
         // TODO class var prop: Int { get }
-        static func meth() {} 
-        func instMeth() {} 
+        static func meth() {}
+        func instMeth() {}
       }
       """
     )
@@ -55,7 +55,7 @@ final class TypeExprTests: XCTestCase {
     AssertParse(
       """
       protocol Bad {
-        init() {} 
+        init() {}
       }
       """
     )
@@ -91,9 +91,9 @@ final class TypeExprTests: XCTestCase {
         _ = Foo.meth
         let _ : () = Foo.meth()
         _ = Foo.instMeth
-        _ = Foo 
-        _ = Foo.dynamicType 
-        _ = Bad 
+        _ = Foo
+        _ = Foo.dynamicType
+        _ = Bad
       }
       """
     )
@@ -105,13 +105,13 @@ final class TypeExprTests: XCTestCase {
       func qualifiedType() {
         _ = Foo.Bar.self
         let _ : Foo.Bar.Type = Foo.Bar.self
-        let _ : Foo.Protocol = Foo.self 
+        let _ : Foo.Protocol = Foo.self
         _ = Foo.Bar()
         _ = Foo.Bar.prop
         _ = Foo.Bar.meth
         let _ : () = Foo.Bar.meth()
         _ = Foo.Bar.instMeth
-        _ = Foo.Bar 
+        _ = Foo.Bar
         _ = Foo.Bar.dynamicType
       }
       """
@@ -129,8 +129,8 @@ final class TypeExprTests: XCTestCase {
       func metaType() {
         let _ = Foo.Type.self
         let _ = Foo.Type.self
-        let _ = Foo.Type 
-        let _ = type(of: Foo.Type) 
+        let _ = Foo.Type
+        let _ = type(of: Foo.Type)
       }
       """
     )
@@ -170,7 +170,7 @@ final class TypeExprTests: XCTestCase {
         _ = Gen<Foo>.Bar.meth
         let _ : () = Gen<Foo>.Bar.meth()
         _ = Gen<Foo>.Bar.instMeth
-        _ = Gen<Foo>.Bar 
+        _ = Gen<Foo>.Bar
         _ = Gen<Foo>.Bar.dynamicType
 
         _ = (G<X>).Y.self
@@ -196,7 +196,7 @@ final class TypeExprTests: XCTestCase {
       """
       func typeOfShadowing() {
         // Try to shadow type(of:)
-        func type<T>(of t: T.Type, flag: Bool) -> T.Type { 
+        func type<T>(of t: T.Type, flag: Bool) -> T.Type {
           return t
         }
         func type<T, U>(of t: T.Type, _ : U) -> T.Type {
@@ -208,8 +208,8 @@ final class TypeExprTests: XCTestCase {
         func type<T>(fo t: T.Type) -> T.Type {
           return t
         }
-        _ = type(of: Gen<Foo>.Bar) 
-        _ = type(Gen<Foo>.Bar) 
+        _ = type(of: Gen<Foo>.Bar)
+        _ = type(Gen<Foo>.Bar)
         _ = type(of: Gen<Foo>.Bar.self, flag: false) // No error here.
         _ = type(fo: Foo.Bar.self) // No error here.
         _ = type(of: Foo.Bar.self, [1, 2, 3]) // No error here.
@@ -227,7 +227,7 @@ final class TypeExprTests: XCTestCase {
         // TODO let prop = T.prop
         _ = T.meth
         let _ : () = T.meth()
-        _ = T 
+        _ = T
       }
       """
     )
@@ -242,7 +242,7 @@ final class TypeExprTests: XCTestCase {
         // TODO _ = T.Zang.prop
         _ = T.Zang.meth
         let _ : () = T.Zang.meth()
-        _ = T.Zang 
+        _ = T.Zang
       }
       """
     )
@@ -271,8 +271,8 @@ final class TypeExprTests: XCTestCase {
         let _: D.Type = D.self
         _ = D.derivedMethod
         let _ : () = D.derivedMethod()
-        let _: B.Type = D 
-        let _: D.Type = D 
+        let _: B.Type = D
+        let _: D.Type = D
       }
       """
     )
@@ -284,9 +284,9 @@ final class TypeExprTests: XCTestCase {
       // Referencing a nonexistent member or constructor should not trigger errors
       // about the type expression.
       func nonexistentMember() {
-        let cons = Foo("this constructor does not exist") 
-        let prop = Foo.nonexistent 
-        let meth = Foo.nonexistent() 
+        let cons = Foo("this constructor does not exist")
+        let prop = Foo.nonexistent
+        let meth = Foo.nonexistent()
       }
       """#
     )
@@ -307,7 +307,7 @@ final class TypeExprTests: XCTestCase {
         let _: P.Protocol = P.self
         _ = P.Type.self
         _ = P.Protocol.self
-        _ = P.Protocol.Protocol.self 
+        _ = P.Protocol.Protocol.self
         _ = P.Protocol.Type.self
         _ = B.Type.self
       }
@@ -329,7 +329,7 @@ final class TypeExprTests: XCTestCase {
     AssertParse(
       """
       func inAccessibleInit() {
-        _ = E 
+        _ = E
       }
       """
     )
@@ -359,8 +359,8 @@ final class TypeExprTests: XCTestCase {
     AssertParse(
       """
       func implicitInit() {
-        _ = F 
-        _ = G 
+        _ = F
+        _ = G
       }
       """
     )
@@ -727,7 +727,7 @@ final class TypeExprTests: XCTestCase {
         takesOneArg(Swift.Int)
         takesTwoArgs(Int, 0)
         takesTwoArgs(Swift.Int, 0)
-        Swift.Int 
+        Swift.Int
         _ = Swift.Int
       }
       """


### PR DESCRIPTION
In mulit-line string literal tests these trailing whitespaces are really hard to spot but influence the test significantly. To make them more obvious, use `\u{20}`, which is visible in the editor and will be replaced by a normal space in `AssertParse`

In all other cases where the trailing whitespace doesn’t matter, remove it.