### PR TITLE
Use the grouped diagnostics formatter in `swift-parser-cli print-diags`

### DIFF
--- a/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
+++ b/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
@@ -61,6 +61,7 @@ public struct GroupedDiagnostics {
   ///     absolute position within that parent source file.
   ///
   /// - Returns: The unique ID for this source file.
+  @discardableResult
   public mutating func addSourceFile(
     tree: SourceFileSyntax,
     displayName: String,
@@ -205,5 +206,14 @@ extension DiagnosticsFormatter {
     return group.rootSourceFiles.map { rootSourceFileID in
       group.annotateSource(rootSourceFileID, formatter: self, indentString: "")
     }.joined(separator: "\n")
+  }
+
+  public static func annotateSources(
+    in group: GroupedDiagnostics,
+    contextSize: Int = 2,
+    colorize: Bool = false
+  ) -> String {
+    let formatter = DiagnosticsFormatter(contextSize: contextSize, colorize: colorize)
+    return formatter.annotateSources(in: group)
   }
 }

--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -214,9 +214,11 @@ class PrintDiags: ParsableCommand {
       if foldSequences {
         diags += foldAllSequences(tree).1
       }
-      let annotatedSource = DiagnosticsFormatter.annotatedSource(
-        tree: tree,
-        diags: diags,
+
+      var group = GroupedDiagnostics()
+      group.addSourceFile(tree: tree, displayName: sourceFile ?? "stdin", diagnostics: diags)
+      let annotatedSource = DiagnosticsFormatter.annotateSources(
+        in: group,
         colorize: colorize || TerminalHelper.isConnectedToTerminal
       )
 

--- a/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
@@ -105,9 +105,7 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
       ]
     )
 
-    let formatter = DiagnosticsFormatter()
-    let annotated = formatter.annotateSources(in: group)
-    print(annotated)
+    let annotated = DiagnosticsFormatter.annotateSources(in: group)
     AssertStringsEqualWithDiff(
       annotated,
       """
@@ -174,9 +172,7 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
       ]
     )
 
-    let formatter = DiagnosticsFormatter()
-    let annotated = formatter.annotateSources(in: group)
-    print(annotated)
+    let annotated = DiagnosticsFormatter.annotateSources(in: group)
     AssertStringsEqualWithDiff(
       annotated,
       """


### PR DESCRIPTION
The grouped diagnostics formatter is what we use to render diagnsotics from the compiler, so I think that `swift-parser-cli print-diags` should match that formatting style.