### PR TITLE
[Variadic Generics] diagnostics + fixits for parameter pack syntax change: T... -> each T

### DIFF
--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -197,6 +197,9 @@ extension DiagnosticMessage where Self == StaticParserError {
   public static var tryOnInitialValueExpression: Self {
     .init("'try' must be placed on the initial value expression")
   }
+  public static var typeParameterPackEllipsis: Self {
+    .init("ellipsis operator cannot be used with a type parameter pack")
+  }
   public static var unexpectedPoundElseSpaceIf: Self {
     .init("unexpected 'if' keyword following '#else' conditional compilation directive; did you mean '#elseif'?")
   }
@@ -504,7 +507,7 @@ public struct MoveTokensInFrontOfFixIt: ParserFixIt {
   /// The token that should be moved
   public let movedTokens: [TokenSyntax]
 
-  /// The token after which 'try' should be moved
+  /// The token before which 'movedTokens' should be moved
   public let inFrontOf: TokenKind
 
   public var message: String {

--- a/Tests/SwiftParserTest/VariadicGenericsTests.swift
+++ b/Tests/SwiftParserTest/VariadicGenericsTests.swift
@@ -74,6 +74,37 @@ final class VariadicGenericsTests: XCTestCase {
     )
   }
 
+  func testTypeParameterPackEllipsis() {
+    AssertParse(
+      """
+      func invalid<T1️⃣...>(_ t: repeat each T) {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "ellipsis operator cannot be used with a type parameter pack",
+          fixIts: ["replace '...' with 'each'"]
+        )
+      ],
+      fixedSource: """
+        func invalid<each T>(_ t: repeat each T) {}
+        """
+    )
+  }
+
+  func testTypeParameterPackEachEllipsis() {
+    AssertParse(
+      """
+      func invalid<each T1️⃣...>(_ t: repeat each T) {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "ellipsis operator cannot be used with a type parameter pack",
+          fixIts: ["remove '...'"]
+        )
+      ]
+    )
+  }
+
   func testPackElementExprSimple() {
     AssertParse(
       """
@@ -293,6 +324,21 @@ final class TypeParameterPackTests: XCTestCase {
     )
   }
   func testParameterPacks4() {
+    AssertParse(
+      """
+      protocol P {
+        associatedtype 1️⃣each T
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(
+          message: "associated types cannot be variadic",
+          fixIts: ["remove 'each'"]
+        )
+      ]
+    )
+  }
+  func testParameterPacks4EarlySyntax() {
     AssertParse(
       """
       protocol P {

--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -1007,6 +1007,19 @@ final class RecoveryTests: XCTestCase {
     )
   }
 
+  func testRecovery87b() {
+    AssertParse(
+      """
+      struct ErrorGenericParameterList1<each1️⃣
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected name in generic parameter"),
+        DiagnosticSpec(message: "expected '>' to end generic parameter clause"),
+        DiagnosticSpec(message: "expected member block in struct"),
+      ]
+    )
+  }
+
   func testRecovery88() {
     AssertParse(
       """


### PR DESCRIPTION
brings parity with https://github.com/apple/swift/pull/64104 in the C++ implementation