### PR TITLE
Don't allow single-line string literals to span multiple lines

### DIFF
--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -1777,7 +1777,7 @@ extension Lexer.Cursor {
             error: error,
             stateTransition: .push(newState: .inStringInterpolationStart(stringLiteralKind: stringLiteralKind))
           )
-        } else if self.isAtEscapedNewline(delimiterLength: delimiterLength) {
+        } else if stringLiteralKind == .multiLine && self.isAtEscapedNewline(delimiterLength: delimiterLength) {
           return Lexer.Result(
             .stringSegment,
             trailingTriviaLexingMode: .escapedNewlineInMultiLineStringLiteral

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -82,9 +82,6 @@ extension Lexer.Cursor {
     /// `stringInterpolationStart` points to the first character inside the interpolation.
     case inStringInterpolation(stringLiteralKind: StringLiteralKind, parenCount: Int)
 
-    /// We have parsed a string interpolation segment and are now expecting the closing `)`.
-    case afterStringInterpolation
-
     /// The mode in which leading trivia should be lexed for this state or `nil`
     /// if no trivia should be lexed.
     func leadingTriviaLexingMode(cursor: Lexer.Cursor) -> TriviaLexingMode? {
@@ -102,7 +99,6 @@ extension Lexer.Cursor {
         case .singleLine, .singleQuote: return .noNewlines
         case .multiLine: return .normal
         }
-      case .afterStringInterpolation: return .normal
       }
     }
 
@@ -117,7 +113,6 @@ extension Lexer.Cursor {
       case .afterClosingStringQuote: return nil
       case .inStringInterpolationStart: return nil
       case .inStringInterpolation: return .noNewlines
-      case .afterStringInterpolation: return .noNewlines
       }
     }
 
@@ -134,7 +129,6 @@ extension Lexer.Cursor {
       case .afterClosingStringQuote: return false
       case .inStringInterpolationStart: return false
       case .inStringInterpolation: return false
-      case .afterStringInterpolation: return false
       }
     }
   }
@@ -333,8 +327,6 @@ extension Lexer.Cursor {
       result = lexInStringInterpolationStart(stringLiteralKind: stringLiteralKind)
     case .inStringInterpolation(stringLiteralKind: let stringLiteralKind, parenCount: let parenCount):
       result = lexInStringInterpolation(stringLiteralKind: stringLiteralKind, parenCount: parenCount, sourceBufferStart: sourceBufferStart)
-    case .afterStringInterpolation:
-      result = lexAfterStringInterpolation()
     }
 
     if let stateTransition = result.stateTransition {
@@ -971,18 +963,6 @@ extension Lexer.Cursor {
     default:
       // If we haven't reached the end of the string interpolation, lex as if we were in a normal expression.
       return self.lexNormal(sourceBufferStart: sourceBufferStart)
-    }
-  }
-
-  private mutating func lexAfterStringInterpolation() -> Lexer.Result {
-    switch self.peek() {
-    case UInt8(ascii: ")"):
-      _ = self.advance()
-      return Lexer.Result(.rightParen, stateTransition: .pop)
-    case nil:
-      return Lexer.Result(.eof)
-    default:
-      preconditionFailure("state 'isAfterStringInterpolation' expects to be positoned at ')'")
     }
   }
 }

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -308,6 +308,16 @@ extension Parser {
       return missingToken(spec)
     }
   }
+
+  /// Same as `expectWithoutRecovery`, but also enforces that the token does
+  /// not have any leading trivia. Otherwise, a missing token is synthesized.
+  @inline(__always)
+  mutating func expectWithoutRecoveryOrLeadingTrivia(_ spec: TokenSpec) -> Token {
+    guard self.at(spec), currentToken.leadingTriviaText.isEmpty else {
+      return missingToken(spec)
+    }
+    return self.eat(spec)
+  }
 }
 
 // MARK: Expecting Tokens with Recovery

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -490,7 +490,7 @@ extension Parser {
           unexpectedBeforeRightParen.append(self.consumeAnyToken())
         }
         let rightParen = self.expectWithoutRecovery(.rightParen)
-        if rightParen.isMissing, case .inStringInterpolation = self.currentToken.cursor.currentState {
+        if case .inStringInterpolation = self.currentToken.cursor.currentState {
           // The parser has more knowledge that we have reached the end of the
           // string interpolation now, even if we haven't seen the closing ')'.
           // For example, consider the following code

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -475,11 +475,15 @@ extension Parser {
     var segments: [RawStringLiteralSegmentsSyntax.Element] = []
     var loopProgress = LoopProgressCondition()
     while loopProgress.evaluate(self.currentToken) {
+      // If we encounter a token with leading trivia, we're no longer in the
+      // string literal.
+      guard currentToken.leadingTriviaText.isEmpty else { break }
+
       if let stringSegment = self.consume(if: .stringSegment) {
         segments.append(.stringSegment(RawStringSegmentSyntax(content: stringSegment, arena: self.arena)))
       } else if let backslash = self.consume(if: .backslash) {
         let (unexpectedBeforeDelimiter, delimiter) = self.parseStringDelimiter(openDelimiter: openDelimiter)
-        let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
+        let leftParen = self.expectWithoutRecoveryOrLeadingTrivia(.leftParen)
         let expressions = RawTupleExprElementListSyntax(elements: self.parseArgumentListElements(pattern: .none), arena: self.arena)
 
         // For recovery, eat anything up to the next token that either starts a new string segment or terminates the string.
@@ -489,7 +493,15 @@ extension Parser {
         while !self.at(.rightParen, .stringSegment, .backslash) && !self.at(TokenSpec(openQuoteKind), .eof) && unexpectedProgress.evaluate(self.currentToken) {
           unexpectedBeforeRightParen.append(self.consumeAnyToken())
         }
-        let rightParen = self.expectWithoutRecovery(.rightParen)
+        // Consume the right paren if present, ensuring that it's on the same
+        // line if this is a single-line literal. Leading trivia is fine as
+        // we allow e.g "\(foo )".
+        let rightParen: Token
+        if self.at(.rightParen) && self.currentToken.isAtStartOfLine && openQuote.tokenKind != .multilineStringQuote {
+          rightParen = missingToken(.rightParen)
+        } else {
+          rightParen = self.expectWithoutRecovery(.rightParen)
+        }
         if case .inStringInterpolation = self.currentToken.cursor.currentState {
           // The parser has more knowledge that we have reached the end of the
           // string interpolation now, even if we haven't seen the closing ')'.
@@ -509,7 +521,6 @@ extension Parser {
               backslash: backslash,
               unexpectedBeforeDelimiter,
               delimiter: delimiter,
-              unexpectedBeforeLeftParen,
               leftParen: leftParen,
               expressions: expressions,
               RawUnexpectedNodesSyntax(unexpectedBeforeRightParen, arena: self.arena),
@@ -527,12 +538,12 @@ extension Parser {
     let unexpectedBeforeCloseQuote: RawUnexpectedNodesSyntax?
     let closeQuote: RawTokenSyntax
     if openQuoteKind == .singleQuote {
-      let singleQuote = self.expectWithoutRecovery(.singleQuote)
+      let singleQuote = self.expectWithoutRecoveryOrLeadingTrivia(.singleQuote)
       unexpectedBeforeCloseQuote = RawUnexpectedNodesSyntax([singleQuote], arena: self.arena)
       closeQuote = missingToken(.stringQuote)
     } else {
       unexpectedBeforeCloseQuote = nil
-      closeQuote = self.expectWithoutRecovery(TokenSpec(openQuote.tokenKind))
+      closeQuote = self.expectWithoutRecoveryOrLeadingTrivia(TokenSpec(openQuote.tokenKind))
     }
 
     let (unexpectedBeforeCloseDelimiter, closeDelimiter) = self.parseStringDelimiter(openDelimiter: openDelimiter)

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -1666,6 +1666,73 @@ final class StatementExpressionTests: XCTestCase {
     )
   }
 
+  func testUnterminatedString1() {
+    AssertParse(
+      #"""
+      "abc1️⃣
+      "2️⃣
+      """#,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: #"expected '"' to end string literal"#),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected '"' to end string literal"#),
+      ]
+    )
+  }
+
+  func testUnterminatedString2() {
+    AssertParse(
+      #"""
+      "1️⃣
+      "2️⃣
+      """#,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: #"expected '"' to end string literal"#),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected '"' to end string literal"#),
+      ]
+    )
+  }
+
+  func testUnterminatedString3() {
+    AssertParse(
+      #"""
+      "abc1️⃣
+      \(def)2️⃣"3️⃣
+      """#,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: #"expected '"' to end string literal"#),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: #"expected '"' to end string literal"#),
+      ]
+    )
+  }
+
+  func testUnterminatedString4() {
+    AssertParse(
+      #"""
+      "abc\(def1️⃣2️⃣
+      3️⃣)"
+      """#,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ')' in string literal"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected '"' to end string literal"#),
+        DiagnosticSpec(locationMarker: "3️⃣", message: #"extraneous code ')"' at top level"#),
+      ]
+    )
+  }
+
+  func testUnterminatedString5() {
+    AssertParse(
+      #"""
+      "abc\(1️⃣2️⃣
+      def3️⃣)"
+      """#,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected value and ')' in string literal"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected '"' to end string literal"#),
+        DiagnosticSpec(locationMarker: "3️⃣", message: #"extraneous code ')"' at top level"#),
+      ]
+    )
+  }
 
   func testUnterminatedString6() {
     AssertParse(
@@ -1681,6 +1748,69 @@ final class StatementExpressionTests: XCTestCase {
       ]
     )
   }
+
+  func testUnterminatedString7() {
+    AssertParse(
+      #"""
+      #1️⃣
+      "abc"2️⃣#3️⃣
+      """#,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in macro expansion"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in macro expansion"),
+      ]
+    )
+  }
+
+  func testUnterminatedString8() {
+    AssertParse(
+      #"""
+      #"1️⃣
+      abc2️⃣"#3️⃣
+      """#,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: ##"expected '"#' to end string literal"##),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: #"expected '"' to end string literal"#),
+      ]
+    )
+  }
+
+  func testUnterminatedString9() {
+    AssertParse(
+      #"""
+      #"abc1️⃣
+      "#2️⃣
+      """#,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: ##"expected '"#' to end string literal"##),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected '"' to end string literal"#),
+      ]
+    )
+  }
+
+  func testUnterminatedString10() {
+    AssertParse(
+      #"""
+      #"abc"1️⃣
+      #2️⃣
+      """#,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: ##"expected '"#' to end string literal"##),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in macro expansion"),
+      ]
+    )
+  }
+
+  func testTriviaEndingInterpolation() {
+    AssertParse(
+      #"""
+      "abc\(def )"
+      """#
+    )
+  }
+
   func testStringLiteralAfterKeyPath() {
     AssertParse(
       #"""

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -1666,6 +1666,21 @@ final class StatementExpressionTests: XCTestCase {
     )
   }
 
+
+  func testUnterminatedString6() {
+    AssertParse(
+      #"""
+      "abc1️⃣\2️⃣
+      (def)3️⃣"4️⃣
+      """#,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "invalid escape sequence in literal"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: #"expected '"' to end string literal"#),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "4️⃣", message: #"expected '"' to end string literal"#),
+      ]
+    )
+  }
   func testStringLiteralAfterKeyPath() {
     AssertParse(
       #"""

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -1656,13 +1656,12 @@ final class StatementExpressionTests: XCTestCase {
   func testUnterminatedInterpolationAtEndOfMultilineStringLiteral() {
     AssertParse(
       #"""
-      """\({(1️⃣})
-      2️⃣"""3️⃣
+      """1️⃣\({(2️⃣})
+      """
       """#,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected value and ')' to end tuple"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: #"unexpected code '"""' in string literal"#),
-        DiagnosticSpec(locationMarker: "3️⃣", message: #"expected '"""' to end string literal"#),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "multi-line string literal content must begin on a new line"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected value and ')' to end tuple"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/UnclosedStringInterpolationTests.swift
+++ b/Tests/SwiftParserTest/translated/UnclosedStringInterpolationTests.swift
@@ -111,7 +111,7 @@ final class UnclosedStringInterpolationTests: XCTestCase {
   func testSkipUnexpectedOpeningParensInStringLiteral() {
     AssertParse(
       #"""
-      "\(e 1️⃣H()2️⃣r
+      "\(e 1️⃣H()r2️⃣
       """#,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code 'H(' in string literal"),


### PR DESCRIPTION
There were a few cases where we could parse tokens that had leading trivia, causing us to incorrectly accept some single-line string literals that spanned multiple lines. Fix up these cases to ensure the tokens we parse don't have leading trivia.