### PR TITLE
Add a fuzzing target for SwiftParser

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/KeywordFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/KeywordFile.swift
@@ -38,7 +38,7 @@ let keywordFile = SourceFileSyntax {
   try! EnumDeclSyntax(
     """
     @frozen  // FIXME: Not actually stable, works around a miscompile
-    public enum Keyword: UInt8, Hashable
+    public enum Keyword: UInt8, Hashable, CaseIterable
     """
   ) {
     for (index, keyword) in KEYWORDS.enumerated() {

--- a/Package.swift
+++ b/Package.swift
@@ -140,6 +140,16 @@ let package = Package(
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ]
     ),
+    .executableTarget(
+      name: "fuzzing-target",
+      dependencies: [
+        "SwiftParser", "SwiftParserDiagnostics", "SwiftSyntax", "SwiftBasicFormat",
+      ],
+      exclude: ["README.md"],
+      swiftSettings: [
+        .unsafeFlags(["-parse-as-library"])
+      ]
+    ),
     .testTarget(name: "IDEUtilsTest", dependencies: ["_SwiftSyntaxTestSupport", "SwiftParser", "SwiftSyntax", "IDEUtils"]),
     .testTarget(
       name: "SwiftDiagnosticsTest",

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -71,6 +71,10 @@ extension Parser.Lookahead: TokenConsumer {
   public mutating func eat(_ kind: RawTokenKind) -> Token {
     return self.consume(if: kind)!
   }
+
+  #if ENABLE_FUZZING_INTERSPECTION
+  public mutating func recordAlternativeTokenChoice(for lexeme: Lexer.Lexeme, choices: [RawTokenKind]) {}
+  #endif
 }
 
 extension Parser.Lookahead {

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -202,6 +202,20 @@ public struct Parser {
       break
     }
   }
+
+  #if ENABLE_FUZZING_INTERSPECTION
+  /// When we are compiling for use with libFuzzer, this records alternative
+  /// interesting token choices for a token that has text (excluding trivia)
+  /// identified by the key in this dictionary. We use the base address of the
+  /// token's text start to identify tokens in the source tree, which is a
+  /// little hacky but works.
+  @_spi(RawSyntax)
+  public var alternativeTokenChoices: [SyntaxText: [RawTokenKind]] = [:]
+
+  public mutating func recordAlternativeTokenChoice(for lexeme: Lexer.Lexeme, choices: [RawTokenKind]) {
+    alternativeTokenChoices[lexeme.tokenText, default: []].append(contentsOf: choices)
+  }
+  #endif
 }
 
 // MARK: Inspecting Tokens

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -72,6 +72,9 @@ extension Parser.Lookahead {
     _ kind3: RawTokenKind,
     recoveryPrecedence: TokenPrecedence? = nil
   ) -> RecoveryConsumptionHandle? {
+    #if ENABLE_FUZZING_INTERSPECTION
+    recordAlternativeTokenChoice(for: self.currentToken, choices: [kind1, kind2, kind3])
+    #endif
     let initialTokensConsumed = self.tokensConsumed
 
     let recoveryPrecedence = recoveryPrecedence ?? min(TokenPrecedence(kind1), TokenPrecedence(kind2), TokenPrecedence(kind3))
@@ -131,6 +134,9 @@ extension Parser.Lookahead {
     anyIn subset: Subset.Type,
     recoveryPrecedence: TokenPrecedence? = nil
   ) -> (matchedKind: Subset, handle: RecoveryConsumptionHandle)? {
+    #if ENABLE_FUZZING_INTERSPECTION
+    recordAlternativeTokenChoice(for: self.currentToken, choices: subset.allCases.map(\.rawTokenKind))
+    #endif
     let initialTokensConsumed = self.tokensConsumed
 
     assert(!subset.allCases.isEmpty, "Subset must have at least one case")

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -24,7 +24,7 @@ extension StaticString: Equatable {
 }
 
 @frozen  // FIXME: Not actually stable, works around a miscompile
-public enum Keyword: UInt8, Hashable {
+public enum Keyword: UInt8, Hashable, CaseIterable {
   case __consuming
   
   case __owned

--- a/Sources/fuzzing-target/README.md
+++ b/Sources/fuzzing-target/README.md
@@ -1,0 +1,17 @@
+# `SwiftParser`’s `fuzzing-target`
+
+`fuzzing-target` is an entry point to fuzz `SwiftParser` using `libFuzzer`.
+
+To run it, compile the package using an open source toolchain using
+
+```
+/path/to/snapshot.xctoolchain/usr/bin/swift build -Xswiftc -sanitize=fuzzer --product fuzzing-target
+```
+
+Then create a directory of Swift files that you would like to use as initial seed inputs for fuzzing and run the fuzzer using
+
+```
+.build/debug/fuzzing-target /path/to/seed/inputs
+``` 
+
+As the fuzzer finds new interesting inputs, i.e. inputs that cover new code paths, it will store them in the directory you passed.

--- a/Sources/fuzzing-target/fuzzing-target.swift
+++ b/Sources/fuzzing-target/fuzzing-target.swift
@@ -1,0 +1,185 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftParser
+import SwiftParserDiagnostics
+import SwiftSyntax
+import SwiftBasicFormat
+import Darwin
+
+// MARK: - Testing an input
+
+@_cdecl("LLVMFuzzerTestOneInput")
+public func LLVMFuzzerTestOneInput(_ data: UnsafePointer<UInt8>, size: Int) -> CInt {
+  let source = UnsafeBufferPointer(start: data, count: size)
+  let tree = Parser.parse(source: source)
+
+  var diags = ParseDiagnosticsGenerator.diagnostics(for: tree)
+
+  if tree.syntaxTextBytes != [UInt8](source) {
+    assertionFailure("Source file did not round-trip")
+  }
+  return 0
+}
+
+// MARK: - Mutating the input
+
+enum RandomTokenGenerator {
+  static let allTokenKinds: [TokenKind] =
+    [
+      .wildcard,
+      .leftParen,
+      .rightParen,
+      .leftBrace,
+      .rightBrace,
+      .leftSquareBracket,
+      .rightSquareBracket,
+      .leftAngle,
+      .rightAngle,
+      .period,
+      .comma,
+      .ellipsis,
+      .colon,
+      .semicolon,
+      .equal,
+      .atSign,
+      .pound,
+      .prefixAmpersand,
+      .arrow,
+      .backtick,
+      .backslash,
+      .exclamationMark,
+      .postfixQuestionMark,
+      .infixQuestionMark,
+      .stringQuote,
+      .singleQuote,
+      .multilineStringQuote,
+      .poundSourceLocationKeyword,
+      .poundIfKeyword,
+      .poundElseKeyword,
+      .poundElseifKeyword,
+      .poundEndifKeyword,
+      .poundAvailableKeyword,
+      .poundUnavailableKeyword,
+      .integerLiteral("1"),
+      .floatingLiteral("1.0"),
+      .regexLiteral("/.*/"),
+      .identifier("myIdent"),
+      .binaryOperator("+"),
+      .postfixOperator("++"),
+      .prefixOperator("!"),
+      .dollarIdentifier("$0"),
+      .rawStringDelimiter("#"),
+      .stringSegment("abc"),
+    ] + Keyword.allCases.map(TokenKind.keyword)
+
+  static func createRandomToken() -> TokenSyntax {
+    let tokenKind = allTokenKinds[Int(drand48() * Double(allTokenKinds.count) - 1)]
+    return TokenSyntax(tokenKind, presence: .present).formatted().cast(TokenSyntax.self)
+  }
+}
+
+enum Mutation {
+  case replace(old: Syntax, new: Syntax)
+  case insert(before: Syntax, insert: Syntax)
+  case remove(node: Syntax)
+}
+
+/// Generates a list of mutations to apply to the tree.
+/// At the moment it just replaces, inserts and deletes tokens with probability 1% each.
+/// Improving this would be the next starting point to improvew the fuzzer.
+class MutationGenerator: SyntaxVisitor {
+  static func getMutations(for tree: Syntax) -> [Mutation] {
+    let generator = MutationGenerator(viewMode: .sourceAccurate)
+    generator.walk(tree)
+    return generator.mutations
+  }
+
+  private var mutations: [Mutation] = []
+
+  override func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
+    switch drand48() {
+    case 0..<0.01:
+      mutations.append(.replace(old: Syntax(node), new: Syntax(RandomTokenGenerator.createRandomToken())))
+    case 0..<0.02:
+      mutations.append(.insert(before: Syntax(node), insert: Syntax(RandomTokenGenerator.createRandomToken())))
+    case 0..<0.03:
+      mutations.append(.remove(node: Syntax(node)))
+    default:
+      break
+    }
+    return .visitChildren
+  }
+}
+
+class MutatedTreePrinter: SyntaxAnyVisitor {
+  /// Prints `tree` as bytes, applying `mutations`.
+  static func print(tree: Syntax, mutations: [Mutation]) -> [UInt8] {
+    let printer = MutatedTreePrinter(mutations: mutations)
+    printer.walk(tree)
+    return printer.printedSource
+  }
+
+  private let mutations: [Mutation]
+  private var printedSource: [UInt8] = []
+
+  private init(mutations: [Mutation]) {
+    self.mutations = mutations
+    super.init(viewMode: .sourceAccurate)
+  }
+
+  override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
+    for mutation in mutations {
+      switch mutation {
+      case .replace(let old, let new) where old == node:
+        printedSource.append(contentsOf: new.syntaxTextBytes)
+        return .skipChildren
+      case .insert(let before, let insert) where before == node:
+        printedSource.append(contentsOf: insert.syntaxTextBytes)
+        return .visitChildren
+      case .remove(let toRemove) where toRemove == node:
+        return .skipChildren
+      default:
+        break
+      }
+    }
+    return .visitChildren
+  }
+
+  override func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
+    if visitAny(Syntax(node)) == .skipChildren {
+      return .skipChildren
+    }
+    printedSource.append(contentsOf: node.syntaxTextBytes)
+    return .skipChildren
+  }
+}
+
+@_cdecl("LLVMFuzzerCustomMutator")
+public func LLVMFuzzerCustomMutator(_ data: UnsafeMutablePointer<UInt8>, size: Int, maxSize: Int, seed: UInt32) -> Int {
+  srand48(Int(seed))
+  let source = UnsafeBufferPointer(start: data, count: size)
+  let tree = Parser.parse(source: source)
+
+  let mutationGenerator = MutationGenerator(viewMode: .sourceAccurate)
+  mutationGenerator.walk(tree)
+
+  let mutations = MutationGenerator.getMutations(for: Syntax(tree))
+  var mutatedSource = MutatedTreePrinter.print(tree: Syntax(tree), mutations: mutations)
+
+  if mutatedSource.count > maxSize {
+    mutatedSource = Array(mutatedSource.prefix(maxSize))
+  }
+
+  data.update(from: &mutatedSource, count: mutatedSource.count)
+  return mutatedSource.count
+}


### PR DESCRIPTION
This is intended to be a starting point to fuzz SwiftParser. The custom mutator still isn’t very good but I hope that it’s something we can iterate from.

---

And I had my first idea to make the fuzzing more directed. When compiling with `-DENABLE_FUZZING_INTERSPECTION=1`, the parser will record token kinds it was checking for at specific offsets in the file. The fuzzing mutator can then use this information to replace tokens by one of the kinds the parser checked for, hopefully triggering a new code path.