### PR TITLE
[Diagnostics formatter] Consistently apply diagnostic kinds

### DIFF
--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -327,20 +327,20 @@ public struct DiagnosticsFormatter {
   /// Annotates the given ``DiagnosticMessage`` with an appropriate ANSI color code (if the value of the `colorize`
   /// property is `true`) and returns the result as a printable string.
   private func colorizeIfRequested(_ message: DiagnosticMessage) -> String {
-    guard colorize else {
-      return message.message
-    }
-
     switch message.severity {
     case .error:
       let annotation = ANSIAnnotation(color: .red, trait: .bold)
-      return annotation.applied(to: "error: \(message.message)")
+      return colorizeIfRequested("error: \(message.message)", annotation: annotation)
+
     case .warning:
       let color = ANSIAnnotation(color: .yellow)
-      let prefix = color.withTrait(.bold).applied(to: "warning: ")
-      return prefix + color.applied(to: message.message)
+      let prefix = colorizeIfRequested("warning: ", annotation: color.withTrait(.bold))
+
+      return prefix + colorizeIfRequested(message.message, annotation: color);
     case .note:
-      return message.message
+      let color = ANSIAnnotation(color: .default, trait: .bold)
+      let prefix = colorizeIfRequested("note: ", annotation: color)
+      return prefix + message.message
     }
   }
 

--- a/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
@@ -30,7 +30,7 @@ final class DiagnosticsFormatterTests: XCTestCase {
       """
     let expectedOutput = """
       1 │ var foo = bar +
-        ∣                ╰─ expected expression after operator
+        ∣                ╰─ error: expected expression after operator
 
       """
     AssertStringsEqualWithDiff(annotate(source: source), expectedOutput)
@@ -42,9 +42,9 @@ final class DiagnosticsFormatterTests: XCTestCase {
       """
     let expectedOutput = """
       1 │ foo.[].[].[]
-        ∣     │  │  ╰─ expected name in member access
-        ∣     │  ╰─ expected name in member access
-        ∣     ╰─ expected name in member access
+        ∣     │  │  ╰─ error: expected name in member access
+        ∣     │  ╰─ error: expected name in member access
+        ∣     ╰─ error: expected name in member access
 
       """
     AssertStringsEqualWithDiff(annotate(source: source), expectedOutput)
@@ -68,14 +68,14 @@ final class DiagnosticsFormatterTests: XCTestCase {
        2 │ i = 2
        3 │ i = foo(
        4 │ i = 4
-         ∣      ╰─ expected ')' to end function call
+         ∣      ╰─ error: expected ')' to end function call
        5 │ i = 5
        6 │ i = 6
          ┆
        9 │ i = 9
       10 │ i = 10
       11 │ i = bar(
-         ∣         ╰─ expected value and ')' to end function call
+         ∣         ╰─ error: expected value and ')' to end function call
 
       """
     AssertStringsEqualWithDiff(annotate(source: source), expectedOutput)
@@ -86,8 +86,8 @@ final class DiagnosticsFormatterTests: XCTestCase {
 
     let expectedOutput = """
       1 │ t as (..)
-        ∣       ├─ expected type in tuple type
-        ∣       ╰─ unexpected code '..' in tuple type
+        ∣       ├─ error: expected type in tuple type
+        ∣       ╰─ error: unexpected code '..' in tuple type
 
       """
 

--- a/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
@@ -114,17 +114,17 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
       === main.swift ===
       1 │ let pi = 3.14159
       2 │ #myAssert(pi == 3)
-        ∣ ╰─ in expansion of macro 'myAssert' here
+        ∣ ╰─ note: in expansion of macro 'myAssert' here
         ╭─── #myAssert ───────────────────────────────────────────────────────
         │1 │ let __a = pi
         │2 │ let __b = 3
         │3 │ if !(__a == __b) {
-        │  ∣          ╰─ no matching operator '==' for types 'Double' and 'Int'
+        │  ∣          ╰─ error: no matching operator '==' for types 'Double' and 'Int'
         │4 │   fatalError("assertion failed: pi != 3")
         │5 │ }
         ╰─────────────────────────────────────────────────────────────────────
       3 │ print("hello"
-        ∣              ╰─ expected ')' to end function call
+        ∣              ╰─ error: expected ')' to end function call
 
       """
     )
@@ -183,21 +183,21 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
       === main.swift ===
       1 │ let pi = 3.14159
       2 │ #myAssert(pi == 3)
-        ∣ ╰─ in expansion of macro 'myAssert' here
+        ∣ ╰─ note: in expansion of macro 'myAssert' here
         ╭─── #myAssert ───────────────────────────────────────────────────────
         │1 │ let __a = pi
         │2 │ let __b = 3
         │3 │ if #invertedEqualityCheck(__a, __b) {
-        │  ∣    ╰─ in expansion of macro 'invertedEqualityCheck' here
+        │  ∣    ╰─ note: in expansion of macro 'invertedEqualityCheck' here
         │  ╭─── #invertedEqualityCheck ───────────────────────────────────────
         │  │1 │ !(__a == __b)
-        │  │  ∣       ╰─ no matching operator '==' for types 'Double' and 'Int'
+        │  │  ∣       ╰─ error: no matching operator '==' for types 'Double' and 'Int'
         │  ╰──────────────────────────────────────────────────────────────────
         │4 │   fatalError("assertion failed: pi != 3")
         │5 │ }
         ╰─────────────────────────────────────────────────────────────────────
       3 │ print("hello"
-        ∣              ╰─ expected ')' to end function call
+        ∣              ╰─ error: expected ')' to end function call
 
       """
     )

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -418,7 +418,7 @@ final class StringInterpolationTests: XCTestCase {
         """
 
         1 │ /*comment*/ invalid /*comm*/
-          ∣             ╰─ unexpected trivia 'invalid'
+          ∣             ╰─ error: unexpected trivia 'invalid'
 
         """
       )
@@ -435,8 +435,8 @@ final class StringInterpolationTests: XCTestCase {
         """
 
         1 │ return 1
-          ∣ │       ╰─ expected declaration
-          ∣ ╰─ unexpected code 'return 1' before declaration
+          ∣ │       ╰─ error: expected declaration
+          ∣ ╰─ error: unexpected code 'return 1' before declaration
 
         """
       )
@@ -453,8 +453,8 @@ final class StringInterpolationTests: XCTestCase {
         """
 
         1 │ struct Foo {}
-          ∣ │            ╰─ expected statement
-          ∣ ╰─ unexpected code 'struct Foo {}' before statement
+          ∣ │            ╰─ error: expected statement
+          ∣ ╰─ error: unexpected code 'struct Foo {}' before statement
 
         """
       )


### PR DESCRIPTION
Address two issues regarding the diagnostic type indicators in formatted diagnostics.

1. When colors were disabled, we wouldn't get any of the diagnostic type indicators because the "colorize" check came too early. Make sure they're consistently applied whether colorized or not.
2. There was no "note:" prefix, so it wasn't clear which things were notes.