### PR TITLE
Implement parsing for  `_forget` statement

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -133,6 +133,7 @@ public let KEYWORDS: [KeywordSpec] = [
   KeywordSpec("fileprivate", isLexerClassified: true, requiresTrailingSpace: true),
   KeywordSpec("final"),
   KeywordSpec("for", isLexerClassified: true, requiresTrailingSpace: true),
+  KeywordSpec("_forget"),
   KeywordSpec("forward"),
   KeywordSpec("func", isLexerClassified: true, requiresTrailingSpace: true),
   KeywordSpec("get"),

--- a/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift.gyb
+++ b/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift.gyb
@@ -4,7 +4,7 @@
   # -*- mode: Swift -*-
   # Ignore the following admonition it applies to the resulting .swift file only
 }%
-//// Automatically Generated From GenericNodes.swift.gyb.
+//// Automatically Generated From StmtNodes.swift.gyb.
 //// Do Not Edit Directly!
 //===----------------------------------------------------------------------===//
 //

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/StmtNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/StmtNodes.swift
@@ -1,4 +1,4 @@
-//// Automatically Generated From GenericNodes.swift.gyb.
+//// Automatically Generated From StmtNodes.swift.gyb.
 //// Do Not Edit Directly!
 //===----------------------------------------------------------------------===//
 //
@@ -209,6 +209,16 @@ public let STMT_NODES: [Node] = [
          Child(name: "Body",
                kind: .node(kind: "CodeBlock"),
                nameForDiagnostics: "body")
+       ]),
+
+  Node(name: "ForgetStmt",
+       nameForDiagnostics: "'forget' statement",
+       kind: "Stmt",
+       children: [
+         Child(name: "ForgetKeyword",
+               kind: .token(choices: [.keyword(text: "_forget")])),
+         Child(name: "Expression",
+               kind: .node(kind: "Expr"))
        ]),
 
   Node(name: "GuardStmt",

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -80,6 +80,7 @@ enum CanBeStatementStart: TokenSpecSet {
   case doKeyword
   case fallthroughKeyword
   case forKeyword
+  case forgetKeyword
   case guardKeyword
   case ifKeyword
   case repeatKeyword
@@ -97,6 +98,7 @@ enum CanBeStatementStart: TokenSpecSet {
     case TokenSpec(.do): self = .doKeyword
     case TokenSpec(.fallthrough): self = .fallthroughKeyword
     case TokenSpec(.for): self = .forKeyword
+    case TokenSpec(._forget): self = .forgetKeyword
     case TokenSpec(.guard): self = .guardKeyword
     case TokenSpec(.if): self = .ifKeyword
     case TokenSpec(.repeat): self = .repeatKeyword
@@ -117,6 +119,7 @@ enum CanBeStatementStart: TokenSpecSet {
     case .doKeyword: return .keyword(.do)
     case .fallthroughKeyword: return .keyword(.fallthrough)
     case .forKeyword: return .keyword(.for)
+    case .forgetKeyword: return TokenSpec(._forget, recoveryPrecedence: .stmtKeyword)
     case .guardKeyword: return .keyword(.guard)
     case .ifKeyword: return .keyword(.if)
     case .repeatKeyword: return .keyword(.repeat)

--- a/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
@@ -97,6 +97,7 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/FallthroughStmtSyntax>
 - <doc:SwiftSyntax/BreakStmtSyntax>
 - <doc:SwiftSyntax/ThrowStmtSyntax>
+- <doc:SwiftSyntax/ForgetStmtSyntax>
 
 ### Expressions
 

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -117,6 +117,7 @@ public enum Keyword: UInt8, Hashable {
   case `fileprivate`
   case final
   case `for`
+  case _forget
   case forward
   case `func`
   case get
@@ -428,6 +429,8 @@ public enum Keyword: UInt8, Hashable {
         self = .`default`
       case "dynamic":
         self = .dynamic
+      case "_forget":
+        self = ._forget
       case "forward":
         self = .forward
       case "message":
@@ -946,6 +949,7 @@ public enum Keyword: UInt8, Hashable {
       "fileprivate", 
       "final", 
       "for", 
+      "_forget", 
       "forward", 
       "func", 
       "get", 

--- a/Sources/SwiftSyntax/generated/Misc.swift
+++ b/Sources/SwiftSyntax/generated/Misc.swift
@@ -120,6 +120,7 @@ extension Syntax {
           .node(FloatLiteralExprSyntax.self), 
           .node(ForInStmtSyntax.self), 
           .node(ForcedValueExprSyntax.self), 
+          .node(ForgetStmtSyntax.self), 
           .node(FunctionCallExprSyntax.self), 
           .node(FunctionDeclSyntax.self), 
           .node(FunctionParameterListSyntax.self), 
@@ -493,6 +494,8 @@ extension SyntaxKind {
       return ForInStmtSyntax.self
     case .forcedValueExpr:
       return ForcedValueExprSyntax.self
+    case .forgetStmt:
+      return ForgetStmtSyntax.self
     case .functionCallExpr:
       return FunctionCallExprSyntax.self
     case .functionDecl:
@@ -1020,6 +1023,8 @@ extension SyntaxKind {
       return "'for' statement"
     case .forcedValueExpr:
       return "force unwrap"
+    case .forgetStmt:
+      return "'forget' statement"
     case .functionCallExpr:
       return "function call"
     case .functionDecl:

--- a/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
@@ -885,6 +885,14 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
   
+  override open func visit(_ node: ForgetStmtSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+  
+  override open func visitPost(_ node: ForgetStmtSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  
   override open func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -522,7 +522,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   
   public init?<S: SyntaxProtocol>(_ node: S) {
     switch node.raw.kind {
-    case .breakStmt, .continueStmt, .deferStmt, .doStmt, .expressionStmt, .fallthroughStmt, .forInStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatWhileStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
+    case .breakStmt, .continueStmt, .deferStmt, .doStmt, .expressionStmt, .fallthroughStmt, .forInStmt, .forgetStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatWhileStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
       self._syntaxNode = node._syntaxNode
     default:
       return nil
@@ -535,7 +535,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     #if DEBUG
     switch data.raw.kind {
-    case .breakStmt, .continueStmt, .deferStmt, .doStmt, .expressionStmt, .fallthroughStmt, .forInStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatWhileStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
+    case .breakStmt, .continueStmt, .deferStmt, .doStmt, .expressionStmt, .fallthroughStmt, .forInStmt, .forgetStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatWhileStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
       break
     default:
       fatalError("Unable to create StmtSyntax from \(data.raw.kind)")
@@ -578,6 +578,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           .node(ExpressionStmtSyntax.self), 
           .node(FallthroughStmtSyntax.self), 
           .node(ForInStmtSyntax.self), 
+          .node(ForgetStmtSyntax.self), 
           .node(GuardStmtSyntax.self), 
           .node(LabeledStmtSyntax.self), 
           .node(MissingStmtSyntax.self), 

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -120,6 +120,7 @@ public enum SyntaxEnum {
   case floatLiteralExpr(FloatLiteralExprSyntax)
   case forInStmt(ForInStmtSyntax)
   case forcedValueExpr(ForcedValueExprSyntax)
+  case forgetStmt(ForgetStmtSyntax)
   case functionCallExpr(FunctionCallExprSyntax)
   case functionDecl(FunctionDeclSyntax)
   case functionParameterList(FunctionParameterListSyntax)
@@ -492,6 +493,8 @@ public extension Syntax {
       return .forInStmt(ForInStmtSyntax(self)!)
     case .forcedValueExpr:
       return .forcedValueExpr(ForcedValueExprSyntax(self)!)
+    case .forgetStmt:
+      return .forgetStmt(ForgetStmtSyntax(self)!)
     case .functionCallExpr:
       return .functionCallExpr(FunctionCallExprSyntax(self)!)
     case .functionDecl:

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -120,6 +120,7 @@ public enum SyntaxKind {
   case floatLiteralExpr
   case forInStmt
   case forcedValueExpr
+  case forgetStmt
   case functionCallExpr
   case functionDecl
   case functionParameterList

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -753,6 +753,13 @@ open class SyntaxRewriter {
     return ExprSyntax(visitChildren(node))
   }
   
+  /// Visit a `ForgetStmtSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: ForgetStmtSyntax) -> StmtSyntax {
+    return StmtSyntax(visitChildren(node))
+  }
+  
   /// Visit a `FunctionCallExprSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -3376,6 +3383,20 @@ open class SyntaxRewriter {
   }
   
   /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplForgetStmtSyntax(_ data: SyntaxData) -> Syntax {
+    let node = ForgetStmtSyntax(data)
+    // Accessing _syntaxNode directly is faster than calling Syntax(node)
+    visitPre(node._syntaxNode)
+    defer { 
+      visitPost(node._syntaxNode) 
+    }
+    if let newNode = visitAny(node._syntaxNode) { 
+      return newNode 
+    }
+    return Syntax(visit(node))
+  }
+  
+  /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplFunctionCallExprSyntax(_ data: SyntaxData) -> Syntax {
     let node = FunctionCallExprSyntax(data)
     // Accessing _syntaxNode directly is faster than calling Syntax(node)
@@ -5809,6 +5830,8 @@ open class SyntaxRewriter {
       return visitImplForInStmtSyntax
     case .forcedValueExpr:
       return visitImplForcedValueExprSyntax
+    case .forgetStmt:
+      return visitImplForgetStmtSyntax
     case .functionCallExpr:
       return visitImplFunctionCallExprSyntax
     case .functionDecl:
@@ -6339,6 +6362,8 @@ open class SyntaxRewriter {
       return visitImplForInStmtSyntax(data)
     case .forcedValueExpr:
       return visitImplForcedValueExprSyntax(data)
+    case .forgetStmt:
+      return visitImplForgetStmtSyntax(data)
     case .functionCallExpr:
       return visitImplFunctionCallExprSyntax(data)
     case .functionDecl:

--- a/Sources/SwiftSyntax/generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTransform.swift
@@ -539,6 +539,11 @@ public protocol SyntaxTransformVisitor {
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: ForcedValueExprSyntax) -> ResultType
   
+  /// Visiting `ForgetStmtSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: ForgetStmtSyntax) -> ResultType
+  
   /// Visiting `FunctionCallExprSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -2053,6 +2058,13 @@ extension SyntaxTransformVisitor {
     visitAny(Syntax(node))
   }
   
+  /// Visiting `ForgetStmtSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: ForgetStmtSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
+  
   /// Visiting `FunctionCallExprSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
@@ -3356,6 +3368,8 @@ extension SyntaxTransformVisitor {
     case .forInStmt(let derived):
       return visit(derived)
     case .forcedValueExpr(let derived):
+      return visit(derived)
+    case .forgetStmt(let derived):
       return visit(derived)
     case .functionCallExpr(let derived):
       return visit(derived)

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -1282,6 +1282,18 @@ open class SyntaxVisitor {
   open func visitPost(_ node: ForcedValueExprSyntax) {
   }
   
+  /// Visiting `ForgetStmtSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: ForgetStmtSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+  
+  /// The function called after visiting `ForgetStmtSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: ForgetStmtSyntax) {
+  }
+  
   /// Visiting `FunctionCallExprSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -4311,6 +4323,17 @@ open class SyntaxVisitor {
   }
   
   /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplForgetStmtSyntax(_ data: SyntaxData) {
+    let node = ForgetStmtSyntax(data)
+    let needsChildren = (visit(node) == .visitChildren)
+    // Avoid calling into visitChildren if possible.
+    if needsChildren && !node.raw.layoutView!.children.isEmpty {
+      visitChildren(node)
+    }
+    visitPost(node)
+  }
+  
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplFunctionCallExprSyntax(_ data: SyntaxData) {
     let node = FunctionCallExprSyntax(data)
     let needsChildren = (visit(node) == .visitChildren)
@@ -6241,6 +6264,8 @@ open class SyntaxVisitor {
       visitImplForInStmtSyntax(data)
     case .forcedValueExpr:
       visitImplForcedValueExprSyntax(data)
+    case .forgetStmt:
+      visitImplForgetStmtSyntax(data)
     case .functionCallExpr:
       visitImplFunctionCallExprSyntax(data)
     case .functionDecl:

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -8150,6 +8150,72 @@ public struct RawForcedValueExprSyntax: RawExprSyntaxNodeProtocol {
 }
 
 @_spi(RawSyntax)
+public struct RawForgetStmtSyntax: RawStmtSyntaxNodeProtocol {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+  
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .forgetStmt
+  }
+  
+  public var raw: RawSyntax
+  
+  init(raw: RawSyntax) {
+    assert(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+    guard Self.isKindOf(other.raw) else { 
+      return nil 
+    }
+    self.init(raw: other.raw)
+  }
+  
+  public init(
+      _ unexpectedBeforeForgetKeyword: RawUnexpectedNodesSyntax? = nil, 
+      forgetKeyword: RawTokenSyntax, 
+      _ unexpectedBetweenForgetKeywordAndExpression: RawUnexpectedNodesSyntax? = nil, 
+      expression: RawExprSyntax, 
+      _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
+      arena: __shared SyntaxArena
+    ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .forgetStmt, uninitializedCount: 5, arena: arena) { layout in 
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeForgetKeyword?.raw
+      layout[1] = forgetKeyword.raw
+      layout[2] = unexpectedBetweenForgetKeywordAndExpression?.raw
+      layout[3] = expression.raw
+      layout[4] = unexpectedAfterExpression?.raw
+    }
+    self.init(raw: raw)
+  }
+  
+  public var unexpectedBeforeForgetKeyword: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var forgetKeyword: RawTokenSyntax {
+    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  
+  public var unexpectedBetweenForgetKeywordAndExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var expression: RawExprSyntax {
+    layoutView.children[3].map(RawExprSyntax.init(raw:))!
+  }
+  
+  public var unexpectedAfterExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+}
+
+@_spi(RawSyntax)
 public struct RawFunctionCallExprSyntax: RawExprSyntaxNodeProtocol {
   @_spi(RawSyntax)
   public var layoutView: RawSyntaxLayoutView {
@@ -16622,7 +16688,7 @@ public struct RawStmtSyntax: RawStmtSyntaxNodeProtocol {
   
   public static func isKindOf(_ raw: RawSyntax) -> Bool {
     switch raw.kind {
-    case .breakStmt, .continueStmt, .deferStmt, .doStmt, .expressionStmt, .fallthroughStmt, .forInStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatWhileStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt: 
+    case .breakStmt, .continueStmt, .deferStmt, .doStmt, .expressionStmt, .fallthroughStmt, .forInStmt, .forgetStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatWhileStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt: 
       return true
     default: 
       return false

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -1092,6 +1092,14 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
     break
+  case .forgetStmt:
+    assert(layout.count == 5)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self))
+    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 3, verify(layout[3], as: RawExprSyntax.self))
+    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
+    break
   case .functionCallExpr:
     assert(layout.count == 13)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -1237,6 +1237,150 @@ extension ForInStmtSyntax: CustomReflectable {
   }
 }
 
+// MARK: - ForgetStmtSyntax
+
+
+public struct ForgetStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+  public let _syntaxNode: Syntax
+  
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .forgetStmt else { 
+      return nil 
+    }
+    self._syntaxNode = node._syntaxNode
+  }
+  
+  /// Creates a `ForgetStmtSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .forgetStmt)
+    self._syntaxNode = Syntax(data)
+  }
+  
+  public init<E: ExprSyntaxProtocol>(
+      leadingTrivia: Trivia? = nil, 
+      _ unexpectedBeforeForgetKeyword: UnexpectedNodesSyntax? = nil, 
+      forgetKeyword: TokenSyntax = .keyword(._forget), 
+      _ unexpectedBetweenForgetKeywordAndExpression: UnexpectedNodesSyntax? = nil, 
+      expression: E, 
+      _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil, 
+      trailingTrivia: Trivia? = nil
+    
+  ) {
+    // Extend the lifetime of all parameters so their arenas don't get destroyed
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (
+            unexpectedBeforeForgetKeyword, 
+            forgetKeyword, 
+            unexpectedBetweenForgetKeywordAndExpression, 
+            expression, 
+            unexpectedAfterExpression
+          ))) {(arena, _) in 
+      let layout: [RawSyntax?] = [
+          unexpectedBeforeForgetKeyword?.raw, 
+          forgetKeyword.raw, 
+          unexpectedBetweenForgetKeywordAndExpression?.raw, 
+          expression.raw, 
+          unexpectedAfterExpression?.raw
+        ]
+      let raw = RawSyntax.makeLayout(
+          kind: SyntaxKind.forgetStmt, 
+          from: layout, 
+          arena: arena, 
+          leadingTrivia: leadingTrivia, 
+          trailingTrivia: trailingTrivia
+        )
+      return SyntaxData.forRoot(raw)
+    }
+    self.init(data)
+  }
+  
+  public var unexpectedBeforeForgetKeyword: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = ForgetStmtSyntax(data.replacingChild(at: 0, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var forgetKeyword: TokenSyntax {
+    get {
+      return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)
+    }
+    set(value) {
+      self = ForgetStmtSyntax(data.replacingChild(at: 1, with: value.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var unexpectedBetweenForgetKeywordAndExpression: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 2, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = ForgetStmtSyntax(data.replacingChild(at: 2, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var expression: ExprSyntax {
+    get {
+      return ExprSyntax(data.child(at: 3, parent: Syntax(self))!)
+    }
+    set(value) {
+      self = ForgetStmtSyntax(data.replacingChild(at: 3, with: value.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = ForgetStmtSyntax(data.replacingChild(at: 4, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public static var structure: SyntaxNodeStructure {
+    return .layout([
+          \Self.unexpectedBeforeForgetKeyword, 
+          \Self.forgetKeyword, 
+          \Self.unexpectedBetweenForgetKeywordAndExpression, 
+          \Self.expression, 
+          \Self.unexpectedAfterExpression
+        ])
+  }
+  
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
+}
+
+extension ForgetStmtSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+          "unexpectedBeforeForgetKeyword": unexpectedBeforeForgetKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
+          "forgetKeyword": Syntax(forgetKeyword).asProtocol(SyntaxProtocol.self), 
+          "unexpectedBetweenForgetKeywordAndExpression": unexpectedBetweenForgetKeywordAndExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
+          "expression": Syntax(expression).asProtocol(SyntaxProtocol.self), 
+          "unexpectedAfterExpression": unexpectedAfterExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any
+        ])
+  }
+}
+
 // MARK: - GuardStmtSyntax
 
 

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -574,6 +574,76 @@ final class StatementTests: XCTestCase {
     )
   }
 
+  func testForget() {
+    AssertParse(
+      """
+      _forget self
+      """,
+      substructure: Syntax(
+        ForgetStmtSyntax(
+          expression: IdentifierExprSyntax(identifier: .keyword(.`self`))
+        )
+      )
+    )
+
+    AssertParse(
+      """
+      _forget Self
+      """,
+      substructure: Syntax(
+        ForgetStmtSyntax(
+          expression: IdentifierExprSyntax(identifier: .keyword(.Self))
+        )
+      )
+    )
+
+    AssertParse(
+      """
+      _forget SarahMarshall
+      """,
+      substructure: Syntax(
+        ForgetStmtSyntax(
+          expression: IdentifierExprSyntax(identifier: .identifier("SarahMarshall"))
+        )
+      )
+    )
+
+    AssertParse(
+      """
+      _forget 1️⃣case
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected expression in 'forget' statement"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "'case' can only appear inside a 'switch' statement or 'enum' declaration"),
+      ]
+    )
+
+    // It's important that we don't parse this one as a forget statement!
+    AssertParse(
+      """
+      func _forget<T>(_ t: T) {}
+
+      func caller() {
+        _forget(self)
+      }
+      """,
+      substructure: Syntax(
+        FunctionCallExprSyntax(
+          callee: IdentifierExprSyntax(
+            identifier: .identifier("_forget")
+          ),
+          argumentList: {
+            TupleExprElementListSyntax([
+              TupleExprElementSyntax(
+                expression: IdentifierExprSyntax(identifier: .keyword(.`self`))
+              )
+            ])
+          }
+        )
+      )
+    )
+  }
+
   func testDefaultIdentIdentifierInReturnStmt() {
     AssertParse("return FileManager.default")
   }

--- a/gyb_syntax_support/StmtNodes.py
+++ b/gyb_syntax_support/StmtNodes.py
@@ -219,6 +219,13 @@ STMT_NODES = [
              Child('Expression', kind='Expr'),
          ]),
 
+     # forget-stmt -> 'forget' expr ';'?
+    Node('ForgetStmt', name_for_diagnostics="'forget' statement", kind='Stmt',
+         children=[
+             Child('ForgetKeyword', kind='KeywordToken', token_choices=['KeywordToken|_forget']),
+             Child('Expression', kind='Expr'),
+         ]),
+
     # catch-item -> pattern? where-clause? ','?
     Node('CatchItem', name_for_diagnostics=None, kind='Syntax',
          traits=['WithTrailingComma'],


### PR DESCRIPTION
rdar://105795731

per SE-390 (under review, hence underscored) https://github.com/jckarter/swift-evolution/blob/noncopyable-structs-and-enums/proposals/0390-noncopyable-structs-and-enums.md#suppressing-deinit-in-a-consuming-method
