### PR TITLE
[Diagnostic formatter] Add ":<line>" to filename header.

### DIFF
--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -227,7 +227,13 @@ public struct DiagnosticsFormatter {
     // If there was a filename, add it first.
     if let fileName = fileName {
       let header = colorizeBufferOutline("===")
-      annotatedSource.append("\(indentString)\(header) \(fileName) \(header)\n")
+      let firstLine =
+        1
+        + (annotatedSourceLines.enumerated().first { (lineIndex, sourceLine) in
+          !sourceLine.isFreeOfAnnotations
+        }?.offset ?? 0)
+
+      annotatedSource.append("\(indentString)\(header) \(fileName):\(firstLine) \(header)\n")
     }
 
     /// Keep track if a line missing char should be printed

--- a/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
@@ -80,6 +80,9 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
     // Main source file.
     let (mainSourceID, mainSourceMarkers) = group.addTestFile(
       """
+
+
+      // test
       let pi = 3.14159
       1️⃣#myAssert(pi == 3)
       print("hello"
@@ -111,9 +114,11 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
     AssertStringsEqualWithDiff(
       annotated,
       """
-      === main.swift ===
-      1 │ let pi = 3.14159
-      2 │ #myAssert(pi == 3)
+      === main.swift:5 ===
+        ┆
+      3 │ // test
+      4 │ let pi = 3.14159
+      5 │ #myAssert(pi == 3)
         │ ╰─ note: in expansion of macro 'myAssert' here
         ╭─── #myAssert ───────────────────────────────────────────────────────
         │1 │ let __a = pi
@@ -123,7 +128,7 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
         │4 │   fatalError("assertion failed: pi != 3")
         │5 │ }
         ╰─────────────────────────────────────────────────────────────────────
-      3 │ print("hello"
+      6 │ print("hello"
         │              ╰─ error: expected ')' to end function call
 
       """
@@ -180,7 +185,7 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
     AssertStringsEqualWithDiff(
       annotated,
       """
-      === main.swift ===
+      === main.swift:2 ===
       1 │ let pi = 3.14159
       2 │ #myAssert(pi == 3)
         │ ╰─ note: in expansion of macro 'myAssert' here


### PR DESCRIPTION
When printing the filename header for diagnostics, also include the line at which the displqy starts using the standard `:<line number>` format, which is recognized by various tools to quickly go to that source file and line.

Fixes https://github.com/apple/swift-syntax/issues/1385.