### PR TITLE
Reduce recovery precedence of arrow in function type to exprKeyword

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1376,7 +1376,9 @@ extension Parser {
 
     let output: RawReturnClauseSyntax?
 
-    if self.at(.arrow) || self.canRecoverTo(TokenSpec(.arrow, allowAtStartOfLine: false)) != nil {
+    /// Only allow recovery to the arrow with exprKeyword precedence so we only
+    /// skip over misplaced identifiers and don't e.g. recover to an arrow in a 'where' clause.
+    if self.at(.arrow) || self.canRecoverTo(TokenSpec(.arrow, recoveryPrecedence: .exprKeyword)) != nil {
       output = self.parseFunctionReturnClause(effectSpecifiers: &effectSpecifiers, allowNamedOpaqueResultType: true)
     } else {
       output = nil

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1531,6 +1531,17 @@ final class DeclarationTests: XCTestCase {
       """
     )
   }
+
+  func testWhereClauseWithFunctionType() {
+    // A function type in the where clause isn't semantically valid but its fine
+    // with the parser. Make sure we don't recover to the arrow to parse the
+    // function return type.
+    AssertParse(
+      """
+      func badTypeConformance3<T>(_: T) where (T) -> () : EqualComparable { }
+      """
+    )
+  }
 }
 
 extension Parser.DeclAttributes {

--- a/Tests/SwiftParserTest/translated/InvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidTests.swift
@@ -205,8 +205,7 @@ final class InvalidTests: XCTestCase {
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' in function type"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected return type in function type"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code '<T>()' in function signature"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "unexpected code ')' in function"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected code '<T>() -> T)' in function"),
       ]
     )
   }


### PR DESCRIPTION
Only allow recovery to the arrow with exprKeyword precedence so we only skip over misplaced identifiers and don't e.g. recover to an errow in a 'where' clause.

CC @StevenWong12 I didn’t think about this case when reviewing your PR.

rdar://106457182