### PR TITLE
Fix code generation on older Swift versions

### DIFF
--- a/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
@@ -170,7 +170,7 @@ public struct SyntaxBuildableType: Hashable {
   }
 
   /// Wraps a type in an optional chaining depending on whether `isOptional` is true.
-  public func optionalChained(expr: ExprSyntaxProtocol) -> ExprSyntax {
+  public func optionalChained<ExprNode: ExprSyntaxProtocol>(expr: ExprNode) -> ExprSyntax {
     if isOptional {
       return ExprSyntax(OptionalChainingExprSyntax(expression: expr))
     } else {
@@ -179,7 +179,7 @@ public struct SyntaxBuildableType: Hashable {
   }
 
   /// Wraps a type in a force unwrap expression depending on whether `isOptional` is true.
-  public func forceUnwrappedIfNeeded(expr: ExprSyntaxProtocol) -> ExprSyntax {
+  public func forceUnwrappedIfNeeded<ExprNode: ExprSyntaxProtocol>(expr: ExprNode) -> ExprSyntax {
     if isOptional {
       return ExprSyntax(ForcedValueExprSyntax(expression: expr))
     } else {

--- a/CodeGeneration/Sources/generate-swiftsyntax/GenerateSwiftSyntax.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/GenerateSwiftSyntax.swift
@@ -120,9 +120,11 @@ struct GenerateSwiftSyntax: ParsableCommand {
           .appendingPathComponent(template.module)
           .appendingPathComponent("generated")
           .appendingPathComponent(template.filename)
-        previouslyGeneratedFilesLock.withLock {
-          _ = previouslyGeneratedFiles.remove(destination)
-        }
+
+        previouslyGeneratedFilesLock.lock();
+        _ = previouslyGeneratedFiles.remove(destination)
+        previouslyGeneratedFilesLock.unlock()
+
         try generateTemplate(
           sourceFile: template.sourceFile,
           destination: destination,


### PR DESCRIPTION
`withLock` is unavailable and `optionalChained` and `forceUnwrappedIfNeeded` were relying on opening the existential.