### PR TITLE
Use CRLF in diagnostics on Windows

### DIFF
--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -49,6 +49,14 @@ extension Sequence where Element == Range<Int> {
   }
 }
 
+extension String {
+#if os(Windows)
+    internal static let newline = "\r\n"
+#else
+    internal static let newline = "\n"
+#endif
+}
+
 public struct DiagnosticsFormatter {
 
   /// A wrapper struct for a source line, its diagnostics, and any
@@ -227,7 +235,7 @@ public struct DiagnosticsFormatter {
     // If there was a filename, add it first.
     if let fileName = fileName {
       let header = colorizeBufferOutline("===")
-      annotatedSource.append("\(indentString)\(header) \(fileName) \(header)\n")
+      annotatedSource.append("\(indentString)\(header) \(fileName) \(header)\(String.newline)")
     }
 
     /// Keep track if a line missing char should be printed
@@ -254,7 +262,7 @@ public struct DiagnosticsFormatter {
       // If necessary, print a line that indicates that there was lines skipped in the source code
       if hasLineBeenSkipped && !annotatedSource.isEmpty {
         let lineMissingInfoLine = indentString + String(repeating: " ", count: maxNumberOfDigits) + " \(colorizeBufferOutline("┆"))"
-        annotatedSource.append("\(lineMissingInfoLine)\n")
+        annotatedSource.append("\(lineMissingInfoLine)\(String.newline)")
       }
       hasLineBeenSkipped = false
 
@@ -274,7 +282,7 @@ public struct DiagnosticsFormatter {
 
       // If the line did not end with \n (e.g. the last line), append it manually
       if annotatedSource.last != "\n" {
-        annotatedSource.append("\n")
+        annotatedSource.append(String.newline)
       }
 
       let columnsWithDiagnostics = Set(annotatedLine.diagnostics.map { $0.location(converter: slc).column ?? 0 })
@@ -296,15 +304,15 @@ public struct DiagnosticsFormatter {
         }
 
         for diag in diags.dropLast(1) {
-          annotatedSource.append("\(preMessage)├─ \(colorizeIfRequested(diag.diagMessage))\n")
+          annotatedSource.append("\(preMessage)├─ \(colorizeIfRequested(diag.diagMessage))\(String.newline)")
         }
-        annotatedSource.append("\(preMessage)╰─ \(colorizeIfRequested(diags.last!.diagMessage))\n")
+        annotatedSource.append("\(preMessage)╰─ \(colorizeIfRequested(diags.last!.diagMessage))\(String.newline)")
       }
 
       // Add suffix text.
       annotatedSource.append(annotatedLine.suffixText)
       if annotatedSource.last != "\n" {
-        annotatedSource.append("\n")
+        annotatedSource.append(String.newline)
       }
     }
     return annotatedSource

--- a/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
+++ b/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
@@ -182,8 +182,8 @@ extension GroupedDiagnostics {
         boxSuffix = ""
       }
 
-      prefixString = colorizeBufferOutline(padding + "╭─── ") + sourceFile.displayName + " " + boxSuffix + "\n"
-      suffixString = colorizeBufferOutline(padding + "╰───" + String(repeating: "─", count: sourceFile.displayName.count + 2)) + boxSuffix + "\n"
+      prefixString = colorizeBufferOutline(padding + "╭─── ") + sourceFile.displayName + " " + boxSuffix + String.newline
+      suffixString = colorizeBufferOutline(padding + "╰───" + String(repeating: "─", count: sourceFile.displayName.count + 2)) + boxSuffix + String.newline
     }
 
     // Render the buffer.
@@ -204,6 +204,6 @@ extension DiagnosticsFormatter {
   public func annotateSources(in group: GroupedDiagnostics) -> String {
     return group.rootSourceFiles.map { rootSourceFileID in
       group.annotateSource(rootSourceFileID, formatter: self, indentString: "")
-    }.joined(separator: "\n")
+    }.joined(separator: String.newline)
   }
 }


### PR DESCRIPTION
Windows has formatting issues in the new diagnostics because we're using the wrong raw newlines and they need to be carriage-return/line-feeds. I added an internal static member on `String`, which is kind of gross, for the platform newline string. Then went through and replaced all of the `\n` characters that I saw getting appended to string in the SwiftDiagnostics directory.

```swift
      // If the line did not end with \n (e.g. the last line), append it manually
      if annotatedSource.last != "\n" {
        annotatedSource.append(String.newline)
      }
```

I left it in the condition because the last character will be `\n` in both cases if there is a newline, and I wanted to avoid even more `#if os` checks. We can change that if needed/wanted, of course.

This is more of a nerd-snipe PR than a "I'm totally ready to go" PR and I'm fully expecting comments to improve and swift-if the code.