### PR TITLE
[Macros] Specify introduced names for example member macro.

### DIFF
--- a/lit_tests/compiler_plugin_basic.swift
+++ b/lit_tests/compiler_plugin_basic.swift
@@ -14,7 +14,7 @@
 @freestanding(expression)
 macro echo<T>(_: T) -> T = #externalMacro(module: "ExamplePlugin", type: "EchoExpressionMacro")
 
-@attached(member)
+@attached(member, names: named(__metadata__))
 macro Metadata() = #externalMacro(module: "ExamplePlugin", type: "MetadataMacro")
 
 @Metadata


### PR DESCRIPTION
This is required in https://github.com/apple/swift/pull/64097