### PR TITLE
Make `RawTokenKind` a trivial enum

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/ideutils/SyntaxClassificationFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/ideutils/SyntaxClassificationFile.swift
@@ -94,7 +94,7 @@ let syntaxClassificationFile = SourceFileSyntax {
 
   try! ExtensionDeclSyntax("extension RawTokenKind") {
     try VariableDeclSyntax("internal var classification: SyntaxClassification") {
-      try SwitchExprSyntax("switch self.base") {
+      try SwitchExprSyntax("switch self") {
         for token in SYNTAX_TOKENS {
           SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
             if let classification = token.classification {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/DeclarationModifierFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/DeclarationModifierFile.swift
@@ -30,7 +30,7 @@ let declarationModifierFile = SourceFileSyntax {
     }
 
     try InitializerDeclSyntax("init?(lexeme: Lexer.Lexeme)") {
-      try SwitchExprSyntax("switch lexeme") {
+      try SwitchExprSyntax("switch PrepareForKeywordMatch(lexeme)") {
         for attribute in DECL_MODIFIER_KINDS {
           SwitchCaseSyntax("case TokenSpec(.\(raw: attribute.swiftName)):") {
             ExprSyntax("self = .\(raw: attribute.swiftName)")

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/TypeAttributeFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/TypeAttributeFile.swift
@@ -31,7 +31,7 @@ let typeAttributeFile = SourceFileSyntax {
       }
 
       try InitializerDeclSyntax("init?(lexeme: Lexer.Lexeme)") {
-        SwitchExprSyntax(switchKeyword: .keyword(.switch), expression: ExprSyntax("lexeme")) {
+        try! SwitchExprSyntax("switch PrepareForKeywordMatch(lexeme)") {
           for attribute in TYPE_ATTR_KINDS {
             SwitchCaseSyntax("case TokenSpec(.\(raw: attribute.name)):") {
               ExprSyntax("self = .\(raw: attribute.swiftName)")

--- a/Sources/IDEUtils/generated/SyntaxClassification.swift
+++ b/Sources/IDEUtils/generated/SyntaxClassification.swift
@@ -135,7 +135,7 @@ extension SyntaxClassification {
 
 extension RawTokenKind {
   internal var classification: SyntaxClassification {
-    switch self.base {
+    switch self {
     case .wildcard: 
       return .none
     case .leftParen: 

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -65,7 +65,7 @@ extension Parser {
     case transpose
 
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme {
+      switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(._alignment): self = ._alignment
       case TokenSpec(._backDeploy): self = ._backDeploy
       case TokenSpec(._cdecl): self = ._cdecl
@@ -366,7 +366,7 @@ extension Parser {
     case forward
 
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme {
+      switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.reverse): self = .reverse
       case TokenSpec(._linear): self = .linear
       case TokenSpec(._forward): self = .forward
@@ -477,7 +477,7 @@ extension Parser {
       case selfKeyword
 
       init?(lexeme: Lexer.Lexeme) {
-        switch lexeme {
+        switch PrepareForKeywordMatch(lexeme) {
         case TokenSpec(.identifier): self = .identifier
         case TokenSpec(.integerLiteral): self = .integerLiteral
         case TokenSpec(.self): self = .selfKeyword
@@ -661,7 +661,7 @@ extension Parser {
     case available
 
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme {
+      switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.target): self = .target
       case TokenSpec(.availability): self = .availability
       case TokenSpec(.exported): self = .exported
@@ -1102,7 +1102,7 @@ extension Parser {
           }
 
           init?(lexeme: Lexer.Lexeme) {
-            switch lexeme {
+            switch PrepareForKeywordMatch(lexeme) {
             case TokenSpec(.private): self = .private
             case TokenSpec(.fileprivate): self = .fileprivate
             case TokenSpec(.internal): self = .internal

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -66,7 +66,7 @@ extension Parser {
     case identifier
 
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme {
+      switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.message): self = .message
       case TokenSpec(.renamed): self = .renamed
       case TokenSpec(.introduced): self = .introduced

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -345,7 +345,7 @@ extension Parser {
       }
 
       init?(lexeme: Lexer.Lexeme) {
-        switch lexeme {
+        switch PrepareForKeywordMatch(lexeme) {
         case TokenSpec(.typealias): self = .typealias
         case TokenSpec(.struct): self = .struct
         case TokenSpec(.class): self = .class
@@ -556,7 +556,7 @@ extension Parser {
     case nativeClassLayout
 
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme {
+      switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(._Trivial): self = .trivialLayout
       case TokenSpec(._TrivialAtMost): self = .trivialAtMostLayout
       case TokenSpec(._UnknownLayout): self = .unknownLayout
@@ -1494,7 +1494,7 @@ extension Parser {
           if hasTryBeforeIntroducer && !value.is(RawTryExprSyntax.self) {
             value = RawExprSyntax(
               RawTryExprSyntax(
-                tryKeyword: missingToken(.keyword(.try), text: nil),
+                tryKeyword: missingToken(.try),
                 questionOrExclamationMark: nil,
                 expression: value,
                 arena: self.arena
@@ -1993,7 +1993,7 @@ extension Parser {
       case lowerThan
 
       init?(lexeme: Lexer.Lexeme) {
-        switch lexeme {
+        switch PrepareForKeywordMatch(lexeme) {
         case TokenSpec(.associativity): self = .associativity
         case TokenSpec(.assignment): self = .assignment
         case TokenSpec(.higherThan): self = .higherThan

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -27,7 +27,7 @@ extension Parser {
     }
 
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme {
+      switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.poundIfKeyword): self = .poundIfKeyword
       case TokenSpec(.poundElseifKeyword): self = .poundElseifKeyword
       case TokenSpec(.poundElseKeyword): self = .poundElseKeyword

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -266,7 +266,7 @@ extension Parser {
       case throwsKeyword
 
       init?(lexeme: Lexer.Lexeme) {
-        switch lexeme {
+        switch PrepareForKeywordMatch(lexeme) {
         case TokenSpec(.binaryOperator): self = .binaryOperator
         case TokenSpec(.infixQuestionMark): self = .infixQuestionMark
         case TokenSpec(.equal): self = .equal
@@ -2256,7 +2256,7 @@ extension Parser {
               unknownAttr: nil,
               label: .case(
                 RawSwitchCaseLabelSyntax(
-                  caseKeyword: missingToken(.keyword(.case), text: nil),
+                  caseKeyword: missingToken(.case),
                   caseItems: RawCaseItemListSyntax(
                     elements: [
                       RawCaseItemSyntax(

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -218,7 +218,7 @@ extension Lexer {
     var input: UnsafeBufferPointer<UInt8>
     var previous: UInt8
     /// If we have already lexed a token, the kind of the previously lexed token
-    var previousTokenKind: RawTokenBaseKind?
+    var previousTokenKind: RawTokenKind?
     private var stateStack: StateStack = StateStack()
 
     init(input: UnsafeBufferPointer<UInt8>, previous: UInt8) {
@@ -357,7 +357,7 @@ extension Lexer.Cursor {
       flags.insert(.isAtStartOfLine)
     }
 
-    self.previousTokenKind = result.tokenKind.base
+    self.previousTokenKind = result.tokenKind
     diagnostic = TokenDiagnostic(combining: diagnostic, result.error?.tokenDiagnostic(tokenStart: cursor))
 
     return .init(
@@ -1900,7 +1900,7 @@ extension Lexer.Cursor {
 
     let text = tokStart.text(upTo: self)
     if let keyword = Keyword(text), keyword.isLexerClassified {
-      return Lexer.Result(.keyword(keyword))
+      return Lexer.Result(.keyword)
     } else if text == "_" {
       return Lexer.Result(.wildcard)
     } else {

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -166,7 +166,7 @@ extension Parser {
       }
 
       init?(lexeme: Lexer.Lexeme) {
-        switch lexeme {
+        switch PrepareForKeywordMatch(lexeme) {
         case TokenSpec(.private): self = .private
         case TokenSpec(.fileprivate): self = .fileprivate
         case TokenSpec(.internal): self = .internal
@@ -200,11 +200,7 @@ extension Parser {
       (unexpectedBeforeDetail, detail) = eat(setHandle)
     } else {
       unexpectedBeforeDetail = nil
-      detail = RawTokenSyntax(
-        missing: .keyword(.set),
-        text: "set",
-        arena: arena
-      )
+      detail = missingToken(.set)
     }
     let (unexpectedBeforeRightParen, rightParen) = expect(.rightParen)
 

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -282,7 +282,7 @@ extension Lexer.Lexeme {
     // Only lexer-classified lexemes have `RawTokenKind` of `keyword.
     // Contextual keywords will only be made keywords when a `RawTokenSyntax` is
     // constructed from them.
-    return self.rawTokenKind.base == .keyword
+    return self.rawTokenKind == .keyword
   }
 
   func starts(with symbol: SyntaxText) -> Bool {

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -169,6 +169,11 @@ public struct Parser {
     return RawTokenSyntax(missing: kind, text: text, arena: self.arena)
   }
 
+  @_spi(RawSyntax)
+  public mutating func missingToken(_ keyword: Keyword) -> RawTokenSyntax {
+    return missingToken(.keyword, text: keyword.defaultText)
+  }
+
   /// Consumes the current token and advances the lexer to the next token.
   ///
   /// - Returns: The token that was consumed.

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -55,7 +55,7 @@ extension Parser {
       case varKeyword
 
       init?(lexeme: Lexer.Lexeme) {
-        switch lexeme {
+        switch PrepareForKeywordMatch(lexeme) {
         case TokenSpec(.leftParen): self = .leftParen
         case TokenSpec(.wildcard): self = .wildcard
         case TokenSpec(.identifier): self = .identifier
@@ -296,7 +296,7 @@ extension Parser.Lookahead {
       case leftParen
 
       init?(lexeme: Lexer.Lexeme) {
-        switch lexeme {
+        switch PrepareForKeywordMatch(lexeme) {
         case TokenSpec(.identifier): self = .identifier
         case TokenSpec(.wildcard): self = .wildcard
         case TokenSpec(.let): self = .letKeyword

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -92,7 +92,7 @@ extension Parser.Lookahead {
           tokenConsumptionHandle: TokenConsumptionHandle(spec: matchedSpec)
         )
       }
-      let currentTokenPrecedence = TokenPrecedence(self.currentToken.rawTokenKind)
+      let currentTokenPrecedence = TokenPrecedence(self.currentToken)
       if currentTokenPrecedence >= recoveryPrecedence {
         break
       }
@@ -141,7 +141,7 @@ extension Parser.Lookahead {
           )
         )
       }
-      let currentTokenPrecedence = TokenPrecedence(self.currentToken.rawTokenKind)
+      let currentTokenPrecedence = TokenPrecedence(self.currentToken)
       if currentTokenPrecedence >= recoveryPrecedence {
         break
       }

--- a/Sources/SwiftParser/Specifiers.swift
+++ b/Sources/SwiftParser/Specifiers.swift
@@ -22,7 +22,7 @@ public enum AsyncEffectSpecifier: TokenSpecSet {
   init?(lexeme: Lexer.Lexeme) {
     // We'll take 'await' too for recovery but they have to be on the same line
     // as the declaration they're modifying.
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.async): self = .async
     case TokenSpec(.await, allowAtStartOfLine: false): self = .await
     case TokenSpec(.reasync): self = .reasync
@@ -57,7 +57,7 @@ public enum ThrowsEffectSpecifier: TokenSpecSet {
   init?(lexeme: Lexer.Lexeme) {
     // We'll take 'throw' and 'try' too for recovery but they have to
     // be on the same line as the declaration they're modifying.
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.rethrows): self = .rethrows
     case TokenSpec(.throw, allowAtStartOfLine: false): self = .throw
     case TokenSpec(.throws): self = .throws
@@ -178,7 +178,7 @@ extension RawDeclEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
     case await
 
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme {
+      switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.await, allowAtStartOfLine: false): self = .await
       default: return nil
       }
@@ -196,7 +196,7 @@ extension RawDeclEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
     case reasync
 
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme {
+      switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.async): self = .async
       case TokenSpec(.reasync): self = .reasync
       default: return nil
@@ -216,7 +216,7 @@ extension RawDeclEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
     case `throw`
 
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme {
+      switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.try, allowAtStartOfLine: false): self = .try
       case TokenSpec(.throw, allowAtStartOfLine: false): self = .throw
       default: return nil
@@ -236,7 +236,7 @@ extension RawDeclEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
     case `throws`
 
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme {
+      switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.rethrows): self = .rethrows
       case TokenSpec(.throws): self = .throws
       default: return nil
@@ -258,7 +258,7 @@ extension RawTypeEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
     case reasync
 
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme {
+      switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.await, allowAtStartOfLine: false): self = .await
       case TokenSpec(.reasync): self = .reasync
       default: return nil
@@ -277,7 +277,7 @@ extension RawTypeEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
     case async
 
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme {
+      switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.async): self = .async
       default: return nil
       }
@@ -296,7 +296,7 @@ extension RawTypeEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
     case `throw`
 
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme {
+      switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.rethrows): self = .rethrows
       case TokenSpec(.try, allowAtStartOfLine: false): self = .try
       case TokenSpec(.throw, allowAtStartOfLine: false): self = .throw
@@ -317,7 +317,7 @@ extension RawTypeEffectSpecifiersSyntax: RawEffectSpecifiersTrait {
     case `throws`
 
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme {
+      switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.throws): self = .throws
       default: return nil
       }

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -358,7 +358,7 @@ extension Parser {
     if hasMisplacedTry && !expr.is(RawTryExprSyntax.self) {
       expr = RawExprSyntax(
         RawTryExprSyntax(
-          tryKeyword: missingToken(.keyword(.try), text: nil),
+          tryKeyword: missingToken(.try),
           questionOrExclamationMark: nil,
           expression: expr,
           arena: self.arena
@@ -641,7 +641,7 @@ extension Parser {
       case eof
 
       init?(lexeme: Lexer.Lexeme) {
-        switch lexeme {
+        switch PrepareForKeywordMatch(lexeme) {
         case TokenSpec(.rightBrace): self = .rightBrace
         case TokenSpec(.case): self = .case
         case TokenSpec(.default): self = .default
@@ -703,7 +703,7 @@ extension Parser {
       if hasMisplacedTry && !parsedExpr.is(RawTryExprSyntax.self) {
         expr = RawExprSyntax(
           RawTryExprSyntax(
-            tryKeyword: missingToken(.keyword(.try), text: nil),
+            tryKeyword: missingToken(.try),
             questionOrExclamationMark: nil,
             expression: parsedExpr,
             arena: self.arena

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
+@_spi(RawSyntax) import SwiftSyntax
 
 /// Describes how distinctive a token is for parser recovery. When expecting a
 /// token, tokens with a lower token precedence may be skipped and considered
@@ -100,8 +100,17 @@ public enum TokenPrecedence: Comparable {
   }
 
   @_spi(RawSyntax)
-  public init(_ tokenKind: RawTokenKind) {
-    switch tokenKind.base {
+  public init(_ lexeme: Lexer.Lexeme) {
+    if lexeme.rawTokenKind == .keyword {
+      self.init(Keyword(lexeme.tokenText)!)
+    } else {
+      self.init(nonKeyword: lexeme.rawTokenKind)
+    }
+  }
+
+  @_spi(RawSyntax)
+  public init(nonKeyword tokenKind: RawTokenKind) {
+    switch tokenKind {
     case .unknown:
       self = .unknownToken
     // MARK: Identifier like
@@ -164,7 +173,8 @@ public enum TokenPrecedence: Comparable {
     case .poundEndifKeyword:
       self = .closingPoundIf
     case .keyword:
-      self.init(tokenKind.keyword)
+      assertionFailure("RawTokenKind passed to init(nonKeyword:) must not be a keyword")
+      self = .exprKeyword
     }
   }
 

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -38,7 +38,7 @@ enum AccessorKind: TokenSpecSet {
   case _modify
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.get): self = .get
     case TokenSpec(.set): self = .set
     case TokenSpec(.didSet): self = .didSet
@@ -90,7 +90,7 @@ enum CanBeStatementStart: TokenSpecSet {
   case yield
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.break): self = .breakKeyword
     case TokenSpec(.continue): self = .continueKeyword
     case TokenSpec(.defer): self = .deferKeyword
@@ -158,7 +158,7 @@ enum ContextualDeclKeyword: TokenSpecSet {
   case weak
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.__consuming): self = .__consuming
     case TokenSpec(._compilerInitialized): self = ._compilerInitialized
     case TokenSpec(._const): self = ._const
@@ -243,7 +243,7 @@ enum DeclarationStart: TokenSpecSet {
   case varKeyword
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.actor): self = .actorKeyword
     case TokenSpec(.macro): self = .macroKeyword
     case TokenSpec(.associatedtype): self = .associatedtypeKeyword
@@ -300,7 +300,7 @@ enum IdentifierTokens: TokenSpecSet {
   case selfKeyword
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.Any): self = .anyKeyword
     case TokenSpec(.Self): self = .capitalSelfKeyword
     case TokenSpec(.identifier): self = .identifier
@@ -329,7 +329,7 @@ enum IdentifierOrRethrowsTokens: TokenSpecSet {
   case rethrowsKeyword
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.Any): self = .anyKeyword
     case TokenSpec(.Self): self = .capitalSelfKeyword
     case TokenSpec(.identifier): self = .identifier
@@ -418,7 +418,7 @@ enum OperatorLike: TokenSpecSet {
     case .postfixQuestionMark: return TokenSpec(.postfixQuestionMark, remapping: .postfixOperator)
     case .equal: return TokenSpec(.equal, remapping: .binaryOperator)
     case .arrow: return TokenSpec(.arrow, remapping: .binaryOperator)
-    case .regexLiteral: return TokenSpec(.regexLiteral, remapping: .binaryOperator, recoveryPrecedence: TokenPrecedence(.binaryOperator))
+    case .regexLiteral: return TokenSpec(.regexLiteral, remapping: .binaryOperator, recoveryPrecedence: TokenPrecedence(nonKeyword: .binaryOperator))
     }
   }
 }
@@ -448,7 +448,7 @@ enum SwitchCaseStart: TokenSpecSet {
   case defaultKeyword
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.case): self = .caseKeyword
     case TokenSpec(.default): self = .defaultKeyword
     default: return nil
@@ -469,7 +469,7 @@ public enum TypeSpecifier: TokenSpecSet {
   case shared
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.inout): self = .inoutKeyword
     case TokenSpec(.__owned): self = .owned
     case TokenSpec(.__shared): self = .shared
@@ -504,7 +504,7 @@ enum AwaitTryMove: TokenSpecSet {
   case tryKeyword
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.await): self = .awaitKeyword
     case TokenSpec(._move): self = ._moveKeyword
     case TokenSpec(._borrow): self = ._borrowKeyword
@@ -528,7 +528,7 @@ enum IfOrSwitch: TokenSpecSet {
   case switchKeyword
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.if): self = .ifKeyword
     case TokenSpec(.switch): self = .switchKeyword
     default: return nil
@@ -572,7 +572,7 @@ enum MatchingPatternStart: TokenSpecSet {
   case varKeyword
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.is): self = .isKeyword
     case TokenSpec(.let): self = .letKeyword
     case TokenSpec(.var): self = .varKeyword
@@ -594,7 +594,7 @@ enum ParameterModifier: TokenSpecSet {
   case isolated
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(._const): self = ._const
     case TokenSpec(.isolated): self = .isolated
     default: return nil
@@ -637,7 +637,7 @@ enum PrimaryExpressionStart: TokenSpecSet {
   case singleQuote
 
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.Any): self = .anyKeyword
     case TokenSpec(.Self): self = .capitalSelfKeyword
     case TokenSpec(.dollarIdentifier): self = .dollarIdentifier

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -949,7 +949,7 @@ extension Parser {
       }
 
       init?(lexeme: Lexer.Lexeme) {
-        switch lexeme {
+        switch PrepareForKeywordMatch(lexeme) {
         case TokenSpec(.inout): self = .inout
         case TokenSpec(.__shared): self = .__shared
         case TokenSpec(.__owned): self = .__owned

--- a/Sources/SwiftParser/generated/DeclarationModifier.swift
+++ b/Sources/SwiftParser/generated/DeclarationModifier.swift
@@ -84,7 +84,7 @@ enum DeclarationModifier: TokenSpecSet {
   case _local
   
   init?(lexeme: Lexer.Lexeme) {
-    switch lexeme {
+    switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.`static`): 
       self = .`static`
     case TokenSpec(.`class`): 

--- a/Sources/SwiftParser/generated/TypeAttribute.swift
+++ b/Sources/SwiftParser/generated/TypeAttribute.swift
@@ -43,7 +43,7 @@ extension Parser {
     case _opaqueReturnTypeOf
     
     init?(lexeme: Lexer.Lexeme) {
-      switch lexeme {
+      switch PrepareForKeywordMatch(lexeme) {
       case TokenSpec(.autoclosure): 
         self = .autoclosure
       case TokenSpec(.convention): 

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -551,6 +551,7 @@ extension RawSyntax {
       presence: presence,
       tokenDiagnostic: tokenDiagnostic
     )
+    assert(kind != .keyword || Keyword(payload.tokenText) != nil, "If kind is keyword, the text must be a known token kind")
     return RawSyntax(arena: arena, payload: .parsedToken(payload))
   }
 
@@ -587,6 +588,7 @@ extension RawSyntax {
       presence: presence,
       tokenDiagnostic: tokenDiagnostic
     )
+    assert(kind != .keyword || Keyword(text) != nil, "If kind is keyword, the text must be a known token kind")
     return RawSyntax(arena: arena, payload: .materializedToken(payload))
   }
 

--- a/Sources/SwiftSyntax/generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/generated/TokenKind.swift
@@ -695,7 +695,7 @@ extension TokenKind: Equatable {
 // `RawTokenBaseKind` for equality. With the raw value, it compiles down to
 // a primitive integer compare, without, it calls into `__derived_enum_equals`.
 @frozen // FIXME: Not actually stable, works around a miscompile
-public enum RawTokenBaseKind: UInt8, Equatable, Hashable {
+public enum RawTokenKind: UInt8, Equatable, Hashable {
   case eof
   
   case wildcard
@@ -789,235 +789,10 @@ public enum RawTokenBaseKind: UInt8, Equatable, Hashable {
   case rawStringDelimiter
   
   case stringSegment
-}
-
-fileprivate extension Keyword {
-  static var rawValueZero: Keyword {
-    return Keyword(rawValue: 0)!
-  }
-}
-
-/// Similar to `TokenKind` but without a `String` associated value.
-/// Technically, this should be an enum like
-/// ```
-/// enum RawTokenKind {
-///   case eof
-///   case associatedtypeKeyword
-///   // remaining case from `RawTokenBaseKind`...
-///   case keyword(Keyword)
-/// }
-/// ```
-///
-/// But modelling it this way has significant performance implications since
-/// comparing two `RawTokenKind` calls into `__derived_enum_equals`. It's more
-/// effient to model the base kind as an enum with a raw value and store the
-/// keyword separately.
-///
-/// Whenever `base` is not `keyword`, `keyword` should have a raw value
-/// of `0`.
-@frozen // FIXME: Not actually stable, works around a miscompile
-public struct RawTokenKind: Equatable, Hashable {
-  public let base: RawTokenBaseKind
-  
-  public let keyword: Keyword
-  
-  public init(base: RawTokenBaseKind, keyword: Keyword) {
-    assert(base == .keyword || keyword.rawValue == 0)
-    self.base = base
-    self.keyword = keyword
-  }
-  
-  public static var eof: RawTokenKind {
-    return RawTokenKind(base: .eof, keyword: .rawValueZero)
-  }
-  
-  public static var wildcard: RawTokenKind {
-    return RawTokenKind(base: .wildcard, keyword: .rawValueZero)
-  }
-  
-  public static var leftParen: RawTokenKind {
-    return RawTokenKind(base: .leftParen, keyword: .rawValueZero)
-  }
-  
-  public static var rightParen: RawTokenKind {
-    return RawTokenKind(base: .rightParen, keyword: .rawValueZero)
-  }
-  
-  public static var leftBrace: RawTokenKind {
-    return RawTokenKind(base: .leftBrace, keyword: .rawValueZero)
-  }
-  
-  public static var rightBrace: RawTokenKind {
-    return RawTokenKind(base: .rightBrace, keyword: .rawValueZero)
-  }
-  
-  public static var leftSquareBracket: RawTokenKind {
-    return RawTokenKind(base: .leftSquareBracket, keyword: .rawValueZero)
-  }
-  
-  public static var rightSquareBracket: RawTokenKind {
-    return RawTokenKind(base: .rightSquareBracket, keyword: .rawValueZero)
-  }
-  
-  public static var leftAngle: RawTokenKind {
-    return RawTokenKind(base: .leftAngle, keyword: .rawValueZero)
-  }
-  
-  public static var rightAngle: RawTokenKind {
-    return RawTokenKind(base: .rightAngle, keyword: .rawValueZero)
-  }
-  
-  public static var period: RawTokenKind {
-    return RawTokenKind(base: .period, keyword: .rawValueZero)
-  }
-  
-  public static var comma: RawTokenKind {
-    return RawTokenKind(base: .comma, keyword: .rawValueZero)
-  }
-  
-  public static var ellipsis: RawTokenKind {
-    return RawTokenKind(base: .ellipsis, keyword: .rawValueZero)
-  }
-  
-  public static var colon: RawTokenKind {
-    return RawTokenKind(base: .colon, keyword: .rawValueZero)
-  }
-  
-  public static var semicolon: RawTokenKind {
-    return RawTokenKind(base: .semicolon, keyword: .rawValueZero)
-  }
-  
-  public static var equal: RawTokenKind {
-    return RawTokenKind(base: .equal, keyword: .rawValueZero)
-  }
-  
-  public static var atSign: RawTokenKind {
-    return RawTokenKind(base: .atSign, keyword: .rawValueZero)
-  }
-  
-  public static var pound: RawTokenKind {
-    return RawTokenKind(base: .pound, keyword: .rawValueZero)
-  }
-  
-  public static var prefixAmpersand: RawTokenKind {
-    return RawTokenKind(base: .prefixAmpersand, keyword: .rawValueZero)
-  }
-  
-  public static var arrow: RawTokenKind {
-    return RawTokenKind(base: .arrow, keyword: .rawValueZero)
-  }
-  
-  public static var backtick: RawTokenKind {
-    return RawTokenKind(base: .backtick, keyword: .rawValueZero)
-  }
-  
-  public static var backslash: RawTokenKind {
-    return RawTokenKind(base: .backslash, keyword: .rawValueZero)
-  }
-  
-  public static var exclamationMark: RawTokenKind {
-    return RawTokenKind(base: .exclamationMark, keyword: .rawValueZero)
-  }
-  
-  public static var postfixQuestionMark: RawTokenKind {
-    return RawTokenKind(base: .postfixQuestionMark, keyword: .rawValueZero)
-  }
-  
-  public static var infixQuestionMark: RawTokenKind {
-    return RawTokenKind(base: .infixQuestionMark, keyword: .rawValueZero)
-  }
-  
-  public static var stringQuote: RawTokenKind {
-    return RawTokenKind(base: .stringQuote, keyword: .rawValueZero)
-  }
-  
-  public static var singleQuote: RawTokenKind {
-    return RawTokenKind(base: .singleQuote, keyword: .rawValueZero)
-  }
-  
-  public static var multilineStringQuote: RawTokenKind {
-    return RawTokenKind(base: .multilineStringQuote, keyword: .rawValueZero)
-  }
-  
-  public static var poundSourceLocationKeyword: RawTokenKind {
-    return RawTokenKind(base: .poundSourceLocationKeyword, keyword: .rawValueZero)
-  }
-  
-  public static var poundIfKeyword: RawTokenKind {
-    return RawTokenKind(base: .poundIfKeyword, keyword: .rawValueZero)
-  }
-  
-  public static var poundElseKeyword: RawTokenKind {
-    return RawTokenKind(base: .poundElseKeyword, keyword: .rawValueZero)
-  }
-  
-  public static var poundElseifKeyword: RawTokenKind {
-    return RawTokenKind(base: .poundElseifKeyword, keyword: .rawValueZero)
-  }
-  
-  public static var poundEndifKeyword: RawTokenKind {
-    return RawTokenKind(base: .poundEndifKeyword, keyword: .rawValueZero)
-  }
-  
-  public static var poundAvailableKeyword: RawTokenKind {
-    return RawTokenKind(base: .poundAvailableKeyword, keyword: .rawValueZero)
-  }
-  
-  public static var poundUnavailableKeyword: RawTokenKind {
-    return RawTokenKind(base: .poundUnavailableKeyword, keyword: .rawValueZero)
-  }
-  
-  public static var integerLiteral: RawTokenKind {
-    return RawTokenKind(base: .integerLiteral, keyword: .rawValueZero)
-  }
-  
-  public static var floatingLiteral: RawTokenKind {
-    return RawTokenKind(base: .floatingLiteral, keyword: .rawValueZero)
-  }
-  
-  public static var regexLiteral: RawTokenKind {
-    return RawTokenKind(base: .regexLiteral, keyword: .rawValueZero)
-  }
-  
-  public static var unknown: RawTokenKind {
-    return RawTokenKind(base: .unknown, keyword: .rawValueZero)
-  }
-  
-  public static var identifier: RawTokenKind {
-    return RawTokenKind(base: .identifier, keyword: .rawValueZero)
-  }
-  
-  public static var binaryOperator: RawTokenKind {
-    return RawTokenKind(base: .binaryOperator, keyword: .rawValueZero)
-  }
-  
-  public static var postfixOperator: RawTokenKind {
-    return RawTokenKind(base: .postfixOperator, keyword: .rawValueZero)
-  }
-  
-  public static var prefixOperator: RawTokenKind {
-    return RawTokenKind(base: .prefixOperator, keyword: .rawValueZero)
-  }
-  
-  public static var dollarIdentifier: RawTokenKind {
-    return RawTokenKind(base: .dollarIdentifier, keyword: .rawValueZero)
-  }
-  
-  public static var rawStringDelimiter: RawTokenKind {
-    return RawTokenKind(base: .rawStringDelimiter, keyword: .rawValueZero)
-  }
-  
-  public static var stringSegment: RawTokenKind {
-    return RawTokenKind(base: .stringSegment, keyword: .rawValueZero)
-  }
-  
-  public static func keyword(_ keyword: Keyword) -> RawTokenKind {
-    return RawTokenKind(base: .keyword, keyword: keyword)
-  }
   
   @_spi(RawSyntax)
   public var defaultText: SyntaxText? {
-    switch self.base {
+    switch self {
     case .eof: 
       return ""
     case .wildcard: 
@@ -1088,8 +863,6 @@ public struct RawTokenKind: Equatable, Hashable {
       return #"#available"#
     case .poundUnavailableKeyword: 
       return #"#unavailable"#
-    case .keyword: 
-      return self.keyword.defaultText
     default: 
       return nil
     }
@@ -1101,7 +874,7 @@ public struct RawTokenKind: Equatable, Hashable {
   /// example, the '<' and '>' characters in a generic parameter list, or the
   /// quote characters in a string literal.
   public var isPunctuation: Bool {
-    switch self.base {
+    switch self {
     case .eof: 
       return false
     case .wildcard: 
@@ -1204,7 +977,7 @@ extension TokenKind {
   /// If the `rawKind` has a `defaultText`, `text` can be empty.
   @_spi(RawSyntax)
   public static func fromRaw(kind rawKind: RawTokenKind, text: String) -> TokenKind {
-    switch rawKind.base {
+    switch rawKind {
     case .eof: 
       return .eof
     case .wildcard: 
@@ -1328,8 +1101,10 @@ extension TokenKind {
     case .dollarIdentifier: 
       return .dollarIdentifier(text)
     case .keyword: 
-      assert(text.isEmpty || String(syntaxText: rawKind.keyword.defaultText) == text)
-      return .keyword(rawKind.keyword)
+      var text = text
+      return text.withSyntaxText { text in 
+        return .keyword(Keyword(text)!)
+      }
     case .rawStringDelimiter: 
       return .rawStringDelimiter(text)
     case .stringSegment: 
@@ -1431,7 +1206,7 @@ extension TokenKind {
     case .dollarIdentifier(let str): 
       return (.dollarIdentifier, str)
     case .keyword(let keyword): 
-      return (.keyword(keyword), nil)
+      return (.keyword, String(syntaxText: keyword.defaultText))
     case .rawStringDelimiter(let str): 
       return (.rawStringDelimiter, str)
     case .stringSegment(let str): 

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -84,7 +84,7 @@ public class LexerTests: XCTestCase {
       func not_doc5() {}
       """,
       lexemes: [
-        LexemeSpec(.keyword(.func), leading: "/*/ */\n", text: "func", trailing: " ", flags: [.isAtStartOfLine]),
+        LexemeSpec(.keyword, leading: "/*/ */\n", text: "func", trailing: " ", flags: [.isAtStartOfLine]),
         LexemeSpec(.identifier, text: "not_doc5"),
         LexemeSpec(.leftParen, text: "("),
         LexemeSpec(.rightParen, text: ")", trailing: " "),
@@ -274,7 +274,7 @@ public class LexerTests: XCTestCase {
       let x = 42
       """,
       lexemes: [
-        LexemeSpec(.keyword(.let), leading: "#!/usr/bin/swiftc\n", text: "let", trailing: " ", flags: [.isAtStartOfLine]),
+        LexemeSpec(.keyword, leading: "#!/usr/bin/swiftc\n", text: "let", trailing: " ", flags: [.isAtStartOfLine]),
         LexemeSpec(.identifier, text: "x", trailing: " "),
         LexemeSpec(.equal, text: "=", trailing: " "),
         LexemeSpec(.integerLiteral, text: "42"),
@@ -290,7 +290,7 @@ public class LexerTests: XCTestCase {
       /* regular comment */
       """,
       lexemes: [
-        LexemeSpec(.keyword(.var), leading: "/** hello */\n", text: "var", trailing: " ", flags: [.isAtStartOfLine]),
+        LexemeSpec(.keyword, leading: "/** hello */\n", text: "var", trailing: " ", flags: [.isAtStartOfLine]),
         LexemeSpec(.identifier, text: "x"),
         LexemeSpec(.colon, text: ":", trailing: " "),
         LexemeSpec(.identifier, text: "Int"),
@@ -312,11 +312,11 @@ public class LexerTests: XCTestCase {
       lexemes: [
         LexemeSpec(.atSign, leading: "/* TestApp */\n", text: "@", flags: [.isAtStartOfLine]),
         LexemeSpec(.identifier, text: "main", trailing: " "),
-        LexemeSpec(.keyword(.struct), text: "struct", trailing: " "),
+        LexemeSpec(.keyword, text: "struct", trailing: " "),
         LexemeSpec(.identifier, text: "TestApp", trailing: " "),
         LexemeSpec(.leftBrace, text: "{"),
-        LexemeSpec(.keyword(.static), leading: "\n  ", text: "static", trailing: " ", flags: [.isAtStartOfLine]),
-        LexemeSpec(.keyword(.func), text: "func", trailing: " "),
+        LexemeSpec(.keyword, leading: "\n  ", text: "static", trailing: " ", flags: [.isAtStartOfLine]),
+        LexemeSpec(.keyword, text: "func", trailing: " "),
         LexemeSpec(.identifier, text: "main"),
         LexemeSpec(.leftParen, text: "("),
         LexemeSpec(.rightParen, text: ")", trailing: " "),
@@ -428,8 +428,8 @@ public class LexerTests: XCTestCase {
     AssertLexemes(
       "static func 1️⃣�() {}",
       lexemes: [
-        LexemeSpec(.keyword(.static), text: "static", trailing: " "),
-        LexemeSpec(.keyword(.func), text: "func", trailing: " �", diagnostic: "invalid character in source file"),
+        LexemeSpec(.keyword, text: "static", trailing: " "),
+        LexemeSpec(.keyword, text: "func", trailing: " �", diagnostic: "invalid character in source file"),
         LexemeSpec(.leftParen, text: "("),
         LexemeSpec(.rightParen, text: ")", trailing: " "),
         LexemeSpec(.leftBrace, text: "{"),
@@ -567,12 +567,12 @@ public class LexerTests: XCTestCase {
       ///
       """,
       lexemes: [
-        LexemeSpec(.keyword(.var), text: "var", trailing: " "),
+        LexemeSpec(.keyword, text: "var", trailing: " "),
         LexemeSpec(.identifier, text: "x"),
         LexemeSpec(.colon, text: ":", trailing: " "),
         LexemeSpec(.identifier, text: "Int", trailing: " "),
         LexemeSpec(.leftBrace, text: "{"),
-        LexemeSpec(.keyword(.return), leading: "\n  ", text: "return", trailing: " ", flags: [.isAtStartOfLine]),
+        LexemeSpec(.keyword, leading: "\n  ", text: "return", trailing: " ", flags: [.isAtStartOfLine]),
         LexemeSpec(.integerLiteral, text: "0", trailing: " "),
         LexemeSpec(.binaryOperator, text: "/"),
         LexemeSpec(.identifier, leading: "\n         ", text: "x", flags: [.isAtStartOfLine]),
@@ -690,7 +690,7 @@ public class LexerTests: XCTestCase {
       }
       """,
       lexemes: [
-        LexemeSpec(.keyword(.func), text: "func", trailing: " "),
+        LexemeSpec(.keyword, text: "func", trailing: " "),
         LexemeSpec(.identifier, text: "foo"),
         LexemeSpec(.leftParen, text: "("),
         LexemeSpec(.rightParen, text: ")", trailing: " "),

--- a/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
@@ -15,7 +15,7 @@ import XCTest
 
 fileprivate func cannedStructDecl(arena: SyntaxArena) -> RawStructDeclSyntax {
   let structKW = RawTokenSyntax(
-    kind: .keyword(.struct),
+    kind: .keyword,
     text: arena.intern("struct"),
     leadingTriviaPieces: [],
     trailingTriviaPieces: [.spaces(1)],
@@ -145,7 +145,7 @@ final class RawSyntaxTests: XCTestCase {
       let barIdentSyntax = identSyntax.withKind(.keyword(.open))
       let barIdent = barIdentSyntax.raw.as(RawTokenSyntax.self)!
 
-      XCTAssertEqual(barIdent.tokenKind, .keyword(.open))
+      XCTAssertEqual(barIdent.tokenKind, .keyword)
       XCTAssertEqual(barIdent.tokenText, "open")
       XCTAssertEqual(barIdent.leadingTriviaPieces, [.unexpectedText("\n")])
       XCTAssertEqual(barIdent.trailingTriviaPieces, [.unexpectedText(" ")])


### PR DESCRIPTION
This changes `RawTokenKind` to be a trivial enum again, after I introduced an associated value for `keyword` a few months ago. To avoid repeatedly comparing strings or accessing `Keyword.defaultText` and thus regressing in performance, before matching a lexeme against a bunc of `TokenSpec` that refer to keywords, we pre-compute the keyword it might represent by wrapping it in `PrepareForKeywordMatch`.

Performance-wise I have seen slight improvements on on the order of ~2%-3% locally but nothing that I would eyeball as being statistically relevant - but there doesn’t seem to be a performance regression.

rdar://104659543