### PR TITLE
Remove `Grammar` doc comments

### DIFF
--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -14,11 +14,6 @@
 
 extension Parser {
   /// Parse a list of availability arguments.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     availability-arguments → availability-argument | availability-argument , availability-arguments
   mutating func parseAvailabilitySpecList() -> RawAvailabilitySpecListSyntax {
     var elements = [RawAvailabilityArgumentSyntax]()
     do {
@@ -181,12 +176,6 @@ extension Parser {
   }
 
   /// Parse an availability argument.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     availability-argument → platform-name platform-version
-  ///     availability-argument → *
   mutating func parseAvailabilitySpec() -> RawAvailabilityArgumentSyntax.Entry {
     if let star = self.consumeIfContextualPunctuator("*") {
       // FIXME: Use makeAvailabilityVersionRestriction here - but swift-format
@@ -200,11 +189,6 @@ extension Parser {
   /// Parse an availability macro.
   ///
   /// Availability macros are not an official part of the Swift language.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     availability-argument → macro-name platform-version
   ///
   /// If `allowStarAsVersionNumber` is `true`, versions like `* 13.0` are accepted.
   /// This is to match the behavior of `@_originallyDefinedIn` in the old parser that accepted such versions
@@ -271,13 +255,6 @@ extension Parser {
   }
 
   /// Parse a dot-separated list of version numbers.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     version-tuple -> integer-literal version-list?
-  ///     version-list -> version-tuple-element version-list?
-  ///     version-tuple-element -> '.' integer-literal
   mutating func parseVersionTuple(maxComponentCount: Int) -> RawVersionTupleSyntax {
     if self.at(.floatingLiteral),
       let periodIndex = self.currentToken.tokenText.firstIndex(of: UInt8(ascii: ".")),

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -168,29 +168,6 @@ extension Parser {
 
   /// Parse a declaration.
   ///
-  /// Grammar
-  /// =======
-  ///
-  ///     declaration → import-declaration
-  ///     declaration → constant-declaration
-  ///     declaration → variable-declaration
-  ///     declaration → typealias-declaration
-  ///     declaration → function-declaration
-  ///     declaration → enum-declaration
-  ///     declaration → struct-declaration
-  ///     declaration → class-declaration
-  ///     declaration → actor-declaration
-  ///     declaration → protocol-declaration
-  ///     declaration → initializer-declaration
-  ///     declaration → deinitializer-declaration
-  ///     declaration → extension-declaration
-  ///     declaration → subscript-declaration
-  ///     declaration → operator-declaration
-  ///     declaration → precedence-group-declaration
-  ///     declaration → macro-declaration
-  ///
-  ///     declarations → declaration declarations?
-  ///
   /// If `inMemberDeclList` is `true`, we know that the next item must be a
   /// declaration and thus start with a keyword. This allows further recovery.
   mutating func parseDeclaration(inMemberDeclList: Bool = false) -> RawDeclSyntax {
@@ -313,13 +290,6 @@ extension Parser {
 
 extension Parser {
   /// Parse an import declaration.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     import-declaration → attributes? 'import' import-kind? import-path
-  ///     import-kind → 'typealias' | 'struct' | 'class' | 'enum' | 'protocol' | 'let' | 'var' | 'func'
-  ///     import-path → identifier | identifier '.' import-path
   mutating func parseImportDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
@@ -363,14 +333,6 @@ extension Parser {
 
 extension Parser {
   /// Parse an extension declaration.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     extension-declaration → attributes? access-level-modifier? 'extension' type-identifier type-inheritance-clause? generic-where-clause?t extension-body
-  ///     extension-body → '{' extension-members? '}'
-  ///     extension-members → extension-member extension-members?
-  ///     extension-member → declaration | compiler-control-statement
   mutating func parseExtensionDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
@@ -798,19 +760,6 @@ extension Parser {
 
 extension Parser {
   /// Parse an enum 'case' declaration.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     union-style-enum-case-clause → attributes? 'indirect'? 'case' union-style-enum-case-list
-  ///     union-style-enum-case-list → union-style-enum-case | union-style-enum-case ',' union-style-enum-case-list
-  ///     union-style-enum-case → enum-case-name tuple-type?
-  ///
-  ///     raw-value-style-enum-case-clause → attributes? 'case' raw-value-style-enum-case-list
-  ///     raw-value-style-enum-case-list → raw-value-style-enum-case | raw-value-style-enum-case ',' raw-value-style-enum-case-list
-  ///     raw-value-style-enum-case → enum-case-name raw-value-assignment?
-  ///     raw-value-assignment → = raw-value-literal
-  ///     raw-value-literal → numeric-literal | static-string-literal | boolean-literal
   mutating func parseEnumCaseDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
@@ -872,11 +821,6 @@ extension Parser {
   }
 
   /// Parse an associated type declaration.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     protocol-associated-type-declaration → attributes? access-level-modifier? 'associatedtype' typealias-name type-inheritance-clause? typealias-assignment? generic-where-clause?
   mutating func parseAssociatedTypeDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
@@ -956,17 +900,6 @@ extension Parser {
 
 extension Parser {
   /// Parse an initializer declaration.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     initializer-declaration → initializer-head generic-parameter-clause? parameter-clause 'async'? 'throws'? generic-where-clause? initializer-body
-  ///     initializer-declaration → initializer-head generic-parameter-clause? parameter-clause 'async'? 'rethrows' generic-where-clause? initializer-body
-  ///
-  ///     initializer-head → attributes? declaration-modifiers? 'init'
-  ///     initializer-head → attributes? declaration-modifiers? 'init' '?'
-  ///     initializer-head → attributes? declaration-modifiers? 'init' '!'
-  ///     initializer-body → code-block
   mutating func parseInitializerDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
@@ -1017,11 +950,6 @@ extension Parser {
   }
 
   /// Parse a deinitializer declaration.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  /// deinitializer-declaration → attributes? 'deinit' code-block
   mutating func parseDeinitializerDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
@@ -1186,15 +1114,6 @@ extension Parser {
 
 extension Parser {
   /// Parse a subscript declaration.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     subscript-declaration → subscript-head subscript-result generic-where-clause? code-block
-  ///     subscript-declaration → subscript-head subscript-result generic-where-clause? getter-setter-block
-  ///     subscript-declaration → subscript-head subscript-result generic-where-clause? getter-setter-keyword-block
-  ///     subscript-head → attributes? declaration-modifiers? 'subscript' generic-parameter-clause? parameter-clause
-  ///     subscript-result → '->' attributes? type
   mutating func parseSubscriptDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
@@ -1256,14 +1175,6 @@ extension Parser {
 
 extension Parser {
   /// Parse a variable declaration starting with a leading 'let' or 'var' keyword.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     constant-declaration → attributes? declaration-modifiers? 'let' pattern-initializer-list
-  ///     pattern-initializer-list → pattern-initializer | pattern-initializer ',' pattern-initializer-list
-  ///     pattern-initializer → pattern initializer?
-  ///     initializer → = expression
   ///
   /// If `inMemberDeclList` is `true`, we know that the next item needs to be a
   /// declaration that is started by a keyword. Thus, we in the following case
@@ -1443,21 +1354,6 @@ extension Parser {
   }
 
   /// Parse an accessor once we know we have an introducer
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     getter-clause → attributes opt mutation-modifier opt get code-block
-  ///     setter-clause → attributes opt mutation-modifier opt set setter-name opt code-block
-  ///     setter-name → ( identifier )
-  ///     getter-setter-keyword-block → { getter-keyword-clause setter-keyword-clause opt }
-  ///     getter-setter-keyword-block → { setter-keyword-clause getter-keyword-clause }
-  ///     getter-keyword-clause → attributes opt mutation-modifier opt get
-  ///     setter-keyword-clause → attributes opt mutation-modifier opt set
-  ///     willSet-didSet-block → { willSet-clause didSet-clause opt }
-  ///     willSet-didSet-block → { didSet-clause willSet-clause opt }
-  ///     willSet-clause → attributes opt willSet setter-name opt code-block
-  ///     didSet-clause → attributes opt didSet setter-name opt code-block
   private mutating func parseAccessorDecl(
     introducer: AccessorIntroducer
   ) -> RawAccessorDeclSyntax {
@@ -1500,13 +1396,6 @@ extension Parser {
 
   /// Parse the body of a variable declaration. This can include explicit
   /// getters, setters, and observers, or the body of a computed property.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     getter-setter-block → code-block
-  ///     getter-setter-block → { getter-clause setter-clause opt }
-  ///     getter-setter-block → { setter-clause getter-clause }
   mutating func parseGetSet() -> RawSubscriptDeclSyntax.Accessors {
     // Parse getter and setter.
     let unexpectedBeforeLBrace: RawUnexpectedNodesSyntax?
@@ -1574,13 +1463,6 @@ extension Parser {
 
 extension Parser {
   /// Parse a typealias declaration.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     typealias-declaration → attributes? access-level-modifier? 'typealias' typealias-name generic-parameter-clause? typealias-assignment
-  ///     typealias-name → identifier
-  ///     typealias-assignment → '=' type
   mutating func parseTypealiasDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
@@ -1637,17 +1519,6 @@ extension Parser {
 }
 
 extension Parser {
-  /// Parse an operator declaration.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     operator-declaration → prefix-operator-declaration | postfix-operator-declaration | infix-operator-declaration
-  ///     prefix-operator-declaration → 'prefix' 'operator' operator
-  ///     postfix-operator-declaration → 'postfix' 'operator' operator
-  ///     infix-operator-declaration → 'infix' 'operator' operator infix-operator-group?
-  ///     infix-operator-group → ':' precedence-group-name
-
   struct OperatorDeclIntroducer {
     var unexpectedBeforeFixity: RawUnexpectedNodesSyntax?
     var fixity: RawTokenSyntax
@@ -1655,6 +1526,7 @@ extension Parser {
     var operatorKeyword: RawTokenSyntax
   }
 
+  /// Parse an operator declaration.
   mutating func parseOperatorDeclIntroducer(_ attrs: DeclAttributes, _ handle: RecoveryConsumptionHandle) -> OperatorDeclIntroducer {
     func isFixity(_ modifier: RawDeclModifierSyntax) -> Bool {
       switch modifier.name {
@@ -1809,28 +1681,6 @@ extension Parser {
   }
 
   /// Parse a precedence group declaration.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     precedence-group-declaration → precedencegroup precedence-group-name '{' precedence-group-attributes? '}'
-  ///
-  ///     precedence-group-attributes → precedence-group-attribute precedence-group-attributes?
-  ///     precedence-group-attribute → precedence-group-relation
-  ///     precedence-group-attribute → precedence-group-assignment
-  ///     precedence-group-attribute → precedence-group-associativity
-  ///
-  ///     precedence-group-relation → 'higherThan' ':' precedence-group-names
-  ///     precedence-group-relation → 'lowerThan' ':' precedence-group-names
-  ///
-  ///     precedence-group-assignment → 'assignment' ':' boolean-literal
-  ///
-  ///     precedence-group-associativity → 'associativity' ':' 'left'
-  ///     precedence-group-associativity → 'associativity' ':' 'right'
-  ///     precedence-group-associativity → 'associativity' ':' 'none'
-  ///
-  ///     precedence-group-names → precedence-group-name | precedence-group-name ',' precedence-group-names
-  ///     precedence-group-name → identifier
   mutating func parsePrecedenceGroupDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle
@@ -2031,12 +1881,6 @@ extension Parser {
   }
 
   /// Parse a macro expansion as a declaration.
-  ///
-  ///
-  /// Grammar
-  /// =======
-  ///
-  /// macro-expansion-declaration → '#' identifier expr-call-suffix?
   mutating func parseMacroExpansionDeclaration(
     _ attrs: DeclAttributes,
     _ handle: RecoveryConsumptionHandle

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -45,41 +45,6 @@ extension Parser {
   /// parsing parses items and collects the items into a ``MemberDeclListSyntax``
   /// node.
   ///
-  /// Grammar
-  /// =======
-  ///
-  ///     conditional-compilation-block → if-directive-clause elseif-directive-clauses? else-directive-clause? endif-directive
-  ///
-  ///     if-directive-clause → if-directive compilation-condition statements?
-  ///     elseif-directive-clauses → elseif-directive-clause elseif-directive-clauses?
-  ///     elseif-directive-clause → elseif-directive compilation-condition statements?
-  ///     else-directive-clause → else-directive statements?
-  ///     if-directive → '#if'
-  ///     elseif-directive → '#elseif'
-  ///     else-directive → '#else'
-  ///     endif-directive → '#endif'
-  ///
-  ///     compilation-condition → platform-condition
-  ///     compilation-condition → identifier
-  ///     compilation-condition → boolean-literal
-  ///     compilation-condition → '(' compilation-condition ')'
-  ///     compilation-condition → '!' compilation-condition
-  ///     compilation-condition → compilation-condition '&&' compilation-condition
-  ///     compilation-condition → compilation-condition '||' compilation-condition
-  ///
-  ///     platform-condition → 'os' '(' operating-system ')'
-  ///     platform-condition → 'arch' '(' architecture ')'
-  ///     platform-condition → 'swift' '(' '>=' swift-version ')' | 'swift' ( < swift-version )
-  ///     platform-condition → 'compiler' '(' '>=' swift-version ')' | 'compiler' ( < swift-version )
-  ///     platform-condition → 'canImport' '(' import-path ')'
-  ///     platform-condition → 'targetEnvironment' '(' environment ')'
-  ///
-  ///     operating-system → 'macOS' | 'iOS' | 'watchOS' | 'tvOS' | 'Linux' | 'Windows'
-  ///     architecture → 'i386' | 'x86_64' | 'arm' | 'arm64'
-  ///     swift-version → decimal-digits swift-version-continuation?
-  ///     swift-version-continuation → '.' decimal-digits swift-version-continuation?
-  ///     environment → 'simulator' | 'macCatalyst'
-  ///
   /// - Parameters:
   ///   - parseElement: Parse an element of the conditional compilation block.
   ///   - addSemicolonIfNeeded: If elements need to be separated by a newline, this
@@ -224,14 +189,6 @@ extension Parser {
 
 extension Parser {
   /// Parse a line control directive.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     line-control-statement → '#sourceLocation' '(' 'file' ':' file-path ',' 'line' ':' line-number ')'
-  ///     line-control-statement → '#sourceLocation' '(' ')'
-  ///     line-number → `A decimal integer greater than zero`
-  ///     file-path → static-string-literal
   mutating func parsePoundSourceLocationDirective() -> RawPoundSourceLocationSyntax {
     let line = self.consumeAnyToken()
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -96,12 +96,6 @@ extension Parser {
   }
 
   /// Parse an expression.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     expression → try-operator? await-operator? prefix-expression infix-expressions?
-  ///     expression-list → expression | expression ',' expression-list
   mutating func parseExpression(_ flavor: ExprFlavor = .trailingClosure, pattern: PatternContext = .none) -> RawExprSyntax {
     // If we are parsing a refutable pattern, check to see if this is the start
     // of a let/var/is pattern.  If so, parse it as an UnresolvedPatternExpr and
@@ -119,15 +113,6 @@ extension Parser {
 
 extension Parser {
   /// Parse a sequence of expressions.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     infix-expression → infix-operator prefix-expression
-  ///     infix-expression → assignment-operator try-operator? prefix-expression
-  ///     infix-expression → conditional-operator try-operator? prefix-expression
-  ///     infix-expression → type-casting-operator
-  ///     infix-expressions → infix-expression infix-expressions?
   mutating func parseSequenceExpression(
     _ flavor: ExprFlavor,
     forDirective: Bool = false,
@@ -209,11 +194,6 @@ extension Parser {
   }
 
   /// Parse an unresolved 'as' expression.
-  ///
-  ///     type-casting-operator → 'as' type
-  ///     type-casting-operator → 'as' '?' type
-  ///     type-casting-operator → 'as' '!' type
-  ///
   mutating func parseUnresolvedAsExpr(
     handle: TokenConsumptionHandle
   ) -> (operator: RawExprSyntax, rhs: RawExprSyntax) {
@@ -238,20 +218,6 @@ extension Parser {
   /// Returns a tuple of an operator expression and an optional right operand
   /// expression. The right operand is only returned if it is not a common
   /// sequence element.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     infix-operator → operator
-  ///     assignment-operator → '='
-  ///     conditional-operator → '?' expression ':'
-  ///     type-casting-operator → 'is' type
-  ///     type-casting-operator → 'as' type
-  ///     type-casting-operator → 'as' '?' type
-  ///     type-casting-operator → 'as' '!' type
-  ///     arrow-operator -> 'async' '->'
-  ///     arrow-operator -> 'throws' '->'
-  ///     arrow-operator -> 'async' 'throws' '->'
   mutating func parseSequenceExpressionOperator(
     _ flavor: ExprFlavor,
     pattern: PatternContext
@@ -383,12 +349,6 @@ extension Parser {
   }
 
   /// Parse an expression sequence element.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     expression → try-operator? await-operator? prefix-expression infix-expressions?
-  ///     expression-list → expression | expression ',' expression-list
   mutating func parseSequenceExpressionElement(
     _ flavor: ExprFlavor,
     forDirective: Bool = false,
@@ -573,14 +533,6 @@ extension Parser {
   }
 
   /// Parse an optional prefix operator followed by an expression.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     prefix-expression → prefix-operator? postfix-expression
-  ///     prefix-expression → in-out-expression
-  ///
-  ///     in-out-expression → '&' identifier
   mutating func parseUnaryExpression(
     _ flavor: ExprFlavor,
     forDirective: Bool = false,
@@ -643,19 +595,6 @@ extension Parser {
   }
 
   /// Parse a postfix expression applied to another expression.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     postfix-expression → primary-expression
-  ///     postfix-expression → postfix-expression postfix-operator
-  ///     postfix-expression → function-call-expression
-  ///     postfix-expression → initializer-expression
-  ///     postfix-expression → explicit-member-expression
-  ///     postfix-expression → postfix-self-expression
-  ///     postfix-expression → subscript-expression
-  ///     postfix-expression → forced-value-expression
-  ///     postfix-expression → optional-chaining-expression
   mutating func parsePostfixExpression(
     _ flavor: ExprFlavor,
     forDirective: Bool,
@@ -786,18 +725,6 @@ extension Parser {
   }
 
   /// Parse the suffix of a postfix expression.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     postfix-expression → postfix-expression postfix-operator
-  ///     postfix-expression → function-call-expression
-  ///     postfix-expression → initializer-expression
-  ///     postfix-expression → explicit-member-expression
-  ///     postfix-expression → postfix-self-expression
-  ///     postfix-expression → subscript-expression
-  ///     postfix-expression → forced-value-expression
-  ///     postfix-expression → optional-chaining-expression
   mutating func parsePostfixExpressionSuffix(
     _ start: RawExprSyntax,
     _ flavor: ExprFlavor,
@@ -1049,17 +976,6 @@ extension Parser {
   }
 
   /// Parse a keypath expression.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     key-path-expression → '\' type? '.' key-path-components
-  ///
-  ///     key-path-components → key-path-component | key-path-component '.' key-path-components
-  ///     key-path-component → identifier key-path-postfixes? | key-path-postfixes
-  ///
-  ///     key-path-postfixes → key-path-postfix key-path-postfixes?
-  ///     key-path-postfix → '?' | '!' | 'self' | '[' function-call-argument-list ']'
   mutating func parseKeyPathExpression(forDirective: Bool, pattern: PatternContext) -> RawKeyPathExprSyntax {
     // Consume '\'.
     let (unexpectedBeforeBackslash, backslash) = self.expect(.backslash)
@@ -1181,21 +1097,6 @@ extension Parser {
 extension Parser {
   /// Parse a "primary expression" - these are the most basic leaves of the
   /// Swift expression grammar.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     primary-expression → identifier generic-argument-clause?
-  ///     primary-expression → literal-expression
-  ///     primary-expression → self-expression
-  ///     primary-expression → superclass-expression
-  ///     primary-expression → closure-expression
-  ///     primary-expression → parenthesized-expression
-  ///     primary-expression → tuple-expression
-  ///     primary-expression → implicit-member-expression
-  ///     primary-expression → wildcard-expression
-  ///     primary-expression → key-path-expression
-  ///     primary-expression → macro-expansion-expression
   mutating func parsePrimaryExpression(
     pattern: PatternContext,
     forDirective: Bool,
@@ -1365,11 +1266,6 @@ extension Parser {
 
 extension Parser {
   /// Parse an identifier as an expression.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     primary-expression → identifier
   mutating func parseIdentifierExpression() -> RawExprSyntax {
     let (name, args) = self.parseDeclNameRef(.compoundNames)
     guard self.withLookahead({ $0.canParseAsGenericArgumentList() }) else {
@@ -1408,12 +1304,6 @@ extension Parser {
 
 extension Parser {
   /// Parse a macro expansion as an expression.
-  ///
-  ///
-  /// Grammar
-  /// =======
-  ///
-  /// macro-expansion-expression → '#' identifier expr-call-suffix?
   mutating func parseMacroExpansionExpr(
     pattern: PatternContext,
     flavor: ExprFlavor
@@ -1492,13 +1382,6 @@ extension Parser {
 
 extension Parser {
   /// Parse a pack expansion as an expression.
-  ///
-  ///
-  /// Grammar
-  /// =======
-  ///
-  /// pack-expansion-expression → 'repeat' pattern-expression
-  /// pattern-expression → expression
   mutating func parsePackExpansionExpr(
     repeatHandle: TokenConsumptionHandle,
     _ flavor: ExprFlavor,
@@ -1519,11 +1402,6 @@ extension Parser {
   /// Parse a regular expression literal.
   ///
   /// The broad structure of the regular expression is validated by the lexer.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     regular-expression-literal → '#'* '/' `Any valid regular expression characters` '/' '#'*
   mutating func parseRegexLiteral() -> RawRegexLiteralExprSyntax {
     // See if we have an opening set of pounds.
     let openPounds = self.consume(if: .extendedRegexDelimiter)
@@ -1560,11 +1438,6 @@ extension Parser {
 
 extension Parser {
   /// Parse a 'super' reference to the superclass instance of a class.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     primary-expression → 'super'
   mutating func parseSuperExpression() -> RawSuperRefExprSyntax {
     // Parse the 'super' reference.
     let (unexpectedBeforeSuperKeyword, superKeyword) = self.expect(.keyword(.super))
@@ -1578,12 +1451,6 @@ extension Parser {
 
 extension Parser {
   /// Parse a tuple expression.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     tuple-expression → '(' ')' | '(' tuple-element ',' tuple-element-list ')'
-  ///     tuple-element-list → tuple-element | tuple-element ',' tuple-element-list
   mutating func parseTupleExpression(pattern: PatternContext) -> RawTupleExprSyntax {
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
     let elements = self.parseArgumentListElements(pattern: pattern)
@@ -1606,13 +1473,6 @@ extension Parser {
   }
 
   /// Parse an element of an array or dictionary literal.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     array-literal-item → expression
-  ///
-  ///     dictionary-literal-item → expression ':' expression
   mutating func parseCollectionElement(_ existing: CollectionKind?) -> CollectionKind {
     let key = self.parseExpression()
     switch existing {
@@ -1631,15 +1491,6 @@ extension Parser {
   }
 
   /// Parse an array or dictionary literal.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     array-literal → '[' array-literal-items? ']'
-  ///     array-literal-items → array-literal-item ','? | array-literal-item ',' array-literal-items
-  ///
-  ///     dictionary-literal → '[' dictionary-literal-items ']' | '[' ':' ']'
-  ///     dictionary-literal-items → dictionary-literal-item ','? | dictionary-literal-item ',' dictionary-literal-items
   mutating func parseCollectionLiteral() -> RawExprSyntax {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return RawExprSyntax(
@@ -1816,11 +1667,6 @@ extension Parser {
 
 extension Parser {
   /// Parse a closure expression.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     closure-expression → '{' attributes? closure-signature? statements? '}'
   mutating func parseClosureExpression() -> RawClosureExprSyntax {
     // Parse the opening left brace.
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
@@ -1846,27 +1692,6 @@ extension Parser {
 
 extension Parser {
   /// Parse the signature of a closure, if one is present.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     closure-signature → capture-list? closure-parameter-clause 'async'? 'throws'? function-result? 'in'
-  ///     closure-signature → capture-list 'in'
-  ///
-  ///     closure-parameter-clause → '(' ')' | '(' closure-parameter-list ')' | identifier-list
-  ///
-  ///     closure-parameter-list → closure-parameter | closure-parameter , closure-parameter-list
-  ///     closure-parameter → closure-parameter-name type-annotation?
-  ///     closure-parameter → closure-parameter-name type-annotation '...'
-  ///     closure-parameter-name → identifier
-  ///
-  ///     capture-list → '[' capture-list-items ']'
-  ///     capture-list-items → capture-list-item | capture-list-item , capture-list-items
-  ///     capture-list-item → capture-specifier? identifier
-  ///     capture-list-item → capture-specifier? identifier '=' expression
-  ///     capture-list-item → capture-specifier? self-expression
-  ///
-  ///     capture-specifier → 'weak' | 'unowned' | 'unowned(safe)' | 'unowned(unsafe)'
   mutating func parseClosureSignatureIfPresent() -> RawClosureSignatureSyntax? {
     // If we have a leading token that may be part of the closure signature, do a
     // speculative parse to validate it and look for 'in'.
@@ -2054,11 +1879,6 @@ extension Parser {
   ///
   /// This is currently the same as parsing a tuple expression. In the future,
   /// this will be a dedicated argument list type.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     tuple-element → expression | identifier ':' expression
   mutating func parseArgumentListElements(pattern: PatternContext) -> [RawTupleExprElementSyntax] {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return [
@@ -2129,13 +1949,6 @@ extension Parser {
 
 extension Parser {
   /// Parse the trailing closure(s) following a call expression.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     trailing-closures → closure-expression labeled-trailing-closures?
-  ///     labeled-trailing-closures → labeled-trailing-closure labeled-trailing-closures?
-  ///     labeled-trailing-closure → identifier ':' closure-expression
   mutating func parseTrailingClosures(_ flavor: ExprFlavor) -> (RawClosureExprSyntax, RawMultipleTrailingClosureElementListSyntax?) {
     // Parse the closure.
     let closure = self.parseClosureExpression()
@@ -2277,12 +2090,6 @@ extension Parser.Lookahead {
 
 extension Parser {
   /// Parse an if statement/expression.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     if-expression → 'if' condition-list code-block else-clause?
-  ///     else-clause  → 'else' code-block | else if-statement
   mutating func parseIfExpression(
     ifHandle: RecoveryConsumptionHandle
   ) -> RawIfExprSyntax {
@@ -2338,12 +2145,6 @@ extension Parser {
 
 extension Parser {
   /// Parse a switch statement/expression.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     switch-expression → 'switch' expression '{' switch-cases? '}'
-  ///     switch-cases → switch-case switch-cases?
   mutating func parseSwitchExpression(
     switchHandle: RecoveryConsumptionHandle
   ) -> RawSwitchExprSyntax {
@@ -2378,11 +2179,6 @@ extension Parser {
   }
 
   /// Parse a list of switch case clauses.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     switch-cases → switch-case switch-cases?
   ///
   /// If `allowStandaloneStmtRecovery` is `true` and we discover a statement that
   /// isn't covered by a case, we assume that the developer forgot to wrote the
@@ -2467,13 +2263,6 @@ extension Parser {
   }
 
   /// Parse a single switch case clause.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     switch-case → case-label statements
-  ///     switch-case → default-label statements
-  ///     switch-case → conditional-switch-case
   mutating func parseSwitchCase() -> RawSwitchCaseSyntax {
     var unknownAttr: RawAttributeSyntax?
     if let at = self.consume(if: .atSign) {
@@ -2531,12 +2320,6 @@ extension Parser {
   }
 
   /// Parse a switch case with a 'case' label.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     case-label → attributes? case case-item-list ':'
-  ///     case-item-list → pattern where-clause? | pattern where-clause? ',' case-item-list
   mutating func parseSwitchCaseLabel(
     _ handle: RecoveryConsumptionHandle
   ) -> RawSwitchCaseLabelSyntax {
@@ -2570,11 +2353,6 @@ extension Parser {
   }
 
   /// Parse a switch case with a 'default' label.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     default-label → attributes? 'default' ':'
   mutating func parseSwitchDefaultLabel(
     _ handle: RecoveryConsumptionHandle
   ) -> RawSwitchDefaultLabelSyntax {
@@ -2591,11 +2369,6 @@ extension Parser {
 
   /// Parse a pattern-matching clause for a case statement,
   /// including the guard expression.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     case-item → pattern where-clause?
   mutating func parseGuardedCasePattern() -> (RawPatternSyntax, RawWhereClauseSyntax?) {
     let pattern = self.parseMatchingPattern(context: .matching)
 

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -14,36 +14,6 @@
 
 extension Parser {
   /// Parse a pattern.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     pattern → wildcard-pattern type-annotation?
-  ///     pattern → identifier-pattern type-annotation?
-  ///     pattern → value-binding-pattern
-  ///     pattern → tuple-pattern type-annotation?
-  ///     pattern → enum-case-pattern
-  ///     pattern → optional-pattern
-  ///     pattern → type-casting-pattern
-  ///     pattern → expression-pattern
-  ///
-  ///     wildcard-pattern → _
-  ///
-  ///     identifier-pattern → identifier
-  ///
-  ///     value-binding-pattern → 'var' pattern | 'let' pattern
-  ///
-  ///     tuple-pattern → ( tuple-pattern-element-list opt )
-  ///
-  ///     enum-case-pattern → type-identifier? '.' enum-case-name tuple-pattern?
-  ///
-  ///     optional-pattern → identifier-pattern '?'
-  ///
-  ///     type-casting-pattern → is-pattern | as-pattern
-  ///     is-pattern → 'is' type
-  ///     as-pattern → pattern 'as' type
-  ///
-  ///     expression-pattern → expression
   mutating func parsePattern() -> RawPatternSyntax {
     enum ExpectedTokens: TokenSpecSet {
       case leftParen
@@ -151,11 +121,6 @@ extension Parser {
   }
 
   /// Parse a typed pattern.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     typed-pattern → pattern ':' attributes? inout? type
   mutating func parseTypedPattern(allowRecoveryFromMissingColon: Bool = true) -> (RawPatternSyntax, RawTypeAnnotationSyntax?) {
     let pattern = self.parsePattern()
 
@@ -189,12 +154,6 @@ extension Parser {
   }
 
   /// Parse the elements of a tuple pattern.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     tuple-pattern-element-list → tuple-pattern-element | tuple-pattern-element ',' tuple-pattern-element-list
-  ///     tuple-pattern-element → pattern | identifier ':' pattern
   mutating func parsePatternTupleElements() -> RawTuplePatternElementListSyntax {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return RawTuplePatternElementListSyntax(

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -39,11 +39,6 @@ extension Parser {
   /// This function is the true parsing entry point that the high-level
   /// ``Parser/parse(source:parseTransition:filenameForDiagnostics:languageVersion:enableBareSlashRegexLiteral:)-7tndx``
   /// API calls.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     source-file → top-level-declaration?
   mutating func parseSourceFile() -> RawSourceFileSyntax {
     let items = self.parseTopLevelCodeBlockItems()
     let unexpectedBeforeEndOfFileToken = consumeRemainingTokens()
@@ -86,11 +81,6 @@ extension Parser {
   }
 
   /// Parse the top level items in a source file.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     top-level-declaration → statements?
   mutating func parseTopLevelCodeBlockItems() -> RawCodeBlockItemListSyntax {
     return parseCodeBlockItemList(isAtTopLevel: true, until: { _ in false })
   }
@@ -108,11 +98,6 @@ extension Parser {
   }
 
   /// Parse a code block.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     code-block → '{' statements? '}'
   ///
   /// `introducer` is the `while`, `if`, ... keyword that is the cause that the code block is being parsed.
   /// If the left brace is missing, its indentation will be used to judge whether a following `}` was
@@ -136,20 +121,6 @@ extension Parser {
   ///
   /// Returns `nil` if the parser did not consume any tokens while trying to
   /// parse the code block item.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     statement → expression ';'?
-  ///     statement → declaration ';'?
-  ///     statement → loop-statement ';'?
-  ///     statement → branch-statement ';'?
-  ///     statement → labeled-statement ';'?
-  ///     statement → control-transfer-statement ';'?
-  ///     statement → defer-statement ';'?
-  ///     statement → do-statement ';'?
-  ///     statement → compiler-control-statement
-  ///     statements → statement statements?
   mutating func parseCodeBlockItem(isAtTopLevel: Bool, allowInitDecl: Bool) -> RawCodeBlockItemSyntax? {
     let startToken = self.currentToken
     if let syntax = self.loadCurrentSyntaxNodeFromCache(for: .codeBlockItem) {

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -14,15 +14,6 @@
 
 extension Parser {
   /// Parse a type.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     type → simple-type
-  ///     type → function-type
-  ///     type → protocol-composition-type
-  ///     type → constrained-sugar-type
-  ///     type → opaque-type
   mutating func parseType(misplacedSpecifiers: [RawTokenSyntax] = []) -> RawTypeSyntax {
     // Parse pack expansion 'repeat T'.
     if let repeatKeyword = self.consume(if: .keyword(.repeat)) {
@@ -126,17 +117,6 @@ extension Parser {
   }
 
   /// Parse a protocol composition involving at least one element.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     protocol-composition-type → simple-type '&' protocol-composition-continuation
-  ///     protocol-composition-continuation → simple-type | protocol-composition-type
-  ///
-  ///     constrained-sugar-type → constrained-sugar-type-specifier constrained-sugar-type-constraint
-  ///     constrained-sugar-type-specifier → 'any' | 'some'
-  ///     constrained-sugar-type-constraint → protocol-composition-type
-  ///     constrained-sugar-type-constraint → type-simple
   mutating func parseSimpleOrCompositionType() -> RawTypeSyntax {
     // 'each' is a contextual keyword for a pack reference.
     if let each = consume(if: .keyword(.each)) {
@@ -213,25 +193,6 @@ extension Parser {
   }
 
   /// Parse a "simple" type
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     simple-type → type-identifier
-  ///     simple-type → any-type
-  ///     simple-type → paren-type
-  ///     simple-type → tuple-type
-  ///     simple-type → array-type
-  ///     simple-type → dictionary-type
-  ///     simple-type → optional-type
-  ///     simple-type → implicitly-unwrapped-optional-type
-  ///     simple-type → metatype-type
-  ///     simple-type → member-type-identifier
-  ///
-  ///     metatype-type → simple-type '.' 'Type' | simple-type '.' 'Protocol'
-  ///
-  ///     member-type-identifier → member-type-identifier-base '.' type-identifier
-  ///     member-type-identifier-base → simple-type | member-type-identifier
   mutating func parseSimpleType(
     stopAtFirstPeriod: Bool = false
   ) -> RawTypeSyntax {
@@ -311,11 +272,6 @@ extension Parser {
   }
 
   /// Parse an optional type.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     optional-type → type '?'
   mutating func parseOptionalType(_ base: RawTypeSyntax) -> RawOptionalTypeSyntax {
     let (unexpectedBeforeMark, mark) = self.expect(.postfixQuestionMark)
     return RawOptionalTypeSyntax(
@@ -327,11 +283,6 @@ extension Parser {
   }
 
   /// Parse an optional type.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     implicitly-unwrapped-optional-type → type '!'
   mutating func parseImplicitlyUnwrappedOptionalType(_ base: RawTypeSyntax) -> RawImplicitlyUnwrappedOptionalTypeSyntax {
     let (unexpectedBeforeMark, mark) = self.expect(.exclamationMark)
     return RawImplicitlyUnwrappedOptionalTypeSyntax(
@@ -358,11 +309,6 @@ extension Parser {
   }
 
   /// Parse a type identifier.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     type-identifier → identifier generic-argument-clause?
   mutating func parseTypeIdentifier() -> RawTypeSyntax {
     if self.at(.keyword(.Any)) {
       return RawTypeSyntax(self.parseAnyType())
@@ -379,11 +325,6 @@ extension Parser {
   }
 
   /// Parse the existential `Any` type.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     any-type → 'Any'
   mutating func parseAnyType() -> RawSimpleTypeIdentifierSyntax {
     let (unexpectedBeforeName, name) = self.expect(.keyword(.Any))
     return RawSimpleTypeIdentifierSyntax(
@@ -395,11 +336,6 @@ extension Parser {
   }
 
   /// Parse a type placeholder.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     placeholder-type → wildcard
   mutating func parsePlaceholderType() -> RawSimpleTypeIdentifierSyntax {
     let (unexpectedBeforeName, name) = self.expect(.wildcard)
     // FIXME: Need a better syntax node than this
@@ -414,13 +350,6 @@ extension Parser {
 
 extension Parser {
   /// Parse the generic arguments applied to a type.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     generic-argument-clause → '<' generic-argument-list '>'
-  ///     generic-argument-list → generic-argument | generic-argument ',' generic-argument-list
-  ///     generic-argument → type
   mutating func parseGenericArguments() -> RawGenericArgumentClauseSyntax {
     let langle = self.expectWithoutRecovery(prefix: "<", as: .leftAngle)
     var arguments = [RawGenericArgumentSyntax]()
@@ -462,16 +391,6 @@ extension Parser {
 
 extension Parser {
   /// Parse a tuple type.
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     paren-type → '(' type ')'
-  ///
-  ///     tuple-type → '(' ')' | '(' tuple-type-element ',' tuple-type-element-list ')'
-  ///     tuple-type-element-list → tuple-type-element | tuple-type-element ',' tuple-type-element-list
-  ///     tuple-type-element → element-name type-annotation | type
-  ///     element-name → identifier
   mutating func parseTupleTypeBody() -> RawTupleTypeSyntax {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return RawTupleTypeSyntax(
@@ -591,13 +510,6 @@ extension Parser {
 
 extension Parser {
   /// Parse an array or dictionary type..
-  ///
-  /// Grammar
-  /// =======
-  ///
-  ///     array-type → '[' type ']'
-  ///
-  ///     dictionary-type → '[' type ':' type ']'
   mutating func parseCollectionType() -> RawTypeSyntax {
     if let remaingingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return RawTypeSyntax(


### PR DESCRIPTION
These grammars were most of the time incomplete, incorrect and in the case of recovery wrong by definition. Instead of having misleading doc comments, let’s delete them entirely.