### PR TITLE
[CMake] Fix detecting -disable-implicit-string-processing-module-import

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ execute_process(
   COMMAND
     "${CMAKE_Swift_COMPILER}"
     -Xfrontend -disable-implicit-string-processing-module-import
+    -Xfrontend -parse-stdlib
     -c - -o /dev/null
   INPUT_FILE
     "${CMAKE_BINARY_DIR}/tmp/empty-check-string-processing.swift"


### PR DESCRIPTION
The check command used to always fail because it fails to load stdlib. Workaround it by adding '-parse-stdlib' to the check command.