### PR TITLE
[Macros] Correct the where clause syntax type in `ConformanceMacro`.

### DIFF
--- a/Sources/SwiftSyntaxMacros/MacroProtocols/ConformanceMacro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/ConformanceMacro.swift
@@ -32,5 +32,5 @@ public protocol ConformanceMacro: AttachedMacro {
     of node: AttributeSyntax,
     providingConformancesOf declaration: Declaration,
     in context: Context
-  ) throws -> [(TypeSyntax, WhereClauseSyntax?)]
+  ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)]
 }


### PR DESCRIPTION
`WhereClauseSyntax` is used for expression conditions in statements; `GenericWhereClauseSyntax` lists generic requirements for conditional conformances.