### PR TITLE
[Doc] Add a note pointing to where the enum-case-pattern is parsed

### DIFF
--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -44,6 +44,8 @@ extension Parser {
   ///     as-pattern → pattern 'as' type
   ///
   ///     expression-pattern → expression
+  ///
+  /// - Note: enum-case-pattern is parsed in ``parseGuardStatement(guardHandle:)``.
   @_spi(RawSyntax)
   public mutating func parsePattern() -> RawPatternSyntax {
     enum ExpectedTokens: TokenSpecSet {


### PR DESCRIPTION
This helps prevent contributors from getting lost.