### PR TITLE
[NFC] Simplify some value bindings

### DIFF
--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -242,28 +242,29 @@ extension Parser {
   mutating func parseMatchingPattern(context: PatternContext) -> RawPatternSyntax {
     // Parse productions that can only be patterns.
     switch self.at(anyIn: MatchingPatternStart.self) {
-    case (.varKeyword, let handle)?,
-      (.letKeyword, let handle)?,
-      (.inoutKeyword, let handle)?:
-      let bindingKeyword = self.eat(handle)
-      let value = self.parseMatchingPattern(context: .bindingIntroducer)
-      return RawPatternSyntax(
-        RawValueBindingPatternSyntax(
-          bindingKeyword: bindingKeyword,
-          valuePattern: value,
-          arena: self.arena
+    case let .some((patternStart, handle)):
+      switch patternStart {
+      case .varKeyword, .letKeyword, .inoutKeyword:
+        let bindingKeyword = self.eat(handle)
+        let value = self.parseMatchingPattern(context: .bindingIntroducer)
+        return RawPatternSyntax(
+          RawValueBindingPatternSyntax(
+            bindingKeyword: bindingKeyword,
+            valuePattern: value,
+            arena: self.arena
+          )
         )
-      )
-    case (.isKeyword, let handle)?:
-      let isKeyword = self.eat(handle)
-      let type = self.parseType()
-      return RawPatternSyntax(
-        RawIsTypePatternSyntax(
-          isKeyword: isKeyword,
-          type: type,
-          arena: self.arena
+      case .isKeyword:
+        let isKeyword = self.eat(handle)
+        let type = self.parseType()
+        return RawPatternSyntax(
+          RawIsTypePatternSyntax(
+            isKeyword: isKeyword,
+            type: type,
+            arena: self.arena
+          )
         )
-      )
+      }
     case nil:
       // matching-pattern ::= expr
       // Fall back to expression parsing for ambiguous forms. Name lookup will


### PR DESCRIPTION
This makes the bindings a little easier to read imo.

Also this might pave a little way for implementing [the pitched `is case`](https://forums.swift.org/t/proposal-draft-for-is-case-pattern-match-boolean-expressions/58260), if we decide to ban

```swift
foo is case is Bar
```

for being too silly.