### PR TITLE
Implement `consume x` operator with the accepted SE-0366 syntax.

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -105,6 +105,7 @@ public let KEYWORDS: [KeywordSpec] = [
   KeywordSpec("case", isLexerClassified: true, requiresTrailingSpace: true),
   KeywordSpec("catch", isLexerClassified: true, requiresLeadingSpace: true),
   KeywordSpec("class", isLexerClassified: true, requiresTrailingSpace: true),
+  KeywordSpec("consume"),
   KeywordSpec("consuming"),
   KeywordSpec("continue", isLexerClassified: true, requiresTrailingSpace: true),
   KeywordSpec("convenience"),

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
@@ -637,7 +637,7 @@ public let EXPR_NODES: [Node] = [
        kind: "Expr",
        children: [
          Child(name: "MoveKeyword",
-               kind: .token(choices: [.keyword(text: "_move")])),
+               kind: .token(choices: [.keyword(text: "_move"), .keyword(text: "consume")])),
          Child(name: "Expression",
                kind: .node(kind: "Expr"))
        ]),

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -471,6 +471,34 @@ extension Parser {
           arena: self.arena
         )
       )
+
+    case (.consumeKeyword, let handle)?:
+      // `consume` is only contextually a keyword, if it's followed by an
+      // identifier or keyword on the same line.
+      let next = peek()
+      if next.isAtStartOfLine {
+        fallthrough
+      }
+      if next.rawTokenKind != .identifier,
+        next.rawTokenKind != .dollarIdentifier,
+        next.rawTokenKind != .keyword
+      {
+        fallthrough
+      }
+
+      let consumeTok = self.eat(handle)
+      let sub = self.parseSequenceExpressionElement(
+        flavor,
+        forDirective: forDirective,
+        pattern: pattern
+      )
+      return RawExprSyntax(
+        RawMoveExprSyntax(
+          moveKeyword: consumeTok,
+          expression: sub,
+          arena: self.arena
+        )
+      )
     case nil:
       return self.parseUnaryExpression(flavor, forDirective: forDirective, pattern: pattern)
     }

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -972,7 +972,12 @@ extension Parser.Lookahead {
         return !self.peek().isAtStartOfLine
       }
     case .forgetKeyword?:
-      switch peek().rawTokenKind {
+      let next = peek()
+      // The thing to be forgotten must be on the same line as `forget`.
+      if next.isAtStartOfLine {
+        return false
+      }
+      switch next.rawTokenKind {
       case .identifier, .keyword:
         // Since some identifiers like "self" are classified as keywords,
         // we want to recognize those too, to handle "forget self". We also

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -513,6 +513,7 @@ enum AwaitTryMove: TokenSpecSet {
   case _moveKeyword
   case _borrowKeyword
   case tryKeyword
+  case consumeKeyword
 
   init?(lexeme: Lexer.Lexeme) {
     switch PrepareForKeywordMatch(lexeme) {
@@ -520,6 +521,7 @@ enum AwaitTryMove: TokenSpecSet {
     case TokenSpec(._move): self = ._moveKeyword
     case TokenSpec(._borrow): self = ._borrowKeyword
     case TokenSpec(.try): self = .tryKeyword
+    case TokenSpec(.consume): self = .consumeKeyword
     default: return nil
     }
   }
@@ -529,6 +531,7 @@ enum AwaitTryMove: TokenSpecSet {
     case .awaitKeyword: return .keyword(.await)
     case ._moveKeyword: return .keyword(._move)
     case ._borrowKeyword: return .keyword(._borrow)
+    case .consumeKeyword: return .keyword(.consume)
     case .tryKeyword: return .keyword(.try)
     }
   }

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -89,6 +89,7 @@ public enum Keyword: UInt8, Hashable {
   case `case`
   case `catch`
   case `class`
+  case consume
   case consuming
   case `continue`
   case convenience
@@ -425,6 +426,8 @@ public enum Keyword: UInt8, Hashable {
         self = ._linear
       case "_modify":
         self = ._modify
+      case "consume":
+        self = .consume
       case "default":
         self = .`default`
       case "dynamic":
@@ -921,6 +924,7 @@ public enum Keyword: UInt8, Hashable {
       "case", 
       "catch", 
       "class", 
+      "consume", 
       "consuming", 
       "continue", 
       "convenience", 

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -4328,7 +4328,7 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public init<E: ExprSyntaxProtocol>(
       leadingTrivia: Trivia? = nil, 
       _ unexpectedBeforeMoveKeyword: UnexpectedNodesSyntax? = nil, 
-      moveKeyword: TokenSyntax = .keyword(._move), 
+      moveKeyword: TokenSyntax, 
       _ unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodesSyntax? = nil, 
       expression: E, 
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil, 

--- a/gyb_syntax_support/ExprNodes.py
+++ b/gyb_syntax_support/ExprNodes.py
@@ -53,7 +53,10 @@ EXPR_NODES = [
     Node('MoveExpr', name_for_diagnostics="'_move' expression", kind='Expr',
          children=[
              Child('MoveKeyword', kind='KeywordToken',
-                   token_choices=['KeywordToken|_move']),
+                   token_choices=[
+                       'KeywordToken|_move',
+                       'KeywordToken|consume',
+                   ]),
              Child('Expression', kind='Expr'),
          ]),
 


### PR DESCRIPTION
Matching compiler changes are https://github.com/apple/swift/pull/64019