### PR TITLE
Enable a mode in the parser in which it inspects alternative token choices to mutate test cases

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,13 @@ if ProcessInfo.processInfo.environment["SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION"
   ]
 }
 
+var swiftParserSwiftSettings: [SwiftSetting] = []
+if ProcessInfo.processInfo.environment["SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION"] != nil {
+  swiftParserSwiftSettings += [
+    .define("SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION")
+  ]
+}
+
 let package = Package(
   name: "SwiftSyntax",
   platforms: [
@@ -170,12 +177,15 @@ let package = Package(
     .target(
       name: "SwiftParser",
       dependencies: ["SwiftSyntax"],
-      exclude: ["CMakeLists.txt", "README.md"]
+      exclude: ["CMakeLists.txt", "README.md"],
+      swiftSettings: swiftParserSwiftSettings
+
     ),
 
     .testTarget(
       name: "SwiftParserTest",
-      dependencies: ["_SwiftSyntaxTestSupport", "SwiftDiagnostics", "SwiftOperators", "SwiftParser", "SwiftSyntaxBuilder"]
+      dependencies: ["_SwiftSyntaxTestSupport", "SwiftDiagnostics", "SwiftOperators", "SwiftParser", "SwiftSyntaxBuilder"],
+      swiftSettings: swiftParserSwiftSettings
     ),
 
     // MARK: SwiftParserDiagnostics

--- a/Sources/SwiftParser/Lexer/LexemeSequence.swift
+++ b/Sources/SwiftParser/Lexer/LexemeSequence.swift
@@ -81,6 +81,20 @@ extension Lexer {
         return remainingText
       }
     }
+
+    #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
+    /// If `pointer` is in the source buffer of this `LexemeSequence`, return
+    /// its offset, otherwise `nil`. Should only be used for the parser's
+    /// alternate token introspection
+    func offset(of pointer: UnsafePointer<UInt8>) -> Int? {
+      let offset = pointer - self.sourceBufferStart.input.baseAddress!
+      if offset <= self.sourceBufferStart.input.count {
+        return offset
+      } else {
+        return nil
+      }
+    }
+    #endif
   }
 
   @_spi(RawSyntax)

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -70,6 +70,12 @@ extension Parser.Lookahead: TokenConsumer {
   mutating func eat(_ spec: TokenSpec) -> Token {
     return self.consume(if: spec)!
   }
+
+  #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
+  var shouldRecordAlternativeTokenChoices: Bool { false }
+
+  mutating public func recordAlternativeTokenChoice(for lexeme: Lexer.Lexeme, choices: [TokenSpec]) {}
+  #endif
 }
 
 extension Parser.Lookahead {

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -207,6 +207,34 @@ public struct Parser {
       break
     }
   }
+
+  #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
+  var shouldRecordAlternativeTokenChoices: Bool = false
+
+  public mutating func enableAlternativeTokenChoices() {
+    shouldRecordAlternativeTokenChoices = true
+  }
+
+  /// When compiled with `SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION`, and
+  /// `shouldRecordAlternativeTokenChoices` is `true` the parser records which
+  /// `TokenSpec`s it checked for a token at a specific offset in the source
+  /// file. The offsets are the location of the token text's start (excluding
+  /// leading trivia).
+  ///
+  /// This information allows testing techniques to replace tokens by these
+  /// alternate token choices to generate new, interesting test cases
+  @_spi(RawSyntax)
+  public var alternativeTokenChoices: [Int: [TokenSpec]] = [:]
+
+  mutating func recordAlternativeTokenChoice(for lexeme: Lexer.Lexeme, choices: [TokenSpec]) {
+    guard let lexemeBaseAddress = lexeme.tokenText.baseAddress,
+      let offset = lexemes.offset(of: lexemeBaseAddress)
+    else {
+      return
+    }
+    alternativeTokenChoices[offset, default: []].append(contentsOf: choices)
+  }
+  #endif
 }
 
 // MARK: Inspecting Tokens

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -67,6 +67,11 @@ extension Parser.Lookahead {
     _ spec2: TokenSpec,
     _ spec3: TokenSpec
   ) -> RecoveryConsumptionHandle? {
+    #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
+    if shouldRecordAlternativeTokenChoices {
+      recordAlternativeTokenChoice(for: self.currentToken, choices: [spec1, spec2, spec3])
+    }
+    #endif
     let initialTokensConsumed = self.tokensConsumed
 
     let recoveryPrecedence = min(spec1.recoveryPrecedence, spec2.recoveryPrecedence, spec3.recoveryPrecedence)
@@ -119,6 +124,11 @@ extension Parser.Lookahead {
     anyIn specSet: SpecSet.Type,
     overrideRecoveryPrecedence: TokenPrecedence? = nil
   ) -> (match: SpecSet, handle: RecoveryConsumptionHandle)? {
+    #if SWIFTPARSER_ENABLE_ALTERNATE_TOKEN_INTROSPECTION
+    if shouldRecordAlternativeTokenChoices {
+      recordAlternativeTokenChoice(for: self.currentToken, choices: specSet.allCases.map(\.spec))
+    }
+    #endif
     let initialTokensConsumed = self.tokensConsumed
 
     precondition(!specSet.allCases.isEmpty, "SpecSet must have at least one case")

--- a/Sources/SwiftParser/TokenSpec.swift
+++ b/Sources/SwiftParser/TokenSpec.swift
@@ -44,7 +44,8 @@ struct PrepareForKeywordMatch {
 /// marked `@inline(__always)` so the compiler inlines the `RawTokenKind` we are
 /// matching against and is thus able to rule out one of the branches in
 /// `matches(rawTokenKind:text:)` based on the matched kind.
-struct TokenSpec {
+@_spi(RawSyntax)
+public struct TokenSpec {
   /// The kind we expect the token that we want to consume to have.
   /// This can be a keyword, in which case the `TokenSpec` will also match an
   /// identifier with the same text as the keyword and remap it to that keyword
@@ -159,6 +160,29 @@ struct TokenSpec {
       keyword: lexeme.keyword,
       atStartOfLine: lexeme.isAtStartOfLine
     )
+  }
+
+  /// Returns a `TokenKind` that will most likely be parsed as a token that
+  /// matches this `TokenSpec`.
+  ///
+  /// IMPORTANT: Should only be used when generating tokens during the
+  /// modification of test cases. This should never be used in the parser itself.
+  public var synthesizedTokenKind: TokenKind {
+    switch rawTokenKind {
+    case .binaryOperator: return .binaryOperator("+")
+    case .dollarIdentifier: return .dollarIdentifier("$0")
+    case .extendedRegexDelimiter: return .extendedRegexDelimiter("#")
+    case .floatingLiteral: return .floatingLiteral("1.0")
+    case .identifier: return .identifier("myIdent")
+    case .integerLiteral: return .integerLiteral("1")
+    case .keyword: return .keyword(keyword!)
+    case .postfixOperator: return .postfixOperator("++")
+    case .prefixOperator: return .prefixOperator("!")
+    case .rawStringDelimiter: return .rawStringDelimiter("#")
+    case .regexLiteralPattern: return .regexLiteralPattern(".*")
+    case .stringSegment: return .stringSegment("abc")
+    default: return TokenKind.fromRaw(kind: rawTokenKind, text: "")
+    }
   }
 }
 

--- a/Tests/SwiftParserTest/Parser+EntryTests.swift
+++ b/Tests/SwiftParserTest/Parser+EntryTests.swift
@@ -16,18 +16,20 @@ import XCTest
 
 public class EntryTests: XCTestCase {
   func testTopLevelStringParse() throws {
-    assertParse("func test() {}", { Parser.parse(source: $0) })
+    let source = "func test() {}"
+    let tree = Parser.parse(source: source)
+    XCTAssert(tree.is(SourceFileSyntax.self))
+    XCTAssert(!tree.hasError)
+    XCTAssertEqual(tree.description, source)
   }
 
   func testTopLevelBufferParse() throws {
-    assertParse(
-      "func test() {}",
-      { (source: String) -> SourceFileSyntax in
-        var source = source
-        source.makeContiguousUTF8()
-        return source.withUTF8 { Parser.parse(source: $0) }
-      }
-    )
+    var source = "func test() {}"
+    source.makeContiguousUTF8()
+    let tree = source.withUTF8 { Parser.parse(source: $0) }
+    XCTAssert(tree.is(SourceFileSyntax.self))
+    XCTAssert(!tree.hasError)
+    XCTAssertEqual(tree.description, source)
   }
 
   func testSyntaxParse() throws {


### PR DESCRIPTION
The basic idea is that the parser records which `TokenSpec`s it checked for at individual offsets in the source. We can then use that information to generate new, interesting test cases by replacing a token by the one of the `TokenSpec` we checked for. This technique has found 7 bugs in the parser and I’m expecting it to find quite a few more once we assert that tokens have one of the expected kinds. I’m fixing the bugs this technique found in https://github.com/apple/swift-syntax/pull/1341.

Gathering of that information is hidden behind a conditional compilation flag because just performing the check of whether we want to record alternative token choices inflicts a 6% performance regression, which doesn’t provide any value except when we are running SwiftParserTest.