### PR TITLE
Output number of instructions executed during performance test in `swift-parser-cli performance-test`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,6 +48,7 @@ let package = Package(
     .library(name: "SwiftRefactor", type: .static, targets: ["SwiftRefactor"]),
   ],
   targets: [
+    .target(name: "_InstructionCounter"),
     .target(
       name: "SwiftBasicFormat",
       dependencies: ["SwiftSyntax"],
@@ -148,7 +149,7 @@ let package = Package(
     .executableTarget(
       name: "swift-parser-cli",
       dependencies: [
-        "SwiftDiagnostics", "SwiftSyntax", "SwiftParser", "SwiftParserDiagnostics", "SwiftOperators",
+        "_InstructionCounter", "SwiftDiagnostics", "SwiftSyntax", "SwiftParser", "SwiftParserDiagnostics", "SwiftOperators",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
       ]
     ),

--- a/Sources/_InstructionCounter/include/InstructionsExecuted.h
+++ b/Sources/_InstructionCounter/include/InstructionsExecuted.h
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <unistd.h>
+
+/// Returns the number of instructions the process has executed since it was
+/// launched.
+uint64_t getInstructionsExecuted();

--- a/Sources/_InstructionCounter/src/InstructionsExecuted.c
+++ b/Sources/_InstructionCounter/src/InstructionsExecuted.c
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "InstructionsExecuted.h"
+#include <libproc.h>
+#include <sys/resource.h>
+
+uint64_t getInstructionsExecuted() {
+  struct rusage_info_v4 ru;
+  if (proc_pid_rusage(getpid(), RUSAGE_INFO_V4, (rusage_info_t *)&ru) == 0) {
+    return ru.ri_instructions;
+  }
+  return 0;
+}

--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import _InstructionCounter
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftParser
@@ -177,6 +178,7 @@ class PerformanceTest: ParsableCommand {
       .map { try Data(contentsOf: $0) }
 
     let start = Date()
+    let startInstructions = getInstructionsExecuted()
     for _ in 0..<self.iterations {
       for file in files {
         file.withUnsafeBytes { buf in
@@ -184,7 +186,11 @@ class PerformanceTest: ParsableCommand {
         }
       }
     }
-    print(Date().timeIntervalSince(start) / Double(self.iterations) * 1000)
+    let endInstructions = getInstructionsExecuted()
+    let endDate = Date()
+
+    print("Time:         \(endDate.timeIntervalSince(start) / Double(self.iterations) * 1000)ms")
+    print("Instructions: \(Double(endInstructions - startInstructions) / Double(self.iterations))")
   }
 }
 


### PR DESCRIPTION
Instruction count is usually a far more stable value than time when it comes to performance measurements