### PR TITLE
Replace DiagnosticsProviding protocol with concrete type

### DIFF
--- a/Sources/SwiftDiagnostics/Diagnostic.swift
+++ b/Sources/SwiftDiagnostics/Diagnostic.swift
@@ -74,12 +74,12 @@ public struct Diagnostic: CustomDebugStringConvertible {
 
 public struct DiagnosticsError: Error {
   public var diagnostics: [Diagnostic]
-  
+
   /// The diagnostics must contain at least one with severity == `.error`.
   /// Asserts if this condition is not satisfied.
   public init(diagnostics: [Diagnostic]) {
     self.diagnostics = diagnostics
-    
+
     assert(
       diagnostics.contains(where: { $0.diagMessage.severity == .error }),
       "at least one diagnostic must have severity == .error"

--- a/Sources/SwiftDiagnostics/Diagnostic.swift
+++ b/Sources/SwiftDiagnostics/Diagnostic.swift
@@ -72,8 +72,17 @@ public struct Diagnostic: CustomDebugStringConvertible {
   }
 }
 
-public protocol DiagnosticsProviding: Error {
-  /// The diagnostics provided by this error.
-  /// At least one diagnostic should have `severity == .error`.
-  var diagnostics: [Diagnostic] { get }
+public struct DiagnosticsError: Error {
+  public var diagnostics: [Diagnostic]
+  
+  /// The diagnostics must contain at least one with severity == `.error`.
+  /// Asserts if this condition is not satisfied.
+  public init(diagnostics: [Diagnostic]) {
+    self.diagnostics = diagnostics
+    
+    assert(
+      diagnostics.contains(where: { $0.diagMessage.severity == .error }),
+      "at least one diagnostic must have severity == .error"
+    )
+  }
 }

--- a/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
@@ -79,7 +79,7 @@ private struct ThrownErrorDiagnostic: DiagnosticMessage {
 extension MacroExpansionContext {
   /// Add diagnostics from the error thrown during macro expansion.
   public func addDiagnostics<S: SyntaxProtocol>(from error: Error, node: S) {
-    guard let diagnosticsProvider = error as? DiagnosticsProviding else {
+    guard let diagnosticsError = error as? DiagnosticsError else {
       diagnose(
         Diagnostic(
           node: Syntax(node),
@@ -89,13 +89,12 @@ extension MacroExpansionContext {
       return
     }
 
-    let providedDiagnostics = diagnosticsProvider.diagnostics
-    for diagnostic in providedDiagnostics {
+    for diagnostic in diagnosticsError.diagnostics {
       diagnose(diagnostic)
     }
 
     // handle possibility that none of the diagnostics was an error
-    if !providedDiagnostics.contains(
+    if !diagnosticsError.diagnostics.contains(
       where: { $0.diagMessage.severity == .error }
     ) {
       diagnose(


### PR DESCRIPTION
As discussed in #1318, a nicer design for providing diagnostics via thrown error is to expose a concrete error type:
```swift
public struct DiagnosticsError: Error {
  public var diagnostics: [Diagnostic]
}
```

This soft-asserts in init if none of the diagnostics has severity == `.error`, and removes the burden from users of creating their own conforming error type just to throw diagnostics.