### PR TITLE
Remove semantic TODOs from translated SwiftParserTest and classify simple issues as “good first issue”

### DIFF
--- a/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
@@ -146,7 +146,6 @@ final class AvailabilityQueryTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected version number
         DiagnosticSpec(
           message: "expected ')' to end availability condition",
           notes: [
@@ -162,10 +161,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """
       if #available(OSX) {
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: expected version number
-      ]
+      """
     )
   }
 
@@ -176,7 +172,6 @@ final class AvailabilityQueryTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected ')'
         DiagnosticSpec(
           message: "expected ')' to end availability condition",
           notes: [
@@ -353,7 +348,6 @@ final class AvailabilityQueryTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected version number
         DiagnosticSpec(
           message: "expected ')' to end availability condition",
           notes: [
@@ -413,7 +407,7 @@ final class AvailabilityQueryTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: version comparison not needed, Fix-It replacements: 19 - 22 = ''
+        // TODO: (good first issue) Old parser expected error on line 1: version comparison not needed, Fix-It replacements: 19 - 22 = ''
         DiagnosticSpec(message: "unexpected code '>= 10.51, *' in availability condition")
       ]
     )

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -127,7 +127,6 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected version number
         DiagnosticSpec(
           message: "expected ')' to end availability condition",
           notes: [
@@ -143,10 +142,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """
       if #unavailable(OSX) {
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: expected version number
-      ]
+      """
     )
   }
 
@@ -321,7 +317,6 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected version number
         DiagnosticSpec(
           message: "expected ')' to end availability condition",
           notes: [
@@ -346,10 +341,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """
       if #unavailable(iDishwasherOS 10.51, OSX 10.51) {
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
-      ]
+      """
     )
   }
 
@@ -373,7 +365,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: version comparison not needed, Fix-It replacements: 21 - 24 = ''
+        // TODO: (good first issue) Old parser expected error on line 2: version comparison not needed, Fix-It replacements: 21 - 24 = ''
         DiagnosticSpec(message: "unexpected code '>= 10.51' in availability condition")
       ]
     )
@@ -424,15 +416,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       }
       if #available(macOS 10.51, *), case 42 = 42, #unavailable(macOS 10.52) {
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: #available and #unavailable cannot be in the same statement
-        // TODO: Old parser expected error on line 4: #available and #unavailable cannot be in the same statement
-        // TODO: Old parser expected error on line 6: #available and #unavailable cannot be in the same statement
-        // TODO: Old parser expected error on line 8: #available and #unavailable cannot be in the same statement
-        // TODO: Old parser expected error on line 10: #available and #unavailable cannot be in the same statement
-        // TODO: Old parser expected error on line 12: #available and #unavailable cannot be in the same statement
-      ]
+      """
     )
   }
 
@@ -458,7 +442,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: #available cannot be used as an expression, did you mean to use '#unavailable'?, Fix-It replacements: 4 - 14 = '#unavailable', 18 - 27 = ''
+        // TODO: (good first issue) Old parser expected error on line 2: #available cannot be used as an expression, did you mean to use '#unavailable'?, Fix-It replacements: 4 - 14 = '#unavailable', 18 - 27 = ''
         DiagnosticSpec(message: "unexpected code '== false' in 'if' statement")
       ]
     )

--- a/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
+++ b/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
@@ -14,6 +14,8 @@
 
 import XCTest
 
+// TODO: The generic where clause next to generic parameters is only valid in language mode 4. We should disallow them in language mode 5.
+
 final class DeprecatedWhereTests: XCTestCase {
   func testDeprecatedWhere1() {
     AssertParse(
@@ -45,10 +47,7 @@ final class DeprecatedWhereTests: XCTestCase {
       func f4<T>(x: T) -> Int { return 2 } // no-warning
       // 4: Trailing where
       func f5<T>(x: T) where T : Equatable {} // no-warning
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 5: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 10 - 30 = '', 37 - 37 = ' where T: Womparable'
-      ]
+      """
     )
   }
 
@@ -68,12 +67,7 @@ final class DeprecatedWhereTests: XCTestCase {
       func f24<T where T: Womparable>(x: T) where T: Equatable {}
       // 3,4
       func f34<T>(x: T) -> Int where T: Equatable { return 2 } // no-warning
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 21 - 41 = '', 48 - 48 = ' where T: Womparable'
-        // TODO: Old parser expected error on line 9: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 11 - 31 = '', 45 - 45 = ' where T: Womparable'
-        // TODO: Old parser expected error on line 11: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 11 - 31 = '', 39 - 44 = 'where T: Womparable,'
-      ]
+      """
     )
   }
 
@@ -87,12 +81,7 @@ final class DeprecatedWhereTests: XCTestCase {
       func f124<T: Mashable where T: Womparable>(x: T) where T: Equatable {}
       // 2,3,4
       func f234<T where T: Womparable>(x: T) -> Int where T: Equatable { return 2 }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 22 - 42 = '', 56 - 56 = ' where T: Womparable'
-        // TODO: Old parser expected error on line 5: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 22 - 42 = '', 50 - 55 = 'where T: Womparable,'
-        // TODO: Old parser expected error on line 7: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 12 - 32 = '', 47 - 52 = 'where T: Womparable,'
-      ]
+      """
     )
   }
 
@@ -102,10 +91,7 @@ final class DeprecatedWhereTests: XCTestCase {
       // FuncDecl: Choose 4
       // 1,2,3,4
       func f1234<T: Mashable where T: Womparable>(x: T) -> Int where T: Equatable { return 2 }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 23 - 43 = '', 58 - 63 = 'where T: Womparable,'
-      ]
+      """
     )
   }
 
@@ -128,10 +114,7 @@ final class DeprecatedWhereTests: XCTestCase {
       struct S2<T where T: Womparable> {}
       // 3: Trailing where
       struct S3<T> where T : Equatable {} // no-warning
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 5: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 12 - 32 = '', 33 - 33 = ' where T: Womparable'
-      ]
+      """
     )
   }
 
@@ -145,11 +128,7 @@ final class DeprecatedWhereTests: XCTestCase {
       struct S13<T: Mashable> where T: Equatable {} // no-warning
       // 2,3
       struct S23<T where T: Womparable> where T: Equatable {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 23 - 43 = '', 44 - 44 = ' where T: Womparable'
-        // TODO: Old parser expected error on line 7: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 13 - 33 = '', 35 - 40 = 'where T: Womparable,'
-      ]
+      """
     )
   }
 
@@ -159,10 +138,7 @@ final class DeprecatedWhereTests: XCTestCase {
       // NominalTypeDecl: Choose 3
       // 1,2,3
       struct S123<T: Mashable where T: Womparable> where T: Equatable {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 24 - 44 = '', 46 - 51 = 'where T: Womparable,'
-      ]
+      """
     )
   }
 
@@ -175,11 +151,7 @@ final class DeprecatedWhereTests: XCTestCase {
       protocol ProtoD {}
       func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) {}
       func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) where T: ProtoD {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 5: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 48 - 64 = '', 71 - 71 = ' where T: ProtoC'
-        // TODO: Old parser expected error on line 6: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 48 - 64 = '', 72 - 77 = 'where T: ProtoC,'
-      ]
+      """
     )
   }
 
@@ -189,8 +161,6 @@ final class DeprecatedWhereTests: XCTestCase {
       func testCombinedConstraintsOld<T: 2️⃣protocol3️⃣<ProtoA, ProtoB> where T: ProtoC4️⃣>(x: T) {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 60 - 76 = '', 83 - 83 = ' where T: ProtoC'
-        // TODO: Old parser expected error on line 1: 'protocol<...>' composition syntax has been removed
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected inherited type in generic parameter"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected '>' to end generic parameter clause"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected parameter clause in function signature"),
@@ -206,8 +176,6 @@ final class DeprecatedWhereTests: XCTestCase {
       func testCombinedConstraintsOld<T: 2️⃣protocol3️⃣<ProtoA, ProtoB> where T: ProtoC4️⃣>(x: T) where T: ProtoD {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 60 - 76 = '', 84 - 89 = 'where T: ProtoC,'
-        // TODO: Old parser expected error on line 1: 'protocol<...>' composition syntax has been removed
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected inherited type in generic parameter"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected '>' to end generic parameter clause"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected parameter clause in function signature"),

--- a/Tests/SwiftParserTest/translated/DiagnoseAvailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseAvailabilityTests.swift
@@ -47,12 +47,7 @@ final class DiagnoseAvailabilityTests: XCTestCase {
       """
       @available(OSX 10.0, deprecated: 10.12)
       func shorthandFollowedByDeprecated() {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'deprecated' can't be combined with shorthand specification 'OSX 10.0'
-        // TODO: Old parser expected note on line 1: did you mean to specify an introduction version?, Fix-It replacements: 15 - 15 = ', introduced:'
-        // TODO: Old parser expected error on line 1: expected declaration
-      ]
+      """
     )
   }
 
@@ -61,11 +56,7 @@ final class DiagnoseAvailabilityTests: XCTestCase {
       """
       @available(OSX 10.0, introduced: 10.12)
       func shorthandFollowedByIntroduced() {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'introduced' can't be combined with shorthand specification 'OSX 10.0'
-        // TODO: Old parser expected error on line 1: expected declaration
-      ]
+      """
     )
   }
 
@@ -83,11 +74,7 @@ final class DiagnoseAvailabilityTests: XCTestCase {
       """
       @available(iOS 6.0, OSX 10.0, deprecated: 10.12)
       func twoShorthandsFollowedByDeprecated() {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'deprecated' can't be combined with shorthand specification 'OSX 10.0'
-        // TODO: Old parser expected error on line 1: expected declaration
-      ]
+      """
     )
   }
 
@@ -105,10 +92,7 @@ final class DiagnoseAvailabilityTests: XCTestCase {
       """
       @available(*, deprecated: 4.2)
       func allPlatformsDeprecatedVersion() {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unexpected version number in 'available' attribute for non-specific platform '*', Fix-It replacements: 25 - 30 = ''
-      ]
+      """
     )
   }
 
@@ -117,10 +101,7 @@ final class DiagnoseAvailabilityTests: XCTestCase {
       """
       @available(*, deprecated, obsoleted: 4.2)
       func allPlatformsDeprecatedAndObsoleted() {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unexpected version number in 'available' attribute for non-specific platform '*', Fix-It replacements: 36 - 41 = ''
-      ]
+      """
     )
   }
 
@@ -129,10 +110,7 @@ final class DiagnoseAvailabilityTests: XCTestCase {
       """
       @available(*, introduced: 4.0, deprecated: 4.1, obsoleted: 4.2)
       func allPlatformsDeprecatedAndObsoleted2() {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unexpected version number in 'available' attribute for non-specific platform '*', Fix-It replacements: 25 - 30 = '', 42 - 47 = '', 58 - 63 = ''
-      ]
+      """
     )
   }
 
@@ -141,10 +119,7 @@ final class DiagnoseAvailabilityTests: XCTestCase {
       """
       @available(swift, unavailable)
       func swiftUnavailable() {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: 'unavailable' cannot be used in 'available' attribute for platform 'swift'
-      ]
+      """
     )
   }
 
@@ -153,10 +128,7 @@ final class DiagnoseAvailabilityTests: XCTestCase {
       """
       @available(swift, unavailable, introduced: 4.2)
       func swiftUnavailableIntroduced() {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: 'unavailable' cannot be used in 'available' attribute for platform 'swift'
-      ]
+      """
     )
   }
 
@@ -165,10 +137,7 @@ final class DiagnoseAvailabilityTests: XCTestCase {
       """
       @available(swift, deprecated)
       func swiftDeprecated() {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: expected version number with 'deprecated' in 'available' attribute for platform 'swift'
-      ]
+      """
     )
   }
 
@@ -177,10 +146,7 @@ final class DiagnoseAvailabilityTests: XCTestCase {
       """
       @available(swift, deprecated, obsoleted: 4.2)
       func swiftDeprecatedObsoleted() {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: expected version number with 'deprecated' in 'available' attribute for platform 'swift'
-      ]
+      """
     )
   }
 
@@ -189,10 +155,7 @@ final class DiagnoseAvailabilityTests: XCTestCase {
       #"""
       @available(swift, message: "missing valid option")
       func swiftMessage() {}
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: expected 'introduced', 'deprecated', or 'obsoleted' in 'available' attribute for platform 'swift'
-      ]
+      """#
     )
   }
 

--- a/Tests/SwiftParserTest/translated/EffectfulPropertiesTests.swift
+++ b/Tests/SwiftParserTest/translated/EffectfulPropertiesTests.swift
@@ -87,10 +87,7 @@ final class EffectfulPropertiesTests: XCTestCase {
             set {}
           }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
-      ]
+      """
     )
   }
 
@@ -103,11 +100,7 @@ final class EffectfulPropertiesTests: XCTestCase {
             set throws {}
           }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
-        // TODO: Old parser expected error on line 4: 'set' accessor cannot have specifier 'throws'
-      ]
+      """
     )
   }
 
@@ -120,10 +113,7 @@ final class EffectfulPropertiesTests: XCTestCase {
           nonmutating set {}
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
-      ]
+      """
     )
   }
 
@@ -132,19 +122,11 @@ final class EffectfulPropertiesTests: XCTestCase {
       """
       var prop3 : Bool {
         _read { yield prop3 }
-        // expected-note@+1 2 {{previous definition of getter here}}
         get throws { false }
         get async { true }
         get {}
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: '_read' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
-        // TODO: Old parser expected error on line 2: variable cannot provide both a 'read' accessor and a getter
-        // TODO: Old parser expected note on line 4: getter defined here
-        // TODO: Old parser expected error on line 5: variable already has a getter
-        // TODO: Old parser expected error on line 6: variable already has a getter
-      ]
+      """
     )
   }
 
@@ -158,11 +140,7 @@ final class EffectfulPropertiesTests: XCTestCase {
           _modify { yield &prop4 }
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
-        // TODO: Old parser expected error on line 5: '_modify' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
-      ]
+      """
     )
   }
 
@@ -179,12 +157,7 @@ final class EffectfulPropertiesTests: XCTestCase {
         var prop6 : T { mutating get throws }
         var prop7 : T { mutating get async nonmutating set }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
-        // TODO: Old parser expected error on line 5: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
-        // TODO: Old parser expected error on line 9: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
-      ]
+      """
     )
   }
 
@@ -207,8 +180,6 @@ final class EffectfulPropertiesTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: only function declarations may be marked 'rethrows'; did you mean 'throws'?
-        // TODO: Old parser expected error on line 3: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
-        // TODO: Old parser expected error on line 3: 'set' accessor cannot have specifier 'rethrows'
       ]
     )
   }
@@ -234,11 +205,7 @@ final class EffectfulPropertiesTests: XCTestCase {
         _read async { yield 0 }
         set(theValue) async { }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: '_read' accessor cannot have specifier 'async'
-        // TODO: Old parser expected error on line 3: 'set' accessor cannot have specifier 'async'
-      ]
+      """
     )
   }
 
@@ -290,8 +257,6 @@ final class EffectfulPropertiesTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: expected '{' to start getter definition
-        // TODO: Old parser expected error on line 2: only function declarations may be marked 'rethrows'; did you mean 'throws'?
         DiagnosticSpec(message: "unexpected code '-> Int { 0 }' in variable")
       ]
     )

--- a/Tests/SwiftParserTest/translated/ErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/ErrorsTests.swift
@@ -86,7 +86,6 @@ final class ErrorsTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: expected expression after '? ... :' in ternary expression
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected expression after ternary operator")
       ]
     )
@@ -142,7 +141,6 @@ final class ErrorsTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 4: expected '{'
         DiagnosticSpec(message: "unexpected code ')' in 'catch' clause")
       ]
     )

--- a/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
+++ b/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
@@ -225,10 +225,10 @@ final class GenericDisambiguationTests: XCTestCase {
   }
 
   func testGenericDisambiguation15() {
+    // TODO: parse empty <> list
     AssertParse(
       """
-      // TODO: parse empty <> list
-      //A<>.c() // e/xpected-error{{xxx}}
+      A<>.c()
       """
     )
   }

--- a/Tests/SwiftParserTest/translated/IdentifiersTests.swift
+++ b/Tests/SwiftParserTest/translated/IdentifiersTests.swift
@@ -86,7 +86,7 @@ final class IdentifiersTests: XCTestCase {
       func <#some name#>() {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: editor placeholder in source file
+        // TODO: (good first issue) Old parser expected error on line 2: editor placeholder in source file
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
+++ b/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
@@ -330,7 +330,6 @@ final class IfconfigExprTests: XCTestCase {
       #endif
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: unexpected ',' separator
         DiagnosticSpec(message: "expected value in function call")
       ]
     )
@@ -370,7 +369,6 @@ final class IfconfigExprTests: XCTestCase {
       #endif
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected expression in list of expressions
         DiagnosticSpec(message: "expected value in function call")
       ]
     )

--- a/Tests/SwiftParserTest/translated/InvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidTests.swift
@@ -22,7 +22,6 @@ final class InvalidTests: XCTestCase {
       func test1(1️⃣inout var x : Int) {}
       """,
       diagnostics: [
-        // TODO: Old parser expected warning on line 2: 'var' in this position is interpreted as an argument label, Fix-It replacements: 18 - 21 = '`var`'
         DiagnosticSpec(message: "'inout' before a parameter name is not allowed", fixIts: ["move 'inout' in front of type"])
       ],
       fixedSource: "func test1(var x : inout Int) {}"
@@ -35,7 +34,6 @@ final class InvalidTests: XCTestCase {
       func test2(1️⃣inout let x : Int) {}
       """,
       diagnostics: [
-        // TODO: Old parser expected warning on line 1: 'let' in this position is interpreted as an argument label, Fix-It replacements: 18 - 21 = '`let`'
         DiagnosticSpec(message: "'inout' before a parameter name is not allowed")
       ]
     )
@@ -59,7 +57,6 @@ final class InvalidTests: XCTestCase {
       func test1s(1️⃣__shared var x : Int) {}
       """,
       diagnostics: [
-        // TODO: Old parser expected warning on line 1: 'var' in this position is interpreted as an argument label, Fix-It replacements: 22 - 25 = '`var`'
         DiagnosticSpec(message: "'__shared' before a parameter name is not allowed")
       ]
     )
@@ -71,7 +68,6 @@ final class InvalidTests: XCTestCase {
       func test2s(1️⃣__shared let x : Int) {}
       """,
       diagnostics: [
-        // TODO: Old parser expected warning on line 1: 'let' in this position is interpreted as an argument label, Fix-It replacements: 22 - 25 = '`let`'
         DiagnosticSpec(message: "'__shared' before a parameter name is not allowed")
       ]
     )
@@ -83,7 +79,6 @@ final class InvalidTests: XCTestCase {
       func test1o(1️⃣__owned var x : Int) {}
       """,
       diagnostics: [
-        // TODO: Old parser expected warning on line 1: 'var' in this position is interpreted as an argument label, Fix-It replacements: 21 - 24 = '`var`'
         DiagnosticSpec(message: "'__owned' before a parameter name is not allowed")
       ]
     )
@@ -95,7 +90,6 @@ final class InvalidTests: XCTestCase {
       func test2o(1️⃣__owned let x : Int) {}
       """,
       diagnostics: [
-        // TODO: Old parser expected warning on line 2: 'let' in this position is interpreted as an argument label, Fix-It replacements: 21 - 24 = '`let`'
         DiagnosticSpec(message: "'__owned' before a parameter name is not allowed")
       ]
     )
@@ -299,7 +293,6 @@ final class InvalidTests: XCTestCase {
       func f3_43591(let let 1️⃣a: Int) {}
       """,
       diagnostics: [
-        // TODO: Old parser expected warning on line 3: 'let' in this position is interpreted as an argument label, Fix-It replacements: 15 - 18 = '`let`'
         DiagnosticSpec(message: "unexpected code 'a' in parameter")
       ]
     )

--- a/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
+++ b/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
@@ -23,18 +23,6 @@ final class MatchingPatternsTests: XCTestCase {
     )
   }
 
-  func testMatchingPatterns2() {
-    AssertParse(
-      """
-      // TODO: Implement tuple equality in the library.
-      // BLOCKED: <rdar://problem/13822406>
-      func ~= (x: (Int,Int,Int), y: (Int,Int,Int)) -> Bool {
-        return true
-      }
-      """
-    )
-  }
-
   func testMatchingPatterns3() {
     AssertParse(
       """

--- a/Tests/SwiftParserTest/translated/OperatorDeclDesignatedTypesTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorDeclDesignatedTypesTests.swift
@@ -14,6 +14,8 @@
 
 import XCTest
 
+// TODO: Designated operator types are only valid in langauge mode 4. We should disallow them in language mode 5.
+
 final class OperatorDeclDesignatedTypesTests: XCTestCase {
   func testOperatorDeclDesignatedTypes1() {
     AssertParse(
@@ -69,12 +71,7 @@ final class OperatorDeclDesignatedTypesTests: XCTestCase {
       prefix operator ^^ : PrefixMagicOperatorProtocol
       infix operator  <*< : MediumPrecedence, InfixMagicOperatorProtocol
       postfix operator ^^ : PostfixMagicOperatorProtocol
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler; please remove the designated type list from this operator declaration, Fix-It replacements: 20 - 49 = ''
-        // TODO: Old parser expected warning on line 2: designated types are no longer used by the compiler, Fix-It replacements: 39 - 67 = ''
-        // TODO: Old parser expected warning on line 3: designated types are no longer used by the compiler, Fix-It replacements: 21 - 51 = ''
-      ]
+      """
     )
   }
 
@@ -92,10 +89,7 @@ final class OperatorDeclDesignatedTypesTests: XCTestCase {
     AssertParse(
       """
       infix operator **>> : UndeclaredPrecedence
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 21 - 43 = ''
-      ]
+      """
     )
   }
 
@@ -103,10 +97,7 @@ final class OperatorDeclDesignatedTypesTests: XCTestCase {
     AssertParse(
       """
       infix operator **+> : MediumPrecedence, UndeclaredProtocol
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 39 - 59 = ''
-      ]
+      """
     )
   }
 
@@ -114,10 +105,7 @@ final class OperatorDeclDesignatedTypesTests: XCTestCase {
     AssertParse(
       """
       prefix operator *+*> : MediumPrecedence
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 22 - 40 = ''
-      ]
+      """
     )
   }
 
@@ -125,10 +113,7 @@ final class OperatorDeclDesignatedTypesTests: XCTestCase {
     AssertParse(
       """
       postfix operator ++*> : MediumPrecedence
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 23 - 41 = ''
-      ]
+      """
     )
   }
 
@@ -137,11 +122,7 @@ final class OperatorDeclDesignatedTypesTests: XCTestCase {
       """
       prefix operator *++> : UndeclaredProtocol
       postfix operator +*+> : UndeclaredProtocol
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 22 - 42 = ''
-        // TODO: Old parser expected warning on line 2: designated types are no longer used by the compiler, Fix-It replacements: 23 - 43 = ''
-      ]
+      """
     )
   }
 
@@ -152,11 +133,7 @@ final class OperatorDeclDesignatedTypesTests: XCTestCase {
       class Class {}
       infix operator *>*> : Struct
       infix operator >**> : Class
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 3: designated types are no longer used by the compiler, Fix-It replacements: 21 - 29 = ''
-        // TODO: Old parser expected warning on line 4: designated types are no longer used by the compiler, Fix-It replacements: 21 - 28 = ''
-      ]
+      """
     )
   }
 
@@ -165,11 +142,7 @@ final class OperatorDeclDesignatedTypesTests: XCTestCase {
       """
       prefix operator **>> : Struct
       prefix operator *>*> : Class
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 22 - 30 = ''
-        // TODO: Old parser expected warning on line 2: designated types are no longer used by the compiler, Fix-It replacements: 22 - 29 = ''
-      ]
+      """
     )
   }
 
@@ -178,11 +151,7 @@ final class OperatorDeclDesignatedTypesTests: XCTestCase {
       """
       postfix operator >*>* : Struct
       postfix operator >>** : Class
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 23 - 31 = ''
-        // TODO: Old parser expected warning on line 2: designated types are no longer used by the compiler, Fix-It replacements: 23 - 30 = ''
-      ]
+      """
     )
   }
 
@@ -190,10 +159,7 @@ final class OperatorDeclDesignatedTypesTests: XCTestCase {
     AssertParse(
       """
       infix operator  <*<<< : MediumPrecedence, &
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 41 - 44 = ''
-      ]
+      """
     )
   }
 
@@ -202,10 +168,7 @@ final class OperatorDeclDesignatedTypesTests: XCTestCase {
       """
       infix operator **^^ : MediumPrecedence
       infix operator **^^ : InfixMagicOperatorProtocol
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 2: designated types are no longer used by the compiler, Fix-It replacements: 21 - 50 = ''
-      ]
+      """
     )
   }
 
@@ -218,16 +181,7 @@ final class OperatorDeclDesignatedTypesTests: XCTestCase {
       postfix operator ^^*^% : Struct, Class
       prefix operator %%*^^ : LowPrecedence, Class
       postfix operator ^^*%% : MediumPrecedence, Class
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 40 - 55 = ''
-        // TODO: Old parser expected warning on line 2: designated types are no longer used by the compiler, Fix-It replacements: 30 - 37 = ''
-        // TODO: Old parser expected warning on line 2: designated types are no longer used by the compiler, Fix-It replacements: 22 - 30 = ''
-        // TODO: Old parser expected warning on line 3: designated types are no longer used by the compiler, Fix-It replacements: 23 - 38 = ''
-        // TODO: Old parser expected warning on line 4: designated types are no longer used by the compiler, Fix-It replacements: 24 - 39 = ''
-        // TODO: Old parser expected warning on line 5: designated types are no longer used by the compiler, Fix-It replacements: 23 - 45 = ''
-        // TODO: Old parser expected warning on line 6: designated types are no longer used by the compiler, Fix-It replacements: 24 - 49 = ''
-      ]
+      """
     )
   }
 
@@ -235,10 +189,7 @@ final class OperatorDeclDesignatedTypesTests: XCTestCase {
     AssertParse(
       """
       infix operator <*<>*> : AdditionPrecedence,
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 43 - 44 = ''
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/OriginalDefinedInAttrTests.swift
+++ b/Tests/SwiftParserTest/translated/OriginalDefinedInAttrTests.swift
@@ -20,10 +20,7 @@ final class OriginalDefinedInAttrTests: XCTestCase {
       #"""
       @_originallyDefinedIn(module: "foo", OSX 13.13)
       public func foo() {}
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: '@_originallyDefinedIn' requires that 'foo()' have explicit availability for macOS
-      ]
+      """#
     )
   }
 
@@ -45,11 +42,7 @@ final class OriginalDefinedInAttrTests: XCTestCase {
       #"""
       @_originallyDefinedIn(module: "foo", OSX 13.13.3)
       public class ToplevelClass {}
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: '@_originallyDefinedIn' only uses major and minor version number
-        // TODO: Old parser expected error on line 1: '@_originallyDefinedIn' requires that 'ToplevelClass' have explicit availability for macOS
-      ]
+      """#
     )
   }
 
@@ -135,10 +128,7 @@ final class OriginalDefinedInAttrTests: XCTestCase {
       @_originallyDefinedIn(module: "foo", OSX 13.13)
       @_originallyDefinedIn(module: "foo", iOS 7.0)
       internal class ToplevelClass5 {}
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 2: '@_originallyDefinedIn' does not have any effect on internal declarations
-      ]
+      """#
     )
   }
 
@@ -149,10 +139,7 @@ final class OriginalDefinedInAttrTests: XCTestCase {
       @_originallyDefinedIn(module: "foo", OSX 13.13)
       @_originallyDefinedIn(module: "foo", iOS 7.0)
       private class ToplevelClass6 {}
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 2: '@_originallyDefinedIn' does not have any effect on private declarations
-      ]
+      """#
     )
   }
 
@@ -163,10 +150,7 @@ final class OriginalDefinedInAttrTests: XCTestCase {
       @_originallyDefinedIn(module: "foo", OSX 13.13)
       @_originallyDefinedIn(module: "foo", iOS 7.0)
       fileprivate class ToplevelClass7 {}
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 2: '@_originallyDefinedIn' does not have any effect on fileprivate declarations
-      ]
+      """#
     )
   }
 
@@ -176,10 +160,7 @@ final class OriginalDefinedInAttrTests: XCTestCase {
       @available(OSX 13.10, *)
       @_originallyDefinedIn(module: "foo", OSX 13.13, iOS 7.0)
       internal class ToplevelClass8 {}
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 2: '@_originallyDefinedIn' does not have any effect on internal declarations
-      ]
+      """#
     )
   }
 

--- a/Tests/SwiftParserTest/translated/RawStringErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/RawStringErrorsTests.swift
@@ -60,7 +60,6 @@ final class RawStringErrorsTests: XCTestCase {
       let _ = ####"invalid"###1️⃣
       """#####,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: unterminated string literal
         DiagnosticSpec(message: #####"expected '"####' to end string literal"#####)
       ]
     )
@@ -72,9 +71,6 @@ final class RawStringErrorsTests: XCTestCase {
       let _ = ###"invalid"###1️⃣###
       """#####,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: too many '#' characters in closing delimiter, Fix-It replacements: 24 - 27 = ''
-        // TODO: Old parser expected error on line 1: consecutive statements on a line must be separated by ';'
-        // TODO: Old parser expected error on line 1: expected expression
         DiagnosticSpec(locationMarker: "1️⃣", message: "too many '#' characters in closing delimiter")
       ]
     )
@@ -89,7 +85,6 @@ final class RawStringErrorsTests: XCTestCase {
       """###,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "multi-line string literal content must begin on a new line"),
-        // TODO: Old parser expected error on line 1: multi-line string literal content must begin on a new line, Fix-It replacements: 14 - 14 = '\n'
         DiagnosticSpec(locationMarker: "2️⃣", message: "multi-line string literal closing delimiter must begin on a new line"),
       ],
       fixedSource: ###"""

--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -214,12 +214,12 @@ final class RecoveryTests: XCTestCase {
   }
 
   func testRecovery17() {
+    // It is debatable if we should do recovery here and parse { true } as the
+    // body, but the error message should be sensible.
     AssertParse(
       """
-      // It is debatable if we should do recovery here and parse { true } as the
-        // body, but the error message should be sensible.
-        if { true } {
-        }
+      if { true } {
+      }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 3: missing condition in 'if' statement
@@ -359,11 +359,7 @@ final class RecoveryTests: XCTestCase {
       {
         missingControllingExprInRepeatWhile();
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: closure expression is unused
-        // TODO: Old parser expected note on line 1: did you mean to use a 'do' statement?, Fix-It replacements: 3 - 3 = 'do '
-      ]
+      """
     )
   }
 
@@ -552,7 +548,6 @@ final class RecoveryTests: XCTestCase {
       }2️⃣
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected '{' to start the body of for-each loop
         DiagnosticSpec(locationMarker: "1️⃣", message: "keyword 'for' cannot be used as an identifier here"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected code block in 'for' statement"),
       ]
@@ -799,9 +794,6 @@ final class RecoveryTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "found an unexpected second identifier in enum"),
-        // TODO: Old parser expected error on line 2: found an unexpected second identifier in enum 'case' declaration; is there an accidental break?
-        // TODO: Old parser expected note on line 2: join the identifiers together, Fix-It replacements: 8 - 11 = 'aa'
-        // TODO: Old parser expected note on line 2: join the identifiers together with camel-case, Fix-It replacements: 8 - 11 = 'aA'
         DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive declarations on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code 'a' before enum case"),
       ]
@@ -821,12 +813,9 @@ final class RecoveryTests: XCTestCase {
       """#,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "found an unexpected second identifier in struct"),
-        // TODO: Old parser expected error on line 2: found an unexpected second identifier in variable declaration; is there an accidental break?
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'String' to specified type 'Int'
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected ':' in type annotation"),
         DiagnosticSpec(locationMarker: "3️⃣", message: #"unexpected code ': Int = ""' before function"#),
-        // TODO: Old parser expected error on line 4: found an unexpected second identifier in variable declaration; is there an accidental break?
-        // TODO: Old parser expected warning on line 4: initialization of variable 'c' was never used; consider replacing with assignment to '_' or removing it
+        // TODO: (good first issue) Old parser expected error on line 4: found an unexpected second identifier in variable declaration; is there an accidental break?
         DiagnosticSpec(locationMarker: "4️⃣", message: "expected ':' in type annotation"),
       ]
     )
@@ -838,7 +827,7 @@ final class RecoveryTests: XCTestCase {
       let (efg 1️⃣hij, foobar) = (5, 6)
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: found an unexpected second identifier in constant declaration; is there an accidental break?
+        // TODO: (good first issue) Old parser expected error on line 1: found an unexpected second identifier in constant declaration; is there an accidental break?
         DiagnosticSpec(message: "unexpected code 'hij, foobar' in tuple pattern")
       ]
     )
@@ -1117,8 +1106,6 @@ final class RecoveryTests: XCTestCase {
       let a2: Set<Int1️⃣]>
       """,
       diagnostics: [
-        // TODO: Old parser expected note on line 3: to match this opening '<'
-        // TODO: Old parser expected error on line 3: expected '>' to complete generic argument list
         DiagnosticSpec(message: "expected '>' to end generic argument clause"),
         DiagnosticSpec(message: "extraneous code ']>' at top level"),
       ]
@@ -1144,8 +1131,6 @@ final class RecoveryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 5: unexpected ']' in type; did you mean to write an array type?, Fix-It replacements: 11 - 11 = '['
-        // TODO: Old parser expected error on line 5: expected declaration
-        // TODO: Old parser expected error on line 5: consecutive declarations on a line must be separated by ';'
         DiagnosticSpec(message: "extraneous code ']?' at top level")
       ]
     )
@@ -1199,7 +1184,6 @@ final class RecoveryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: unexpected ':' in type; did you mean to write a dictionary type?, Fix-It replacements: 11 - 11 = '['
-        // TODO: Old parser expected error on line 2: expected dictionary value type
         DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive declarations on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code ':' before variable"),
         // TODO: Old parser expected error on line 3: unexpected ':' in type; did you mean to write a dictionary type?, Fix-It replacements: 11 - 11 = '['
@@ -1225,10 +1209,7 @@ final class RecoveryTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: expected '{' in body of function declaration
-        // TODO: Old parser expected note on line 2: to match this opening '['
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected '}' to end struct"),
-        // TODO: Old parser expected error on line 4: expected ']' in array type
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected ']' to end array"),
         // TODO: Old parser expected error on line 5: unexpected ']' in type; did you mean to write an array type?, Fix-It replacements: 17 - 17 = '['
         DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous code at top level"),
@@ -1312,13 +1293,6 @@ final class RecoveryTests: XCTestCase {
       2️⃣}
       """,
       diagnostics: [
-        // TODO: Old parser expected note on line 1: in declaration of 'ErrorInFunctionSignatureResultArrayType11'
-        // TODO: Old parser expected error on line 2: consecutive declarations on a line must be separated by ';', Fix-It replacements: 29 - 29 = ';'
-        // TODO: Old parser expected error on line 2: expected ']' in array type
-        // TODO: Old parser expected note on line 2: to match this opening '['
-        // TODO: Old parser expected error on line 2: cannot find operator '++' in scope; did you mean '+= 1'?
-        // TODO: Old parser expected error on line 2: cannot find 'a' in scope
-        // TODO: Old parser expected error on line 2: expected declaration
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected '}' to end struct"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous brace at top level"),
       ]
@@ -1468,7 +1442,6 @@ final class RecoveryTests: XCTestCase {
       }
       """#,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: expected parameter name followed by ':'
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected 'func' in function"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in parameter"),
         DiagnosticSpec(locationMarker: "2️⃣", message: #"unexpected code '"No one else was in the room where it happened"' in parameter clause"#),
@@ -1484,7 +1457,6 @@ final class RecoveryTests: XCTestCase {
       }
       """#,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: expected parameter name followed by ':'
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected 'func' in function"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in parameter"),
         DiagnosticSpec(locationMarker: "2️⃣", message: #"unexpected code '"The room where it happened, the room where it happened"' in parameter clause"#),
@@ -1654,9 +1626,6 @@ final class RecoveryTests: XCTestCase {
       }
       """#,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: expected '{' in body of function declaration
-        // TODO: Old parser expected error on line 3: expected parameter name followed by ':'
-        // TODO: Old parser expected error on line 4: expected parameter name followed by ':'
         DiagnosticSpec(message: #"unexpected code '!= 0, "Can't form a Character from an empty String"' in parameter clause"#)
       ]
     )
@@ -1671,9 +1640,6 @@ final class RecoveryTests: XCTestCase {
       }
       """#,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: expected '{' in body of function declaration
-        // TODO: Old parser expected error on line 2: expected parameter name followed by ':'
-        // TODO: Old parser expected error on line 3: expected parameter name followed by ':'
         DiagnosticSpec(message: #"unexpected code '?= 0, "Can't form a Character from an empty String"' in parameter clause"#)
       ]
     )
@@ -1696,7 +1662,6 @@ final class RecoveryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: unnamed parameters must be written with the empty name '_'
-        // TODO: Old parser expected note on line 2: did you mean 'foo1'?
       ]
     )
   }
@@ -1708,7 +1673,6 @@ final class RecoveryTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: unnamed parameters must be written with the empty name '_'
-        // TODO: Old parser expected note on line 1: did you mean 'foo2'?
       ]
     )
   }
@@ -1774,7 +1738,7 @@ final class RecoveryTests: XCTestCase {
       init 1️⃣a(b: Int) {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: initializers cannot have a name, Fix-It replacements: 8 - 9 = ''
+        // TODO: (good first issue) Old parser expected error on line 3: initializers cannot have a name, Fix-It replacements: 8 - 9 = ''
         DiagnosticSpec(message: "unexpected code 'a' before parameter clause")
       ]
     )
@@ -1786,7 +1750,7 @@ final class RecoveryTests: XCTestCase {
       init? 1️⃣c(_ d: Int) {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: initializers cannot have a name, Fix-It replacements: 9 - 10 = ''
+        // TODO: (good first issue) Old parser expected error on line 1: initializers cannot have a name, Fix-It replacements: 9 - 10 = ''
         DiagnosticSpec(message: "unexpected code 'c' before parameter clause")
       ]
     )
@@ -1798,7 +1762,7 @@ final class RecoveryTests: XCTestCase {
       init 1️⃣e<T>(f: T) {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: initializers cannot have a name, Fix-It replacements: 8 - 9 = ''
+        // TODO: (good first issue) Old parser expected error on line 1: initializers cannot have a name, Fix-It replacements: 8 - 9 = ''
         DiagnosticSpec(message: "unexpected code 'e<T>' before parameter clause")
       ]
     )
@@ -1810,7 +1774,7 @@ final class RecoveryTests: XCTestCase {
       init? 1️⃣g<T>(_: T) {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: initializers cannot have a name, Fix-It replacements: 9 - 10 = ''
+        // TODO: (good first issue) Old parser expected error on line 1: initializers cannot have a name, Fix-It replacements: 9 - 10 = ''
         DiagnosticSpec(message: "unexpected code 'g<T>' before parameter clause")
       ]
     )
@@ -2104,7 +2068,6 @@ final class RecoveryTests: XCTestCase {
       infix operator -1️⃣@-class Recover1 {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: '@' is not allowed in operator names
         DiagnosticSpec(message: "'@-class' is not allowed in operator names")
       ]
     )
@@ -2116,7 +2079,6 @@ final class RecoveryTests: XCTestCase {
       prefix operator -1️⃣фф--class Recover2 {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: 'фф' is considered an identifier and must not appear within an operator name
         DiagnosticSpec(message: "'фф--class' is not allowed in operator names")
       ]
     )

--- a/Tests/SwiftParserTest/translated/StringLiteralEofTests.swift
+++ b/Tests/SwiftParserTest/translated/StringLiteralEofTests.swift
@@ -22,8 +22,6 @@ final class StringLiteralEofTests: XCTestCase {
       _ = "foo\(1️⃣
       """##,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: unterminated string literal
-        // TODO: Old parser expected error on line 2: cannot find ')' to match opening '(' in string interpolation
         DiagnosticSpec(message: "expected value and ')' in string literal"),
         DiagnosticSpec(message: #"expected '"' to end string literal"#),
       ]
@@ -37,8 +35,6 @@ final class StringLiteralEofTests: XCTestCase {
       _ = 9️⃣"foo\8️⃣(7️⃣"bar1️⃣
       """##,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot find ')' to match opening '(' in string interpolation
-        // TODO: Old parser expected error on line 2: unterminated string literal
         DiagnosticSpec(message: #"expected '"' to end string literal"#, notes: [NoteSpec(locationMarker: "7️⃣", message: #"to match this opening '"'"#)]),
         DiagnosticSpec(message: #"expected ')' in string literal"#, notes: [NoteSpec(locationMarker: "8️⃣", message: "to match this opening '('")]),
         DiagnosticSpec(message: #"expected '"' to end string literal"#, notes: [NoteSpec(locationMarker: "9️⃣", message: #"to match this opening '"'"#)]),
@@ -82,7 +78,6 @@ final class StringLiteralEofTests: XCTestCase {
           foo1️⃣
       """#,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: unterminated string literal
         DiagnosticSpec(message: #"expected '"""' to end string literal"#)
       ]
     )

--- a/Tests/SwiftParserTest/translated/SubscriptingTests.swift
+++ b/Tests/SwiftParserTest/translated/SubscriptingTests.swift
@@ -401,7 +401,6 @@ final class SubscriptingTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: subscripts cannot have a name, Fix-It replacements: 13 - 14 = ''
         DiagnosticSpec(message: "subscripts cannot have a name", fixIts: ["remove 'x'"])
       ],
       fixedSource: """

--- a/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
+++ b/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
@@ -200,12 +200,12 @@ final class TrailingClosuresTests: XCTestCase {
   }
 
   func testTrailingClosures14() {
+    // TODO: The diagnostics here are perhaps a little overboard.
     AssertParse(
       """
       func produce(fn: () -> Int?, default d: () -> Int) -> Int {
         return fn() ?? d()
       }
-      // TODO: The diagnostics here are perhaps a little overboard.
       _ = produce { 0 }1️⃣ 2️⃣default: { 1 }
       _ = produce { 2 } `default`: { 3 }
       """,


### PR DESCRIPTION
The TODOs marked as “good first issue” should serve as a good starting point for people that want to contribute to SwiftSyntax while the other TODOs should be good issues to fix for someone who has already gained some experience in contributing to SwiftSyntax.