### PR TITLE
Fix broken link to ExamplePlugin

### DIFF
--- a/Examples/README.md
+++ b/Examples/README.md
@@ -4,7 +4,7 @@ Each example can be executed by navigating into this folder and running `swift r
 
 - [AddOneToIntegerLiterals](Sources/AddOneToIntegerLiterals/AddOneToIntegerLiterals.swift): Command line tool to add 1 to every integer literal in a source file
 - [CodeGenerationUsingSwiftSyntaxBuilder](Sources/CodeGenerationUsingSwiftSyntaxBuilder/CodeGenerationUsingSwiftSyntaxBuilder.swift): Code-generate a simple source file using SwiftSyntaxBuilder
-- [ExamplePlugin](Sources/ExamplePlugn): Compiler plugin executable using [`SwiftCompilerPlugin`](../Sources/SwiftCompilerPlugin)
+- [ExamplePlugin](Sources/ExamplePlugin): Compiler plugin executable using [`SwiftCompilerPlugin`](../Sources/SwiftCompilerPlugin)
 
 ## Some Example Usages
 


### PR DESCRIPTION
Fix typo in `ExamplePlugin` link, `i` in `Plugin` is missing 🙃 