### PR TITLE
Produce a meaningful diagnostic for "#elif" typo

### DIFF
--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -865,10 +865,18 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
           unexpectedBeforePoundKeyword
           .suffix(2)
           .compactMap { $0.as(TokenSyntax.self) }
+        var diagnosticMessage: DiagnosticMessage?
+
         if unexpectedTokens.map(\.tokenKind) == [.poundElseKeyword, .keyword(.if)] {
+          diagnosticMessage = StaticParserError.unexpectedPoundElseSpaceIf
+        } else if unexpectedTokens.first?.tokenKind == .pound, unexpectedTokens.last?.text == "elif" {
+          diagnosticMessage = UnknownDirectiveError(unexpected: unexpectedBeforePoundKeyword)
+        }
+
+        if let diagnosticMessage = diagnosticMessage {
           addDiagnostic(
             unexpectedBeforePoundKeyword,
-            StaticParserError.unexpectedPoundElseSpaceIf,
+            diagnosticMessage,
             fixIts: [
               FixIt(
                 message: ReplaceTokensFixIt(replaceTokens: unexpectedTokens, replacements: [clause.poundKeyword]),


### PR DESCRIPTION
## Purpose

To fix the second part of issue https://github.com/apple/swift-syntax/issues/1221: emit a proper diagnostic and fixit for the common `#elif` typo.

## Implementation details

I've considered two approaches:
1. Add a new `elif` case to the `TokenKind` enums, and later on use it to generate the proper diagnostic
2. Use the existing `pound` `TokenKind`  to determine if the user has a typo in the code and generate the diagnostic

I chose the second option because it didn't require changes to the `TokenKind` enums. I'm now adding unexpected tokens for the `.pound` + `.identifier` cases. If the identifier text is `elif`, I synthesize a `poundElseIf` token. I don't know how we could also check for `.pound` + `.keywords`, or if this would be needed.

For the diagnostic generations, I'm adding the proper fixit for the `elif` case, and if the identifier is any other word, I just add a generic diagnostic for it.

Any tip or help to get this right is really appreciated. Thank you in advance.