### PR TITLE
Accept access level attributes on imports

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/AttributeKinds.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/AttributeKinds.swift
@@ -286,6 +286,7 @@ public let DECL_MODIFIER_KINDS: [Attribute] = [
                   "OnSubscript",
                   "OnConstructor",
                   "OnMacro",
+                  "OnImport",
                   "DeclModifier",
                   "NotSerialized",
                   "ABIStableToAdd",

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -556,4 +556,18 @@ final class AttributeTests: XCTestCase {
       """
     )
   }
+
+  func testImportAttributes() {
+    AssertParse(
+      """
+      import A
+      @_implementationOnly import B
+      public import C
+      package import D
+      internal import E
+      fileprivate import F
+      private import G
+      """
+    )
+  }
 }

--- a/gyb_syntax_support/AttributeKinds.py
+++ b/gyb_syntax_support/AttributeKinds.py
@@ -818,7 +818,7 @@ DECL_MODIFIER_KINDS = [
                                   code=44),
     DeclAttribute('private', 'AccessControl',
                   OnFunc,  OnAccessor,  OnExtension,  OnGenericType,  OnVar,  OnSubscript,
-                  OnConstructor, OnMacro,
+                  OnConstructor, OnMacro, OnImport,
                   DeclModifier,
                   NotSerialized,
                   ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,


### PR DESCRIPTION
This feature will be protected by an experimental flag on the compiler side.