### PR TITLE
Replace `assert` by `precondition` in most places

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/Node.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Node.swift
@@ -162,6 +162,6 @@ public class Node {
     self.elementsSeparatedByNewline = elementsSeparatedByNewline
 
     // For SyntaxCollections make sure that the elementName is set.
-    assert(!isSyntaxCollection || elementName != nil || element != "")
+    precondition(!isSyntaxCollection || elementName != nil || element != "")
   }
 }

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
@@ -63,7 +63,7 @@ public extension Child {
   }
 
   /// If this node is a token that can't contain arbitrary text, generate a Swift
-  /// `assert` statement that verifies the variable with name var_name and of type
+  /// `precondition` statement that verifies the variable with name var_name and of type
   /// `TokenSyntax` contains one of the supported text options. Otherwise return `nil`.
   func generateAssertStmtTextChoices(varName: String) -> FunctionCallExprSyntax? {
     guard case .token(choices: let choices, requiresLeadingSpace: _, requiresTrailingSpace: _) = kind else {
@@ -79,7 +79,7 @@ public extension Child {
 
     let choicesTexts: [String]
     if tokenCanContainArbitraryText {
-      // Don't generate an assert statement if token can contain arbitrary text.
+      // Don't generate an precondition statement if token can contain arbitrary text.
       return nil
     } else if !choices.isEmpty {
       choicesTexts = choices.compactMap {
@@ -92,9 +92,9 @@ public extension Child {
       return nil
     }
 
-    var assertChoices: [ExprSyntax] = []
+    var preconditionChoices: [ExprSyntax] = []
     if type.isOptional {
-      assertChoices.append(
+      preconditionChoices.append(
         ExprSyntax(
           SequenceExprSyntax {
             IdentifierExprSyntax(identifier: .identifier(varName))
@@ -105,7 +105,7 @@ public extension Child {
       )
     }
     for textChoice in choicesTexts {
-      assertChoices.append(
+      preconditionChoices.append(
         ExprSyntax(
           SequenceExprSyntax {
             MemberAccessExprSyntax(base: type.forceUnwrappedIfNeeded(expr: IdentifierExprSyntax(identifier: .identifier(varName))), name: "text")
@@ -115,8 +115,8 @@ public extension Child {
         )
       )
     }
-    let disjunction = ExprListSyntax(assertChoices.flatMap { [$0, ExprSyntax(BinaryOperatorExprSyntax(text: "||"))] }.dropLast())
-    return FunctionCallExprSyntax(callee: ExprSyntax("assert")) {
+    let disjunction = ExprListSyntax(preconditionChoices.flatMap { [$0, ExprSyntax(BinaryOperatorExprSyntax(text: "||"))] }.dropLast())
+    return FunctionCallExprSyntax(callee: ExprSyntax("precondition")) {
       TupleExprElementSyntax(expression: SequenceExprSyntax(elements: disjunction))
     }
   }

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableNode.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableNode.swift
@@ -44,14 +44,14 @@ public extension Node {
 
   /// Assuming this node is a syntax collection, the type of its elements.
   var collectionElementType: SyntaxBuildableType {
-    assert(isSyntaxCollection)
+    precondition(isSyntaxCollection)
     return SyntaxBuildableType(syntaxKind: collectionElement)
   }
 
   /// Assuming this node has a single child without a default value, that child.
   var singleNonDefaultedChild: Child {
     let nonDefaultedParams = children.filter { $0.type.defaultInitialization == nil }
-    assert(nonDefaultedParams.count == 1)
+    precondition(nonDefaultedParams.count == 1)
     return nonDefaultedParams[0]
   }
 

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserEntryFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserEntryFile.swift
@@ -78,8 +78,7 @@ let parserEntryFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
       mutating func parseRemainder<R: RawSyntaxNodeProtocol>(into: R) -> R {
         guard !into.raw.kind.isSyntaxCollection, let layout = into.raw.layoutView else {
-          assertionFailure("Only support parsing of non-collection layout nodes")
-          return into
+          preconditionFailure("Only support parsing of non-collection layout nodes")
         }
 
         let remainingTokens = self.consumeRemainingTokens()
@@ -89,7 +88,7 @@ let parserEntryFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
         let existingUnexpected: [RawSyntax]
         if let unexpectedNode = layout.children[layout.children.count - 1] {
-           assert(unexpectedNode.is(RawUnexpectedNodesSyntax.self))
+           precondition(unexpectedNode.is(RawUnexpectedNodesSyntax.self))
            existingUnexpected = unexpectedNode.as(RawUnexpectedNodesSyntax.self).elements
         } else {
            existingUnexpected = []

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
@@ -129,7 +129,15 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       DeclSyntax(
         """
         init(raw: RawSyntax) {
-          assert(Self.isKindOf(raw))
+          precondition(Self.isKindOf(raw))
+          self.raw = raw
+        }
+        """
+      )
+
+      DeclSyntax(
+        """
+        private init(unchecked raw: RawSyntax) {
           self.raw = raw
         }
         """
@@ -139,7 +147,7 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         """
         public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
           guard Self.isKindOf(other.raw) else { return nil }
-          self.init(raw: other.raw)
+          self.init(unchecked: other.raw)
         }
         """
       )
@@ -148,7 +156,7 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         DeclSyntax(
           """
           public init<Node: Raw\(raw: node.name)NodeProtocol>(_ other: Node) {
-            self.init(raw: other.raw)
+            self.init(unchecked: other.raw)
           }
           """
         )
@@ -167,7 +175,7 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
                     ptr += 1
                   }
             }
-            self.init(raw: raw)
+            self.init(unchecked: raw)
           }
           """
         )
@@ -217,7 +225,7 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           } else {
             DeclSyntax("let raw = RawSyntax.makeEmptyLayout(kind: .\(raw: node.swiftSyntaxKind), arena: arena)")
           }
-          ExprSyntax("self.init(raw: raw)")
+          ExprSyntax("self.init(unchecked: raw)")
         }
 
         for (index, child) in node.children.enumerated() {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -158,7 +158,7 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
         /// is undefined.
         internal init(_ data: SyntaxData) {
-          assert(data.raw.kind == .\(raw: node.swiftSyntaxKind))
+          precondition(data.raw.kind == .\(raw: node.swiftSyntaxKind))
           self._syntaxNode = Syntax(data)
         }
         """

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodeFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodeFile.swift
@@ -59,7 +59,7 @@ func syntaxNode(emitKind: String) -> SourceFileSyntax {
           /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
           /// is undefined.
           internal init(_ data: SyntaxData) {
-            assert(data.raw.kind == .\(raw: node.swiftSyntaxKind))
+            precondition(data.raw.kind == .\(raw: node.swiftSyntaxKind))
             self._syntaxNode = Syntax(data)
           }
           """

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -320,7 +320,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           // A child node was rewritten. Build the updated node.
           
           // Sanity check, ensure the new children are the same length.
-          assert(newLayout.count == node.raw.layoutView!.children.count)
+          precondition(newLayout.count == node.raw.layoutView!.children.count)
           
           let arena = SyntaxArena()
           let newRaw = node.raw.layoutView!.replacingLayout(with: Array(newLayout), arena: arena)

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
@@ -282,7 +282,7 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             }
           } else if token.text != nil {
             SwitchCaseSyntax("case .\(raw: token.swiftKind):") {
-              ExprSyntax("assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)")
+              ExprSyntax("precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)")
               StmtSyntax("return .\(raw: token.swiftKind)")
             }
           } else {

--- a/Sources/IDEUtils/SyntaxClassifier.swift
+++ b/Sources/IDEUtils/SyntaxClassifier.swift
@@ -189,7 +189,7 @@ private struct ClassificationVisitor {
       byteOffset += piece.byteLength
     }
 
-    assert(byteOffset == descriptor.byteOffset + descriptor.node.byteLength)
+    precondition(byteOffset == descriptor.byteOffset + descriptor.node.byteLength)
     return .continue
   }
 

--- a/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
+++ b/Sources/SwiftCompilerPlugin/CompilerPlugin.swift
@@ -179,7 +179,7 @@ internal struct PluginHostConnection: MessageConnection {
     // Write the header (a 64-bit length field in little endian byte order).
     var count = UInt64(payload.count).littleEndian
     let header = Swift.withUnsafeBytes(of: &count) { Data($0) }
-    assert(header.count == 8)
+    precondition(header.count == 8)
 
     // Write the header and payload.
     try outputStream._write(contentsOf: header)

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
@@ -127,7 +127,7 @@ class SourceManager {
     }
     let localStartPosition = node.position(at: startKind)
     let localEndPosition = node.position(at: endKind)
-    assert(localStartPosition <= localEndPosition)
+    precondition(localStartPosition <= localEndPosition)
 
     let positionOffset = base.location.offset
 

--- a/Sources/SwiftDiagnostics/Diagnostic.swift
+++ b/Sources/SwiftDiagnostics/Diagnostic.swift
@@ -80,7 +80,7 @@ public struct DiagnosticsError: Error {
   public init(diagnostics: [Diagnostic]) {
     self.diagnostics = diagnostics
 
-    assert(
+    precondition(
       diagnostics.contains(where: { $0.diagMessage.severity == .error }),
       "at least one diagnostic must have severity == .error"
     )

--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -29,7 +29,7 @@ extension Sequence where Element == Range<Int> {
       }
 
       // If the ranges overlap, expand the prior range.
-      assert(priorRange.lowerBound <= range.lowerBound)
+      precondition(priorRange.lowerBound <= range.lowerBound)
       if priorRange.overlaps(range) {
         let lower = priorRange.lowerBound
         let upper = Swift.max(priorRange.upperBound, range.upperBound)

--- a/Sources/SwiftDiagnostics/FixIt.swift
+++ b/Sources/SwiftDiagnostics/FixIt.swift
@@ -57,7 +57,7 @@ public struct FixIt {
   public let changes: Changes
 
   public init(message: FixItMessage, changes: Changes) {
-    assert(!changes.changes.isEmpty, "A Fix-It must have at least one change associated with it")
+    precondition(!changes.changes.isEmpty, "A Fix-It must have at least one change associated with it")
     self.message = message
     self.changes = changes
   }

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -464,7 +464,7 @@ extension Parser {
       )
     }
 
-    assert(self.currentToken.starts(with: "<"))
+    precondition(self.currentToken.starts(with: "<"))
     let langle = self.consumeAnyToken(remapping: .leftAngle)
     var elements = [RawGenericParameterSyntax]()
     do {

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -192,7 +192,7 @@ extension Parser {
       return lastElement
     }
 
-    assert(
+    precondition(
       elements.count.isMultiple(of: 2),
       "elements must have a even number of elements"
     )
@@ -619,7 +619,7 @@ extension Parser {
     declNameArgs: RawDeclNameArgumentsSyntax?,
     generics: RawGenericArgumentClauseSyntax?
   ) {
-    assert(self.at(.period))
+    precondition(self.at(.period))
     let (unexpectedPeriod, period, skipMemberName) = self.consumeMemberPeriod(previousNode: previousNode)
     if skipMemberName {
       let missingIdentifier = missingToken(.identifier)
@@ -685,7 +685,7 @@ extension Parser {
     _ flavor: ExprFlavor,
     forDirective: Bool
   ) -> RawExprSyntax {
-    assert(self.at(.poundIfKeyword))
+    precondition(self.at(.poundIfKeyword))
 
     let config = self.parsePoundIfDirective { (parser, isFirstElement) -> RawExprSyntax? in
       if !isFirstElement {
@@ -978,7 +978,7 @@ extension Parser {
       if self.currentToken.starts(with: "!") {
         questionOrExclaim = self.consumePrefix("!", as: .exclamationMark)
       } else {
-        assert(self.currentToken.starts(with: "?"))
+        precondition(self.currentToken.starts(with: "?"))
         questionOrExclaim = self.consumePrefix("?", as: .postfixQuestionMark)
       }
 
@@ -1044,7 +1044,7 @@ extension Parser {
           period = nil
         }
 
-        assert(self.at(.leftSquareBracket))
+        precondition(self.at(.leftSquareBracket))
         let lsquare = self.consumeAnyToken()
         let args: [RawTupleExprElementSyntax]
         if self.at(.rightSquareBracket) {
@@ -2085,7 +2085,7 @@ extension Parser.Lookahead {
   /// handle this by doing some lookahead in common situations. And later, Sema
   /// will emit a diagnostic with a fixit to add wrapping parens.
   mutating func isValidTrailingClosure(_ flavor: Parser.ExprFlavor) -> Bool {
-    assert(self.at(.leftBrace), "Couldn't be a trailing closure")
+    precondition(self.at(.leftBrace), "Couldn't be a trailing closure")
 
     // If this is the start of a get/set accessor, then it isn't a trailing
     // closure.
@@ -2270,7 +2270,7 @@ extension Parser {
               { (parser, _) in parser.parseSwitchCases(allowStandaloneStmtRecovery: allowStandaloneStmtRecovery) },
               syntax: { parser, cases in
                 guard cases.count == 1, let firstCase = cases.first else {
-                  assert(cases.isEmpty)
+                  precondition(cases.isEmpty)
                   return .switchCases(RawSwitchCaseListSyntax(elements: [], arena: parser.arena))
                 }
                 return .switchCases(firstCase)

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -406,7 +406,7 @@ struct CharacterByte: ExpressibleByUnicodeScalarLiteral, ExpressibleByIntegerLit
 
 extension Lexer.Cursor {
   func peek(at offset: Int = 0) -> UInt8? {
-    assert(offset >= 0)
+    precondition(offset >= 0)
     guard offset < self.input.count else {
       return nil
     }
@@ -497,7 +497,7 @@ extension Lexer.Cursor {
   /// Returns the text from `self` to `other`.
   func text(upTo other: Lexer.Cursor) -> SyntaxText {
     let count = other.input.baseAddress! - self.input.baseAddress!
-    assert(count >= 0)
+    precondition(count >= 0)
     return SyntaxText(baseAddress: self.input.baseAddress, count: count)
   }
 }
@@ -594,11 +594,11 @@ extension Lexer.Cursor {
   /// Returns `true` if the comment spaned multiple lines and `false` otherwise.
   /// Assumes that the curser is currently pointing at the `*` of the opening `/*`.
   mutating func advanceToEndOfSlashStarComment() -> Bool {
-    assert(self.previous == UInt8(ascii: "/"))
+    precondition(self.previous == UInt8(ascii: "/"))
     // Make sure to advance over the * so that we don't incorrectly handle /*/ as
     // the beginning and end of the comment.
     let consumedStar = self.advance(matching: "*")
-    assert(consumedStar)
+    precondition(consumedStar)
 
     var depth = 1
     var isMultiline = false
@@ -634,7 +634,7 @@ extension Lexer.Cursor {
   /// of `#` in the raw string delimiter.
   /// Assumes that the parser is currently pointing at the first `#`.
   mutating func advanceIfOpeningRawStringDelimiter() -> Int? {
-    assert(self.is(at: "#"))
+    precondition(self.is(at: "#"))
 
     var tmp = self
     var length = 0
@@ -661,7 +661,7 @@ extension Lexer.Cursor {
   mutating func advanceIfMultilineStringDelimiter(
     openingRawStringDelimiters: Int?
   ) -> Bool {
-    assert(self.previous == UInt8(ascii: #"""#))
+    precondition(self.previous == UInt8(ascii: #"""#))
     // Test for single-line string literals that resemble multiline delimiter.
     var sameLineCloseCheck = self
     _ = sameLineCloseCheck.advance()
@@ -888,8 +888,7 @@ extension Lexer.Cursor {
       case .lexemeContents(let result):
         return result
       case .trivia:
-        assertionFailure("Invalid UTF-8 sequence should be eaten by lexTrivia as LeadingTrivia")
-        return Lexer.Result(.unknown, error: LexingDiagnostic(.invalidUtf8, position: self))
+        preconditionFailure("Invalid UTF-8 sequence should be eaten by lexTrivia as LeadingTrivia")
       }
     }
   }
@@ -969,7 +968,7 @@ extension Lexer.Cursor {
       // eaten. If we reach a newline inside string interpolation of a
       // single-line string, emit an empty string segment to indicate to the
       // parser that the string has ended and pop out of string interpolation.
-      assert(stringLiteralKind != .multiLine)
+      precondition(stringLiteralKind != .multiLine)
       return Lexer.Result(.stringSegment, stateTransition: .pop)
     default:
       // If we haven't reached the end of the string interpolation, lex as if we were in a normal expression.
@@ -1164,7 +1163,7 @@ extension Lexer.Cursor {
   ///   floating_literal ::= 0x[0-9A-Fa-f][0-9A-Fa-f_]*
   ///                          (\.[0-9A-Fa-f][0-9A-Fa-f_]*)?[pP][+-]?[0-9][0-9_]*
   mutating func lexNumber() -> Lexer.Result {
-    assert(self.peek().map(Unicode.Scalar.init)?.isDigit == true, "Unexpected start")
+    precondition(self.peek().map(Unicode.Scalar.init)?.isDigit == true, "Unexpected start")
 
     if self.is(at: "0") && self.is(offset: 1, at: "x") {
       return self.lexHexNumber()
@@ -1175,7 +1174,7 @@ extension Lexer.Cursor {
 
       let zeroConsumed = self.advance(matching: "0")  // Consume '0'
       let oConsumed = self.advance(matching: "o")  // Consome 'o'
-      assert(zeroConsumed && oConsumed)
+      precondition(zeroConsumed && oConsumed)
       if let peeked = self.peek(), peeked < UInt8(ascii: "0") || peeked > UInt8(ascii: "7") {
         let errorPos = self
         self.advance(while: { $0.isValidIdentifierContinuationCodePoint })
@@ -1206,7 +1205,7 @@ extension Lexer.Cursor {
       // 0b[01][01_]*
       let zeroConsumed = self.advance(matching: "0")  // Consume '0'
       let bConsumed = self.advance(matching: "b")  // Consume 'b'
-      assert(zeroConsumed && bConsumed)
+      precondition(zeroConsumed && bConsumed)
       if self.is(notAt: "0", "1") {
         let errorPos = self
         self.advance(while: { $0.isValidIdentifierContinuationCodePoint })
@@ -1321,7 +1320,7 @@ extension Lexer.Cursor {
     // We assume we're starting from the 'x' in a '0x...' floating-point literal.
     let zeroConsumed = self.advance(matching: "0")
     let xConsumed = self.advance(matching: "x")
-    assert(zeroConsumed && xConsumed, "not a hex literal")
+    precondition(zeroConsumed && xConsumed, "not a hex literal")
 
     // 0x[0-9a-fA-F][0-9a-fA-F_]*
     guard let peeked = self.peek() else {
@@ -1385,7 +1384,7 @@ extension Lexer.Cursor {
 
     // [pP][+-]?[0-9][0-9_]*
     let pConsumed = self.advance(matching: "p", "P")
-    assert(self.isAtEndOfFile || pConsumed, "not at a hex float exponent?!")
+    precondition(self.isAtEndOfFile || pConsumed, "not at a hex float exponent?!")
 
     var signedExponent = false
     if self.advance(matching: "+", "-") {
@@ -1441,7 +1440,7 @@ extension Lexer.Cursor {
 extension Lexer.Cursor {
   mutating func lexMagicPoundLiteral() -> Lexer.Result {
     let poundConsumed = self.advance(matching: "#")
-    assert(poundConsumed)
+    precondition(poundConsumed)
     var tmp = self
     // Scan for [a-zA-Z]+ to see what we match.
     while let peeked = tmp.peek(), Unicode.Scalar(peeked).isAsciiIdentifierStart {
@@ -1524,7 +1523,7 @@ extension Lexer.Cursor {
       switch stringLiteralKind {
       case .singleQuote:
         let quoteConsumed = self.advance(matching: "'")
-        assert(quoteConsumed)
+        precondition(quoteConsumed)
         return .endOfString
       case .singleLine, .multiLine:
         // Otherwise, this is just a character.
@@ -1536,7 +1535,7 @@ extension Lexer.Cursor {
       return .error(.nulCharacter)
     case UInt8(ascii: "\n"), UInt8(ascii: "\r"):  // String literals cannot have \n or \r in them.
       let character = self.advance()!
-      assert(stringLiteralKind == .multiLine, "Caller must handle newlines in non-multiline")
+      precondition(stringLiteralKind == .multiLine, "Caller must handle newlines in non-multiline")
       return .success(Unicode.Scalar(character))
 
     case UInt8(ascii: "\\"):  // Escapes.
@@ -1582,7 +1581,7 @@ extension Lexer.Cursor {
   ///
   /// If the character is not a valid escape sequence, return `nil`.
   private mutating func lexEscapedCharacter(isMultilineString: Bool) -> EscapedCharacterLex {
-    assert(self.previous == UInt8(ascii: "\\") || self.previous == UInt8(ascii: "#"))
+    precondition(self.previous == UInt8(ascii: "\\") || self.previous == UInt8(ascii: "#"))
     // Escape processing.  We already ate the "\".
     switch self.peek() {
     // Simple single-character escapes.
@@ -1626,7 +1625,7 @@ extension Lexer.Cursor {
   /// If this is not a valid unicode escape, return `nil`.
   private mutating func lexUnicodeEscape() -> EscapedCharacterLex {
     let quoteConsumed = self.advance(matching: "{")
-    assert(quoteConsumed)
+    precondition(quoteConsumed)
 
     let digitStart = self
     var numDigits = 0
@@ -1696,7 +1695,7 @@ extension Lexer.Cursor {
     }
 
     let firstQuoteConsumed = self.advance(matching: #"""#)
-    assert(firstQuoteConsumed)
+    precondition(firstQuoteConsumed)
 
     var lookingForMultilineString = self
     if lookingForMultilineString.advance(matching: #"""#), lookingForMultilineString.advance(matching: #"""#) {
@@ -1764,7 +1763,7 @@ extension Lexer.Cursor {
 
     var tmp = self
     let backslashConsumed = tmp.advance(matching: "\\")  // Skip over the '\' to look for '#' and '('
-    assert(backslashConsumed)
+    precondition(backslashConsumed)
     guard tmp.advanceIfStringDelimiter(delimiterLength: delimiterLength) else {
       return false
     }
@@ -1870,7 +1869,7 @@ extension Lexer.Cursor {
   mutating func lexIdentifier() -> Lexer.Result {
     let tokStart = self
     let didStart = self.advance(if: { $0.isValidIdentifierStartCodePoint })
-    assert(didStart, "Unexpected start")
+    precondition(didStart, "Unexpected start")
 
     // Lex [a-zA-Z_$0-9[[:XID_Continue:]]]*
     self.advance(while: { $0.isValidIdentifierContinuationCodePoint })
@@ -1888,7 +1887,7 @@ extension Lexer.Cursor {
   mutating func lexEscapedIdentifier() -> Lexer.Result {
     let quote = self
     let backtickConsumed = self.advance(matching: "`")
-    assert(backtickConsumed, "Unexpected start of escaped identifier")
+    precondition(backtickConsumed, "Unexpected start of escaped identifier")
 
     // Check whether we have an identifier followed by another backtick, in which
     // case this is an escaped identifier.
@@ -1909,7 +1908,7 @@ extension Lexer.Cursor {
       let firstBacktickConsumed = self.advance(matching: "`")
       let dollarConsumed = self.advance(matching: "$")
       let secondBacktickConsumed = self.advance(matching: "`")
-      assert(firstBacktickConsumed && dollarConsumed && secondBacktickConsumed)
+      precondition(firstBacktickConsumed && dollarConsumed && secondBacktickConsumed)
       return Lexer.Result(.identifier)
     }
 
@@ -1921,7 +1920,7 @@ extension Lexer.Cursor {
   mutating func lexOperatorIdentifier(sourceBufferStart: Lexer.Cursor) -> Lexer.Result {
     let tokStart = self
     let didStart = self.advance(if: { $0.isOperatorStartCodePoint })
-    assert(didStart, "unexpected operator start")
+    precondition(didStart, "unexpected operator start")
 
     repeat {
       // '.' cannot appear in the middle of an operator unless the operator
@@ -2013,7 +2012,7 @@ extension Lexer.Cursor {
   mutating func lexDollarIdentifier() -> Lexer.Result {
     let tokStart = self
     let dollarConsumed = self.advance(matching: "$")
-    assert(dollarConsumed)
+    precondition(dollarConsumed)
 
     var isAllDigits = true
     while true {
@@ -2044,11 +2043,11 @@ extension Lexer.Cursor {
 
 extension Lexer.Cursor {
   mutating func tryLexEditorPlaceholder(sourceBufferStart: Lexer.Cursor) -> Lexer.Result {
-    assert(self.is(at: "<") && self.is(offset: 1, at: "#"))
+    precondition(self.is(at: "<") && self.is(offset: 1, at: "#"))
     var ptr = self
     let leftAngleConsumed = ptr.advance(matching: "<")
     let poundConsumed = ptr.advance(matching: "#")
-    assert(leftAngleConsumed && poundConsumed)
+    precondition(leftAngleConsumed && poundConsumed)
     LOOP: while let consumed = ptr.advance() {
       switch consumed {
       case UInt8(ascii: "\n"):
@@ -2057,7 +2056,7 @@ extension Lexer.Cursor {
         break LOOP
       case UInt8(ascii: "#") where ptr.is(at: ">"):
         let closingAngleConsumed = ptr.advance(matching: ">")
-        assert(closingAngleConsumed)
+        precondition(closingAngleConsumed)
         self = ptr
         return Lexer.Result(.identifier)
       default:
@@ -2112,7 +2111,7 @@ extension Lexer.Cursor {
   /// valid operator start, advance the cursor by what can be considered a
   /// lexeme.
   mutating func lexUnknown() -> UnknownCharactersClassification {
-    assert(!(self.peekScalar()?.isValidIdentifierStartCodePoint ?? false) && !(self.peekScalar()?.isOperatorStartCodePoint ?? false))
+    precondition(!(self.peekScalar()?.isValidIdentifierStartCodePoint ?? false) && !(self.peekScalar()?.isOperatorStartCodePoint ?? false))
     let start = self
     var tmp = self
     if tmp.advance(if: { Unicode.Scalar($0).isValidIdentifierContinuationCodePoint }) {

--- a/Sources/SwiftParser/Lexer/LexemeSequence.swift
+++ b/Sources/SwiftParser/Lexer/LexemeSequence.swift
@@ -101,7 +101,7 @@ extension Lexer {
     _ input: UnsafeBufferPointer<UInt8>,
     from startIndex: Int = 0
   ) -> LexemeSequence {
-    assert(input.isEmpty || startIndex < input.endIndex)
+    precondition(input.isEmpty || startIndex < input.endIndex)
     let startChar = startIndex == input.startIndex ? UInt8(ascii: "\0") : input[startIndex - 1]
     let start = Cursor(input: input, previous: UInt8(ascii: "\0"))
     let cursor = Cursor(input: UnsafeBufferPointer(rebasing: input[startIndex...]), previous: startChar)

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -120,7 +120,7 @@ extension Parser.Lookahead {
     if tokenText == prefix {
       return self.consumeAnyToken()
     }
-    assert(tokenText.hasPrefix(prefix))
+    precondition(tokenText.hasPrefix(prefix))
 
     self.currentToken = self.lexemes.resetForSplit(
       splitToken: self.currentToken,
@@ -209,11 +209,11 @@ extension Parser.Lookahead {
   ///  - the directive contained non-attributes
   ///  - the directive did not contain any attributes
   mutating func consumeIfConfigOfAttributes() -> Bool {
-    assert(self.at(.poundIfKeyword))
+    precondition(self.at(.poundIfKeyword))
     var didSeeAnyAttributes = false
     var poundIfLoopProgress = LoopProgressCondition()
     repeat {
-      assert(self.at(.poundIfKeyword, .poundElseKeyword, .poundElseifKeyword))
+      precondition(self.at(.poundIfKeyword, .poundElseKeyword, .poundElseifKeyword))
       self.consumeAnyToken()
 
       // <expression> after `#if` or `#elseif`
@@ -241,7 +241,7 @@ extension Parser.Lookahead {
 
 extension Parser.Lookahead {
   mutating func isStartOfGetSetAccessor() -> Bool {
-    assert(self.at(.leftBrace), "not checking a brace?")
+    precondition(self.at(.leftBrace), "not checking a brace?")
 
     // The only case this can happen is if the accessor label is immediately after
     // a brace (possibly preceded by attributes).  "get" is implicit, so it can't

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -24,7 +24,7 @@ extension Parser {
   }
 
   mutating func parseArgumentLabel() -> (RawUnexpectedNodesSyntax?, RawTokenSyntax) {
-    assert(self.currentToken.canBeArgumentLabel(allowDollarIdentifier: true))
+    precondition(self.currentToken.canBeArgumentLabel(allowDollarIdentifier: true))
     if let dollarIdent = self.consume(if: .dollarIdentifier) {
       return (
         RawUnexpectedNodesSyntax(elements: [RawSyntax(dollarIdent)], arena: self.arena),
@@ -115,7 +115,7 @@ extension Parser {
       var loopProgress = LoopProgressCondition()
       while !self.at(.eof, .rightParen) && loopProgress.evaluate(currentToken) {
         // Check to see if there is an argument label.
-        assert(self.currentToken.canBeArgumentLabel() && self.peek().rawTokenKind == .colon)
+        precondition(self.currentToken.canBeArgumentLabel() && self.peek().rawTokenKind == .colon)
         let name = self.consumeAnyToken()
         let (unexpectedBeforeColon, colon) = self.expect(.colon)
         elements.append(

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -151,7 +151,7 @@ public struct Parser {
     if let arena = arena {
       self.arena = arena
       sourceBuffer = input
-      assert(arena.contains(text: SyntaxText(baseAddress: input.baseAddress, count: input.count)))
+      precondition(arena.contains(text: SyntaxText(baseAddress: input.baseAddress, count: input.count)))
     } else {
       self.arena = ParsingSyntaxArena(
         parseTriviaFunction: TriviaParser.parseTrivia(_:position:)
@@ -545,7 +545,7 @@ extension Parser {
     if tokenText == prefix {
       return self.consumeAnyToken(remapping: tokenKind)
     }
-    assert(tokenText.hasPrefix(prefix))
+    precondition(tokenText.hasPrefix(prefix))
 
     let endIndex = current.textRange.lowerBound.advanced(by: prefix.count)
     var tokenDiagnostic = current.diagnostic
@@ -589,7 +589,7 @@ extension Parser {
   ///     period. If there is a newline also set `skipMember` to inform
   ///     callers to not parse any futher member names.
   mutating func consumeMemberPeriod<R: RawSyntaxNodeProtocol>(previousNode: R?) -> (unexpected: RawUnexpectedNodesSyntax?, period: RawTokenSyntax, skipMemberName: Bool) {
-    assert(self.at(.period))
+    precondition(self.at(.period))
 
     let beforePeriodWhitespace = previousNode?.raw.trailingTriviaByteLength ?? 0 > 0 || self.currentToken.leadingTriviaByteLength > 0
     let afterPeriodWhitespace = self.currentToken.trailingTriviaByteLength > 0 || self.peek().leadingTriviaByteLength > 0

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -121,7 +121,7 @@ extension Parser.Lookahead {
   ) -> (match: SpecSet, handle: RecoveryConsumptionHandle)? {
     let initialTokensConsumed = self.tokensConsumed
 
-    assert(!specSet.allCases.isEmpty, "SpecSet must have at least one case")
+    precondition(!specSet.allCases.isEmpty, "SpecSet must have at least one case")
     let recoveryPrecedence =
       overrideRecoveryPrecedence ?? specSet.allCases.map({
         return $0.spec.recoveryPrecedence

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -244,7 +244,7 @@ extension Parser {
     }
 
     // We're parsing a conditional binding.
-    assert(self.at(.keyword(.let), .keyword(.var)) || self.at(.keyword(.inout), .keyword(.case)))
+    precondition(self.at(.keyword(.let), .keyword(.var)) || self.at(.keyword(.inout), .keyword(.case)))
     enum BindingKind {
       case pattern(RawTokenSyntax, RawPatternSyntax)
       case optional(RawTokenSyntax, RawPatternSyntax)
@@ -326,7 +326,7 @@ extension Parser {
   ///     availability-condition → '#unavailable' '(' availability-arguments ')'
   @_spi(RawSyntax)
   public mutating func parsePoundAvailableConditionElement() -> RawConditionElementSyntax.Condition {
-    assert(self.at(.poundAvailableKeyword, .poundUnavailableKeyword))
+    precondition(self.at(.poundAvailableKeyword, .poundUnavailableKeyword))
     let keyword = self.consumeAnyToken()
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
     let spec = self.parseAvailabilitySpecList()

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -79,7 +79,7 @@ fileprivate class StringLiteralExpressionIndentationChecker {
         rewrittenChildren.append(child)
       }
     }
-    assert(rewrittenChildren.count == layoutView.children.count)
+    precondition(rewrittenChildren.count == layoutView.children.count)
     if hasRewrittenChild {
       return layoutView.replacingLayout(with: rewrittenChildren, arena: arena)
     } else {
@@ -138,8 +138,8 @@ extension Parser {
     trailing reclassifyTrailing: SyntaxText = "",
     tokenDiagnostic: TokenDiagnostic? = nil
   ) -> RawTokenSyntax {
-    assert(SyntaxText(rebasing: token.tokenText.prefix(reclassifyLeading.count)) == reclassifyLeading)
-    assert(SyntaxText(rebasing: token.tokenText.suffix(reclassifyTrailing.count)) == reclassifyTrailing)
+    precondition(SyntaxText(rebasing: token.tokenText.prefix(reclassifyLeading.count)) == reclassifyLeading)
+    precondition(SyntaxText(rebasing: token.tokenText.suffix(reclassifyTrailing.count)) == reclassifyTrailing)
     return RawTokenSyntax(
       kind: token.tokenKind,
       text: SyntaxText(rebasing: token.tokenText.dropFirst(reclassifyLeading.count).dropLast(reclassifyTrailing.count)),
@@ -165,7 +165,7 @@ extension Parser {
     switch middleSegments.last {
     case .stringSegment(let lastMiddleSegment):
       if !lastMiddleSegment.content.trailingTriviaPieces.isEmpty {
-        assert(
+        precondition(
           lastMiddleSegment.content.trailingTriviaPieces.contains(where: { $0.isBackslash }),
           "The lexer should only add trailing trivia to a string segment if the newline is escaped by a backslash"
         )
@@ -238,7 +238,7 @@ extension Parser {
         // We are not considering leading trivia for indentation computation.
         // If these assertions are violated, we can probably lift them but we
         // would need to check that they produce the expected results.
-        assert(segment.content.leadingTriviaByteLength == 0)
+        precondition(segment.content.leadingTriviaByteLength == 0)
 
         // Re-classify indentation as leading trivia
         if isSegmentOnNewLine {
@@ -309,7 +309,7 @@ extension Parser {
     // -------------------------------------------------------------------------
     // Precondition
 
-    assert(
+    precondition(
       allSegments.allSatisfy {
         if case .stringSegment(let segment) = $0 {
           return segment.unexpectedBeforeContent == nil

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -94,7 +94,7 @@ extension TokenConsumer {
   @inline(__always)
   mutating func at<SpecSet: TokenSpecSet>(anyIn specSet: SpecSet.Type) -> (SpecSet, TokenConsumptionHandle)? {
     if let matchedKind = SpecSet(lexeme: self.currentToken) {
-      assert(matchedKind.spec ~= self.currentToken)
+      precondition(matchedKind.spec ~= self.currentToken)
       return (
         matchedKind,
         TokenConsumptionHandle(spec: matchedKind.spec)

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -173,8 +173,7 @@ public enum TokenPrecedence: Comparable {
     case .poundEndifKeyword:
       self = .closingPoundIf
     case .keyword:
-      assertionFailure("RawTokenKind passed to init(nonKeyword:) must not be a keyword")
-      self = .exprKeyword
+      preconditionFailure("RawTokenKind passed to init(nonKeyword:) must not be a keyword")
     }
   }
 

--- a/Sources/SwiftParser/TokenSpec.swift
+++ b/Sources/SwiftParser/TokenSpec.swift
@@ -81,7 +81,7 @@ struct TokenSpec {
     recoveryPrecedence: TokenPrecedence? = nil,
     allowAtStartOfLine: Bool = true
   ) {
-    assert(rawTokenKind != .keyword, "To create a TokenSpec for a keyword use the initializer that takes a keyword")
+    precondition(rawTokenKind != .keyword, "To create a TokenSpec for a keyword use the initializer that takes a keyword")
     self.rawTokenKind = rawTokenKind
     self.keyword = nil
     self.remapping = remapping
@@ -113,7 +113,7 @@ struct TokenSpec {
       return false
     }
     if self.rawTokenKind == .keyword {
-      assert(self.keyword != nil)
+      precondition(self.keyword != nil)
       switch rawTokenKind {
       case .keyword, .identifier:
         return keyword() == self.keyword
@@ -176,7 +176,7 @@ extension TokenConsumer {
   /// `eat`. Introduce new users of this very sparingly.
   @inline(__always)
   mutating func eat(_ spec: TokenSpec) -> Token {
-    assert(spec ~= self.currentToken)
+    precondition(spec ~= self.currentToken)
     if let remapping = spec.remapping {
       return self.consumeAnyToken(remapping: remapping)
     } else if spec.rawTokenKind == .keyword {

--- a/Sources/SwiftParser/TriviaParser.swift
+++ b/Sources/SwiftParser/TriviaParser.swift
@@ -28,7 +28,7 @@ public struct TriviaParser {
       switch cursor.advance() {
       case nil:
         // Finished.
-        assert(cursor.isAtEndOfFile)
+        precondition(cursor.isAtEndOfFile)
         return pieces
 
       case UInt8(ascii: "\n"):
@@ -127,7 +127,7 @@ public struct TriviaParser {
       // unexpected text trivia piece and were not a comment), merge it to
       // the last piece.
       if case .unexpectedText(let preUnexpected) = pieces.last {
-        assert(start.pointer == preUnexpected.baseAddress! + preUnexpected.count)
+        precondition(start.pointer == preUnexpected.baseAddress! + preUnexpected.count)
         let mergedText = SyntaxText(
           baseAddress: preUnexpected.baseAddress,
           count: preUnexpected.count + start.distance(to: cursor)
@@ -145,7 +145,7 @@ public struct TriviaParser {
 
 extension Lexer.Cursor {
   fileprivate mutating func lexCarriageReturn(start: Lexer.Cursor) -> RawTriviaPiece {
-    assert(self.previous == UInt8(ascii: "\r"))
+    precondition(self.previous == UInt8(ascii: "\r"))
     if self.advance(if: { $0 == "\n" }) {
       var mark = self
       while true {
@@ -178,7 +178,7 @@ extension Lexer.Cursor {
   fileprivate mutating func lexLineComment(start: Lexer.Cursor) -> RawTriviaPiece {
     // "///...": .docLineComment.
     // "//...": .lineComment.
-    assert(self.previous == UInt8(ascii: "/") && self.is(at: "/"))
+    precondition(self.previous == UInt8(ascii: "/") && self.is(at: "/"))
     let isDocComment = self.input.count > 1 && self.is(offset: 1, at: "/")
     self.advanceToEndOfLine()
     let contents = start.text(upTo: self)
@@ -189,7 +189,7 @@ extension Lexer.Cursor {
     // "/**...*/": .docBlockComment.
     // "/*...*/": .blockComment.
     // "/**/": .blockComment.
-    assert(self.previous == UInt8(ascii: "/") && self.is(at: "*"))
+    precondition(self.previous == UInt8(ascii: "/") && self.is(at: "*"))
     let isDocComment = self.input.count > 2 && self.is(offset: 1, at: "*") && self.is(offset: 2, notAt: "/")
     _ = self.advanceToEndOfSlashStarComment()
     let contents = start.text(upTo: self)

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -413,7 +413,7 @@ extension Parser {
   ///     generic-argument → type
   @_spi(RawSyntax)
   public mutating func parseGenericArguments() -> RawGenericArgumentClauseSyntax {
-    assert(self.currentToken.starts(with: "<"))
+    precondition(self.currentToken.starts(with: "<"))
     let langle = self.consumePrefix("<", as: .leftAngle)
     var arguments = [RawGenericArgumentSyntax]()
     do {

--- a/Sources/SwiftParser/generated/Parser+Entry.swift
+++ b/Sources/SwiftParser/generated/Parser+Entry.swift
@@ -140,8 +140,7 @@ extension TypeSyntax: SyntaxParseable {
 fileprivate extension Parser {
   mutating func parseRemainder<R: RawSyntaxNodeProtocol>(into: R) -> R {
     guard !into.raw.kind.isSyntaxCollection, let layout = into.raw.layoutView else {
-      assertionFailure("Only support parsing of non-collection layout nodes")
-      return into
+      preconditionFailure("Only support parsing of non-collection layout nodes")
     }
 
     let remainingTokens = self.consumeRemainingTokens()
@@ -151,7 +150,7 @@ fileprivate extension Parser {
 
     let existingUnexpected: [RawSyntax]
     if let unexpectedNode = layout.children[layout.children.count - 1] {
-      assert(unexpectedNode.is(RawUnexpectedNodesSyntax.self))
+      precondition(unexpectedNode.is(RawUnexpectedNodesSyntax.self))
       existingUnexpected = unexpectedNode.as(RawUnexpectedNodesSyntax.self).elements
     } else {
       existingUnexpected = []

--- a/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
@@ -44,8 +44,8 @@ extension FixIt.Changes {
   /// If `transferTrivia` is `true`, the leading and trailing trivia of the
   /// removed node will be transferred to the trailing trivia of the previous token.
   static func makeMissing(_ tokens: [TokenSyntax], transferTrivia: Bool = true) -> Self {
-    assert(!tokens.isEmpty)
-    assert(tokens.allSatisfy({ $0.presence == .present }))
+    precondition(!tokens.isEmpty)
+    precondition(tokens.allSatisfy({ $0.presence == .present }))
     var changes = tokens.map {
       FixIt.Change.replace(
         oldNode: Syntax($0),

--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -206,7 +206,7 @@ public struct MissingNodesError: ParserError {
   public let missingNodes: [Syntax]
 
   init(missingNodes: [Syntax]) {
-    assert(!missingNodes.isEmpty)
+    precondition(!missingNodes.isEmpty)
     self.missingNodes = missingNodes
   }
 
@@ -301,7 +301,7 @@ public struct InsertTokenFixIt: ParserFixIt {
   public let missingNodes: [Syntax]
 
   init(missingNodes: [Syntax]) {
-    assert(!missingNodes.isEmpty)
+    precondition(!missingNodes.isEmpty)
     self.missingNodes = missingNodes
   }
 

--- a/Sources/SwiftParserDiagnostics/MissingTokenError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingTokenError.swift
@@ -127,7 +127,7 @@ extension ParseDiagnosticsGenerator {
     if missingToken.parent?.is(ExpressionSegmentSyntax.self) == true {
       message = .tooManyRawStringDelimitersToStartInterpolation
     } else {
-      assert(
+      precondition(
         missingToken.parent?.is(StringLiteralExprSyntax.self) == true,
         "Raw string delimiters should only occur in string interpolation and at the end of a string literal"
       )

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -24,8 +24,7 @@ fileprivate extension TokenSyntax {
     case .poundUnavailableKeyword:
       return self.withKind(.poundAvailableKeyword)
     default:
-      assertionFailure("The availability token of an AvailabilityConditionSyntax should always be #available or #unavailable")
-      return self
+      preconditionFailure("The availability token of an AvailabilityConditionSyntax should always be #available or #unavailable")
     }
   }
 }
@@ -361,7 +360,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     } else {
       if let tokenDiagnostic = token.tokenDiagnostic {
         let message = tokenDiagnostic.diagnosticMessage(in: token)
-        assert(message.severity.matches(tokenDiagnostic.severity))
+        precondition(message.severity.matches(tokenDiagnostic.severity))
         self.addDiagnostic(
           token,
           position: token.position.advanced(by: Int(tokenDiagnostic.byteOffset)),

--- a/Sources/SwiftSyntax/IncrementalParseTransition.swift
+++ b/Sources/SwiftSyntax/IncrementalParseTransition.swift
@@ -161,7 +161,7 @@ public struct ConcurrentEdits {
           )
         }
       }
-      assert(editIndiciesMergedWithNewEdit.isSorted)
+      precondition(editIndiciesMergedWithNewEdit.isSorted)
       for indexToRemove in editIndiciesMergedWithNewEdit.reversed() {
         concurrentEdits.remove(at: indexToRemove)
       }
@@ -170,7 +170,7 @@ public struct ConcurrentEdits {
           editToAdd.endOffset <= edit.offset
         }) ?? concurrentEdits.count
       concurrentEdits.insert(editToAdd, at: insertPos)
-      assert(ConcurrentEdits.isValidConcurrentEditArray(concurrentEdits))
+      precondition(ConcurrentEdits.isValidConcurrentEditArray(concurrentEdits))
     }
     return concurrentEdits
   }

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -499,7 +499,7 @@ extension RawSyntax {
   /// this.
   var contentByteLength: Int {
     let result = byteLength - leadingTriviaByteLength - trailingTriviaByteLength
-    assert(result >= 0)
+    precondition(result >= 0)
     return result
   }
 
@@ -551,7 +551,7 @@ extension RawSyntax {
       presence: presence,
       tokenDiagnostic: tokenDiagnostic
     )
-    assert(kind != .keyword || Keyword(payload.tokenText) != nil, "If kind is keyword, the text must be a known token kind")
+    precondition(kind != .keyword || Keyword(payload.tokenText) != nil, "If kind is keyword, the text must be a known token kind")
     return RawSyntax(arena: arena, payload: .parsedToken(payload))
   }
 
@@ -588,7 +588,7 @@ extension RawSyntax {
       presence: presence,
       tokenDiagnostic: tokenDiagnostic
     )
-    assert(kind != .keyword || Keyword(text) != nil, "If kind is keyword, the text must be a known token kind")
+    precondition(kind != .keyword || Keyword(text) != nil, "If kind is keyword, the text must be a known token kind")
     return RawSyntax(arena: arena, payload: .materializedToken(payload))
   }
 
@@ -614,7 +614,7 @@ extension RawSyntax {
     initializingLeadingTriviaWith: (UnsafeMutableBufferPointer<RawTriviaPiece>) -> Void,
     initializingTrailingTriviaWith: (UnsafeMutableBufferPointer<RawTriviaPiece>) -> Void
   ) -> RawSyntax {
-    assert(kind.defaultText == nil || text.isEmpty || kind.defaultText == text)
+    precondition(kind.defaultText == nil || text.isEmpty || kind.defaultText == text)
     let totalTriviaCount = leadingTriviaPieceCount + trailingTriviaPieceCount
     let triviaBuffer = arena.allocateRawTriviaPieceBuffer(count: totalTriviaCount)
     initializingLeadingTriviaWith(

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -96,13 +96,17 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
 
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
 
   public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
     guard Self.isKindOf(other.raw) else { return nil }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
 
   public var tokenKind: RawTokenKind {
@@ -159,7 +163,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
       tokenDiagnostic: tokenDiagnostic,
       arena: arena
     )
-    self = RawTokenSyntax(raw: raw)
+    self = RawTokenSyntax(unchecked: raw)
   }
 
   /// Creates a `RawTokenSyntax`. `text` and trivia must be managed by the same
@@ -222,7 +226,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
         _ = buffer.initialize(from: trailingTriviaPieces)
       }
     )
-    self = RawTokenSyntax(raw: raw)
+    self = RawTokenSyntax(unchecked: raw)
   }
 
   /// Creates a missing `TokenSyntax` with the specified kind.

--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -35,7 +35,7 @@ struct ComputedLocation: Hashable, Codable, CustomDebugStringConvertible {
   }
   init(offset: Int, using converter: SourceLocationConverter) {
     let loc = converter.location(for: AbsolutePosition(utf8Offset: offset))
-    assert(loc.offset == offset)
+    precondition(loc.offset == offset)
     self.line = loc.line!
     self.column = loc.column!
     self.file = loc.file!
@@ -125,11 +125,11 @@ public final class SourceLocationConverter {
   ///   - file: The file path associated with the syntax tree.
   ///   - tree: The root of the syntax tree to convert positions to line/columns for.
   public init<SyntaxType: SyntaxProtocol>(file: String, tree: SyntaxType) {
-    assert(tree.parent == nil, "SourceLocationConverter must be passed the root of the syntax tree")
+    precondition(tree.parent == nil, "SourceLocationConverter must be passed the root of the syntax tree")
     self.file = file
     self.source = tree.syntaxTextBytes
     (self.lines, endOfFile) = computeLines(tree: Syntax(tree))
-    assert(tree.byteSize == endOfFile.utf8Offset)
+    precondition(tree.byteSize == endOfFile.utf8Offset)
   }
 
   /// - Parameters:
@@ -141,7 +141,7 @@ public final class SourceLocationConverter {
     (self.lines, endOfFile) = self.source.withUnsafeBufferPointer { buf in
       return computeLines(SyntaxText(buffer: buf))
     }
-    assert(source.utf8.count == endOfFile.utf8Offset)
+    precondition(source.utf8.count == endOfFile.utf8Offset)
   }
 
   /// Execute the body with an array that contains each source line.
@@ -149,7 +149,7 @@ public final class SourceLocationConverter {
     return try source.withUnsafeBufferPointer { (sourcePointer: UnsafeBufferPointer<UInt8>) in
       var result: [SyntaxText] = []
       var previousLoc = AbsolutePosition.startOfFile
-      assert(lines.first == AbsolutePosition.startOfFile)
+      precondition(lines.first == AbsolutePosition.startOfFile)
       for lineStartLoc in lines.dropFirst() + [endOfFile] {
         result.append(
           SyntaxText(
@@ -182,7 +182,7 @@ public final class SourceLocationConverter {
       return SourceLocation(line: 1, column: 1, offset: 0, file: self.file)
     }
 
-    assert(!lines.isEmpty)
+    precondition(!lines.isEmpty)
     var first = lines.startIndex
     var i: Int
     var step: Int
@@ -200,7 +200,7 @@ public final class SourceLocationConverter {
       }
     }
 
-    assert(first > 0)
+    precondition(first > 0)
     let lineIdx = first - 1
     let lineStartOffset = lines[lineIdx].utf8Offset
     let colOffset = pos.utf8Offset - lineStartOffset
@@ -497,7 +497,7 @@ fileprivate extension RawTriviaPiece {
       let .lineComment(text),
       let .docLineComment(text):
       // Line comments are not supposed to contain newlines.
-      assert(!text.containsSwiftNewline(), "line comment created that contained a new-line character")
+      precondition(!text.containsSwiftNewline(), "line comment created that contained a new-line character")
       lineLength += SourceLength(utf8Length: text.count)
     case let .blockComment(text),
       let .docBlockComment(text),

--- a/Sources/SwiftSyntax/SyntaxOtherNodes.swift
+++ b/Sources/SwiftSyntax/SyntaxOtherNodes.swift
@@ -30,7 +30,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .token)
+    precondition(data.raw.kind == .token)
     self._syntaxNode = Syntax(data)
   }
 

--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -42,7 +42,7 @@ public struct SyntaxText {
   }
 
   public init(baseAddress: UnsafePointer<UInt8>?, count: Int) {
-    assert(
+    precondition(
       count == 0 || baseAddress != nil,
       "If count is not zero, base address must be exist"
     )
@@ -231,7 +231,7 @@ private func compareMemory(
   _ s2: UnsafePointer<UInt8>,
   _ count: Int
 ) -> Bool {
-  assert(count >= 0)
+  precondition(count >= 0)
   #if SWIFT_SYNTAX_ALWAYS_SINGLE_THREADED
   return UnsafeBufferPointer(start: s1, count: count)
     .elementsEqual(UnsafeBufferPointer(start: s2, count: count))

--- a/Sources/SwiftSyntax/TokenDiagnostic.swift
+++ b/Sources/SwiftSyntax/TokenDiagnostic.swift
@@ -61,7 +61,7 @@ public struct TokenDiagnostic: Hashable {
   }
 
   public init(_ kind: Kind, byteOffset: Int) {
-    assert(byteOffset >= 0)
+    precondition(byteOffset >= 0)
     // `type(of: self.byteOffset).max` gets optimized to a constant
     if byteOffset > type(of: self.byteOffset).max {
       self.kind = .tokenDiagnosticOffsetOverflow

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -50,7 +50,7 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .accessPath)
+    precondition(data.raw.kind == .accessPath)
     self._syntaxNode = Syntax(data)
   }
   
@@ -265,7 +265,7 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .accessorList)
+    precondition(data.raw.kind == .accessorList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -480,7 +480,7 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .arrayElementList)
+    precondition(data.raw.kind == .arrayElementList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -738,7 +738,7 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .attributeList)
+    precondition(data.raw.kind == .attributeList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -953,7 +953,7 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .availabilitySpecList)
+    precondition(data.raw.kind == .availabilitySpecList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1168,7 +1168,7 @@ public struct AvailabilityVersionRestrictionListSyntax: SyntaxCollection, Syntax
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .availabilityVersionRestrictionList)
+    precondition(data.raw.kind == .availabilityVersionRestrictionList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1383,7 +1383,7 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .caseItemList)
+    precondition(data.raw.kind == .caseItemList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1598,7 +1598,7 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .catchClauseList)
+    precondition(data.raw.kind == .catchClauseList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1813,7 +1813,7 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .catchItemList)
+    precondition(data.raw.kind == .catchItemList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2028,7 +2028,7 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .closureCaptureItemList)
+    precondition(data.raw.kind == .closureCaptureItemList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2243,7 +2243,7 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .closureParamList)
+    precondition(data.raw.kind == .closureParamList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2458,7 +2458,7 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .codeBlockItemList)
+    precondition(data.raw.kind == .codeBlockItemList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2673,7 +2673,7 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .compositionTypeElementList)
+    precondition(data.raw.kind == .compositionTypeElementList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2888,7 +2888,7 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .conditionElementList)
+    precondition(data.raw.kind == .conditionElementList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3103,7 +3103,7 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .declNameArgumentList)
+    precondition(data.raw.kind == .declNameArgumentList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3318,7 +3318,7 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .designatedTypeList)
+    precondition(data.raw.kind == .designatedTypeList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3533,7 +3533,7 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .dictionaryElementList)
+    precondition(data.raw.kind == .dictionaryElementList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3748,7 +3748,7 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .differentiabilityParamList)
+    precondition(data.raw.kind == .differentiabilityParamList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3960,7 +3960,7 @@ public struct DocumentationAttributeArgumentsSyntax: SyntaxCollection, SyntaxHas
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .documentationAttributeArguments)
+    precondition(data.raw.kind == .documentationAttributeArguments)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4172,7 +4172,7 @@ public struct EffectsArgumentsSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .effectsArguments)
+    precondition(data.raw.kind == .effectsArguments)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4384,7 +4384,7 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .enumCaseElementList)
+    precondition(data.raw.kind == .enumCaseElementList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4596,7 +4596,7 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .exprList)
+    precondition(data.raw.kind == .exprList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4811,7 +4811,7 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .functionParameterList)
+    precondition(data.raw.kind == .functionParameterList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5026,7 +5026,7 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .genericArgumentList)
+    precondition(data.raw.kind == .genericArgumentList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5241,7 +5241,7 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .genericParameterList)
+    precondition(data.raw.kind == .genericParameterList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5456,7 +5456,7 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .genericRequirementList)
+    precondition(data.raw.kind == .genericRequirementList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5671,7 +5671,7 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .ifConfigClauseList)
+    precondition(data.raw.kind == .ifConfigClauseList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5886,7 +5886,7 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .inheritedTypeList)
+    precondition(data.raw.kind == .inheritedTypeList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6101,7 +6101,7 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .keyPathComponentList)
+    precondition(data.raw.kind == .keyPathComponentList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6316,7 +6316,7 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .memberDeclList)
+    precondition(data.raw.kind == .memberDeclList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6531,7 +6531,7 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .modifierList)
+    precondition(data.raw.kind == .modifierList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6746,7 +6746,7 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .multipleTrailingClosureElementList)
+    precondition(data.raw.kind == .multipleTrailingClosureElementList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6961,7 +6961,7 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .objCSelector)
+    precondition(data.raw.kind == .objCSelector)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7176,7 +7176,7 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .patternBindingList)
+    precondition(data.raw.kind == .patternBindingList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7446,7 +7446,7 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .precedenceGroupAttributeList)
+    precondition(data.raw.kind == .precedenceGroupAttributeList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7661,7 +7661,7 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .precedenceGroupNameList)
+    precondition(data.raw.kind == .precedenceGroupNameList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7876,7 +7876,7 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .primaryAssociatedTypeList)
+    precondition(data.raw.kind == .primaryAssociatedTypeList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -8156,7 +8156,7 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .specializeAttributeSpecList)
+    precondition(data.raw.kind == .specializeAttributeSpecList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -8414,7 +8414,7 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .stringLiteralSegments)
+    precondition(data.raw.kind == .stringLiteralSegments)
     self._syntaxNode = Syntax(data)
   }
   
@@ -8672,7 +8672,7 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .switchCaseList)
+    precondition(data.raw.kind == .switchCaseList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -8887,7 +8887,7 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .tupleExprElementList)
+    precondition(data.raw.kind == .tupleExprElementList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -9102,7 +9102,7 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .tuplePatternElementList)
+    precondition(data.raw.kind == .tuplePatternElementList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -9317,7 +9317,7 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .tupleTypeElementList)
+    precondition(data.raw.kind == .tupleTypeElementList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -9529,7 +9529,7 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .unexpectedNodes)
+    precondition(data.raw.kind == .unexpectedNodes)
     self._syntaxNode = Syntax(data)
   }
   
@@ -9744,7 +9744,7 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .yieldExprList)
+    precondition(data.raw.kind == .yieldExprList)
     self._syntaxNode = Syntax(data)
   }
   

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -6753,7 +6753,7 @@ open class SyntaxRewriter {
       // A child node was rewritten. Build the updated node.
       
       // Sanity check, ensure the new children are the same length.
-      assert(newLayout.count == node.raw.layoutView!.children.count)
+      precondition(newLayout.count == node.raw.layoutView!.children.count)
       
       let arena = SyntaxArena()
       let newRaw = node.raw.layoutView!.replacingLayout(with: Array(newLayout), arena: arena)

--- a/Sources/SwiftSyntax/generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/generated/TokenKind.swift
@@ -901,42 +901,42 @@ extension TokenKind {
     case .eof:
       return .eof
     case .arrow:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .arrow
     case .atSign:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .atSign
     case .backslash:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .backslash
     case .backtick:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .backtick
     case .binaryOperator:
       return .binaryOperator(text)
     case .colon:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .colon
     case .comma:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .comma
     case .dollarIdentifier:
       return .dollarIdentifier(text)
     case .ellipsis:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .ellipsis
     case .equal:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .equal
     case .exclamationMark:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .exclamationMark
     case .floatingLiteral:
       return .floatingLiteral(text)
     case .identifier:
       return .identifier(text)
     case .infixQuestionMark:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .infixQuestionMark
     case .integerLiteral:
       return .integerLiteral(text)
@@ -946,54 +946,54 @@ extension TokenKind {
         return .keyword(Keyword(text)!)
       }
     case .leftAngle:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .leftAngle
     case .leftBrace:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .leftBrace
     case .leftParen:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .leftParen
     case .leftSquareBracket:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .leftSquareBracket
     case .multilineStringQuote:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .multilineStringQuote
     case .period:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .period
     case .postfixOperator:
       return .postfixOperator(text)
     case .postfixQuestionMark:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .postfixQuestionMark
     case .pound:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .pound
     case .poundAvailableKeyword:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .poundAvailableKeyword
     case .poundElseKeyword:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .poundElseKeyword
     case .poundElseifKeyword:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .poundElseifKeyword
     case .poundEndifKeyword:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .poundEndifKeyword
     case .poundIfKeyword:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .poundIfKeyword
     case .poundSourceLocationKeyword:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .poundSourceLocationKeyword
     case .poundUnavailableKeyword:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .poundUnavailableKeyword
     case .prefixAmpersand:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .prefixAmpersand
     case .prefixOperator:
       return .prefixOperator(text)
@@ -1002,32 +1002,32 @@ extension TokenKind {
     case .regexLiteral:
       return .regexLiteral(text)
     case .rightAngle:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .rightAngle
     case .rightBrace:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .rightBrace
     case .rightParen:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .rightParen
     case .rightSquareBracket:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .rightSquareBracket
     case .semicolon:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .semicolon
     case .singleQuote:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .singleQuote
     case .stringQuote:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .stringQuote
     case .stringSegment:
       return .stringSegment(text)
     case .unknown:
       return .unknown(text)
     case .wildcard:
-      assert(text.isEmpty || rawKind.defaultText.map(String.init) == text)
+      precondition(text.isEmpty || rawKind.defaultText.map(String.init) == text)
       return .wildcard
     }
   }

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -41,7 +41,11 @@ public struct RawAccessPathComponentSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -49,7 +53,7 @@ public struct RawAccessPathComponentSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -69,7 +73,7 @@ public struct RawAccessPathComponentSyntax: RawSyntaxNodeProtocol {
       layout[3] = trailingDot?.raw
       layout[4] = unexpectedAfterTrailingDot?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeName: RawUnexpectedNodesSyntax? {
@@ -107,7 +111,11 @@ public struct RawAccessPathSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -115,7 +123,7 @@ public struct RawAccessPathSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawAccessPathComponentSyntax], arena: __shared SyntaxArena) {
@@ -129,7 +137,7 @@ public struct RawAccessPathSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawAccessPathComponentSyntax] {
@@ -153,7 +161,11 @@ public struct RawAccessorBlockSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -161,7 +173,7 @@ public struct RawAccessorBlockSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -185,7 +197,7 @@ public struct RawAccessorBlockSyntax: RawSyntaxNodeProtocol {
       layout[5] = rightBrace.raw
       layout[6] = unexpectedAfterRightBrace?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftBrace: RawUnexpectedNodesSyntax? {
@@ -231,7 +243,11 @@ public struct RawAccessorDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -239,7 +255,7 @@ public struct RawAccessorDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -275,7 +291,7 @@ public struct RawAccessorDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[11] = body?.raw
       layout[12] = unexpectedAfterBody?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -345,7 +361,11 @@ public struct RawAccessorListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -353,7 +373,7 @@ public struct RawAccessorListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawAccessorDeclSyntax], arena: __shared SyntaxArena) {
@@ -367,7 +387,7 @@ public struct RawAccessorListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawAccessorDeclSyntax] {
@@ -391,7 +411,11 @@ public struct RawAccessorParameterSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -399,7 +423,7 @@ public struct RawAccessorParameterSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -423,7 +447,7 @@ public struct RawAccessorParameterSyntax: RawSyntaxNodeProtocol {
       layout[5] = rightParen.raw
       layout[6] = unexpectedAfterRightParen?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax? {
@@ -469,7 +493,11 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -477,7 +505,7 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -521,7 +549,7 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[15] = members.raw
       layout[16] = unexpectedAfterMembers?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -607,7 +635,11 @@ public struct RawArrayElementListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -615,7 +647,7 @@ public struct RawArrayElementListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawArrayElementSyntax], arena: __shared SyntaxArena) {
@@ -629,7 +661,7 @@ public struct RawArrayElementListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawArrayElementSyntax] {
@@ -653,7 +685,11 @@ public struct RawArrayElementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -661,7 +697,7 @@ public struct RawArrayElementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -681,7 +717,7 @@ public struct RawArrayElementSyntax: RawSyntaxNodeProtocol {
       layout[3] = trailingComma?.raw
       layout[4] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeExpression: RawUnexpectedNodesSyntax? {
@@ -719,7 +755,11 @@ public struct RawArrayExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -727,7 +767,7 @@ public struct RawArrayExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -751,7 +791,7 @@ public struct RawArrayExprSyntax: RawExprSyntaxNodeProtocol {
       layout[5] = rightSquare.raw
       layout[6] = unexpectedAfterRightSquare?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftSquare: RawUnexpectedNodesSyntax? {
@@ -797,7 +837,11 @@ public struct RawArrayTypeSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -805,7 +849,7 @@ public struct RawArrayTypeSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -829,7 +873,7 @@ public struct RawArrayTypeSyntax: RawTypeSyntaxNodeProtocol {
       layout[5] = rightSquareBracket.raw
       layout[6] = unexpectedAfterRightSquareBracket?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftSquareBracket: RawUnexpectedNodesSyntax? {
@@ -875,7 +919,11 @@ public struct RawArrowExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -883,7 +931,7 @@ public struct RawArrowExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -903,7 +951,7 @@ public struct RawArrowExprSyntax: RawExprSyntaxNodeProtocol {
       layout[3] = arrowToken.raw
       layout[4] = unexpectedAfterArrowToken?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeEffectSpecifiers: RawUnexpectedNodesSyntax? {
@@ -941,7 +989,11 @@ public struct RawAsExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -949,7 +1001,7 @@ public struct RawAsExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -977,7 +1029,7 @@ public struct RawAsExprSyntax: RawExprSyntaxNodeProtocol {
       layout[7] = typeName.raw
       layout[8] = unexpectedAfterTypeName?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeExpression: RawUnexpectedNodesSyntax? {
@@ -1031,7 +1083,11 @@ public struct RawAssignmentExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -1039,7 +1095,7 @@ public struct RawAssignmentExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -1055,7 +1111,7 @@ public struct RawAssignmentExprSyntax: RawExprSyntaxNodeProtocol {
       layout[1] = assignToken.raw
       layout[2] = unexpectedAfterAssignToken?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAssignToken: RawUnexpectedNodesSyntax? {
@@ -1085,7 +1141,11 @@ public struct RawAssociatedtypeDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -1093,7 +1153,7 @@ public struct RawAssociatedtypeDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -1133,7 +1193,7 @@ public struct RawAssociatedtypeDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[13] = genericWhereClause?.raw
       layout[14] = unexpectedAfterGenericWhereClause?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -1242,7 +1302,11 @@ public struct RawAttributeListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -1250,7 +1314,7 @@ public struct RawAttributeListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [Element], arena: __shared SyntaxArena) {
@@ -1264,7 +1328,7 @@ public struct RawAttributeListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawSyntax] {
@@ -1445,7 +1509,11 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -1453,7 +1521,7 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -1485,7 +1553,7 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
       layout[9] = rightParen?.raw
       layout[10] = unexpectedAfterRightParen?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAtSignToken: RawUnexpectedNodesSyntax? {
@@ -1547,7 +1615,11 @@ public struct RawAttributedTypeSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -1555,7 +1627,7 @@ public struct RawAttributedTypeSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -1579,7 +1651,7 @@ public struct RawAttributedTypeSyntax: RawTypeSyntaxNodeProtocol {
       layout[5] = baseType.raw
       layout[6] = unexpectedAfterBaseType?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeSpecifier: RawUnexpectedNodesSyntax? {
@@ -1663,7 +1735,11 @@ public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -1671,7 +1747,7 @@ public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -1691,7 +1767,7 @@ public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol {
       layout[3] = trailingComma?.raw
       layout[4] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeEntry: RawUnexpectedNodesSyntax? {
@@ -1729,7 +1805,11 @@ public struct RawAvailabilityConditionSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -1737,7 +1817,7 @@ public struct RawAvailabilityConditionSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -1765,7 +1845,7 @@ public struct RawAvailabilityConditionSyntax: RawSyntaxNodeProtocol {
       layout[7] = rightParen.raw
       layout[8] = unexpectedAfterRightParen?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAvailabilityKeyword: RawUnexpectedNodesSyntax? {
@@ -1819,7 +1899,11 @@ public struct RawAvailabilityEntrySyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -1827,7 +1911,7 @@ public struct RawAvailabilityEntrySyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -1855,7 +1939,7 @@ public struct RawAvailabilityEntrySyntax: RawSyntaxNodeProtocol {
       layout[7] = semicolon.raw
       layout[8] = unexpectedAfterSemicolon?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLabel: RawUnexpectedNodesSyntax? {
@@ -1940,7 +2024,11 @@ public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -1948,7 +2036,7 @@ public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -1972,7 +2060,7 @@ public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol {
       layout[5] = value.raw
       layout[6] = unexpectedAfterValue?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLabel: RawUnexpectedNodesSyntax? {
@@ -2018,7 +2106,11 @@ public struct RawAvailabilitySpecListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2026,7 +2118,7 @@ public struct RawAvailabilitySpecListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawAvailabilityArgumentSyntax], arena: __shared SyntaxArena) {
@@ -2040,7 +2132,7 @@ public struct RawAvailabilitySpecListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawAvailabilityArgumentSyntax] {
@@ -2064,7 +2156,11 @@ public struct RawAvailabilityVersionRestrictionListEntrySyntax: RawSyntaxNodePro
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2072,7 +2168,7 @@ public struct RawAvailabilityVersionRestrictionListEntrySyntax: RawSyntaxNodePro
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -2092,7 +2188,7 @@ public struct RawAvailabilityVersionRestrictionListEntrySyntax: RawSyntaxNodePro
       layout[3] = trailingComma?.raw
       layout[4] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAvailabilityVersionRestriction: RawUnexpectedNodesSyntax? {
@@ -2130,7 +2226,11 @@ public struct RawAvailabilityVersionRestrictionListSyntax: RawSyntaxNodeProtocol
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2138,7 +2238,7 @@ public struct RawAvailabilityVersionRestrictionListSyntax: RawSyntaxNodeProtocol
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawAvailabilityVersionRestrictionListEntrySyntax], arena: __shared SyntaxArena) {
@@ -2152,7 +2252,7 @@ public struct RawAvailabilityVersionRestrictionListSyntax: RawSyntaxNodeProtocol
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawAvailabilityVersionRestrictionListEntrySyntax] {
@@ -2176,7 +2276,11 @@ public struct RawAvailabilityVersionRestrictionSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2184,7 +2288,7 @@ public struct RawAvailabilityVersionRestrictionSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -2204,7 +2308,7 @@ public struct RawAvailabilityVersionRestrictionSyntax: RawSyntaxNodeProtocol {
       layout[3] = version?.raw
       layout[4] = unexpectedAfterVersion?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforePlatform: RawUnexpectedNodesSyntax? {
@@ -2242,7 +2346,11 @@ public struct RawAwaitExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2250,7 +2358,7 @@ public struct RawAwaitExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -2270,7 +2378,7 @@ public struct RawAwaitExprSyntax: RawExprSyntaxNodeProtocol {
       layout[3] = expression.raw
       layout[4] = unexpectedAfterExpression?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAwaitKeyword: RawUnexpectedNodesSyntax? {
@@ -2308,7 +2416,11 @@ public struct RawBackDeployedAttributeSpecListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2316,7 +2428,7 @@ public struct RawBackDeployedAttributeSpecListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -2340,7 +2452,7 @@ public struct RawBackDeployedAttributeSpecListSyntax: RawSyntaxNodeProtocol {
       layout[5] = versionList.raw
       layout[6] = unexpectedAfterVersionList?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeBeforeLabel: RawUnexpectedNodesSyntax? {
@@ -2386,7 +2498,11 @@ public struct RawBinaryOperatorExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2394,7 +2510,7 @@ public struct RawBinaryOperatorExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -2410,7 +2526,7 @@ public struct RawBinaryOperatorExprSyntax: RawExprSyntaxNodeProtocol {
       layout[1] = operatorToken.raw
       layout[2] = unexpectedAfterOperatorToken?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeOperatorToken: RawUnexpectedNodesSyntax? {
@@ -2440,7 +2556,11 @@ public struct RawBooleanLiteralExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2448,7 +2568,7 @@ public struct RawBooleanLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -2464,7 +2584,7 @@ public struct RawBooleanLiteralExprSyntax: RawExprSyntaxNodeProtocol {
       layout[1] = booleanLiteral.raw
       layout[2] = unexpectedAfterBooleanLiteral?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeBooleanLiteral: RawUnexpectedNodesSyntax? {
@@ -2494,7 +2614,11 @@ public struct RawBorrowExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2502,7 +2626,7 @@ public struct RawBorrowExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -2522,7 +2646,7 @@ public struct RawBorrowExprSyntax: RawExprSyntaxNodeProtocol {
       layout[3] = expression.raw
       layout[4] = unexpectedAfterExpression?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeBorrowKeyword: RawUnexpectedNodesSyntax? {
@@ -2560,7 +2684,11 @@ public struct RawBreakStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2568,7 +2696,7 @@ public struct RawBreakStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -2588,7 +2716,7 @@ public struct RawBreakStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout[3] = label?.raw
       layout[4] = unexpectedAfterLabel?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeBreakKeyword: RawUnexpectedNodesSyntax? {
@@ -2626,7 +2754,11 @@ public struct RawCaseItemListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2634,7 +2766,7 @@ public struct RawCaseItemListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawCaseItemSyntax], arena: __shared SyntaxArena) {
@@ -2648,7 +2780,7 @@ public struct RawCaseItemListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawCaseItemSyntax] {
@@ -2672,7 +2804,11 @@ public struct RawCaseItemSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2680,7 +2816,7 @@ public struct RawCaseItemSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -2704,7 +2840,7 @@ public struct RawCaseItemSyntax: RawSyntaxNodeProtocol {
       layout[5] = trailingComma?.raw
       layout[6] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforePattern: RawUnexpectedNodesSyntax? {
@@ -2750,7 +2886,11 @@ public struct RawCatchClauseListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2758,7 +2898,7 @@ public struct RawCatchClauseListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawCatchClauseSyntax], arena: __shared SyntaxArena) {
@@ -2772,7 +2912,7 @@ public struct RawCatchClauseListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawCatchClauseSyntax] {
@@ -2796,7 +2936,11 @@ public struct RawCatchClauseSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2804,7 +2948,7 @@ public struct RawCatchClauseSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -2828,7 +2972,7 @@ public struct RawCatchClauseSyntax: RawSyntaxNodeProtocol {
       layout[5] = body.raw
       layout[6] = unexpectedAfterBody?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeCatchKeyword: RawUnexpectedNodesSyntax? {
@@ -2874,7 +3018,11 @@ public struct RawCatchItemListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2882,7 +3030,7 @@ public struct RawCatchItemListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawCatchItemSyntax], arena: __shared SyntaxArena) {
@@ -2896,7 +3044,7 @@ public struct RawCatchItemListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawCatchItemSyntax] {
@@ -2920,7 +3068,11 @@ public struct RawCatchItemSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -2928,7 +3080,7 @@ public struct RawCatchItemSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -2952,7 +3104,7 @@ public struct RawCatchItemSyntax: RawSyntaxNodeProtocol {
       layout[5] = trailingComma?.raw
       layout[6] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforePattern: RawUnexpectedNodesSyntax? {
@@ -2998,7 +3150,11 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -3006,7 +3162,7 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -3050,7 +3206,7 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[15] = members.raw
       layout[16] = unexpectedAfterMembers?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -3136,7 +3292,11 @@ public struct RawClassRestrictionTypeSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -3144,7 +3304,7 @@ public struct RawClassRestrictionTypeSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -3160,7 +3320,7 @@ public struct RawClassRestrictionTypeSyntax: RawTypeSyntaxNodeProtocol {
       layout[1] = classKeyword.raw
       layout[2] = unexpectedAfterClassKeyword?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeClassKeyword: RawUnexpectedNodesSyntax? {
@@ -3190,7 +3350,11 @@ public struct RawClosureCaptureItemListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -3198,7 +3362,7 @@ public struct RawClosureCaptureItemListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawClosureCaptureItemSyntax], arena: __shared SyntaxArena) {
@@ -3212,7 +3376,7 @@ public struct RawClosureCaptureItemListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawClosureCaptureItemSyntax] {
@@ -3236,7 +3400,11 @@ public struct RawClosureCaptureItemSpecifierSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -3244,7 +3412,7 @@ public struct RawClosureCaptureItemSpecifierSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -3272,7 +3440,7 @@ public struct RawClosureCaptureItemSpecifierSyntax: RawSyntaxNodeProtocol {
       layout[7] = rightParen?.raw
       layout[8] = unexpectedAfterRightParen?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeSpecifier: RawUnexpectedNodesSyntax? {
@@ -3326,7 +3494,11 @@ public struct RawClosureCaptureItemSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -3334,7 +3506,7 @@ public struct RawClosureCaptureItemSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -3366,7 +3538,7 @@ public struct RawClosureCaptureItemSyntax: RawSyntaxNodeProtocol {
       layout[9] = trailingComma?.raw
       layout[10] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeSpecifier: RawUnexpectedNodesSyntax? {
@@ -3428,7 +3600,11 @@ public struct RawClosureCaptureSignatureSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -3436,7 +3612,7 @@ public struct RawClosureCaptureSignatureSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -3460,7 +3636,7 @@ public struct RawClosureCaptureSignatureSyntax: RawSyntaxNodeProtocol {
       layout[5] = rightSquare.raw
       layout[6] = unexpectedAfterRightSquare?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftSquare: RawUnexpectedNodesSyntax? {
@@ -3506,7 +3682,11 @@ public struct RawClosureExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -3514,7 +3694,7 @@ public struct RawClosureExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -3542,7 +3722,7 @@ public struct RawClosureExprSyntax: RawExprSyntaxNodeProtocol {
       layout[7] = rightBrace.raw
       layout[8] = unexpectedAfterRightBrace?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftBrace: RawUnexpectedNodesSyntax? {
@@ -3596,7 +3776,11 @@ public struct RawClosureParamListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -3604,7 +3788,7 @@ public struct RawClosureParamListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawClosureParamSyntax], arena: __shared SyntaxArena) {
@@ -3618,7 +3802,7 @@ public struct RawClosureParamListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawClosureParamSyntax] {
@@ -3642,7 +3826,11 @@ public struct RawClosureParamSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -3650,7 +3838,7 @@ public struct RawClosureParamSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -3670,7 +3858,7 @@ public struct RawClosureParamSyntax: RawSyntaxNodeProtocol {
       layout[3] = trailingComma?.raw
       layout[4] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeName: RawUnexpectedNodesSyntax? {
@@ -3739,7 +3927,11 @@ public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -3747,7 +3939,7 @@ public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -3783,7 +3975,7 @@ public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol {
       layout[11] = inTok.raw
       layout[12] = unexpectedAfterInTok?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -3853,7 +4045,11 @@ public struct RawCodeBlockItemListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -3861,7 +4057,7 @@ public struct RawCodeBlockItemListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawCodeBlockItemSyntax], arena: __shared SyntaxArena) {
@@ -3875,7 +4071,7 @@ public struct RawCodeBlockItemListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawCodeBlockItemSyntax] {
@@ -3937,7 +4133,11 @@ public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -3945,7 +4145,7 @@ public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -3965,7 +4165,7 @@ public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol {
       layout[3] = semicolon?.raw
       layout[4] = unexpectedAfterSemicolon?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeItem: RawUnexpectedNodesSyntax? {
@@ -4003,7 +4203,11 @@ public struct RawCodeBlockSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -4011,7 +4215,7 @@ public struct RawCodeBlockSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -4035,7 +4239,7 @@ public struct RawCodeBlockSyntax: RawSyntaxNodeProtocol {
       layout[5] = rightBrace.raw
       layout[6] = unexpectedAfterRightBrace?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftBrace: RawUnexpectedNodesSyntax? {
@@ -4081,7 +4285,11 @@ public struct RawCompositionTypeElementListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -4089,7 +4297,7 @@ public struct RawCompositionTypeElementListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawCompositionTypeElementSyntax], arena: __shared SyntaxArena) {
@@ -4103,7 +4311,7 @@ public struct RawCompositionTypeElementListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawCompositionTypeElementSyntax] {
@@ -4127,7 +4335,11 @@ public struct RawCompositionTypeElementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -4135,7 +4347,7 @@ public struct RawCompositionTypeElementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -4155,7 +4367,7 @@ public struct RawCompositionTypeElementSyntax: RawSyntaxNodeProtocol {
       layout[3] = ampersand?.raw
       layout[4] = unexpectedAfterAmpersand?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeType: RawUnexpectedNodesSyntax? {
@@ -4193,7 +4405,11 @@ public struct RawCompositionTypeSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -4201,7 +4417,7 @@ public struct RawCompositionTypeSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -4217,7 +4433,7 @@ public struct RawCompositionTypeSyntax: RawTypeSyntaxNodeProtocol {
       layout[1] = elements.raw
       layout[2] = unexpectedAfterElements?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeElements: RawUnexpectedNodesSyntax? {
@@ -4247,7 +4463,11 @@ public struct RawConditionElementListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -4255,7 +4475,7 @@ public struct RawConditionElementListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawConditionElementSyntax], arena: __shared SyntaxArena) {
@@ -4269,7 +4489,7 @@ public struct RawConditionElementListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawConditionElementSyntax] {
@@ -4338,7 +4558,11 @@ public struct RawConditionElementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -4346,7 +4570,7 @@ public struct RawConditionElementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -4366,7 +4590,7 @@ public struct RawConditionElementSyntax: RawSyntaxNodeProtocol {
       layout[3] = trailingComma?.raw
       layout[4] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeCondition: RawUnexpectedNodesSyntax? {
@@ -4404,7 +4628,11 @@ public struct RawConformanceRequirementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -4412,7 +4640,7 @@ public struct RawConformanceRequirementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -4436,7 +4664,7 @@ public struct RawConformanceRequirementSyntax: RawSyntaxNodeProtocol {
       layout[5] = rightTypeIdentifier.raw
       layout[6] = unexpectedAfterRightTypeIdentifier?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftTypeIdentifier: RawUnexpectedNodesSyntax? {
@@ -4482,7 +4710,11 @@ public struct RawConstrainedSugarTypeSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -4490,7 +4722,7 @@ public struct RawConstrainedSugarTypeSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -4510,7 +4742,7 @@ public struct RawConstrainedSugarTypeSyntax: RawTypeSyntaxNodeProtocol {
       layout[3] = baseType.raw
       layout[4] = unexpectedAfterBaseType?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeSomeOrAnySpecifier: RawUnexpectedNodesSyntax? {
@@ -4548,7 +4780,11 @@ public struct RawContinueStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -4556,7 +4792,7 @@ public struct RawContinueStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -4576,7 +4812,7 @@ public struct RawContinueStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout[3] = label?.raw
       layout[4] = unexpectedAfterLabel?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeContinueKeyword: RawUnexpectedNodesSyntax? {
@@ -4614,7 +4850,11 @@ public struct RawConventionAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -4622,7 +4862,7 @@ public struct RawConventionAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -4654,7 +4894,7 @@ public struct RawConventionAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
       layout[9] = cTypeString?.raw
       layout[10] = unexpectedAfterCTypeString?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeConventionLabel: RawUnexpectedNodesSyntax? {
@@ -4716,7 +4956,11 @@ public struct RawConventionWitnessMethodAttributeArgumentsSyntax: RawSyntaxNodeP
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -4724,7 +4968,7 @@ public struct RawConventionWitnessMethodAttributeArgumentsSyntax: RawSyntaxNodeP
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -4748,7 +4992,7 @@ public struct RawConventionWitnessMethodAttributeArgumentsSyntax: RawSyntaxNodeP
       layout[5] = protocolName.raw
       layout[6] = unexpectedAfterProtocolName?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeWitnessMethodLabel: RawUnexpectedNodesSyntax? {
@@ -4794,7 +5038,11 @@ public struct RawDeclEffectSpecifiersSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -4802,7 +5050,7 @@ public struct RawDeclEffectSpecifiersSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -4822,7 +5070,7 @@ public struct RawDeclEffectSpecifiersSyntax: RawSyntaxNodeProtocol {
       layout[3] = throwsSpecifier?.raw
       layout[4] = unexpectedAfterThrowsSpecifier?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAsyncSpecifier: RawUnexpectedNodesSyntax? {
@@ -4860,7 +5108,11 @@ public struct RawDeclModifierDetailSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -4868,7 +5120,7 @@ public struct RawDeclModifierDetailSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -4892,7 +5144,7 @@ public struct RawDeclModifierDetailSyntax: RawSyntaxNodeProtocol {
       layout[5] = rightParen.raw
       layout[6] = unexpectedAfterRightParen?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax? {
@@ -4938,7 +5190,11 @@ public struct RawDeclModifierSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -4946,7 +5202,7 @@ public struct RawDeclModifierSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -4966,7 +5222,7 @@ public struct RawDeclModifierSyntax: RawSyntaxNodeProtocol {
       layout[3] = detail?.raw
       layout[4] = unexpectedAfterDetail?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeName: RawUnexpectedNodesSyntax? {
@@ -5004,7 +5260,11 @@ public struct RawDeclNameArgumentListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -5012,7 +5272,7 @@ public struct RawDeclNameArgumentListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawDeclNameArgumentSyntax], arena: __shared SyntaxArena) {
@@ -5026,7 +5286,7 @@ public struct RawDeclNameArgumentListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawDeclNameArgumentSyntax] {
@@ -5050,7 +5310,11 @@ public struct RawDeclNameArgumentSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -5058,7 +5322,7 @@ public struct RawDeclNameArgumentSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -5078,7 +5342,7 @@ public struct RawDeclNameArgumentSyntax: RawSyntaxNodeProtocol {
       layout[3] = colon.raw
       layout[4] = unexpectedAfterColon?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeName: RawUnexpectedNodesSyntax? {
@@ -5116,7 +5380,11 @@ public struct RawDeclNameArgumentsSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -5124,7 +5392,7 @@ public struct RawDeclNameArgumentsSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -5148,7 +5416,7 @@ public struct RawDeclNameArgumentsSyntax: RawSyntaxNodeProtocol {
       layout[5] = rightParen.raw
       layout[6] = unexpectedAfterRightParen?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax? {
@@ -5194,7 +5462,11 @@ public struct RawDeclNameSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -5202,7 +5474,7 @@ public struct RawDeclNameSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -5222,7 +5494,7 @@ public struct RawDeclNameSyntax: RawSyntaxNodeProtocol {
       layout[3] = declNameArguments?.raw
       layout[4] = unexpectedAfterDeclNameArguments?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeDeclBaseName: RawUnexpectedNodesSyntax? {
@@ -5265,7 +5537,11 @@ public struct RawDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -5273,11 +5549,11 @@ public struct RawDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init<Node: RawDeclSyntaxNodeProtocol>(_ other: Node) {
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
 }
 
@@ -5295,7 +5571,11 @@ public struct RawDeferStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -5303,7 +5583,7 @@ public struct RawDeferStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -5323,7 +5603,7 @@ public struct RawDeferStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout[3] = body.raw
       layout[4] = unexpectedAfterBody?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeDeferKeyword: RawUnexpectedNodesSyntax? {
@@ -5361,7 +5641,11 @@ public struct RawDeinitializerDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -5369,7 +5653,7 @@ public struct RawDeinitializerDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -5397,7 +5681,7 @@ public struct RawDeinitializerDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[7] = body?.raw
       layout[8] = unexpectedAfterBody?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -5451,7 +5735,11 @@ public struct RawDerivativeRegistrationAttributeArgumentsSyntax: RawSyntaxNodePr
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -5459,7 +5747,7 @@ public struct RawDerivativeRegistrationAttributeArgumentsSyntax: RawSyntaxNodePr
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -5499,7 +5787,7 @@ public struct RawDerivativeRegistrationAttributeArgumentsSyntax: RawSyntaxNodePr
       layout[13] = diffParams?.raw
       layout[14] = unexpectedAfterDiffParams?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeOfLabel: RawUnexpectedNodesSyntax? {
@@ -5577,7 +5865,11 @@ public struct RawDesignatedTypeElementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -5585,7 +5877,7 @@ public struct RawDesignatedTypeElementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -5605,7 +5897,7 @@ public struct RawDesignatedTypeElementSyntax: RawSyntaxNodeProtocol {
       layout[3] = name.raw
       layout[4] = unexpectedAfterName?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeadingComma: RawUnexpectedNodesSyntax? {
@@ -5643,7 +5935,11 @@ public struct RawDesignatedTypeListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -5651,7 +5947,7 @@ public struct RawDesignatedTypeListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawDesignatedTypeElementSyntax], arena: __shared SyntaxArena) {
@@ -5665,7 +5961,7 @@ public struct RawDesignatedTypeListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawDesignatedTypeElementSyntax] {
@@ -5689,7 +5985,11 @@ public struct RawDictionaryElementListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -5697,7 +5997,7 @@ public struct RawDictionaryElementListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawDictionaryElementSyntax], arena: __shared SyntaxArena) {
@@ -5711,7 +6011,7 @@ public struct RawDictionaryElementListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawDictionaryElementSyntax] {
@@ -5735,7 +6035,11 @@ public struct RawDictionaryElementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -5743,7 +6047,7 @@ public struct RawDictionaryElementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -5771,7 +6075,7 @@ public struct RawDictionaryElementSyntax: RawSyntaxNodeProtocol {
       layout[7] = trailingComma?.raw
       layout[8] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeKeyExpression: RawUnexpectedNodesSyntax? {
@@ -5856,7 +6160,11 @@ public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -5864,7 +6172,7 @@ public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -5888,7 +6196,7 @@ public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol {
       layout[5] = rightSquare.raw
       layout[6] = unexpectedAfterRightSquare?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftSquare: RawUnexpectedNodesSyntax? {
@@ -5934,7 +6242,11 @@ public struct RawDictionaryTypeSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -5942,7 +6254,7 @@ public struct RawDictionaryTypeSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -5974,7 +6286,7 @@ public struct RawDictionaryTypeSyntax: RawTypeSyntaxNodeProtocol {
       layout[9] = rightSquareBracket.raw
       layout[10] = unexpectedAfterRightSquareBracket?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftSquareBracket: RawUnexpectedNodesSyntax? {
@@ -6036,7 +6348,11 @@ public struct RawDifferentiabilityParamListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -6044,7 +6360,7 @@ public struct RawDifferentiabilityParamListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawDifferentiabilityParamSyntax], arena: __shared SyntaxArena) {
@@ -6058,7 +6374,7 @@ public struct RawDifferentiabilityParamListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawDifferentiabilityParamSyntax] {
@@ -6082,7 +6398,11 @@ public struct RawDifferentiabilityParamSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -6090,7 +6410,7 @@ public struct RawDifferentiabilityParamSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -6110,7 +6430,7 @@ public struct RawDifferentiabilityParamSyntax: RawSyntaxNodeProtocol {
       layout[3] = trailingComma?.raw
       layout[4] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeParameter: RawUnexpectedNodesSyntax? {
@@ -6179,7 +6499,11 @@ public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -6187,7 +6511,7 @@ public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -6211,7 +6535,7 @@ public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol {
       layout[5] = parameters.raw
       layout[6] = unexpectedAfterParameters?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeWrtLabel: RawUnexpectedNodesSyntax? {
@@ -6257,7 +6581,11 @@ public struct RawDifferentiabilityParamsSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -6265,7 +6593,7 @@ public struct RawDifferentiabilityParamsSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -6289,7 +6617,7 @@ public struct RawDifferentiabilityParamsSyntax: RawSyntaxNodeProtocol {
       layout[5] = rightParen.raw
       layout[6] = unexpectedAfterRightParen?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax? {
@@ -6335,7 +6663,11 @@ public struct RawDifferentiableAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -6343,7 +6675,7 @@ public struct RawDifferentiableAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -6375,7 +6707,7 @@ public struct RawDifferentiableAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
       layout[9] = whereClause?.raw
       layout[10] = unexpectedAfterWhereClause?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeDiffKind: RawUnexpectedNodesSyntax? {
@@ -6437,7 +6769,11 @@ public struct RawDiscardAssignmentExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -6445,7 +6781,7 @@ public struct RawDiscardAssignmentExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -6461,7 +6797,7 @@ public struct RawDiscardAssignmentExprSyntax: RawExprSyntaxNodeProtocol {
       layout[1] = wildcard.raw
       layout[2] = unexpectedAfterWildcard?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeWildcard: RawUnexpectedNodesSyntax? {
@@ -6491,7 +6827,11 @@ public struct RawDoStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -6499,7 +6839,7 @@ public struct RawDoStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -6523,7 +6863,7 @@ public struct RawDoStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout[5] = catchClauses?.raw
       layout[6] = unexpectedAfterCatchClauses?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeDoKeyword: RawUnexpectedNodesSyntax? {
@@ -6600,7 +6940,11 @@ public struct RawDocumentationAttributeArgumentSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -6608,7 +6952,7 @@ public struct RawDocumentationAttributeArgumentSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -6636,7 +6980,7 @@ public struct RawDocumentationAttributeArgumentSyntax: RawSyntaxNodeProtocol {
       layout[7] = trailingComma?.raw
       layout[8] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLabel: RawUnexpectedNodesSyntax? {
@@ -6690,7 +7034,11 @@ public struct RawDocumentationAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -6698,7 +7046,7 @@ public struct RawDocumentationAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawDocumentationAttributeArgumentSyntax], arena: __shared SyntaxArena) {
@@ -6712,7 +7060,7 @@ public struct RawDocumentationAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawDocumentationAttributeArgumentSyntax] {
@@ -6736,7 +7084,11 @@ public struct RawDynamicReplacementArgumentsSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -6744,7 +7096,7 @@ public struct RawDynamicReplacementArgumentsSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -6768,7 +7120,7 @@ public struct RawDynamicReplacementArgumentsSyntax: RawSyntaxNodeProtocol {
       layout[5] = declname.raw
       layout[6] = unexpectedAfterDeclname?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeForLabel: RawUnexpectedNodesSyntax? {
@@ -6814,7 +7166,11 @@ public struct RawEditorPlaceholderDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -6822,7 +7178,7 @@ public struct RawEditorPlaceholderDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -6838,7 +7194,7 @@ public struct RawEditorPlaceholderDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[1] = identifier.raw
       layout[2] = unexpectedAfterIdentifier?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeIdentifier: RawUnexpectedNodesSyntax? {
@@ -6868,7 +7224,11 @@ public struct RawEditorPlaceholderExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -6876,7 +7236,7 @@ public struct RawEditorPlaceholderExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -6892,7 +7252,7 @@ public struct RawEditorPlaceholderExprSyntax: RawExprSyntaxNodeProtocol {
       layout[1] = identifier.raw
       layout[2] = unexpectedAfterIdentifier?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeIdentifier: RawUnexpectedNodesSyntax? {
@@ -6922,7 +7282,11 @@ public struct RawEffectsArgumentsSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -6930,7 +7294,7 @@ public struct RawEffectsArgumentsSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawTokenSyntax], arena: __shared SyntaxArena) {
@@ -6944,7 +7308,7 @@ public struct RawEffectsArgumentsSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawTokenSyntax] {
@@ -6968,7 +7332,11 @@ public struct RawEnumCaseDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -6976,7 +7344,7 @@ public struct RawEnumCaseDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -7004,7 +7372,7 @@ public struct RawEnumCaseDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[7] = elements.raw
       layout[8] = unexpectedAfterElements?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -7058,7 +7426,11 @@ public struct RawEnumCaseElementListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -7066,7 +7438,7 @@ public struct RawEnumCaseElementListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawEnumCaseElementSyntax], arena: __shared SyntaxArena) {
@@ -7080,7 +7452,7 @@ public struct RawEnumCaseElementListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawEnumCaseElementSyntax] {
@@ -7104,7 +7476,11 @@ public struct RawEnumCaseElementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -7112,7 +7488,7 @@ public struct RawEnumCaseElementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -7140,7 +7516,7 @@ public struct RawEnumCaseElementSyntax: RawSyntaxNodeProtocol {
       layout[7] = trailingComma?.raw
       layout[8] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeIdentifier: RawUnexpectedNodesSyntax? {
@@ -7194,7 +7570,11 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -7202,7 +7582,7 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -7246,7 +7626,7 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[15] = members.raw
       layout[16] = unexpectedAfterMembers?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -7332,7 +7712,11 @@ public struct RawExposeAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -7340,7 +7724,7 @@ public struct RawExposeAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -7364,7 +7748,7 @@ public struct RawExposeAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
       layout[5] = cxxName?.raw
       layout[6] = unexpectedAfterCxxName?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLanguage: RawUnexpectedNodesSyntax? {
@@ -7410,7 +7794,11 @@ public struct RawExprListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -7418,7 +7806,7 @@ public struct RawExprListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawExprSyntax], arena: __shared SyntaxArena) {
@@ -7432,7 +7820,7 @@ public struct RawExprListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawExprSyntax] {
@@ -7461,7 +7849,11 @@ public struct RawExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -7469,11 +7861,11 @@ public struct RawExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init<Node: RawExprSyntaxNodeProtocol>(_ other: Node) {
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
 }
 
@@ -7491,7 +7883,11 @@ public struct RawExpressionPatternSyntax: RawPatternSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -7499,7 +7895,7 @@ public struct RawExpressionPatternSyntax: RawPatternSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -7515,7 +7911,7 @@ public struct RawExpressionPatternSyntax: RawPatternSyntaxNodeProtocol {
       layout[1] = expression.raw
       layout[2] = unexpectedAfterExpression?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeExpression: RawUnexpectedNodesSyntax? {
@@ -7545,7 +7941,11 @@ public struct RawExpressionSegmentSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -7553,7 +7953,7 @@ public struct RawExpressionSegmentSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -7585,7 +7985,7 @@ public struct RawExpressionSegmentSyntax: RawSyntaxNodeProtocol {
       layout[9] = rightParen.raw
       layout[10] = unexpectedAfterRightParen?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeBackslash: RawUnexpectedNodesSyntax? {
@@ -7647,7 +8047,11 @@ public struct RawExpressionStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -7655,7 +8059,7 @@ public struct RawExpressionStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -7671,7 +8075,7 @@ public struct RawExpressionStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout[1] = expression.raw
       layout[2] = unexpectedAfterExpression?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeExpression: RawUnexpectedNodesSyntax? {
@@ -7701,7 +8105,11 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -7709,7 +8117,7 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -7749,7 +8157,7 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[13] = members.raw
       layout[14] = unexpectedAfterMembers?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -7827,7 +8235,11 @@ public struct RawFallthroughStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -7835,7 +8247,7 @@ public struct RawFallthroughStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -7851,7 +8263,7 @@ public struct RawFallthroughStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout[1] = fallthroughKeyword.raw
       layout[2] = unexpectedAfterFallthroughKeyword?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeFallthroughKeyword: RawUnexpectedNodesSyntax? {
@@ -7881,7 +8293,11 @@ public struct RawFloatLiteralExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -7889,7 +8305,7 @@ public struct RawFloatLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -7905,7 +8321,7 @@ public struct RawFloatLiteralExprSyntax: RawExprSyntaxNodeProtocol {
       layout[1] = floatingDigits.raw
       layout[2] = unexpectedAfterFloatingDigits?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeFloatingDigits: RawUnexpectedNodesSyntax? {
@@ -7935,7 +8351,11 @@ public struct RawForInStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -7943,7 +8363,7 @@ public struct RawForInStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -7995,7 +8415,7 @@ public struct RawForInStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout[19] = body.raw
       layout[20] = unexpectedAfterBody?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeForKeyword: RawUnexpectedNodesSyntax? {
@@ -8097,7 +8517,11 @@ public struct RawForcedValueExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -8105,7 +8529,7 @@ public struct RawForcedValueExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -8125,7 +8549,7 @@ public struct RawForcedValueExprSyntax: RawExprSyntaxNodeProtocol {
       layout[3] = exclamationMark.raw
       layout[4] = unexpectedAfterExclamationMark?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeExpression: RawUnexpectedNodesSyntax? {
@@ -8163,7 +8587,11 @@ public struct RawForgetStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -8171,7 +8599,7 @@ public struct RawForgetStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -8191,7 +8619,7 @@ public struct RawForgetStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout[3] = expression.raw
       layout[4] = unexpectedAfterExpression?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeForgetKeyword: RawUnexpectedNodesSyntax? {
@@ -8229,7 +8657,11 @@ public struct RawFunctionCallExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -8237,7 +8669,7 @@ public struct RawFunctionCallExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -8273,7 +8705,7 @@ public struct RawFunctionCallExprSyntax: RawExprSyntaxNodeProtocol {
       layout[11] = additionalTrailingClosures?.raw
       layout[12] = unexpectedAfterAdditionalTrailingClosures?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeCalledExpression: RawUnexpectedNodesSyntax? {
@@ -8343,7 +8775,11 @@ public struct RawFunctionDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -8351,7 +8787,7 @@ public struct RawFunctionDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -8395,7 +8831,7 @@ public struct RawFunctionDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[15] = body?.raw
       layout[16] = unexpectedAfterBody?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -8481,7 +8917,11 @@ public struct RawFunctionParameterListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -8489,7 +8929,7 @@ public struct RawFunctionParameterListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawFunctionParameterSyntax], arena: __shared SyntaxArena) {
@@ -8503,7 +8943,7 @@ public struct RawFunctionParameterListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawFunctionParameterSyntax] {
@@ -8527,7 +8967,11 @@ public struct RawFunctionParameterSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -8535,7 +8979,7 @@ public struct RawFunctionParameterSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -8583,7 +9027,7 @@ public struct RawFunctionParameterSyntax: RawSyntaxNodeProtocol {
       layout[17] = trailingComma?.raw
       layout[18] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -8677,7 +9121,11 @@ public struct RawFunctionSignatureSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -8685,7 +9133,7 @@ public struct RawFunctionSignatureSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -8709,7 +9157,7 @@ public struct RawFunctionSignatureSyntax: RawSyntaxNodeProtocol {
       layout[5] = output?.raw
       layout[6] = unexpectedAfterOutput?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeInput: RawUnexpectedNodesSyntax? {
@@ -8755,7 +9203,11 @@ public struct RawFunctionTypeSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -8763,7 +9215,7 @@ public struct RawFunctionTypeSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -8795,7 +9247,7 @@ public struct RawFunctionTypeSyntax: RawTypeSyntaxNodeProtocol {
       layout[9] = output.raw
       layout[10] = unexpectedAfterOutput?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax? {
@@ -8857,7 +9309,11 @@ public struct RawGenericArgumentClauseSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -8865,7 +9321,7 @@ public struct RawGenericArgumentClauseSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -8889,7 +9345,7 @@ public struct RawGenericArgumentClauseSyntax: RawSyntaxNodeProtocol {
       layout[5] = rightAngleBracket.raw
       layout[6] = unexpectedAfterRightAngleBracket?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftAngleBracket: RawUnexpectedNodesSyntax? {
@@ -8935,7 +9391,11 @@ public struct RawGenericArgumentListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -8943,7 +9403,7 @@ public struct RawGenericArgumentListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawGenericArgumentSyntax], arena: __shared SyntaxArena) {
@@ -8957,7 +9417,7 @@ public struct RawGenericArgumentListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawGenericArgumentSyntax] {
@@ -8981,7 +9441,11 @@ public struct RawGenericArgumentSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -8989,7 +9453,7 @@ public struct RawGenericArgumentSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -9009,7 +9473,7 @@ public struct RawGenericArgumentSyntax: RawSyntaxNodeProtocol {
       layout[3] = trailingComma?.raw
       layout[4] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeArgumentType: RawUnexpectedNodesSyntax? {
@@ -9047,7 +9511,11 @@ public struct RawGenericParameterClauseSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -9055,7 +9523,7 @@ public struct RawGenericParameterClauseSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -9083,7 +9551,7 @@ public struct RawGenericParameterClauseSyntax: RawSyntaxNodeProtocol {
       layout[7] = rightAngleBracket.raw
       layout[8] = unexpectedAfterRightAngleBracket?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftAngleBracket: RawUnexpectedNodesSyntax? {
@@ -9137,7 +9605,11 @@ public struct RawGenericParameterListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -9145,7 +9617,7 @@ public struct RawGenericParameterListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawGenericParameterSyntax], arena: __shared SyntaxArena) {
@@ -9159,7 +9631,7 @@ public struct RawGenericParameterListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawGenericParameterSyntax] {
@@ -9183,7 +9655,11 @@ public struct RawGenericParameterSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -9191,7 +9667,7 @@ public struct RawGenericParameterSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -9227,7 +9703,7 @@ public struct RawGenericParameterSyntax: RawSyntaxNodeProtocol {
       layout[11] = trailingComma?.raw
       layout[12] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -9297,7 +9773,11 @@ public struct RawGenericRequirementListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -9305,7 +9785,7 @@ public struct RawGenericRequirementListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawGenericRequirementSyntax], arena: __shared SyntaxArena) {
@@ -9319,7 +9799,7 @@ public struct RawGenericRequirementListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawGenericRequirementSyntax] {
@@ -9381,7 +9861,11 @@ public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -9389,7 +9873,7 @@ public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -9409,7 +9893,7 @@ public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol {
       layout[3] = trailingComma?.raw
       layout[4] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeBody: RawUnexpectedNodesSyntax? {
@@ -9447,7 +9931,11 @@ public struct RawGenericWhereClauseSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -9455,7 +9943,7 @@ public struct RawGenericWhereClauseSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -9475,7 +9963,7 @@ public struct RawGenericWhereClauseSyntax: RawSyntaxNodeProtocol {
       layout[3] = requirementList.raw
       layout[4] = unexpectedAfterRequirementList?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeWhereKeyword: RawUnexpectedNodesSyntax? {
@@ -9513,7 +10001,11 @@ public struct RawGuardStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -9521,7 +10013,7 @@ public struct RawGuardStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -9549,7 +10041,7 @@ public struct RawGuardStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout[7] = body.raw
       layout[8] = unexpectedAfterBody?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeGuardKeyword: RawUnexpectedNodesSyntax? {
@@ -9603,7 +10095,11 @@ public struct RawIdentifierExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -9611,7 +10107,7 @@ public struct RawIdentifierExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -9631,7 +10127,7 @@ public struct RawIdentifierExprSyntax: RawExprSyntaxNodeProtocol {
       layout[3] = declNameArguments?.raw
       layout[4] = unexpectedAfterDeclNameArguments?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeIdentifier: RawUnexpectedNodesSyntax? {
@@ -9669,7 +10165,11 @@ public struct RawIdentifierPatternSyntax: RawPatternSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -9677,7 +10177,7 @@ public struct RawIdentifierPatternSyntax: RawPatternSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -9693,7 +10193,7 @@ public struct RawIdentifierPatternSyntax: RawPatternSyntaxNodeProtocol {
       layout[1] = identifier.raw
       layout[2] = unexpectedAfterIdentifier?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeIdentifier: RawUnexpectedNodesSyntax? {
@@ -9723,7 +10223,11 @@ public struct RawIfConfigClauseListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -9731,7 +10235,7 @@ public struct RawIfConfigClauseListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawIfConfigClauseSyntax], arena: __shared SyntaxArena) {
@@ -9745,7 +10249,7 @@ public struct RawIfConfigClauseListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawIfConfigClauseSyntax] {
@@ -9821,7 +10325,11 @@ public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -9829,7 +10337,7 @@ public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -9853,7 +10361,7 @@ public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol {
       layout[5] = elements?.raw
       layout[6] = unexpectedAfterElements?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforePoundKeyword: RawUnexpectedNodesSyntax? {
@@ -9899,7 +10407,11 @@ public struct RawIfConfigDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -9907,7 +10419,7 @@ public struct RawIfConfigDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -9927,7 +10439,7 @@ public struct RawIfConfigDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[3] = poundEndif.raw
       layout[4] = unexpectedAfterPoundEndif?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeClauses: RawUnexpectedNodesSyntax? {
@@ -9996,7 +10508,11 @@ public struct RawIfExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -10004,7 +10520,7 @@ public struct RawIfExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -10036,7 +10552,7 @@ public struct RawIfExprSyntax: RawExprSyntaxNodeProtocol {
       layout[9] = elseBody?.raw
       layout[10] = unexpectedAfterElseBody?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeIfKeyword: RawUnexpectedNodesSyntax? {
@@ -10098,7 +10614,11 @@ public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -10106,7 +10626,7 @@ public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -10134,7 +10654,7 @@ public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
       layout[7] = declNameArguments?.raw
       layout[8] = unexpectedAfterDeclNameArguments?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeType: RawUnexpectedNodesSyntax? {
@@ -10188,7 +10708,11 @@ public struct RawImplicitlyUnwrappedOptionalTypeSyntax: RawTypeSyntaxNodeProtoco
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -10196,7 +10720,7 @@ public struct RawImplicitlyUnwrappedOptionalTypeSyntax: RawTypeSyntaxNodeProtoco
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -10216,7 +10740,7 @@ public struct RawImplicitlyUnwrappedOptionalTypeSyntax: RawTypeSyntaxNodeProtoco
       layout[3] = exclamationMark.raw
       layout[4] = unexpectedAfterExclamationMark?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeWrappedType: RawUnexpectedNodesSyntax? {
@@ -10254,7 +10778,11 @@ public struct RawImportDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -10262,7 +10790,7 @@ public struct RawImportDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -10294,7 +10822,7 @@ public struct RawImportDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[9] = path.raw
       layout[10] = unexpectedAfterPath?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -10356,7 +10884,11 @@ public struct RawInOutExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -10364,7 +10896,7 @@ public struct RawInOutExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -10384,7 +10916,7 @@ public struct RawInOutExprSyntax: RawExprSyntaxNodeProtocol {
       layout[3] = expression.raw
       layout[4] = unexpectedAfterExpression?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAmpersand: RawUnexpectedNodesSyntax? {
@@ -10422,7 +10954,11 @@ public struct RawInfixOperatorExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -10430,7 +10966,7 @@ public struct RawInfixOperatorExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -10454,7 +10990,7 @@ public struct RawInfixOperatorExprSyntax: RawExprSyntaxNodeProtocol {
       layout[5] = rightOperand.raw
       layout[6] = unexpectedAfterRightOperand?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftOperand: RawUnexpectedNodesSyntax? {
@@ -10500,7 +11036,11 @@ public struct RawInheritedTypeListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -10508,7 +11048,7 @@ public struct RawInheritedTypeListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawInheritedTypeSyntax], arena: __shared SyntaxArena) {
@@ -10522,7 +11062,7 @@ public struct RawInheritedTypeListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawInheritedTypeSyntax] {
@@ -10546,7 +11086,11 @@ public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -10554,7 +11098,7 @@ public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -10574,7 +11118,7 @@ public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol {
       layout[3] = trailingComma?.raw
       layout[4] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeTypeName: RawUnexpectedNodesSyntax? {
@@ -10612,7 +11156,11 @@ public struct RawInitializerClauseSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -10620,7 +11168,7 @@ public struct RawInitializerClauseSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -10640,7 +11188,7 @@ public struct RawInitializerClauseSyntax: RawSyntaxNodeProtocol {
       layout[3] = value.raw
       layout[4] = unexpectedAfterValue?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeEqual: RawUnexpectedNodesSyntax? {
@@ -10678,7 +11226,11 @@ public struct RawInitializerDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -10686,7 +11238,7 @@ public struct RawInitializerDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -10730,7 +11282,7 @@ public struct RawInitializerDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[15] = body?.raw
       layout[16] = unexpectedAfterBody?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -10816,7 +11368,11 @@ public struct RawIntegerLiteralExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -10824,7 +11380,7 @@ public struct RawIntegerLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -10840,7 +11396,7 @@ public struct RawIntegerLiteralExprSyntax: RawExprSyntaxNodeProtocol {
       layout[1] = digits.raw
       layout[2] = unexpectedAfterDigits?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeDigits: RawUnexpectedNodesSyntax? {
@@ -10870,7 +11426,11 @@ public struct RawIsExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -10878,7 +11438,7 @@ public struct RawIsExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -10902,7 +11462,7 @@ public struct RawIsExprSyntax: RawExprSyntaxNodeProtocol {
       layout[5] = typeName.raw
       layout[6] = unexpectedAfterTypeName?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeExpression: RawUnexpectedNodesSyntax? {
@@ -10948,7 +11508,11 @@ public struct RawIsTypePatternSyntax: RawPatternSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -10956,7 +11520,7 @@ public struct RawIsTypePatternSyntax: RawPatternSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -10976,7 +11540,7 @@ public struct RawIsTypePatternSyntax: RawPatternSyntaxNodeProtocol {
       layout[3] = type.raw
       layout[4] = unexpectedAfterType?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeIsKeyword: RawUnexpectedNodesSyntax? {
@@ -11014,7 +11578,11 @@ public struct RawKeyPathComponentListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -11022,7 +11590,7 @@ public struct RawKeyPathComponentListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawKeyPathComponentSyntax], arena: __shared SyntaxArena) {
@@ -11036,7 +11604,7 @@ public struct RawKeyPathComponentListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawKeyPathComponentSyntax] {
@@ -11098,7 +11666,11 @@ public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -11106,7 +11678,7 @@ public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -11126,7 +11698,7 @@ public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol {
       layout[3] = component.raw
       layout[4] = unexpectedAfterComponent?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforePeriod: RawUnexpectedNodesSyntax? {
@@ -11164,7 +11736,11 @@ public struct RawKeyPathExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -11172,7 +11748,7 @@ public struct RawKeyPathExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -11196,7 +11772,7 @@ public struct RawKeyPathExprSyntax: RawExprSyntaxNodeProtocol {
       layout[5] = components.raw
       layout[6] = unexpectedAfterComponents?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeBackslash: RawUnexpectedNodesSyntax? {
@@ -11242,7 +11818,11 @@ public struct RawKeyPathOptionalComponentSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -11250,7 +11830,7 @@ public struct RawKeyPathOptionalComponentSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -11266,7 +11846,7 @@ public struct RawKeyPathOptionalComponentSyntax: RawSyntaxNodeProtocol {
       layout[1] = questionOrExclamationMark.raw
       layout[2] = unexpectedAfterQuestionOrExclamationMark?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeQuestionOrExclamationMark: RawUnexpectedNodesSyntax? {
@@ -11296,7 +11876,11 @@ public struct RawKeyPathPropertyComponentSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -11304,7 +11888,7 @@ public struct RawKeyPathPropertyComponentSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -11328,7 +11912,7 @@ public struct RawKeyPathPropertyComponentSyntax: RawSyntaxNodeProtocol {
       layout[5] = genericArgumentClause?.raw
       layout[6] = unexpectedAfterGenericArgumentClause?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeIdentifier: RawUnexpectedNodesSyntax? {
@@ -11374,7 +11958,11 @@ public struct RawKeyPathSubscriptComponentSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -11382,7 +11970,7 @@ public struct RawKeyPathSubscriptComponentSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -11406,7 +11994,7 @@ public struct RawKeyPathSubscriptComponentSyntax: RawSyntaxNodeProtocol {
       layout[5] = rightBracket.raw
       layout[6] = unexpectedAfterRightBracket?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftBracket: RawUnexpectedNodesSyntax? {
@@ -11452,7 +12040,11 @@ public struct RawLabeledSpecializeEntrySyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -11460,7 +12052,7 @@ public struct RawLabeledSpecializeEntrySyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -11488,7 +12080,7 @@ public struct RawLabeledSpecializeEntrySyntax: RawSyntaxNodeProtocol {
       layout[7] = trailingComma?.raw
       layout[8] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLabel: RawUnexpectedNodesSyntax? {
@@ -11542,7 +12134,11 @@ public struct RawLabeledStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -11550,7 +12146,7 @@ public struct RawLabeledStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -11574,7 +12170,7 @@ public struct RawLabeledStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout[5] = statement.raw
       layout[6] = unexpectedAfterStatement?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLabelName: RawUnexpectedNodesSyntax? {
@@ -11620,7 +12216,11 @@ public struct RawLayoutRequirementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -11628,7 +12228,7 @@ public struct RawLayoutRequirementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -11672,7 +12272,7 @@ public struct RawLayoutRequirementSyntax: RawSyntaxNodeProtocol {
       layout[15] = rightParen?.raw
       layout[16] = unexpectedAfterRightParen?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeTypeIdentifier: RawUnexpectedNodesSyntax? {
@@ -11789,7 +12389,11 @@ public struct RawMacroDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -11797,7 +12401,7 @@ public struct RawMacroDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -11841,7 +12445,7 @@ public struct RawMacroDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[15] = genericWhereClause?.raw
       layout[16] = unexpectedAfterGenericWhereClause?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -11927,7 +12531,11 @@ public struct RawMacroExpansionDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -11935,7 +12543,7 @@ public struct RawMacroExpansionDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -11979,7 +12587,7 @@ public struct RawMacroExpansionDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[15] = additionalTrailingClosures?.raw
       layout[16] = unexpectedAfterAdditionalTrailingClosures?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforePoundToken: RawUnexpectedNodesSyntax? {
@@ -12065,7 +12673,11 @@ public struct RawMacroExpansionExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -12073,7 +12685,7 @@ public struct RawMacroExpansionExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -12117,7 +12729,7 @@ public struct RawMacroExpansionExprSyntax: RawExprSyntaxNodeProtocol {
       layout[15] = additionalTrailingClosures?.raw
       layout[16] = unexpectedAfterAdditionalTrailingClosures?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforePoundToken: RawUnexpectedNodesSyntax? {
@@ -12203,7 +12815,11 @@ public struct RawMatchingPatternConditionSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -12211,7 +12827,7 @@ public struct RawMatchingPatternConditionSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -12239,7 +12855,7 @@ public struct RawMatchingPatternConditionSyntax: RawSyntaxNodeProtocol {
       layout[7] = initializer.raw
       layout[8] = unexpectedAfterInitializer?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeCaseKeyword: RawUnexpectedNodesSyntax? {
@@ -12293,7 +12909,11 @@ public struct RawMemberAccessExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -12301,7 +12921,7 @@ public struct RawMemberAccessExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -12329,7 +12949,7 @@ public struct RawMemberAccessExprSyntax: RawExprSyntaxNodeProtocol {
       layout[7] = declNameArguments?.raw
       layout[8] = unexpectedAfterDeclNameArguments?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeBase: RawUnexpectedNodesSyntax? {
@@ -12383,7 +13003,11 @@ public struct RawMemberDeclBlockSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -12391,7 +13015,7 @@ public struct RawMemberDeclBlockSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -12415,7 +13039,7 @@ public struct RawMemberDeclBlockSyntax: RawSyntaxNodeProtocol {
       layout[5] = rightBrace.raw
       layout[6] = unexpectedAfterRightBrace?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftBrace: RawUnexpectedNodesSyntax? {
@@ -12461,7 +13085,11 @@ public struct RawMemberDeclListItemSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -12469,7 +13097,7 @@ public struct RawMemberDeclListItemSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -12489,7 +13117,7 @@ public struct RawMemberDeclListItemSyntax: RawSyntaxNodeProtocol {
       layout[3] = semicolon?.raw
       layout[4] = unexpectedAfterSemicolon?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeDecl: RawUnexpectedNodesSyntax? {
@@ -12527,7 +13155,11 @@ public struct RawMemberDeclListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -12535,7 +13167,7 @@ public struct RawMemberDeclListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawMemberDeclListItemSyntax], arena: __shared SyntaxArena) {
@@ -12549,7 +13181,7 @@ public struct RawMemberDeclListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawMemberDeclListItemSyntax] {
@@ -12573,7 +13205,11 @@ public struct RawMemberTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -12581,7 +13217,7 @@ public struct RawMemberTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -12609,7 +13245,7 @@ public struct RawMemberTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol {
       layout[7] = genericArgumentClause?.raw
       layout[8] = unexpectedAfterGenericArgumentClause?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeBaseType: RawUnexpectedNodesSyntax? {
@@ -12663,7 +13299,11 @@ public struct RawMetatypeTypeSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -12671,7 +13311,7 @@ public struct RawMetatypeTypeSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -12695,7 +13335,7 @@ public struct RawMetatypeTypeSyntax: RawTypeSyntaxNodeProtocol {
       layout[5] = typeOrProtocol.raw
       layout[6] = unexpectedAfterTypeOrProtocol?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeBaseType: RawUnexpectedNodesSyntax? {
@@ -12741,7 +13381,11 @@ public struct RawMissingDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -12749,7 +13393,7 @@ public struct RawMissingDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -12769,7 +13413,7 @@ public struct RawMissingDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[3] = modifiers?.raw
       layout[4] = unexpectedAfterModifiers?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -12807,7 +13451,11 @@ public struct RawMissingExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -12815,7 +13463,7 @@ public struct RawMissingExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(_ unexpected: RawUnexpectedNodesSyntax? = nil, arena: __shared SyntaxArena) {
@@ -12824,7 +13472,7 @@ public struct RawMissingExprSyntax: RawExprSyntaxNodeProtocol {
       layout.initialize(repeating: nil)
       layout[0] = unexpected?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpected: RawUnexpectedNodesSyntax? {
@@ -12846,7 +13494,11 @@ public struct RawMissingPatternSyntax: RawPatternSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -12854,7 +13506,7 @@ public struct RawMissingPatternSyntax: RawPatternSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(_ unexpected: RawUnexpectedNodesSyntax? = nil, arena: __shared SyntaxArena) {
@@ -12863,7 +13515,7 @@ public struct RawMissingPatternSyntax: RawPatternSyntaxNodeProtocol {
       layout.initialize(repeating: nil)
       layout[0] = unexpected?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpected: RawUnexpectedNodesSyntax? {
@@ -12885,7 +13537,11 @@ public struct RawMissingStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -12893,7 +13549,7 @@ public struct RawMissingStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(_ unexpected: RawUnexpectedNodesSyntax? = nil, arena: __shared SyntaxArena) {
@@ -12902,7 +13558,7 @@ public struct RawMissingStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout.initialize(repeating: nil)
       layout[0] = unexpected?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpected: RawUnexpectedNodesSyntax? {
@@ -12924,7 +13580,11 @@ public struct RawMissingSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -12932,7 +13592,7 @@ public struct RawMissingSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(_ unexpected: RawUnexpectedNodesSyntax? = nil, arena: __shared SyntaxArena) {
@@ -12941,7 +13601,7 @@ public struct RawMissingSyntax: RawSyntaxNodeProtocol {
       layout.initialize(repeating: nil)
       layout[0] = unexpected?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpected: RawUnexpectedNodesSyntax? {
@@ -12963,7 +13623,11 @@ public struct RawMissingTypeSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -12971,7 +13635,7 @@ public struct RawMissingTypeSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(_ unexpected: RawUnexpectedNodesSyntax? = nil, arena: __shared SyntaxArena) {
@@ -12980,7 +13644,7 @@ public struct RawMissingTypeSyntax: RawTypeSyntaxNodeProtocol {
       layout.initialize(repeating: nil)
       layout[0] = unexpected?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpected: RawUnexpectedNodesSyntax? {
@@ -13002,7 +13666,11 @@ public struct RawModifierListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -13010,7 +13678,7 @@ public struct RawModifierListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawDeclModifierSyntax], arena: __shared SyntaxArena) {
@@ -13024,7 +13692,7 @@ public struct RawModifierListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawDeclModifierSyntax] {
@@ -13048,7 +13716,11 @@ public struct RawMoveExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -13056,7 +13728,7 @@ public struct RawMoveExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -13076,7 +13748,7 @@ public struct RawMoveExprSyntax: RawExprSyntaxNodeProtocol {
       layout[3] = expression.raw
       layout[4] = unexpectedAfterExpression?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeMoveKeyword: RawUnexpectedNodesSyntax? {
@@ -13114,7 +13786,11 @@ public struct RawMultipleTrailingClosureElementListSyntax: RawSyntaxNodeProtocol
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -13122,7 +13798,7 @@ public struct RawMultipleTrailingClosureElementListSyntax: RawSyntaxNodeProtocol
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawMultipleTrailingClosureElementSyntax], arena: __shared SyntaxArena) {
@@ -13136,7 +13812,7 @@ public struct RawMultipleTrailingClosureElementListSyntax: RawSyntaxNodeProtocol
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawMultipleTrailingClosureElementSyntax] {
@@ -13160,7 +13836,11 @@ public struct RawMultipleTrailingClosureElementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -13168,7 +13848,7 @@ public struct RawMultipleTrailingClosureElementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -13192,7 +13872,7 @@ public struct RawMultipleTrailingClosureElementSyntax: RawSyntaxNodeProtocol {
       layout[5] = closure.raw
       layout[6] = unexpectedAfterClosure?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLabel: RawUnexpectedNodesSyntax? {
@@ -13238,7 +13918,11 @@ public struct RawNamedOpaqueReturnTypeSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -13246,7 +13930,7 @@ public struct RawNamedOpaqueReturnTypeSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -13266,7 +13950,7 @@ public struct RawNamedOpaqueReturnTypeSyntax: RawTypeSyntaxNodeProtocol {
       layout[3] = baseType.raw
       layout[4] = unexpectedAfterBaseType?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeGenericParameters: RawUnexpectedNodesSyntax? {
@@ -13304,7 +13988,11 @@ public struct RawNilLiteralExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -13312,7 +14000,7 @@ public struct RawNilLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -13328,7 +14016,7 @@ public struct RawNilLiteralExprSyntax: RawExprSyntaxNodeProtocol {
       layout[1] = nilKeyword.raw
       layout[2] = unexpectedAfterNilKeyword?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeNilKeyword: RawUnexpectedNodesSyntax? {
@@ -13358,7 +14046,11 @@ public struct RawObjCSelectorPieceSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -13366,7 +14058,7 @@ public struct RawObjCSelectorPieceSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -13386,7 +14078,7 @@ public struct RawObjCSelectorPieceSyntax: RawSyntaxNodeProtocol {
       layout[3] = colon?.raw
       layout[4] = unexpectedAfterColon?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeName: RawUnexpectedNodesSyntax? {
@@ -13424,7 +14116,11 @@ public struct RawObjCSelectorSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -13432,7 +14128,7 @@ public struct RawObjCSelectorSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawObjCSelectorPieceSyntax], arena: __shared SyntaxArena) {
@@ -13446,7 +14142,7 @@ public struct RawObjCSelectorSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawObjCSelectorPieceSyntax] {
@@ -13470,7 +14166,11 @@ public struct RawOpaqueReturnTypeOfAttributeArgumentsSyntax: RawSyntaxNodeProtoc
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -13478,7 +14178,7 @@ public struct RawOpaqueReturnTypeOfAttributeArgumentsSyntax: RawSyntaxNodeProtoc
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -13502,7 +14202,7 @@ public struct RawOpaqueReturnTypeOfAttributeArgumentsSyntax: RawSyntaxNodeProtoc
       layout[5] = ordinal.raw
       layout[6] = unexpectedAfterOrdinal?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeMangledName: RawUnexpectedNodesSyntax? {
@@ -13548,7 +14248,11 @@ public struct RawOperatorDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -13556,7 +14260,7 @@ public struct RawOperatorDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -13588,7 +14292,7 @@ public struct RawOperatorDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[9] = operatorPrecedenceAndTypes?.raw
       layout[10] = unexpectedAfterOperatorPrecedenceAndTypes?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -13650,7 +14354,11 @@ public struct RawOperatorPrecedenceAndTypesSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -13658,7 +14366,7 @@ public struct RawOperatorPrecedenceAndTypesSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -13682,7 +14390,7 @@ public struct RawOperatorPrecedenceAndTypesSyntax: RawSyntaxNodeProtocol {
       layout[5] = designatedTypes.raw
       layout[6] = unexpectedAfterDesignatedTypes?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeColon: RawUnexpectedNodesSyntax? {
@@ -13728,7 +14436,11 @@ public struct RawOptionalBindingConditionSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -13736,7 +14448,7 @@ public struct RawOptionalBindingConditionSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -13764,7 +14476,7 @@ public struct RawOptionalBindingConditionSyntax: RawSyntaxNodeProtocol {
       layout[7] = initializer?.raw
       layout[8] = unexpectedAfterInitializer?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeBindingKeyword: RawUnexpectedNodesSyntax? {
@@ -13818,7 +14530,11 @@ public struct RawOptionalChainingExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -13826,7 +14542,7 @@ public struct RawOptionalChainingExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -13846,7 +14562,7 @@ public struct RawOptionalChainingExprSyntax: RawExprSyntaxNodeProtocol {
       layout[3] = questionMark.raw
       layout[4] = unexpectedAfterQuestionMark?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeExpression: RawUnexpectedNodesSyntax? {
@@ -13884,7 +14600,11 @@ public struct RawOptionalTypeSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -13892,7 +14612,7 @@ public struct RawOptionalTypeSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -13912,7 +14632,7 @@ public struct RawOptionalTypeSyntax: RawTypeSyntaxNodeProtocol {
       layout[3] = questionMark.raw
       layout[4] = unexpectedAfterQuestionMark?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeWrappedType: RawUnexpectedNodesSyntax? {
@@ -13950,7 +14670,11 @@ public struct RawOriginallyDefinedInArgumentsSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -13958,7 +14682,7 @@ public struct RawOriginallyDefinedInArgumentsSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -13990,7 +14714,7 @@ public struct RawOriginallyDefinedInArgumentsSyntax: RawSyntaxNodeProtocol {
       layout[9] = platforms.raw
       layout[10] = unexpectedAfterPlatforms?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeModuleLabel: RawUnexpectedNodesSyntax? {
@@ -14052,7 +14776,11 @@ public struct RawPackElementExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -14060,7 +14788,7 @@ public struct RawPackElementExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -14080,7 +14808,7 @@ public struct RawPackElementExprSyntax: RawExprSyntaxNodeProtocol {
       layout[3] = packRefExpr.raw
       layout[4] = unexpectedAfterPackRefExpr?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeEachKeyword: RawUnexpectedNodesSyntax? {
@@ -14118,7 +14846,11 @@ public struct RawPackExpansionExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -14126,7 +14858,7 @@ public struct RawPackExpansionExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -14146,7 +14878,7 @@ public struct RawPackExpansionExprSyntax: RawExprSyntaxNodeProtocol {
       layout[3] = patternExpr.raw
       layout[4] = unexpectedAfterPatternExpr?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeRepeatKeyword: RawUnexpectedNodesSyntax? {
@@ -14184,7 +14916,11 @@ public struct RawPackExpansionTypeSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -14192,7 +14928,7 @@ public struct RawPackExpansionTypeSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -14212,7 +14948,7 @@ public struct RawPackExpansionTypeSyntax: RawTypeSyntaxNodeProtocol {
       layout[3] = patternType.raw
       layout[4] = unexpectedAfterPatternType?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeRepeatKeyword: RawUnexpectedNodesSyntax? {
@@ -14250,7 +14986,11 @@ public struct RawPackReferenceTypeSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -14258,7 +14998,7 @@ public struct RawPackReferenceTypeSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -14278,7 +15018,7 @@ public struct RawPackReferenceTypeSyntax: RawTypeSyntaxNodeProtocol {
       layout[3] = packType.raw
       layout[4] = unexpectedAfterPackType?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeEachKeyword: RawUnexpectedNodesSyntax? {
@@ -14316,7 +15056,11 @@ public struct RawParameterClauseSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -14324,7 +15068,7 @@ public struct RawParameterClauseSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -14348,7 +15092,7 @@ public struct RawParameterClauseSyntax: RawSyntaxNodeProtocol {
       layout[5] = rightParen.raw
       layout[6] = unexpectedAfterRightParen?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax? {
@@ -14394,7 +15138,11 @@ public struct RawPatternBindingListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -14402,7 +15150,7 @@ public struct RawPatternBindingListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawPatternBindingSyntax], arena: __shared SyntaxArena) {
@@ -14416,7 +15164,7 @@ public struct RawPatternBindingListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawPatternBindingSyntax] {
@@ -14471,7 +15219,11 @@ public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -14479,7 +15231,7 @@ public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -14511,7 +15263,7 @@ public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol {
       layout[9] = trailingComma?.raw
       layout[10] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforePattern: RawUnexpectedNodesSyntax? {
@@ -14578,7 +15330,11 @@ public struct RawPatternSyntax: RawPatternSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -14586,11 +15342,11 @@ public struct RawPatternSyntax: RawPatternSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init<Node: RawPatternSyntaxNodeProtocol>(_ other: Node) {
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
 }
 
@@ -14608,7 +15364,11 @@ public struct RawPostfixIfConfigExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -14616,7 +15376,7 @@ public struct RawPostfixIfConfigExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -14636,7 +15396,7 @@ public struct RawPostfixIfConfigExprSyntax: RawExprSyntaxNodeProtocol {
       layout[3] = config.raw
       layout[4] = unexpectedAfterConfig?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeBase: RawUnexpectedNodesSyntax? {
@@ -14674,7 +15434,11 @@ public struct RawPostfixUnaryExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -14682,7 +15446,7 @@ public struct RawPostfixUnaryExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -14702,7 +15466,7 @@ public struct RawPostfixUnaryExprSyntax: RawExprSyntaxNodeProtocol {
       layout[3] = operatorToken.raw
       layout[4] = unexpectedAfterOperatorToken?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeExpression: RawUnexpectedNodesSyntax? {
@@ -14740,7 +15504,11 @@ public struct RawPoundSourceLocationArgsSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -14748,7 +15516,7 @@ public struct RawPoundSourceLocationArgsSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -14788,7 +15556,7 @@ public struct RawPoundSourceLocationArgsSyntax: RawSyntaxNodeProtocol {
       layout[13] = lineNumber.raw
       layout[14] = unexpectedAfterLineNumber?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeFileArgLabel: RawUnexpectedNodesSyntax? {
@@ -14866,7 +15634,11 @@ public struct RawPoundSourceLocationSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -14874,7 +15646,7 @@ public struct RawPoundSourceLocationSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -14902,7 +15674,7 @@ public struct RawPoundSourceLocationSyntax: RawDeclSyntaxNodeProtocol {
       layout[7] = rightParen.raw
       layout[8] = unexpectedAfterRightParen?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforePoundSourceLocation: RawUnexpectedNodesSyntax? {
@@ -14956,7 +15728,11 @@ public struct RawPrecedenceGroupAssignmentSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -14964,7 +15740,7 @@ public struct RawPrecedenceGroupAssignmentSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -14988,7 +15764,7 @@ public struct RawPrecedenceGroupAssignmentSyntax: RawSyntaxNodeProtocol {
       layout[5] = flag.raw
       layout[6] = unexpectedAfterFlag?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAssignmentKeyword: RawUnexpectedNodesSyntax? {
@@ -15034,7 +15810,11 @@ public struct RawPrecedenceGroupAssociativitySyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -15042,7 +15822,7 @@ public struct RawPrecedenceGroupAssociativitySyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -15066,7 +15846,7 @@ public struct RawPrecedenceGroupAssociativitySyntax: RawSyntaxNodeProtocol {
       layout[5] = value.raw
       layout[6] = unexpectedAfterValue?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAssociativityKeyword: RawUnexpectedNodesSyntax? {
@@ -15150,7 +15930,11 @@ public struct RawPrecedenceGroupAttributeListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -15158,7 +15942,7 @@ public struct RawPrecedenceGroupAttributeListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [Element], arena: __shared SyntaxArena) {
@@ -15172,7 +15956,7 @@ public struct RawPrecedenceGroupAttributeListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawSyntax] {
@@ -15196,7 +15980,11 @@ public struct RawPrecedenceGroupDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -15204,7 +15992,7 @@ public struct RawPrecedenceGroupDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -15244,7 +16032,7 @@ public struct RawPrecedenceGroupDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[13] = rightBrace.raw
       layout[14] = unexpectedAfterRightBrace?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -15322,7 +16110,11 @@ public struct RawPrecedenceGroupNameElementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -15330,7 +16122,7 @@ public struct RawPrecedenceGroupNameElementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -15350,7 +16142,7 @@ public struct RawPrecedenceGroupNameElementSyntax: RawSyntaxNodeProtocol {
       layout[3] = trailingComma?.raw
       layout[4] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeName: RawUnexpectedNodesSyntax? {
@@ -15388,7 +16180,11 @@ public struct RawPrecedenceGroupNameListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -15396,7 +16192,7 @@ public struct RawPrecedenceGroupNameListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawPrecedenceGroupNameElementSyntax], arena: __shared SyntaxArena) {
@@ -15410,7 +16206,7 @@ public struct RawPrecedenceGroupNameListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawPrecedenceGroupNameElementSyntax] {
@@ -15434,7 +16230,11 @@ public struct RawPrecedenceGroupRelationSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -15442,7 +16242,7 @@ public struct RawPrecedenceGroupRelationSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -15466,7 +16266,7 @@ public struct RawPrecedenceGroupRelationSyntax: RawSyntaxNodeProtocol {
       layout[5] = otherNames.raw
       layout[6] = unexpectedAfterOtherNames?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeHigherThanOrLowerThan: RawUnexpectedNodesSyntax? {
@@ -15512,7 +16312,11 @@ public struct RawPrefixOperatorExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -15520,7 +16324,7 @@ public struct RawPrefixOperatorExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -15540,7 +16344,7 @@ public struct RawPrefixOperatorExprSyntax: RawExprSyntaxNodeProtocol {
       layout[3] = postfixExpression.raw
       layout[4] = unexpectedAfterPostfixExpression?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeOperatorToken: RawUnexpectedNodesSyntax? {
@@ -15578,7 +16382,11 @@ public struct RawPrimaryAssociatedTypeClauseSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -15586,7 +16394,7 @@ public struct RawPrimaryAssociatedTypeClauseSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -15610,7 +16418,7 @@ public struct RawPrimaryAssociatedTypeClauseSyntax: RawSyntaxNodeProtocol {
       layout[5] = rightAngleBracket.raw
       layout[6] = unexpectedAfterRightAngleBracket?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftAngleBracket: RawUnexpectedNodesSyntax? {
@@ -15656,7 +16464,11 @@ public struct RawPrimaryAssociatedTypeListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -15664,7 +16476,7 @@ public struct RawPrimaryAssociatedTypeListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawPrimaryAssociatedTypeSyntax], arena: __shared SyntaxArena) {
@@ -15678,7 +16490,7 @@ public struct RawPrimaryAssociatedTypeListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawPrimaryAssociatedTypeSyntax] {
@@ -15702,7 +16514,11 @@ public struct RawPrimaryAssociatedTypeSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -15710,7 +16526,7 @@ public struct RawPrimaryAssociatedTypeSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -15730,7 +16546,7 @@ public struct RawPrimaryAssociatedTypeSyntax: RawSyntaxNodeProtocol {
       layout[3] = trailingComma?.raw
       layout[4] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeName: RawUnexpectedNodesSyntax? {
@@ -15768,7 +16584,11 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -15776,7 +16596,7 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -15820,7 +16640,7 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[15] = members.raw
       layout[16] = unexpectedAfterMembers?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -15906,7 +16726,11 @@ public struct RawQualifiedDeclNameSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -15914,7 +16738,7 @@ public struct RawQualifiedDeclNameSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -15942,7 +16766,7 @@ public struct RawQualifiedDeclNameSyntax: RawSyntaxNodeProtocol {
       layout[7] = arguments?.raw
       layout[8] = unexpectedAfterArguments?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeBaseType: RawUnexpectedNodesSyntax? {
@@ -15996,7 +16820,11 @@ public struct RawRegexLiteralExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -16004,7 +16832,7 @@ public struct RawRegexLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -16020,7 +16848,7 @@ public struct RawRegexLiteralExprSyntax: RawExprSyntaxNodeProtocol {
       layout[1] = regex.raw
       layout[2] = unexpectedAfterRegex?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeRegex: RawUnexpectedNodesSyntax? {
@@ -16050,7 +16878,11 @@ public struct RawRepeatWhileStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -16058,7 +16890,7 @@ public struct RawRepeatWhileStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -16086,7 +16918,7 @@ public struct RawRepeatWhileStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout[7] = condition.raw
       layout[8] = unexpectedAfterCondition?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeRepeatKeyword: RawUnexpectedNodesSyntax? {
@@ -16140,7 +16972,11 @@ public struct RawReturnClauseSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -16148,7 +16984,7 @@ public struct RawReturnClauseSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -16168,7 +17004,7 @@ public struct RawReturnClauseSyntax: RawSyntaxNodeProtocol {
       layout[3] = returnType.raw
       layout[4] = unexpectedAfterReturnType?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeArrow: RawUnexpectedNodesSyntax? {
@@ -16206,7 +17042,11 @@ public struct RawReturnStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -16214,7 +17054,7 @@ public struct RawReturnStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -16234,7 +17074,7 @@ public struct RawReturnStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout[3] = expression?.raw
       layout[4] = unexpectedAfterExpression?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeReturnKeyword: RawUnexpectedNodesSyntax? {
@@ -16272,7 +17112,11 @@ public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -16280,7 +17124,7 @@ public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -16304,7 +17148,7 @@ public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol {
       layout[5] = rightTypeIdentifier.raw
       layout[6] = unexpectedAfterRightTypeIdentifier?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftTypeIdentifier: RawUnexpectedNodesSyntax? {
@@ -16350,7 +17194,11 @@ public struct RawSequenceExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -16358,7 +17206,7 @@ public struct RawSequenceExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -16374,7 +17222,7 @@ public struct RawSequenceExprSyntax: RawExprSyntaxNodeProtocol {
       layout[1] = elements.raw
       layout[2] = unexpectedAfterElements?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeElements: RawUnexpectedNodesSyntax? {
@@ -16404,7 +17252,11 @@ public struct RawSimpleTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -16412,7 +17264,7 @@ public struct RawSimpleTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -16432,7 +17284,7 @@ public struct RawSimpleTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol {
       layout[3] = genericArgumentClause?.raw
       layout[4] = unexpectedAfterGenericArgumentClause?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeName: RawUnexpectedNodesSyntax? {
@@ -16470,7 +17322,11 @@ public struct RawSourceFileSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -16478,7 +17334,7 @@ public struct RawSourceFileSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -16498,7 +17354,7 @@ public struct RawSourceFileSyntax: RawSyntaxNodeProtocol {
       layout[3] = eofToken.raw
       layout[4] = unexpectedAfterEOFToken?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeStatements: RawUnexpectedNodesSyntax? {
@@ -16581,7 +17437,11 @@ public struct RawSpecializeAttributeSpecListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -16589,7 +17449,7 @@ public struct RawSpecializeAttributeSpecListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [Element], arena: __shared SyntaxArena) {
@@ -16603,7 +17463,7 @@ public struct RawSpecializeAttributeSpecListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawSyntax] {
@@ -16627,7 +17487,11 @@ public struct RawSpecializeExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -16635,7 +17499,7 @@ public struct RawSpecializeExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -16655,7 +17519,7 @@ public struct RawSpecializeExprSyntax: RawExprSyntaxNodeProtocol {
       layout[3] = genericArgumentClause.raw
       layout[4] = unexpectedAfterGenericArgumentClause?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeExpression: RawUnexpectedNodesSyntax? {
@@ -16698,7 +17562,11 @@ public struct RawStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -16706,11 +17574,11 @@ public struct RawStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init<Node: RawStmtSyntaxNodeProtocol>(_ other: Node) {
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
 }
 
@@ -16728,7 +17596,11 @@ public struct RawStringLiteralExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -16736,7 +17608,7 @@ public struct RawStringLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -16768,7 +17640,7 @@ public struct RawStringLiteralExprSyntax: RawExprSyntaxNodeProtocol {
       layout[9] = closeDelimiter?.raw
       layout[10] = unexpectedAfterCloseDelimiter?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeOpenDelimiter: RawUnexpectedNodesSyntax? {
@@ -16861,7 +17733,11 @@ public struct RawStringLiteralSegmentsSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -16869,7 +17745,7 @@ public struct RawStringLiteralSegmentsSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [Element], arena: __shared SyntaxArena) {
@@ -16883,7 +17759,7 @@ public struct RawStringLiteralSegmentsSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawSyntax] {
@@ -16907,7 +17783,11 @@ public struct RawStringSegmentSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -16915,7 +17795,7 @@ public struct RawStringSegmentSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -16931,7 +17811,7 @@ public struct RawStringSegmentSyntax: RawSyntaxNodeProtocol {
       layout[1] = content.raw
       layout[2] = unexpectedAfterContent?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeContent: RawUnexpectedNodesSyntax? {
@@ -16961,7 +17841,11 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -16969,7 +17853,7 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -17013,7 +17897,7 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[15] = members.raw
       layout[16] = unexpectedAfterMembers?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -17130,7 +18014,11 @@ public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -17138,7 +18026,7 @@ public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -17182,7 +18070,7 @@ public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[15] = accessor?.raw
       layout[16] = unexpectedAfterAccessor?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -17268,7 +18156,11 @@ public struct RawSubscriptExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -17276,7 +18168,7 @@ public struct RawSubscriptExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -17312,7 +18204,7 @@ public struct RawSubscriptExprSyntax: RawExprSyntaxNodeProtocol {
       layout[11] = additionalTrailingClosures?.raw
       layout[12] = unexpectedAfterAdditionalTrailingClosures?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeCalledExpression: RawUnexpectedNodesSyntax? {
@@ -17382,7 +18274,11 @@ public struct RawSuperRefExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -17390,7 +18286,7 @@ public struct RawSuperRefExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -17406,7 +18302,7 @@ public struct RawSuperRefExprSyntax: RawExprSyntaxNodeProtocol {
       layout[1] = superKeyword.raw
       layout[2] = unexpectedAfterSuperKeyword?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeSuperKeyword: RawUnexpectedNodesSyntax? {
@@ -17436,7 +18332,11 @@ public struct RawSwitchCaseLabelSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -17444,7 +18344,7 @@ public struct RawSwitchCaseLabelSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -17468,7 +18368,7 @@ public struct RawSwitchCaseLabelSyntax: RawSyntaxNodeProtocol {
       layout[5] = colon.raw
       layout[6] = unexpectedAfterColon?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeCaseKeyword: RawUnexpectedNodesSyntax? {
@@ -17545,7 +18445,11 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -17553,7 +18457,7 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [Element], arena: __shared SyntaxArena) {
@@ -17567,7 +18471,7 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawSyntax] {
@@ -17622,7 +18526,11 @@ public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -17630,7 +18538,7 @@ public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -17654,7 +18562,7 @@ public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol {
       layout[5] = statements.raw
       layout[6] = unexpectedAfterStatements?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeUnknownAttr: RawUnexpectedNodesSyntax? {
@@ -17700,7 +18608,11 @@ public struct RawSwitchDefaultLabelSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -17708,7 +18620,7 @@ public struct RawSwitchDefaultLabelSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -17728,7 +18640,7 @@ public struct RawSwitchDefaultLabelSyntax: RawSyntaxNodeProtocol {
       layout[3] = colon.raw
       layout[4] = unexpectedAfterColon?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeDefaultKeyword: RawUnexpectedNodesSyntax? {
@@ -17766,7 +18678,11 @@ public struct RawSwitchExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -17774,7 +18690,7 @@ public struct RawSwitchExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -17806,7 +18722,7 @@ public struct RawSwitchExprSyntax: RawExprSyntaxNodeProtocol {
       layout[9] = rightBrace.raw
       layout[10] = unexpectedAfterRightBrace?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeSwitchKeyword: RawUnexpectedNodesSyntax? {
@@ -17868,7 +18784,11 @@ public struct RawTargetFunctionEntrySyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -17876,7 +18796,7 @@ public struct RawTargetFunctionEntrySyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -17904,7 +18824,7 @@ public struct RawTargetFunctionEntrySyntax: RawSyntaxNodeProtocol {
       layout[7] = trailingComma?.raw
       layout[8] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLabel: RawUnexpectedNodesSyntax? {
@@ -17958,7 +18878,11 @@ public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -17966,7 +18890,7 @@ public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -17998,7 +18922,7 @@ public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol {
       layout[9] = secondChoice.raw
       layout[10] = unexpectedAfterSecondChoice?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeConditionExpression: RawUnexpectedNodesSyntax? {
@@ -18060,7 +18984,11 @@ public struct RawThrowStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -18068,7 +18996,7 @@ public struct RawThrowStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -18088,7 +19016,7 @@ public struct RawThrowStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout[3] = expression.raw
       layout[4] = unexpectedAfterExpression?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeThrowKeyword: RawUnexpectedNodesSyntax? {
@@ -18126,7 +19054,11 @@ public struct RawTryExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -18134,7 +19066,7 @@ public struct RawTryExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -18158,7 +19090,7 @@ public struct RawTryExprSyntax: RawExprSyntaxNodeProtocol {
       layout[5] = expression.raw
       layout[6] = unexpectedAfterExpression?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeTryKeyword: RawUnexpectedNodesSyntax? {
@@ -18204,7 +19136,11 @@ public struct RawTupleExprElementListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -18212,7 +19148,7 @@ public struct RawTupleExprElementListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawTupleExprElementSyntax], arena: __shared SyntaxArena) {
@@ -18226,7 +19162,7 @@ public struct RawTupleExprElementListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawTupleExprElementSyntax] {
@@ -18250,7 +19186,11 @@ public struct RawTupleExprElementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -18258,7 +19198,7 @@ public struct RawTupleExprElementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -18286,7 +19226,7 @@ public struct RawTupleExprElementSyntax: RawSyntaxNodeProtocol {
       layout[7] = trailingComma?.raw
       layout[8] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLabel: RawUnexpectedNodesSyntax? {
@@ -18340,7 +19280,11 @@ public struct RawTupleExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -18348,7 +19292,7 @@ public struct RawTupleExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -18372,7 +19316,7 @@ public struct RawTupleExprSyntax: RawExprSyntaxNodeProtocol {
       layout[5] = rightParen.raw
       layout[6] = unexpectedAfterRightParen?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax? {
@@ -18418,7 +19362,11 @@ public struct RawTuplePatternElementListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -18426,7 +19374,7 @@ public struct RawTuplePatternElementListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawTuplePatternElementSyntax], arena: __shared SyntaxArena) {
@@ -18440,7 +19388,7 @@ public struct RawTuplePatternElementListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawTuplePatternElementSyntax] {
@@ -18464,7 +19412,11 @@ public struct RawTuplePatternElementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -18472,7 +19424,7 @@ public struct RawTuplePatternElementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -18500,7 +19452,7 @@ public struct RawTuplePatternElementSyntax: RawSyntaxNodeProtocol {
       layout[7] = trailingComma?.raw
       layout[8] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLabelName: RawUnexpectedNodesSyntax? {
@@ -18554,7 +19506,11 @@ public struct RawTuplePatternSyntax: RawPatternSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -18562,7 +19518,7 @@ public struct RawTuplePatternSyntax: RawPatternSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -18586,7 +19542,7 @@ public struct RawTuplePatternSyntax: RawPatternSyntaxNodeProtocol {
       layout[5] = rightParen.raw
       layout[6] = unexpectedAfterRightParen?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax? {
@@ -18632,7 +19588,11 @@ public struct RawTupleTypeElementListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -18640,7 +19600,7 @@ public struct RawTupleTypeElementListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawTupleTypeElementSyntax], arena: __shared SyntaxArena) {
@@ -18654,7 +19614,7 @@ public struct RawTupleTypeElementListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawTupleTypeElementSyntax] {
@@ -18678,7 +19638,11 @@ public struct RawTupleTypeElementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -18686,7 +19650,7 @@ public struct RawTupleTypeElementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -18730,7 +19694,7 @@ public struct RawTupleTypeElementSyntax: RawSyntaxNodeProtocol {
       layout[15] = trailingComma?.raw
       layout[16] = unexpectedAfterTrailingComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeInOut: RawUnexpectedNodesSyntax? {
@@ -18816,7 +19780,11 @@ public struct RawTupleTypeSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -18824,7 +19792,7 @@ public struct RawTupleTypeSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -18848,7 +19816,7 @@ public struct RawTupleTypeSyntax: RawTypeSyntaxNodeProtocol {
       layout[5] = rightParen.raw
       layout[6] = unexpectedAfterRightParen?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax? {
@@ -18894,7 +19862,11 @@ public struct RawTypeAnnotationSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -18902,7 +19874,7 @@ public struct RawTypeAnnotationSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -18922,7 +19894,7 @@ public struct RawTypeAnnotationSyntax: RawSyntaxNodeProtocol {
       layout[3] = type.raw
       layout[4] = unexpectedAfterType?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeColon: RawUnexpectedNodesSyntax? {
@@ -18960,7 +19932,11 @@ public struct RawTypeEffectSpecifiersSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -18968,7 +19944,7 @@ public struct RawTypeEffectSpecifiersSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -18988,7 +19964,7 @@ public struct RawTypeEffectSpecifiersSyntax: RawSyntaxNodeProtocol {
       layout[3] = throwsSpecifier?.raw
       layout[4] = unexpectedAfterThrowsSpecifier?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAsyncSpecifier: RawUnexpectedNodesSyntax? {
@@ -19026,7 +20002,11 @@ public struct RawTypeExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -19034,7 +20014,7 @@ public struct RawTypeExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -19050,7 +20030,7 @@ public struct RawTypeExprSyntax: RawExprSyntaxNodeProtocol {
       layout[1] = type.raw
       layout[2] = unexpectedAfterType?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeType: RawUnexpectedNodesSyntax? {
@@ -19080,7 +20060,11 @@ public struct RawTypeInheritanceClauseSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -19088,7 +20072,7 @@ public struct RawTypeInheritanceClauseSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -19108,7 +20092,7 @@ public struct RawTypeInheritanceClauseSyntax: RawSyntaxNodeProtocol {
       layout[3] = inheritedTypeCollection.raw
       layout[4] = unexpectedAfterInheritedTypeCollection?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeColon: RawUnexpectedNodesSyntax? {
@@ -19146,7 +20130,11 @@ public struct RawTypeInitializerClauseSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -19154,7 +20142,7 @@ public struct RawTypeInitializerClauseSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -19174,7 +20162,7 @@ public struct RawTypeInitializerClauseSyntax: RawSyntaxNodeProtocol {
       layout[3] = value.raw
       layout[4] = unexpectedAfterValue?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeEqual: RawUnexpectedNodesSyntax? {
@@ -19217,7 +20205,11 @@ public struct RawTypeSyntax: RawTypeSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -19225,11 +20217,11 @@ public struct RawTypeSyntax: RawTypeSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init<Node: RawTypeSyntaxNodeProtocol>(_ other: Node) {
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
 }
 
@@ -19247,7 +20239,11 @@ public struct RawTypealiasDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -19255,7 +20251,7 @@ public struct RawTypealiasDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -19295,7 +20291,7 @@ public struct RawTypealiasDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[13] = genericWhereClause?.raw
       layout[14] = unexpectedAfterGenericWhereClause?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -19373,7 +20369,11 @@ public struct RawUnavailableFromAsyncArgumentsSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -19381,7 +20381,7 @@ public struct RawUnavailableFromAsyncArgumentsSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -19405,7 +20405,7 @@ public struct RawUnavailableFromAsyncArgumentsSyntax: RawSyntaxNodeProtocol {
       layout[5] = message.raw
       layout[6] = unexpectedAfterMessage?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeMessageLabel: RawUnexpectedNodesSyntax? {
@@ -19451,7 +20451,11 @@ public struct RawUnderscorePrivateAttributeArgumentsSyntax: RawSyntaxNodeProtoco
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -19459,7 +20463,7 @@ public struct RawUnderscorePrivateAttributeArgumentsSyntax: RawSyntaxNodeProtoco
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -19483,7 +20487,7 @@ public struct RawUnderscorePrivateAttributeArgumentsSyntax: RawSyntaxNodeProtoco
       layout[5] = filename.raw
       layout[6] = unexpectedAfterFilename?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeSourceFileLabel: RawUnexpectedNodesSyntax? {
@@ -19529,7 +20533,11 @@ public struct RawUnexpectedNodesSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -19537,7 +20545,7 @@ public struct RawUnexpectedNodesSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawSyntax], arena: __shared SyntaxArena) {
@@ -19551,7 +20559,7 @@ public struct RawUnexpectedNodesSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawSyntax] {
@@ -19575,7 +20583,11 @@ public struct RawUnresolvedAsExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -19583,7 +20595,7 @@ public struct RawUnresolvedAsExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -19603,7 +20615,7 @@ public struct RawUnresolvedAsExprSyntax: RawExprSyntaxNodeProtocol {
       layout[3] = questionOrExclamationMark?.raw
       layout[4] = unexpectedAfterQuestionOrExclamationMark?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAsTok: RawUnexpectedNodesSyntax? {
@@ -19641,7 +20653,11 @@ public struct RawUnresolvedIsExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -19649,7 +20665,7 @@ public struct RawUnresolvedIsExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -19665,7 +20681,7 @@ public struct RawUnresolvedIsExprSyntax: RawExprSyntaxNodeProtocol {
       layout[1] = isTok.raw
       layout[2] = unexpectedAfterIsTok?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeIsTok: RawUnexpectedNodesSyntax? {
@@ -19695,7 +20711,11 @@ public struct RawUnresolvedPatternExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -19703,7 +20723,7 @@ public struct RawUnresolvedPatternExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -19719,7 +20739,7 @@ public struct RawUnresolvedPatternExprSyntax: RawExprSyntaxNodeProtocol {
       layout[1] = pattern.raw
       layout[2] = unexpectedAfterPattern?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforePattern: RawUnexpectedNodesSyntax? {
@@ -19749,7 +20769,11 @@ public struct RawUnresolvedTernaryExprSyntax: RawExprSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -19757,7 +20781,7 @@ public struct RawUnresolvedTernaryExprSyntax: RawExprSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -19781,7 +20805,7 @@ public struct RawUnresolvedTernaryExprSyntax: RawExprSyntaxNodeProtocol {
       layout[5] = colonMark.raw
       layout[6] = unexpectedAfterColonMark?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeQuestionMark: RawUnexpectedNodesSyntax? {
@@ -19827,7 +20851,11 @@ public struct RawValueBindingPatternSyntax: RawPatternSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -19835,7 +20863,7 @@ public struct RawValueBindingPatternSyntax: RawPatternSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -19855,7 +20883,7 @@ public struct RawValueBindingPatternSyntax: RawPatternSyntaxNodeProtocol {
       layout[3] = valuePattern.raw
       layout[4] = unexpectedAfterValuePattern?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeBindingKeyword: RawUnexpectedNodesSyntax? {
@@ -19893,7 +20921,11 @@ public struct RawVariableDeclSyntax: RawDeclSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -19901,7 +20933,7 @@ public struct RawVariableDeclSyntax: RawDeclSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -19929,7 +20961,7 @@ public struct RawVariableDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[7] = bindings.raw
       layout[8] = unexpectedAfterBindings?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeAttributes: RawUnexpectedNodesSyntax? {
@@ -19983,7 +21015,11 @@ public struct RawVersionTupleSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -19991,7 +21027,7 @@ public struct RawVersionTupleSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -20015,7 +21051,7 @@ public struct RawVersionTupleSyntax: RawSyntaxNodeProtocol {
       layout[5] = patchVersion?.raw
       layout[6] = unexpectedAfterPatchVersion?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeMajorMinor: RawUnexpectedNodesSyntax? {
@@ -20061,7 +21097,11 @@ public struct RawWhereClauseSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -20069,7 +21109,7 @@ public struct RawWhereClauseSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -20089,7 +21129,7 @@ public struct RawWhereClauseSyntax: RawSyntaxNodeProtocol {
       layout[3] = guardResult.raw
       layout[4] = unexpectedAfterGuardResult?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeWhereKeyword: RawUnexpectedNodesSyntax? {
@@ -20127,7 +21167,11 @@ public struct RawWhileStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -20135,7 +21179,7 @@ public struct RawWhileStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -20159,7 +21203,7 @@ public struct RawWhileStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout[5] = body.raw
       layout[6] = unexpectedAfterBody?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeWhileKeyword: RawUnexpectedNodesSyntax? {
@@ -20205,7 +21249,11 @@ public struct RawWildcardPatternSyntax: RawPatternSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -20213,7 +21261,7 @@ public struct RawWildcardPatternSyntax: RawPatternSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -20233,7 +21281,7 @@ public struct RawWildcardPatternSyntax: RawPatternSyntaxNodeProtocol {
       layout[3] = typeAnnotation?.raw
       layout[4] = unexpectedAfterTypeAnnotation?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeWildcard: RawUnexpectedNodesSyntax? {
@@ -20271,7 +21319,11 @@ public struct RawYieldExprListElementSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -20279,7 +21331,7 @@ public struct RawYieldExprListElementSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -20299,7 +21351,7 @@ public struct RawYieldExprListElementSyntax: RawSyntaxNodeProtocol {
       layout[3] = comma?.raw
       layout[4] = unexpectedAfterComma?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeExpression: RawUnexpectedNodesSyntax? {
@@ -20337,7 +21389,11 @@ public struct RawYieldExprListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -20345,7 +21401,7 @@ public struct RawYieldExprListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(elements: [RawYieldExprListElementSyntax], arena: __shared SyntaxArena) {
@@ -20359,7 +21415,7 @@ public struct RawYieldExprListSyntax: RawSyntaxNodeProtocol {
           ptr += 1
         }
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var elements: [RawYieldExprListElementSyntax] {
@@ -20383,7 +21439,11 @@ public struct RawYieldListSyntax: RawSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -20391,7 +21451,7 @@ public struct RawYieldListSyntax: RawSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -20415,7 +21475,7 @@ public struct RawYieldListSyntax: RawSyntaxNodeProtocol {
       layout[5] = rightParen.raw
       layout[6] = unexpectedAfterRightParen?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax? {
@@ -20492,7 +21552,11 @@ public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol {
   public var raw: RawSyntax
   
   init(raw: RawSyntax) {
-    assert(Self.isKindOf(raw))
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
     self.raw = raw
   }
   
@@ -20500,7 +21564,7 @@ public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol {
     guard Self.isKindOf(other.raw) else { 
       return nil 
     }
-    self.init(raw: other.raw)
+    self.init(unchecked: other.raw)
   }
   
   public init(
@@ -20520,7 +21584,7 @@ public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol {
       layout[3] = yields.raw
       layout[4] = unexpectedAfterYields?.raw
     }
-    self.init(raw: raw)
+    self.init(unchecked: raw)
   }
   
   public var unexpectedBeforeYieldKeyword: RawUnexpectedNodesSyntax? {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -29,7 +29,7 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .accessorDecl)
+    precondition(data.raw.kind == .accessorDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -320,7 +320,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .actorDecl)
+    precondition(data.raw.kind == .actorDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -694,7 +694,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .associatedtypeDecl)
+    precondition(data.raw.kind == .associatedtypeDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1036,7 +1036,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .classDecl)
+    precondition(data.raw.kind == .classDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1410,7 +1410,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .deinitializerDecl)
+    precondition(data.raw.kind == .deinitializerDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1656,7 +1656,7 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .editorPlaceholderDecl)
+    precondition(data.raw.kind == .editorPlaceholderDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1755,7 +1755,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .enumCaseDecl)
+    precondition(data.raw.kind == .enumCaseDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2024,7 +2024,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .enumDecl)
+    precondition(data.raw.kind == .enumDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2406,7 +2406,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .extensionDecl)
+    precondition(data.raw.kind == .extensionDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2748,7 +2748,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .functionDecl)
+    precondition(data.raw.kind == .functionDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3122,7 +3122,7 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .ifConfigDecl)
+    precondition(data.raw.kind == .ifConfigDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3285,7 +3285,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .importDecl)
+    precondition(data.raw.kind == .importDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3582,7 +3582,7 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .initializerDecl)
+    precondition(data.raw.kind == .initializerDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3998,7 +3998,7 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .macroDecl)
+    precondition(data.raw.kind == .macroDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4372,7 +4372,7 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .macroExpansionDecl)
+    precondition(data.raw.kind == .macroExpansionDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4747,7 +4747,7 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .missingDecl)
+    precondition(data.raw.kind == .missingDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4929,7 +4929,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .operatorDecl)
+    precondition(data.raw.kind == .operatorDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5210,7 +5210,7 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .poundSourceLocation)
+    precondition(data.raw.kind == .poundSourceLocation)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5418,7 +5418,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .precedenceGroupDecl)
+    precondition(data.raw.kind == .precedenceGroupDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5783,7 +5783,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .protocolDecl)
+    precondition(data.raw.kind == .protocolDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6157,7 +6157,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .structDecl)
+    precondition(data.raw.kind == .structDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6573,7 +6573,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .subscriptDecl)
+    precondition(data.raw.kind == .subscriptDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6947,7 +6947,7 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .typealiasDecl)
+    precondition(data.raw.kind == .typealiasDecl)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7289,7 +7289,7 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .variableDecl)
+    precondition(data.raw.kind == .variableDecl)
     self._syntaxNode = Syntax(data)
   }
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -29,7 +29,7 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .arrayExpr)
+    precondition(data.raw.kind == .arrayExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -224,7 +224,7 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .arrowExpr)
+    precondition(data.raw.kind == .arrowExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -368,7 +368,7 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .asExpr)
+    precondition(data.raw.kind == .asExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -576,7 +576,7 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .assignmentExpr)
+    precondition(data.raw.kind == .assignmentExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -675,7 +675,7 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .awaitExpr)
+    precondition(data.raw.kind == .awaitExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -819,7 +819,7 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .binaryOperatorExpr)
+    precondition(data.raw.kind == .binaryOperatorExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -918,7 +918,7 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .booleanLiteralExpr)
+    precondition(data.raw.kind == .booleanLiteralExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1017,7 +1017,7 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .borrowExpr)
+    precondition(data.raw.kind == .borrowExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1161,7 +1161,7 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .closureExpr)
+    precondition(data.raw.kind == .closureExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1430,7 +1430,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .dictionaryExpr)
+    precondition(data.raw.kind == .dictionaryExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1606,7 +1606,7 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .discardAssignmentExpr)
+    precondition(data.raw.kind == .discardAssignmentExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1705,7 +1705,7 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .editorPlaceholderExpr)
+    precondition(data.raw.kind == .editorPlaceholderExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1804,7 +1804,7 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .floatLiteralExpr)
+    precondition(data.raw.kind == .floatLiteralExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1903,7 +1903,7 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .forcedValueExpr)
+    precondition(data.raw.kind == .forcedValueExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2047,7 +2047,7 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .functionCallExpr)
+    precondition(data.raw.kind == .functionCallExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2357,7 +2357,7 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .identifierExpr)
+    precondition(data.raw.kind == .identifierExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2543,7 +2543,7 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .ifExpr)
+    precondition(data.raw.kind == .ifExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2802,7 +2802,7 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .inOutExpr)
+    precondition(data.raw.kind == .inOutExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2946,7 +2946,7 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .infixOperatorExpr)
+    precondition(data.raw.kind == .infixOperatorExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3122,7 +3122,7 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .integerLiteralExpr)
+    precondition(data.raw.kind == .integerLiteralExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3221,7 +3221,7 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .isExpr)
+    precondition(data.raw.kind == .isExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3397,7 +3397,7 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .keyPathExpr)
+    precondition(data.raw.kind == .keyPathExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3627,7 +3627,7 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .macroExpansionExpr)
+    precondition(data.raw.kind == .macroExpansionExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4002,7 +4002,7 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .memberAccessExpr)
+    precondition(data.raw.kind == .memberAccessExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4249,7 +4249,7 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .missingExpr)
+    precondition(data.raw.kind == .missingExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4321,7 +4321,7 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .moveExpr)
+    precondition(data.raw.kind == .moveExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4465,7 +4465,7 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .nilLiteralExpr)
+    precondition(data.raw.kind == .nilLiteralExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4564,7 +4564,7 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .optionalChainingExpr)
+    precondition(data.raw.kind == .optionalChainingExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4708,7 +4708,7 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .packElementExpr)
+    precondition(data.raw.kind == .packElementExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4852,7 +4852,7 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .packExpansionExpr)
+    precondition(data.raw.kind == .packExpansionExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4996,7 +4996,7 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .postfixIfConfigExpr)
+    precondition(data.raw.kind == .postfixIfConfigExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5171,7 +5171,7 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .postfixUnaryExpr)
+    precondition(data.raw.kind == .postfixUnaryExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5315,7 +5315,7 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .prefixOperatorExpr)
+    precondition(data.raw.kind == .prefixOperatorExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5459,7 +5459,7 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .regexLiteralExpr)
+    precondition(data.raw.kind == .regexLiteralExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5558,7 +5558,7 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .sequenceExpr)
+    precondition(data.raw.kind == .sequenceExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5676,7 +5676,7 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .specializeExpr)
+    precondition(data.raw.kind == .specializeExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5820,7 +5820,7 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .stringLiteralExpr)
+    precondition(data.raw.kind == .stringLiteralExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6079,7 +6079,7 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .subscriptExpr)
+    precondition(data.raw.kind == .subscriptExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6389,7 +6389,7 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .superRefExpr)
+    precondition(data.raw.kind == .superRefExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6488,7 +6488,7 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .switchExpr)
+    precondition(data.raw.kind == .switchExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6747,7 +6747,7 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .ternaryExpr)
+    precondition(data.raw.kind == .ternaryExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6987,7 +6987,7 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .tryExpr)
+    precondition(data.raw.kind == .tryExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7163,7 +7163,7 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .tupleExpr)
+    precondition(data.raw.kind == .tupleExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7358,7 +7358,7 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .typeExpr)
+    precondition(data.raw.kind == .typeExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7457,7 +7457,7 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .unresolvedAsExpr)
+    precondition(data.raw.kind == .unresolvedAsExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7601,7 +7601,7 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .unresolvedIsExpr)
+    precondition(data.raw.kind == .unresolvedIsExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7700,7 +7700,7 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .unresolvedPatternExpr)
+    precondition(data.raw.kind == .unresolvedPatternExpr)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7799,7 +7799,7 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .unresolvedTernaryExpr)
+    precondition(data.raw.kind == .unresolvedTernaryExpr)
     self._syntaxNode = Syntax(data)
   }
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -29,7 +29,7 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .accessPathComponent)
+    precondition(data.raw.kind == .accessPathComponent)
     self._syntaxNode = Syntax(data)
   }
   
@@ -173,7 +173,7 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .accessorBlock)
+    precondition(data.raw.kind == .accessorBlock)
     self._syntaxNode = Syntax(data)
   }
   
@@ -368,7 +368,7 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .accessorParameter)
+    precondition(data.raw.kind == .accessorParameter)
     self._syntaxNode = Syntax(data)
   }
   
@@ -544,7 +544,7 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .arrayElement)
+    precondition(data.raw.kind == .arrayElement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -949,7 +949,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .attribute)
+    precondition(data.raw.kind == .attribute)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1247,7 +1247,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .availabilityArgument)
+    precondition(data.raw.kind == .availabilityArgument)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1393,7 +1393,7 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .availabilityCondition)
+    precondition(data.raw.kind == .availabilityCondition)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1620,7 +1620,7 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .availabilityEntry)
+    precondition(data.raw.kind == .availabilityEntry)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1891,7 +1891,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .availabilityLabeledArgument)
+    precondition(data.raw.kind == .availabilityLabeledArgument)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2070,7 +2070,7 @@ public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, Syn
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .availabilityVersionRestrictionListEntry)
+    precondition(data.raw.kind == .availabilityVersionRestrictionListEntry)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2215,7 +2215,7 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .availabilityVersionRestriction)
+    precondition(data.raw.kind == .availabilityVersionRestriction)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2360,7 +2360,7 @@ public struct BackDeployedAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashabl
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .backDeployedAttributeSpecList)
+    precondition(data.raw.kind == .backDeployedAttributeSpecList)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2558,7 +2558,7 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .caseItem)
+    precondition(data.raw.kind == .caseItem)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2734,7 +2734,7 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .catchClause)
+    precondition(data.raw.kind == .catchClause)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2929,7 +2929,7 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .catchItem)
+    precondition(data.raw.kind == .catchItem)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3140,7 +3140,7 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .closureCaptureItemSpecifier)
+    precondition(data.raw.kind == .closureCaptureItemSpecifier)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3348,7 +3348,7 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .closureCaptureItem)
+    precondition(data.raw.kind == .closureCaptureItem)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3588,7 +3588,7 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .closureCaptureSignature)
+    precondition(data.raw.kind == .closureCaptureSignature)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3783,7 +3783,7 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .closureParam)
+    precondition(data.raw.kind == .closureParam)
     self._syntaxNode = Syntax(data)
   }
   
@@ -3969,7 +3969,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .closureSignature)
+    precondition(data.raw.kind == .closureSignature)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4313,7 +4313,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .codeBlockItem)
+    precondition(data.raw.kind == .codeBlockItem)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4459,7 +4459,7 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .codeBlock)
+    precondition(data.raw.kind == .codeBlock)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4654,7 +4654,7 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .compositionTypeElement)
+    precondition(data.raw.kind == .compositionTypeElement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -4867,7 +4867,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .conditionElement)
+    precondition(data.raw.kind == .conditionElement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5011,7 +5011,7 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .conformanceRequirement)
+    precondition(data.raw.kind == .conformanceRequirement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5187,7 +5187,7 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .conventionAttributeArguments)
+    precondition(data.raw.kind == .conventionAttributeArguments)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5428,7 +5428,7 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .conventionWitnessMethodAttributeArguments)
+    precondition(data.raw.kind == .conventionWitnessMethodAttributeArguments)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5604,7 +5604,7 @@ public struct DeclEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .declEffectSpecifiers)
+    precondition(data.raw.kind == .declEffectSpecifiers)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5748,7 +5748,7 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .declModifierDetail)
+    precondition(data.raw.kind == .declModifierDetail)
     self._syntaxNode = Syntax(data)
   }
   
@@ -5924,7 +5924,7 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .declModifier)
+    precondition(data.raw.kind == .declModifier)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6068,7 +6068,7 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .declNameArgument)
+    precondition(data.raw.kind == .declNameArgument)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6212,7 +6212,7 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .declNameArguments)
+    precondition(data.raw.kind == .declNameArguments)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6407,7 +6407,7 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .declName)
+    precondition(data.raw.kind == .declName)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6553,7 +6553,7 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .derivativeRegistrationAttributeArguments)
+    precondition(data.raw.kind == .derivativeRegistrationAttributeArguments)
     self._syntaxNode = Syntax(data)
   }
   
@@ -6862,7 +6862,7 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .designatedTypeElement)
+    precondition(data.raw.kind == .designatedTypeElement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7006,7 +7006,7 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .dictionaryElement)
+    precondition(data.raw.kind == .dictionaryElement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7214,7 +7214,7 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .differentiabilityParam)
+    precondition(data.raw.kind == .differentiabilityParam)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7400,7 +7400,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .differentiabilityParamsClause)
+    precondition(data.raw.kind == .differentiabilityParamsClause)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7578,7 +7578,7 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .differentiabilityParams)
+    precondition(data.raw.kind == .differentiabilityParams)
     self._syntaxNode = Syntax(data)
   }
   
@@ -7774,7 +7774,7 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .differentiableAttributeArguments)
+    precondition(data.raw.kind == .differentiableAttributeArguments)
     self._syntaxNode = Syntax(data)
   }
   
@@ -8058,7 +8058,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .documentationAttributeArgument)
+    precondition(data.raw.kind == .documentationAttributeArgument)
     self._syntaxNode = Syntax(data)
   }
   
@@ -8267,7 +8267,7 @@ public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable 
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .dynamicReplacementArguments)
+    precondition(data.raw.kind == .dynamicReplacementArguments)
     self._syntaxNode = Syntax(data)
   }
   
@@ -8443,7 +8443,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .enumCaseElement)
+    precondition(data.raw.kind == .enumCaseElement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -8655,7 +8655,7 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .exposeAttributeArguments)
+    precondition(data.raw.kind == .exposeAttributeArguments)
     self._syntaxNode = Syntax(data)
   }
   
@@ -8831,7 +8831,7 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .expressionSegment)
+    precondition(data.raw.kind == .expressionSegment)
     self._syntaxNode = Syntax(data)
   }
   
@@ -9090,7 +9090,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .functionParameter)
+    precondition(data.raw.kind == .functionParameter)
     self._syntaxNode = Syntax(data)
   }
   
@@ -9555,7 +9555,7 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .functionSignature)
+    precondition(data.raw.kind == .functionSignature)
     self._syntaxNode = Syntax(data)
   }
   
@@ -9731,7 +9731,7 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .genericArgumentClause)
+    precondition(data.raw.kind == .genericArgumentClause)
     self._syntaxNode = Syntax(data)
   }
   
@@ -9926,7 +9926,7 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .genericArgument)
+    precondition(data.raw.kind == .genericArgument)
     self._syntaxNode = Syntax(data)
   }
   
@@ -10070,7 +10070,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .genericParameterClause)
+    precondition(data.raw.kind == .genericParameterClause)
     self._syntaxNode = Syntax(data)
   }
   
@@ -10297,7 +10297,7 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .genericParameter)
+    precondition(data.raw.kind == .genericParameter)
     self._syntaxNode = Syntax(data)
   }
   
@@ -10688,7 +10688,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .genericRequirement)
+    precondition(data.raw.kind == .genericRequirement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -10832,7 +10832,7 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .genericWhereClause)
+    precondition(data.raw.kind == .genericWhereClause)
     self._syntaxNode = Syntax(data)
   }
   
@@ -11076,7 +11076,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .ifConfigClause)
+    precondition(data.raw.kind == .ifConfigClause)
     self._syntaxNode = Syntax(data)
   }
   
@@ -11287,7 +11287,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .implementsAttributeArguments)
+    precondition(data.raw.kind == .implementsAttributeArguments)
     self._syntaxNode = Syntax(data)
   }
   
@@ -11499,7 +11499,7 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .inheritedType)
+    precondition(data.raw.kind == .inheritedType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -11643,7 +11643,7 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .initializerClause)
+    precondition(data.raw.kind == .initializerClause)
     self._syntaxNode = Syntax(data)
   }
   
@@ -11840,7 +11840,7 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .keyPathComponent)
+    precondition(data.raw.kind == .keyPathComponent)
     self._syntaxNode = Syntax(data)
   }
   
@@ -11984,7 +11984,7 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .keyPathOptionalComponent)
+    precondition(data.raw.kind == .keyPathOptionalComponent)
     self._syntaxNode = Syntax(data)
   }
   
@@ -12083,7 +12083,7 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .keyPathPropertyComponent)
+    precondition(data.raw.kind == .keyPathPropertyComponent)
     self._syntaxNode = Syntax(data)
   }
   
@@ -12259,7 +12259,7 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .keyPathSubscriptComponent)
+    precondition(data.raw.kind == .keyPathSubscriptComponent)
     self._syntaxNode = Syntax(data)
   }
   
@@ -12454,7 +12454,7 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .labeledSpecializeEntry)
+    precondition(data.raw.kind == .labeledSpecializeEntry)
     self._syntaxNode = Syntax(data)
   }
   
@@ -12666,7 +12666,7 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .layoutRequirement)
+    precondition(data.raw.kind == .layoutRequirement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -13002,7 +13002,7 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .matchingPatternCondition)
+    precondition(data.raw.kind == .matchingPatternCondition)
     self._syntaxNode = Syntax(data)
   }
   
@@ -13210,7 +13210,7 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .memberDeclBlock)
+    precondition(data.raw.kind == .memberDeclBlock)
     self._syntaxNode = Syntax(data)
   }
   
@@ -13405,7 +13405,7 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .memberDeclListItem)
+    precondition(data.raw.kind == .memberDeclListItem)
     self._syntaxNode = Syntax(data)
   }
   
@@ -13551,7 +13551,7 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .missing)
+    precondition(data.raw.kind == .missing)
     self._syntaxNode = Syntax(data)
   }
   
@@ -13623,7 +13623,7 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .multipleTrailingClosureElement)
+    precondition(data.raw.kind == .multipleTrailingClosureElement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -13799,7 +13799,7 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .objCSelectorPiece)
+    precondition(data.raw.kind == .objCSelectorPiece)
     self._syntaxNode = Syntax(data)
   }
   
@@ -13943,7 +13943,7 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .opaqueReturnTypeOfAttributeArguments)
+    precondition(data.raw.kind == .opaqueReturnTypeOfAttributeArguments)
     self._syntaxNode = Syntax(data)
   }
   
@@ -14121,7 +14121,7 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .operatorPrecedenceAndTypes)
+    precondition(data.raw.kind == .operatorPrecedenceAndTypes)
     self._syntaxNode = Syntax(data)
   }
   
@@ -14318,7 +14318,7 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .optionalBindingCondition)
+    precondition(data.raw.kind == .optionalBindingCondition)
     self._syntaxNode = Syntax(data)
   }
   
@@ -14526,7 +14526,7 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .originallyDefinedInArguments)
+    precondition(data.raw.kind == .originallyDefinedInArguments)
     self._syntaxNode = Syntax(data)
   }
   
@@ -14785,7 +14785,7 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .parameterClause)
+    precondition(data.raw.kind == .parameterClause)
     self._syntaxNode = Syntax(data)
   }
   
@@ -15022,7 +15022,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .patternBinding)
+    precondition(data.raw.kind == .patternBinding)
     self._syntaxNode = Syntax(data)
   }
   
@@ -15262,7 +15262,7 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .poundSourceLocationArgs)
+    precondition(data.raw.kind == .poundSourceLocationArgs)
     self._syntaxNode = Syntax(data)
   }
   
@@ -15566,7 +15566,7 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .precedenceGroupAssignment)
+    precondition(data.raw.kind == .precedenceGroupAssignment)
     self._syntaxNode = Syntax(data)
   }
   
@@ -15743,7 +15743,7 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .precedenceGroupAssociativity)
+    precondition(data.raw.kind == .precedenceGroupAssociativity)
     self._syntaxNode = Syntax(data)
   }
   
@@ -15920,7 +15920,7 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .precedenceGroupNameElement)
+    precondition(data.raw.kind == .precedenceGroupNameElement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -16064,7 +16064,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .precedenceGroupRelation)
+    precondition(data.raw.kind == .precedenceGroupRelation)
     self._syntaxNode = Syntax(data)
   }
   
@@ -16261,7 +16261,7 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .primaryAssociatedTypeClause)
+    precondition(data.raw.kind == .primaryAssociatedTypeClause)
     self._syntaxNode = Syntax(data)
   }
   
@@ -16456,7 +16456,7 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .primaryAssociatedType)
+    precondition(data.raw.kind == .primaryAssociatedType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -16600,7 +16600,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .qualifiedDeclName)
+    precondition(data.raw.kind == .qualifiedDeclName)
     self._syntaxNode = Syntax(data)
   }
   
@@ -16850,7 +16850,7 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .returnClause)
+    precondition(data.raw.kind == .returnClause)
     self._syntaxNode = Syntax(data)
   }
   
@@ -16994,7 +16994,7 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .sameTypeRequirement)
+    precondition(data.raw.kind == .sameTypeRequirement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -17170,7 +17170,7 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .sourceFile)
+    precondition(data.raw.kind == .sourceFile)
     self._syntaxNode = Syntax(data)
   }
   
@@ -17333,7 +17333,7 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .stringSegment)
+    precondition(data.raw.kind == .stringSegment)
     self._syntaxNode = Syntax(data)
   }
   
@@ -17432,7 +17432,7 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .switchCaseLabel)
+    precondition(data.raw.kind == .switchCaseLabel)
     self._syntaxNode = Syntax(data)
   }
   
@@ -17669,7 +17669,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .switchCase)
+    precondition(data.raw.kind == .switchCase)
     self._syntaxNode = Syntax(data)
   }
   
@@ -17864,7 +17864,7 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .switchDefaultLabel)
+    precondition(data.raw.kind == .switchDefaultLabel)
     self._syntaxNode = Syntax(data)
   }
   
@@ -18008,7 +18008,7 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .targetFunctionEntry)
+    precondition(data.raw.kind == .targetFunctionEntry)
     self._syntaxNode = Syntax(data)
   }
   
@@ -18220,7 +18220,7 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .tupleExprElement)
+    precondition(data.raw.kind == .tupleExprElement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -18428,7 +18428,7 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .tuplePatternElement)
+    precondition(data.raw.kind == .tuplePatternElement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -18636,7 +18636,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .tupleTypeElement)
+    precondition(data.raw.kind == .tupleTypeElement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -18972,7 +18972,7 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .typeAnnotation)
+    precondition(data.raw.kind == .typeAnnotation)
     self._syntaxNode = Syntax(data)
   }
   
@@ -19116,7 +19116,7 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .typeEffectSpecifiers)
+    precondition(data.raw.kind == .typeEffectSpecifiers)
     self._syntaxNode = Syntax(data)
   }
   
@@ -19260,7 +19260,7 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .typeInheritanceClause)
+    precondition(data.raw.kind == .typeInheritanceClause)
     self._syntaxNode = Syntax(data)
   }
   
@@ -19423,7 +19423,7 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .typeInitializerClause)
+    precondition(data.raw.kind == .typeInitializerClause)
     self._syntaxNode = Syntax(data)
   }
   
@@ -19567,7 +19567,7 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .unavailableFromAsyncArguments)
+    precondition(data.raw.kind == .unavailableFromAsyncArguments)
     self._syntaxNode = Syntax(data)
   }
   
@@ -19743,7 +19743,7 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .underscorePrivateAttributeArguments)
+    precondition(data.raw.kind == .underscorePrivateAttributeArguments)
     self._syntaxNode = Syntax(data)
   }
   
@@ -19919,7 +19919,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .versionTuple)
+    precondition(data.raw.kind == .versionTuple)
     self._syntaxNode = Syntax(data)
   }
   
@@ -20098,7 +20098,7 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .whereClause)
+    precondition(data.raw.kind == .whereClause)
     self._syntaxNode = Syntax(data)
   }
   
@@ -20242,7 +20242,7 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .yieldExprListElement)
+    precondition(data.raw.kind == .yieldExprListElement)
     self._syntaxNode = Syntax(data)
   }
   
@@ -20386,7 +20386,7 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .yieldList)
+    precondition(data.raw.kind == .yieldList)
     self._syntaxNode = Syntax(data)
   }
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
@@ -29,7 +29,7 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .expressionPattern)
+    precondition(data.raw.kind == .expressionPattern)
     self._syntaxNode = Syntax(data)
   }
   
@@ -128,7 +128,7 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .identifierPattern)
+    precondition(data.raw.kind == .identifierPattern)
     self._syntaxNode = Syntax(data)
   }
   
@@ -227,7 +227,7 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .isTypePattern)
+    precondition(data.raw.kind == .isTypePattern)
     self._syntaxNode = Syntax(data)
   }
   
@@ -371,7 +371,7 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .missingPattern)
+    precondition(data.raw.kind == .missingPattern)
     self._syntaxNode = Syntax(data)
   }
   
@@ -443,7 +443,7 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .tuplePattern)
+    precondition(data.raw.kind == .tuplePattern)
     self._syntaxNode = Syntax(data)
   }
   
@@ -638,7 +638,7 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .valueBindingPattern)
+    precondition(data.raw.kind == .valueBindingPattern)
     self._syntaxNode = Syntax(data)
   }
   
@@ -782,7 +782,7 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .wildcardPattern)
+    precondition(data.raw.kind == .wildcardPattern)
     self._syntaxNode = Syntax(data)
   }
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -29,7 +29,7 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .breakStmt)
+    precondition(data.raw.kind == .breakStmt)
     self._syntaxNode = Syntax(data)
   }
   
@@ -173,7 +173,7 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .continueStmt)
+    precondition(data.raw.kind == .continueStmt)
     self._syntaxNode = Syntax(data)
   }
   
@@ -317,7 +317,7 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .deferStmt)
+    precondition(data.raw.kind == .deferStmt)
     self._syntaxNode = Syntax(data)
   }
   
@@ -461,7 +461,7 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .doStmt)
+    precondition(data.raw.kind == .doStmt)
     self._syntaxNode = Syntax(data)
   }
   
@@ -656,7 +656,7 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .expressionStmt)
+    precondition(data.raw.kind == .expressionStmt)
     self._syntaxNode = Syntax(data)
   }
   
@@ -755,7 +755,7 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .fallthroughStmt)
+    precondition(data.raw.kind == .fallthroughStmt)
     self._syntaxNode = Syntax(data)
   }
   
@@ -854,7 +854,7 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .forInStmt)
+    precondition(data.raw.kind == .forInStmt)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1254,7 +1254,7 @@ public struct ForgetStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .forgetStmt)
+    precondition(data.raw.kind == .forgetStmt)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1398,7 +1398,7 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .guardStmt)
+    precondition(data.raw.kind == .guardStmt)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1625,7 +1625,7 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .labeledStmt)
+    precondition(data.raw.kind == .labeledStmt)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1801,7 +1801,7 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .missingStmt)
+    precondition(data.raw.kind == .missingStmt)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1873,7 +1873,7 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .repeatWhileStmt)
+    precondition(data.raw.kind == .repeatWhileStmt)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2081,7 +2081,7 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .returnStmt)
+    precondition(data.raw.kind == .returnStmt)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2256,7 +2256,7 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .throwStmt)
+    precondition(data.raw.kind == .throwStmt)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2400,7 +2400,7 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .whileStmt)
+    precondition(data.raw.kind == .whileStmt)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2637,7 +2637,7 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .yieldStmt)
+    precondition(data.raw.kind == .yieldStmt)
     self._syntaxNode = Syntax(data)
   }
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
@@ -29,7 +29,7 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .arrayType)
+    precondition(data.raw.kind == .arrayType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -205,7 +205,7 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .attributedType)
+    precondition(data.raw.kind == .attributedType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -400,7 +400,7 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .classRestrictionType)
+    precondition(data.raw.kind == .classRestrictionType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -499,7 +499,7 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .compositionType)
+    precondition(data.raw.kind == .compositionType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -617,7 +617,7 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .constrainedSugarType)
+    precondition(data.raw.kind == .constrainedSugarType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -761,7 +761,7 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .dictionaryType)
+    precondition(data.raw.kind == .dictionaryType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1001,7 +1001,7 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .functionType)
+    precondition(data.raw.kind == .functionType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1260,7 +1260,7 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .implicitlyUnwrappedOptionalType)
+    precondition(data.raw.kind == .implicitlyUnwrappedOptionalType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1404,7 +1404,7 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .memberTypeIdentifier)
+    precondition(data.raw.kind == .memberTypeIdentifier)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1612,7 +1612,7 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .metatypeType)
+    precondition(data.raw.kind == .metatypeType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1788,7 +1788,7 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .missingType)
+    precondition(data.raw.kind == .missingType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -1860,7 +1860,7 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .namedOpaqueReturnType)
+    precondition(data.raw.kind == .namedOpaqueReturnType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2004,7 +2004,7 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .optionalType)
+    precondition(data.raw.kind == .optionalType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2148,7 +2148,7 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .packExpansionType)
+    precondition(data.raw.kind == .packExpansionType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2292,7 +2292,7 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .packReferenceType)
+    precondition(data.raw.kind == .packReferenceType)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2436,7 +2436,7 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .simpleTypeIdentifier)
+    precondition(data.raw.kind == .simpleTypeIdentifier)
     self._syntaxNode = Syntax(data)
   }
   
@@ -2580,7 +2580,7 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .tupleType)
+    precondition(data.raw.kind == .tupleType)
     self._syntaxNode = Syntax(data)
   }
   

--- a/Sources/SwiftSyntaxBuilder/SyntaxNodeWithBody.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxNodeWithBody.swift
@@ -179,7 +179,7 @@ public extension VariableDeclSyntax {
       throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualNode: decl)
     }
     self = castedDecl
-    assert(self.bindings.count == 1)
+    precondition(self.bindings.count == 1)
     var binding: PatternBindingSyntax? = self.bindings.last
     binding?.accessor = try .getter(CodeBlockSyntax(statements: accessor()))
     bindings = PatternBindingListSyntax([binding].compactMap { $0 })

--- a/Sources/SwiftSyntaxBuilder/ValidatingSyntaxNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/ValidatingSyntaxNodes.swift
@@ -24,7 +24,7 @@ extension SyntaxProtocol {
   public init(validating node: Self) throws {
     if node.hasError {
       let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: node)
-      assert(!diagnostics.isEmpty)
+      precondition(!diagnostics.isEmpty)
       throw SyntaxStringInterpolationError.diagnostics(diagnostics, tree: Syntax(node))
     }
     self = node

--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -178,7 +178,7 @@ struct ByteSourceRangeSet {
     var result = ByteSourceRangeSet()
     var currentOffset = 0
     for range in ranges {
-      assert(
+      precondition(
         currentOffset <= range.offset,
         "Ranges must be sorted in ascending order and not be overlapping"
       )

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -145,7 +145,7 @@ final class DeclarationTests: XCTestCase {
       actor Foo {
         nonisolated init?() {
           for (x, y, z) in self.triples {
-            assert(isSafe)
+            precondition(isSafe)
           }
         }
         subscript(_ param: String) -> Int {


### PR DESCRIPTION
This replaces `assert` statements by `precondition` statements in most cases. Afterwards I did a few performance measurements and reverted a few `precondition`s that had significant performance impact back to `assert` statements.

As it stands now, this regresses performance of parsing [MovieSwiftUI](https://github.com/Dimillian/MovieSwiftUI) by 2.9% (measured in number of instructions executed). 

The biggest (>0.1%) performance regressions are coming from the following files. I’m open to debate if any of the preconditions in there should be changed to `assert` to improve performance but they all seem to provide good value at a reasonable cost to me

```
0.62% Sources/SwiftParser/TokenConsumer.swift
0.58% Sources/SwiftSyntax/Raw/RawSyntax.swift
0.52% Sources/SwiftParser/Lexer/Cursor.swift
0.41% Sources/SwiftSyntax/SyntaxText.swift
0.39% Sources/SwiftParser/TokenSpec.swift
0.29% Sources/SwiftParser/Recovery.swift
0.26% Sources/SwiftParser/Names.swift
```

I am also attaching the numbers spreadsheet that contains all performance measurements: [Precondition performance measurements.zip](https://github.com/apple/swift-syntax/files/11029797/Precondition.performance.measurements.zip)

rdar://106874489