### PR TITLE
Fix a misparser where we would classify a call to 'open' as a DeclModifier

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -60,7 +60,9 @@ extension TokenConsumer {
         modifierProgress.evaluate(subparser.currentToken)
       {
         subparser.eat(handle)
-        if subparser.at(.leftParen) && modifierKind.canHaveParenthesizedArgument {
+        if modifierKind != .open && subparser.at(.leftParen) && modifierKind.canHaveParenthesizedArgument {
+          // When determining whether we are at a declaration, don't consume anything in parentheses after 'open'
+          // so we don't consider a function call to open as a decl modifier. This matches the C++ parser.
           subparser.consumeAnyToken()
           subparser.consume(to: .rightParen)
         }
@@ -100,7 +102,7 @@ extension TokenConsumer {
       var lookahead = subparser.lookahead()
       repeat {
         lookahead.consumeAnyToken()
-      } while lookahead.atStartOfDeclaration(allowInitDecl: allowInitDecl)
+      } while lookahead.atStartOfDeclaration(isAtTopLevel: isAtTopLevel, allowInitDecl: allowInitDecl)
       return lookahead.at(.identifier)
     case .caseKeyword:
       // When 'case' appears inside a function, it's probably a switch

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -249,7 +249,7 @@ extension Parser {
       return .decl(RawDeclSyntax(directive))
     } else if self.at(.poundSourceLocationKeyword) {
       return .decl(RawDeclSyntax(self.parsePoundSourceLocationDirective()))
-    } else if self.atStartOfDeclaration(allowInitDecl: allowInitDecl) {
+    } else if self.atStartOfDeclaration(isAtTopLevel: isAtTopLevel, allowInitDecl: allowInitDecl) {
       return .decl(self.parseDeclaration())
     } else if self.atStartOfStatement() {
       return self.parseStatementItem()

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -286,7 +286,11 @@ final class DeclarationTests: XCTestCase {
       fileprivate fileprivate(set) var fileprivateProp = 0
       private private(set) var privateProp = 0
       internal(set) var defaultProp = 0
-      """
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
+      ]
     )
 
     AssertParse(
@@ -1406,6 +1410,79 @@ final class DeclarationTests: XCTestCase {
       fixedSource: """
         let a = <#expression#>
         """
+    )
+  }
+
+  func testCallToOpenThatLooksLikeDeclarationModifier() {
+    AssertParse(
+      """
+      func test() {
+        open(set)
+        var foo = 2
+      }
+      """,
+      substructure: Syntax(
+        FunctionCallExprSyntax(
+          calledExpression: IdentifierExprSyntax(identifier: .identifier("open")),
+          leftParen: .leftParenToken(),
+          argumentList: TupleExprElementListSyntax([
+            TupleExprElementSyntax(
+              expression: IdentifierExprSyntax(identifier: .identifier("set"))
+            )
+          ]),
+          rightParen: .rightParenToken()
+        )
+      )
+    )
+  }
+
+  func testReferenceToOpenThatLooksLikeDeclarationModifier() {
+    // Ideally, this should be parsed as an identifier expression to 'open',
+    // followed by a variable declaration but the current behavior matches the C++ parser.
+    AssertParse(
+      """
+      func test() {
+        open
+        var foo = 2
+      }
+      """,
+      substructure: Syntax(
+        VariableDeclSyntax(
+          modifiers: ModifierListSyntax([
+            DeclModifierSyntax(name: .keyword(.open))
+          ]),
+          bindingKeyword: .keyword(.var),
+          bindings: PatternBindingListSyntax([
+            PatternBindingSyntax(
+              pattern: IdentifierPatternSyntax(identifier: .identifier("foo")),
+              initializer: InitializerClauseSyntax(
+                value: IntegerLiteralExprSyntax(digits: .integerLiteral("2"))
+              )
+            )
+          ])
+        )
+      )
+    )
+  }
+
+  func testOpenVarInCodeBlockItemList() {
+    AssertParse(
+      """
+      func test() {
+        open var foo = 2
+      }
+      """,
+      substructure: Syntax(DeclModifierSyntax(name: .keyword(.open)))
+    )
+  }
+
+  func testAsyncLetInLocalContext() {
+    AssertParse(
+      """
+      func foo() async {
+        async let x: String = "x"
+      }
+      """
     )
   }
 }


### PR DESCRIPTION
While I was working on this, I also noticed that we forgot to pass `isAtTopLevel` in a few places. They didn’t really matter here but I made sure to correctly pass the flag regardless.