### PR TITLE
[NFC] Rename `TokenConsumptionHandle.missing` to `.tokenIsMissing`

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1658,7 +1658,7 @@ extension Parser {
 
   /// Parse an accessor.
   mutating func parseAccessorDecl() -> RawAccessorDeclSyntax {
-    let forcedHandle = TokenConsumptionHandle(spec: .keyword(.get), missing: true)
+    let forcedHandle = TokenConsumptionHandle(spec: .keyword(.get), tokenIsMissing: true)
     let introducer = parseAccessorIntroducer(forcedKind: (.get, forcedHandle))!
     return parseAccessorDecl(introducer: introducer)
   }

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -34,7 +34,7 @@ public struct RecoveryConsumptionHandle {
   static func missing(_ spec: TokenSpec) -> RecoveryConsumptionHandle {
     return RecoveryConsumptionHandle(
       unexpectedTokens: 0,
-      tokenConsumptionHandle: TokenConsumptionHandle(spec: spec, missing: true)
+      tokenConsumptionHandle: TokenConsumptionHandle(spec: spec, tokenIsMissing: true)
     )
   }
 }

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -44,7 +44,7 @@ struct TokenConsumptionHandle {
   var spec: TokenSpec
   /// If `true`, the token we should consume should be synthesized as a missing token
   /// and no tokens should be consumed.
-  var missing: Bool = false
+  var tokenIsMissing: Bool = false
 }
 
 extension TokenConsumer {
@@ -106,7 +106,7 @@ extension TokenConsumer {
   /// Eat a token that we know we are currently positioned at, based on `at(anyIn:)`.
   @inline(__always)
   mutating func eat(_ handle: TokenConsumptionHandle) -> Token {
-    if handle.missing {
+    if handle.tokenIsMissing {
       return missingToken(handle.spec)
     } else {
       return eat(handle.spec)


### PR DESCRIPTION
This clarifies what is missing at the use site. Also according the the API design guidelines:

> **Uses of Boolean methods and properties should read as assertions about the receiver** when the use is nonmutating, e.g. `x.isEmpty`, `line1.intersects(line2)`.