### PR TITLE
Revert "Add missing code for parser entry template and fix `build-script.py`"

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserEntryFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserEntryFile.swift
@@ -87,15 +87,7 @@ let parserEntryFile = SourceFileSyntax(leadingTrivia: generateCopyrightHeader(fo
           return into
         }
 
-        let existingUnexpected: [RawSyntax]
-        if let unexpectedNode = layout.children[layout.children.count - 1] {
-           assert(unexpectedNode.is(RawUnexpectedNodesSyntax.self))
-           existingUnexpected = unexpectedNode.as(RawUnexpectedNodesSyntax.self).elements
-        } else {
-           existingUnexpected = []
-        }
-        let unexpected = RawUnexpectedNodesSyntax(elements: existingUnexpected + remainingTokens, arena: self.arena)
-
+        let unexpected = RawUnexpectedNodesSyntax(elements: remainingTokens, arena: self.arena)
         let withUnexpected = layout.replacingChild(at: layout.children.count - 1, with: unexpected.raw, arena: self.arena)
         return R.init(withUnexpected)!
       }

--- a/build-script.py
+++ b/build-script.py
@@ -433,8 +433,8 @@ def verify_gyb_generated_files(gyb_exec: str, verbose: bool) -> None:
 def verify_code_generated_files(
     toolchain: str, verbose: bool
 ) -> None:
-    self_temp_dir = tempfile.mkdtemp()
-
+    
+    
     try:
         run_code_generation(
             source_dir=self_temp_dir,
@@ -451,7 +451,7 @@ def verify_code_generated_files(
 
     for module in ["SwiftBasicFormat", "IDEUtils", \
       "SwiftParser", "SwiftSyntax", "SwiftSyntaxBuilder"]:
-      self_generated_dir = os.path.join(self_temp_dir, module, "generated")
+      self_generated_dir = os.path.join(self_temp_dir, "Sources", module, "generated")
       user_generated_dir = os.path.join(SOURCES_DIR, module, "generated")
       check_generated_files_match(self_generated_dir, user_generated_dir)
     


### PR DESCRIPTION
Reverts apple/swift-syntax#1352

Broke the build: https://ci.swift.org/job/oss-swift-incremental-RA-macos/2331/