### PR TITLE
[reference-bindings] Add support for borrow, inout bindings.

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/DeclNodes.swift
@@ -574,7 +574,7 @@ public let DECL_NODES: [Node] = [
          Child(name: "ImportTok",
                kind: .token(choices: [.keyword(text: "import")])),
          Child(name: "ImportKind",
-               kind: .token(choices: [.keyword(text: "typealias"), .keyword(text: "struct"), .keyword(text: "class"), .keyword(text: "enum"), .keyword(text: "protocol"), .keyword(text: "var"), .keyword(text: "let"), .keyword(text: "func")]),
+               kind: .token(choices: [.keyword(text: "typealias"), .keyword(text: "struct"), .keyword(text: "class"), .keyword(text: "enum"), .keyword(text: "protocol"), .keyword(text: "var"), .keyword(text: "let"), .keyword(text: "func"), .keyword(text: "inout")]),
                isOptional: true),
          Child(name: "Path",
                kind: .collection(kind: "AccessPath", collectionElementName: "PathComponent"))
@@ -1214,7 +1214,7 @@ public let DECL_NODES: [Node] = [
                nameForDiagnostics: "modifiers",
                isOptional: true),
          Child(name: "BindingKeyword",
-               kind: .token(choices: [.keyword(text: "let"), .keyword(text: "var")])),
+               kind: .token(choices: [.keyword(text: "let"), .keyword(text: "var"), .keyword(text: "inout")])),
          Child(name: "Bindings",
                kind: .collection(kind: "PatternBindingList", collectionElementName: "Binding"))
        ]),

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/PatternNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/PatternNodes.swift
@@ -95,7 +95,7 @@ public let PATTERN_NODES: [Node] = [
        kind: "Pattern",
        children: [
          Child(name: "BindingKeyword",
-               kind: .token(choices: [.keyword(text: "let"), .keyword(text: "var")])),
+               kind: .token(choices: [.keyword(text: "let"), .keyword(text: "var"), .keyword(text: "inout")])),
          Child(name: "ValuePattern",
                kind: .node(kind: "Pattern"))
        ]),

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/StmtNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/StmtNodes.swift
@@ -263,7 +263,7 @@ public let STMT_NODES: [Node] = [
        kind: "Syntax",
        children: [
          Child(name: "BindingKeyword",
-               kind: .token(choices: [.keyword(text: "let"), .keyword(text: "var")])),
+               kind: .token(choices: [.keyword(text: "let"), .keyword(text: "var"), .keyword(text: "inout")])),
          Child(name: "Pattern",
                kind: .node(kind: "Pattern")),
          Child(name: "TypeAnnotation",

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -241,7 +241,8 @@ extension Parser {
       return RawDeclSyntax(self.parseFuncDeclaration(attrs, handle))
     case (.subscriptKeyword, let handle)?:
       return RawDeclSyntax(self.parseSubscriptDeclaration(attrs, handle))
-    case (.letKeyword, let handle)?, (.varKeyword, let handle)?:
+    case (.letKeyword, let handle)?, (.varKeyword, let handle)?,
+         (.inoutKeyword, let handle)?:
       return RawDeclSyntax(self.parseBindingDeclaration(attrs, handle, inMemberDeclList: inMemberDeclList))
     case (.initKeyword, let handle)?:
       return RawDeclSyntax(self.parseInitializerDeclaration(attrs, handle))
@@ -330,6 +331,7 @@ extension Parser {
       case `var`
       case `let`
       case `func`
+      case `inout`
 
       var spec: TokenSpec {
         switch self {
@@ -341,6 +343,7 @@ extension Parser {
         case .var: return .keyword(.var)
         case .let: return .keyword(.let)
         case .func: return .keyword(.func)
+        case .inout: return .keyword(.inout)
         }
       }
 
@@ -354,6 +357,7 @@ extension Parser {
         case TokenSpec(.var): self = .var
         case TokenSpec(.let): self = .let
         case TokenSpec(.func): self = .func
+        case TokenSpec(.inout): self = .inout
         default: return nil
         }
       }

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -242,7 +242,7 @@ extension Parser {
     case (.subscriptKeyword, let handle)?:
       return RawDeclSyntax(self.parseSubscriptDeclaration(attrs, handle))
     case (.letKeyword, let handle)?, (.varKeyword, let handle)?,
-         (.inoutKeyword, let handle)?:
+      (.inoutKeyword, let handle)?:
       return RawDeclSyntax(self.parseBindingDeclaration(attrs, handle, inMemberDeclList: inMemberDeclList))
     case (.initKeyword, let handle)?:
       return RawDeclSyntax(self.parseInitializerDeclaration(attrs, handle))

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -75,16 +75,16 @@ extension Parser {
     /// case x.y <- 'x' must refer to some 'x' defined in another scope, it cannot be e.g. an enum type.
     /// ```
     case matching
-    /// We're parsing a matching pattern that is introduced via `let` or `var`.
+    /// We're parsing a matching pattern that is introduced via `let`, `var`, or `inout`
     ///
     /// ```
     /// case let x.y <- 'x' must refer to the base of some member access, y must refer to some pattern-compatible identfier
     /// ```
-    case letOrVar
+    case bindingIntroducer
 
     var admitsBinding: Bool {
       switch self {
-      case .letOrVar:
+      case .bindingIntroducer:
         return true
       case .none, .matching:
         return false
@@ -328,7 +328,7 @@ extension Parser {
 
     case (.equal, let handle)?:
       switch pattern {
-      case .matching, .letOrVar:
+      case .matching, .bindingIntroducer:
         return nil
       case .none:
         let eq = self.eat(handle)

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -123,8 +123,8 @@ extension Parser {
         )
       )
     case (.letKeyword, let handle)?,
-         (.varKeyword, let handle)?,
-         (.inoutKeyword, let handle)?:
+      (.varKeyword, let handle)?,
+      (.inoutKeyword, let handle)?:
       let bindingKeyword = self.eat(handle)
       let value = self.parsePattern()
       return RawPatternSyntax(
@@ -243,8 +243,8 @@ extension Parser {
     // Parse productions that can only be patterns.
     switch self.at(anyIn: MatchingPatternStart.self) {
     case (.varKeyword, let handle)?,
-         (.letKeyword, let handle)?,
-         (.inoutKeyword, let handle)?:
+      (.letKeyword, let handle)?,
+      (.inoutKeyword, let handle)?:
       let bindingKeyword = self.eat(handle)
       let value = self.parseMatchingPattern(context: .bindingIntroducer)
       return RawPatternSyntax(
@@ -332,8 +332,8 @@ extension Parser.Lookahead {
       self.eat(handle)
       return true
     case (.letKeyword, let handle)?,
-         (.varKeyword, let handle)?,
-         (.inoutKeyword, let handle)?:
+      (.varKeyword, let handle)?,
+      (.inoutKeyword, let handle)?:
       self.eat(handle)
       return self.canParsePattern()
     case (.leftParen, _)?:

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -53,6 +53,7 @@ extension Parser {
       case dollarIdentifier  // For recovery
       case letKeyword
       case varKeyword
+      case inoutKeyword
 
       init?(lexeme: Lexer.Lexeme) {
         switch PrepareForKeywordMatch(lexeme) {
@@ -62,6 +63,7 @@ extension Parser {
         case TokenSpec(.dollarIdentifier): self = .dollarIdentifier
         case TokenSpec(.let): self = .letKeyword
         case TokenSpec(.var): self = .varKeyword
+        case TokenSpec(.inout): self = .inoutKeyword
         default: return nil
         }
       }
@@ -74,6 +76,7 @@ extension Parser {
         case .dollarIdentifier: return .dollarIdentifier
         case .letKeyword: return .keyword(.let)
         case .varKeyword: return .keyword(.var)
+        case .inoutKeyword: return .keyword(.inout)
         }
       }
     }
@@ -120,12 +123,13 @@ extension Parser {
         )
       )
     case (.letKeyword, let handle)?,
-      (.varKeyword, let handle)?:
-      let letOrVar = self.eat(handle)
+         (.varKeyword, let handle)?,
+         (.inoutKeyword, let handle)?:
+      let bindingKeyword = self.eat(handle)
       let value = self.parsePattern()
       return RawPatternSyntax(
         RawValueBindingPatternSyntax(
-          bindingKeyword: letOrVar,
+          bindingKeyword: bindingKeyword,
           valuePattern: value,
           arena: self.arena
         )
@@ -239,12 +243,13 @@ extension Parser {
     // Parse productions that can only be patterns.
     switch self.at(anyIn: MatchingPatternStart.self) {
     case (.varKeyword, let handle)?,
-      (.letKeyword, let handle)?:
-      let letOrVar = self.eat(handle)
-      let value = self.parseMatchingPattern(context: .letOrVar)
+         (.letKeyword, let handle)?,
+         (.inoutKeyword, let handle)?:
+      let bindingKeyword = self.eat(handle)
+      let value = self.parseMatchingPattern(context: .bindingIntroducer)
       return RawPatternSyntax(
         RawValueBindingPatternSyntax(
-          bindingKeyword: letOrVar,
+          bindingKeyword: bindingKeyword,
           valuePattern: value,
           arena: self.arena
         )
@@ -287,6 +292,7 @@ extension Parser.Lookahead {
   ///   pattern ::= pattern-tuple
   ///   pattern ::= 'var' pattern
   ///   pattern ::= 'let' pattern
+  ///   pattern ::= 'inout' pattern
   mutating func canParsePattern() -> Bool {
     enum PatternStartTokens: TokenSpecSet {
       case identifier
@@ -294,6 +300,7 @@ extension Parser.Lookahead {
       case letKeyword
       case varKeyword
       case leftParen
+      case inoutKeyword
 
       init?(lexeme: Lexer.Lexeme) {
         switch PrepareForKeywordMatch(lexeme) {
@@ -302,6 +309,7 @@ extension Parser.Lookahead {
         case TokenSpec(.let): self = .letKeyword
         case TokenSpec(.var): self = .varKeyword
         case TokenSpec(.leftParen): self = .leftParen
+        case TokenSpec(.inout): self = .inoutKeyword
         default: return nil
         }
       }
@@ -313,6 +321,7 @@ extension Parser.Lookahead {
         case .letKeyword: return .keyword(.let)
         case .varKeyword: return .keyword(.var)
         case .leftParen: return .leftParen
+        case .inoutKeyword: return .keyword(.inout)
         }
       }
     }
@@ -323,7 +332,8 @@ extension Parser.Lookahead {
       self.eat(handle)
       return true
     case (.letKeyword, let handle)?,
-      (.varKeyword, let handle)?:
+         (.varKeyword, let handle)?,
+         (.inoutKeyword, let handle)?:
       self.eat(handle)
       return self.canParsePattern()
     case (.leftParen, _)?:

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -213,7 +213,8 @@ extension Parser {
   ///     condition → expression | availability-condition | case-condition | optional-binding-condition
   ///
   ///     case-condition → 'case' pattern initializer
-  ///     optional-binding-condition → 'let' pattern initializer? | 'var' pattern initializer?
+  ///     optional-binding-condition → 'let' pattern initializer? | 'var' pattern initializer? |
+  ///                                  'inout' pattern initializer?
   @_spi(RawSyntax)
   public mutating func parseConditionElement() -> RawConditionElementSyntax.Condition {
     // Parse a leading #available/#unavailable condition if present.
@@ -221,9 +222,9 @@ extension Parser {
       return self.parsePoundAvailableConditionElement()
     }
 
-    // Parse the basic expression case.  If we have a leading let/var/case
-    // keyword or an assignment, then we know this is a binding.
-    guard self.at(.keyword(.let), .keyword(.var), .keyword(.case)) else {
+    // Parse the basic expression case.  If we have a leading let, var, inout,
+    // borrow, case keyword or an assignment, then we know this is a binding.
+    guard self.at(.keyword(.let), .keyword(.var), .keyword(.case)) || self.at(.keyword(.inout)) else {
       // If we lack it, then this is theoretically a boolean condition.
       // However, we also need to handle migrating from Swift 2 syntax, in
       // which a comma followed by an expression could actually be a pattern
@@ -240,7 +241,7 @@ extension Parser {
     }
 
     // We're parsing a conditional binding.
-    assert(self.at(.keyword(.let), .keyword(.var), .keyword(.case)))
+    assert(self.at(.keyword(.let), .keyword(.var)) || self.at(.keyword(.inout), .keyword(.case)))
     enum BindingKind {
       case pattern(RawTokenSyntax, RawPatternSyntax)
       case optional(RawTokenSyntax, RawPatternSyntax)
@@ -252,7 +253,7 @@ extension Parser {
       kind = .pattern(caseKeyword, pattern)
     } else {
       let letOrVar = self.consumeAnyToken()
-      let pattern = self.parseMatchingPattern(context: .letOrVar)
+      let pattern = self.parseMatchingPattern(context: .bindingIntroducer)
       kind = .optional(letOrVar, pattern)
     }
 
@@ -285,10 +286,10 @@ extension Parser {
     }
 
     switch kind {
-    case let .optional(letOrVar, pattern):
+    case let .optional(bindingKeyword, pattern):
       return .optionalBinding(
         RawOptionalBindingConditionSyntax(
-          bindingKeyword: letOrVar,
+          bindingKeyword: bindingKeyword,
           pattern: pattern,
           typeAnnotation: annotation,
           initializer: initializer,

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -192,6 +192,9 @@ public enum TokenPrecedence: Comparable {
       // Keywords in function types (we should be allowed to skip them inside parenthesis)
       .rethrows, .throws,
       // Consider 'any' and 'inout' like a prefix operator to a type and a type is expression-like.
+      //
+      // NOTE: We reuse this for inout bindings and choose the higher precedence level of expr keywords
+      // so we do not break anything.
       .inout,
       // Consider 'any' and 'inout' like a prefix operator to a type and a type is expression-like.
       .Any,

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -290,7 +290,7 @@ enum DeclarationStart: TokenSpecSet {
     case .subscriptKeyword: return .keyword(.subscript)
     case .typealiasKeyword: return .keyword(.typealias)
     case .varKeyword: return .keyword(.var)
-    case .inoutKeyword: return .keyword(.inout)
+    case .inoutKeyword: return TokenSpec(.inout, recoveryPrecedence: .declKeyword)
     }
   }
 }

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -241,6 +241,7 @@ enum DeclarationStart: TokenSpecSet {
   case subscriptKeyword
   case typealiasKeyword
   case varKeyword
+  case inoutKeyword
 
   init?(lexeme: Lexer.Lexeme) {
     switch PrepareForKeywordMatch(lexeme) {
@@ -263,6 +264,7 @@ enum DeclarationStart: TokenSpecSet {
     case TokenSpec(.subscript): self = .subscriptKeyword
     case TokenSpec(.typealias): self = .typealiasKeyword
     case TokenSpec(.var): self = .varKeyword
+    case TokenSpec(.inout): self = .inoutKeyword
     default: return nil
     }
   }
@@ -288,6 +290,7 @@ enum DeclarationStart: TokenSpecSet {
     case .subscriptKeyword: return .keyword(.subscript)
     case .typealiasKeyword: return .keyword(.typealias)
     case .varKeyword: return .keyword(.var)
+    case .inoutKeyword: return .keyword(.inout)
     }
   }
 }
@@ -570,12 +573,14 @@ enum MatchingPatternStart: TokenSpecSet {
   case isKeyword
   case letKeyword
   case varKeyword
+  case inoutKeyword
 
   init?(lexeme: Lexer.Lexeme) {
     switch PrepareForKeywordMatch(lexeme) {
     case TokenSpec(.is): self = .isKeyword
     case TokenSpec(.let): self = .letKeyword
     case TokenSpec(.var): self = .varKeyword
+    case TokenSpec(.inout): self = .inoutKeyword
     default: return nil
     }
   }
@@ -585,6 +590,7 @@ enum MatchingPatternStart: TokenSpecSet {
     case .isKeyword: return .keyword(.is)
     case .letKeyword: return .keyword(.let)
     case .varKeyword: return .keyword(.var)
+    case .inoutKeyword: return .keyword(.inout)
     }
   }
 }

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -783,10 +783,10 @@ extension Parser.Lookahead {
 
   mutating func canParseTupleBodyType() -> Bool {
     guard
-      !self.at(.rightParen, .rightBrace) && !self.atContextualPunctuator("...") &&
-      // In types, we do not allow for an inout binding to be declared in a
-      // tuple type.
-      (self.at(.keyword(.inout)) || !self.atStartOfDeclaration())
+      !self.at(.rightParen, .rightBrace) && !self.atContextualPunctuator("...")
+        // In types, we do not allow for an inout binding to be declared in a
+        // tuple type.
+        && (self.at(.keyword(.inout)) || !self.atStartOfDeclaration())
     else {
       return self.consume(if: .rightParen) != nil
     }

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -783,7 +783,10 @@ extension Parser.Lookahead {
 
   mutating func canParseTupleBodyType() -> Bool {
     guard
-      !self.at(.rightParen, .rightBrace) && !self.atContextualPunctuator("...") && !self.atStartOfDeclaration()
+      !self.at(.rightParen, .rightBrace) && !self.atContextualPunctuator("...") &&
+      // In types, we do not allow for an inout binding to be declared in a
+      // tuple type.
+      (self.at(.keyword(.inout)) || !self.atStartOfDeclaration())
     else {
       return self.consume(if: .rightParen) != nil
     }

--- a/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
+++ b/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
@@ -77,6 +77,8 @@ final class MatchingPatternsTests: XCTestCase {
         a = 1
       case let a:
         a = 1
+      case inout a:
+        a = 1
       case var var a:
         a += 1
       case var let a:
@@ -193,6 +195,7 @@ final class MatchingPatternsTests: XCTestCase {
       var n : Voluntary<Int> = .Naught
       if case let .Naught(value) = n {}
       if case let .Naught(value1, value2, value3) = n {}
+      if case inout .Naught(value) = n {}
       """
     )
   }
@@ -369,6 +372,8 @@ final class MatchingPatternsTests: XCTestCase {
       case .Payload((let x)):
         acceptInt(x)
         acceptString("\(x)")
+      case .Payload(inout x):
+        acceptInt(x)
       }
       """#
     )
@@ -431,6 +436,8 @@ final class MatchingPatternsTests: XCTestCase {
       """
       switch t {
       case (_, var a, 3):
+        a += 1
+      case (_, inout a, 3):
         a += 1
       case var (_, b, 3):
         b += 1

--- a/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
+++ b/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
@@ -19,6 +19,7 @@ final class PatternWithoutVariablesTests: XCTestCase {
     AssertParse(
       """
       let _ = 1
+      inout _ = 1
       """
     )
   }
@@ -28,6 +29,7 @@ final class PatternWithoutVariablesTests: XCTestCase {
       """
       func foo() {
         let _ = 1 // OK
+        inout _ = 1
       }
       """
     )
@@ -42,6 +44,7 @@ final class PatternWithoutVariablesTests: XCTestCase {
         func foo() {
           let _ = 1 // OK
         }
+        inout (_, _) = (1, 2)
       }
       """
     )
@@ -73,6 +76,9 @@ final class PatternWithoutVariablesTests: XCTestCase {
         case let (_, x): _ = x; break    // ok
         }
         if case let _ = "str" {}
+        switch a {
+        case inout .Bar: break
+        }
       }
       """#
     )

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -25,11 +25,25 @@ final class VariableTests: XCTestCase {
     AssertBuildResult(buildable, "␣let a: [Int]")
   }
 
+  func testInoutBindingDecl() {
+    let leadingTrivia = Trivia.unexpectedText("␣")
+
+    let buildable = VariableDeclSyntax(leadingTrivia: leadingTrivia, bindingKeyword: .keyword(.inout)) {
+      PatternBindingSyntax(pattern: PatternSyntax("a"), typeAnnotation: TypeAnnotationSyntax(type: ArrayTypeSyntax(elementType: TypeSyntax("Int"))))
+    }
+
+    AssertBuildResult(buildable, "␣inout a: [Int]")
+  }
+
   func testVariableDeclWithStringParsing() {
     let testCases: [UInt: (DeclSyntax, String)] = [
       #line: (
         DeclSyntax("let content = try? String(contentsOf: url)"),
         "let content = try? String(contentsOf: url)"
+      ),
+      #line: (
+        DeclSyntax("inout content = try? String(contentsOf: url)"),
+        "inout content = try? String(contentsOf: url)"
       ),
       #line: (
         DeclSyntax("let content = try! String(contentsOf: url)"),
@@ -43,6 +57,14 @@ final class VariableTests: XCTestCase {
         DeclSyntax("var foo: String { myOptional!.someProperty }"),
         """
         var foo: String {
+            myOptional!.someProperty
+        }
+        """
+      ),
+      #line: (
+        DeclSyntax("inout foo: String { myOptional!.someProperty }"),
+        """
+        inout foo: String {
             myOptional!.someProperty
         }
         """
@@ -109,6 +131,16 @@ final class VariableTests: XCTestCase {
         DeclSyntax("var bar: [String] { bar.map({ $0.description }) }"),
         """
         var bar: [String] {
+            bar.map({
+                    $0.description
+                })
+        }
+        """
+      ),
+      #line: (
+        DeclSyntax("inout bar: [String] { bar.map({ $0.description }) }"),
+        """
+        inout bar: [String] {
             bar.map({
                     $0.description
                 })

--- a/gyb_syntax_support/DeclNodes.py
+++ b/gyb_syntax_support/DeclNodes.py
@@ -514,7 +514,7 @@ DECL_NODES = [
              Child('ImportKind', kind='KeywordToken', is_optional=True,
                    token_choices=[
                       'KeywordToken|typealias', 'KeywordToken|struct', 'KeywordToken|class', 'KeywordToken|enum', 'KeywordToken|protocol', 'KeywordToken|var',
-                      'KeywordToken|let', 'KeywordToken|func',
+                      'KeywordToken|let', 'KeywordToken|func', 'KeywordToken|inout'
                    ]),
              Child('Path', kind='AccessPath',
                    collection_element_name='PathComponent'),
@@ -588,6 +588,7 @@ DECL_NODES = [
              Child('BindingKeyword', kind='KeywordToken',
                    token_choices=[
                        'KeywordToken|let', 'KeywordToken|var',
+                       'KeywordToken|inout'
                    ]),
              Child('Bindings', kind='PatternBindingList',
                    collection_element_name='Binding'),

--- a/gyb_syntax_support/PatternNodes.py
+++ b/gyb_syntax_support/PatternNodes.py
@@ -71,11 +71,13 @@ PATTERN_NODES = [
 
     # value-binding-pattern -> 'let' pattern
     #                        | 'var' pattern
+    #                        | 'inout' pattern
     Node('ValueBindingPattern', name_for_diagnostics='value binding pattern',
          kind='Pattern',
          children=[
              Child('BindingKeyword', kind='KeywordToken',
-                   token_choices=['KeywordToken|let', 'KeywordToken|var']),
+                   token_choices=['KeywordToken|let', 'KeywordToken|var',
+                                  'KeywordToken|inout']),
              Child('ValuePattern', kind='Pattern'),
          ]),
 ]

--- a/gyb_syntax_support/StmtNodes.py
+++ b/gyb_syntax_support/StmtNodes.py
@@ -199,7 +199,8 @@ STMT_NODES = [
          kind='Syntax',
          children=[
              Child('BindingKeyword', kind='KeywordToken',
-                   token_choices=['KeywordToken|let', 'KeywordToken|var']),
+                   token_choices=['KeywordToken|let', 'KeywordToken|var',
+                                  'KeywordToken|inout']),
              Child('Pattern', kind='Pattern'),
              Child('TypeAnnotation', kind='TypeAnnotation',
                    is_optional=True),


### PR DESCRIPTION
To make sure that I did not stomp on anything already working around borrow, inout, I decided to (for now) use the keywords inoutBindingKW and borrowBindingKW, just to be careful.