### PR TITLE
Improved diagnostics for misplaced AttributeList in variable declaration

### DIFF
--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -191,6 +191,9 @@ extension DiagnosticMessage where Self == StaticParserError {
   public static var maximumNestingLevelOverflow: Self {
     .init("parsing has exceeded the maximum nesting level")
   }
+  public static var misplacedAttributeInVarDecl: Self {
+    .init("misplaced attribute in variable declaration")
+  }
   public static var missingColonAndExprInTernaryExpr: Self {
     .init("expected ':' and expression after '? ...' in ternary expression")
   }
@@ -710,15 +713,15 @@ public struct MoveTokensAfterFixIt: ParserFixIt {
   }
 }
 
-public struct MoveTokensInFrontOfFixIt: ParserFixIt {
-  /// The token that should be moved
-  public let movedTokens: [TokenSyntax]
+public struct MoveNodesInFrontOfFixIt<Node: SyntaxProtocol>: ParserFixIt {
+  /// The nodes that should be moved
+  public let movedNodes: [Node]
 
-  /// The token before which 'movedTokens' should be moved
+  /// The token before which `movedNodes` should be moved
   public let inFrontOf: TokenKind
 
   public var message: String {
-    "move \(nodesDescription(movedTokens, format: false)) in front of '\(inFrontOf.nameForDiagnostics)'"
+    "move \(nodesDescription(movedNodes, format: false)) in front of '\(inFrontOf.nameForDiagnostics)'"
   }
 }
 

--- a/Tests/SwiftParserTest/AttributeTests.swift
+++ b/Tests/SwiftParserTest/AttributeTests.swift
@@ -1022,4 +1022,26 @@ final class AttributeTests: ParserTestCase {
       ]
     )
   }
+
+  func testMisplacedAttributeInVariableDecl() {
+    assertParse(
+      """
+      struct A {
+        var 1️⃣@State name: String
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "misplaced attribute in variable declaration",
+          fixIts: ["move attributes in front of 'var'"]
+        )
+      ],
+      fixedSource:
+        """
+        struct A {
+          @State var name: String
+        }
+        """
+    )
+  }
 }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -3308,4 +3308,21 @@ final class DeclarationTests: ParserTestCase {
       experimentalFeatures: .transferringArgsAndResults
     )
   }
+
+  func testMisplacedAttributeInVarDeclWithMultipleBindings() {
+    assertParse(
+      """
+      let a = "a", 1️⃣@foo b = "b"
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "misplaced attribute in variable declaration",
+          fixIts: ["move attributes in front of 'let'"]
+        )
+      ],
+      fixedSource: """
+        @foo let a = "a", b = "b"
+        """
+    )
+  }
 }


### PR DESCRIPTION
Previously the error messages for this code were quite bad. Now they are great!

```swift
struct A {
  var @State name: String
}
```

Part of this PR are some minor changes:
- The fixit message is shown in the diagnostics formatter
- The SyntaxRewriter now can use a given arena 
- Do not print colors if run within Xcode (debatable, feel free to remove)

Best regards from [Cocoaheads](https://cocoaheads.de) 😉 