### PR TITLE
Don’t override existing unexpected tokens when parsing remainder in `SyntaxParsable`

### DIFF
--- a/Sources/SwiftParser/generated/Parser+Entry.swift
+++ b/Sources/SwiftParser/generated/Parser+Entry.swift
@@ -151,7 +151,15 @@ fileprivate extension Parser {
       return into
     }
 
-    let unexpected = RawUnexpectedNodesSyntax(elements: remainingTokens, arena: self.arena)
+    let existingUnexpected: [RawSyntax]
+    if let unexpectedNode = layout.children[layout.children.count - 1] {
+      assert(unexpectedNode.is(RawUnexpectedNodesSyntax.self))
+      existingUnexpected = unexpectedNode.as(RawUnexpectedNodesSyntax.self).elements
+    } else {
+      existingUnexpected = []
+    }
+    let unexpected = RawUnexpectedNodesSyntax(elements: existingUnexpected + remainingTokens, arena: self.arena)
+
     let withUnexpected = layout.replacingChild(at: layout.children.count - 1, with: unexpected.raw, arena: self.arena)
     return R.init(withUnexpected)!
   }

--- a/Tests/SwiftParserTest/Parser+EntryTests.swift
+++ b/Tests/SwiftParserTest/Parser+EntryTests.swift
@@ -44,4 +44,25 @@ public class EntryTests: XCTestCase {
       diagnostics: [DiagnosticSpec(message: "unexpected code 'other tokens' in function")]
     )
   }
+
+  func testRemainderUnexpectedDoesntOverrideExistingUnexpected() throws {
+    AssertParse(
+      "operator 1️⃣test 2️⃣{} other tokens",
+      { DeclSyntax.parse(from: &$0) },
+      substructure: Syntax(
+        UnexpectedNodesSyntax([
+          TokenSyntax.leftBraceToken(),
+          PrecedenceGroupAttributeListSyntax([]),
+          TokenSyntax.rightBraceToken(),
+          TokenSyntax.identifier("other"),
+          TokenSyntax.identifier("tokens"),
+        ])
+      ),
+      substructureAfterMarker: "2️⃣",
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "'test' is considered an identifier and must not appear within an operator name"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "operator should not be declared with body"),
+      ]
+    )
+  }
 }


### PR DESCRIPTION
Before, this was causing a round-trip failure because we we overriding the unexpected `{}` in the operator declaration by the tokens that were consumed by `consumeRemainder`.