### PR TITLE
Rename `createUniqueName` to `makeUniqueName`.

### DIFF
--- a/Sources/SwiftSyntaxMacros/BasicMacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacros/BasicMacroExpansionContext.swift
@@ -104,7 +104,7 @@ extension String {
 }
 extension BasicMacroExpansionContext: MacroExpansionContext {
   /// Generate a unique name for use in the macro.
-  public func createUniqueName(_ providedName: String) -> TokenSyntax {
+  public func makeUniqueName(_ providedName: String) -> TokenSyntax {
     // If provided with an empty name, substitute in something.
     let name = providedName.isEmpty ? "__local" : providedName
 

--- a/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
@@ -25,7 +25,18 @@ public protocol MacroExpansionContext: AnyObject {
   ///
   /// - Returns: an identifier token containing a unique name that will not
   ///   conflict with any other name in a well-formed program.
+  @available(*, renamed: "makeUniqueName(_:)")
   func createUniqueName(_ name: String) -> TokenSyntax
+
+  /// Generate a unique name for use in the macro.
+  ///
+  /// - Parameters:
+  ///   - name: The name to use as a basis for the uniquely-generated name,
+  ///     which will appear in the unique name that's produced here.
+  ///
+  /// - Returns: an identifier token containing a unique name that will not
+  ///   conflict with any other name in a well-formed program.
+  func makeUniqueName(_ name: String) -> TokenSyntax
 
   /// Produce a diagnostic while expanding the macro.
   func diagnose(_ diagnostic: Diagnostic)
@@ -136,6 +147,31 @@ extension MacroExpansionContext {
       line: "\(literal: line)",
       column: "\(literal: column)"
     )
+  }
+
+  /// Generate a unique name for use in the macro.
+  ///
+  /// - Parameters:
+  ///   - name: The name to use as a basis for the uniquely-generated name,
+  ///     which will appear in the unique name that's produced here.
+  ///
+  /// - Returns: an identifier token containing a unique name that will not
+  ///   conflict with any other name in a well-formed program.
+  @available(*, renamed: "makeUniqueName(_:)")
+  public func createUniqueName(_ name: String) -> TokenSyntax {
+    makeUniqueName(name)
+  }
+
+  /// Generate a unique name for use in the macro.
+  ///
+  /// - Parameters:
+  ///   - name: The name to use as a basis for the uniquely-generated name,
+  ///     which will appear in the unique name that's produced here.
+  ///
+  /// - Returns: an identifier token containing a unique name that will not
+  ///   conflict with any other name in a well-formed program.
+  public func makeUniqueName(_ name: String) -> TokenSyntax {
+    createUniqueName(name)
   }
 }
 

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -739,8 +739,8 @@ final class MacroSystemTests: XCTestCase {
   func testContextUniqueLocalNames() {
     let context = BasicMacroExpansionContext()
 
-    let t1 = context.createUniqueName("mine")
-    let t2 = context.createUniqueName("mine")
+    let t1 = context.makeUniqueName("mine")
+    let t2 = context.makeUniqueName("mine")
     XCTAssertNotEqual(t1.description, t2.description)
     XCTAssertEqual(t1.description, "__macro_local_4minefMu_")
     XCTAssertEqual(t2.description, "__macro_local_4minefMu0_")


### PR DESCRIPTION
As per Evolution comment: https://forums.swift.org/t/se-0382-second-review-expression-macros/63064/20