### PR TITLE
Tweak `.gitignore` to always ignore `.swiftpm`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@
 .build/
 # Ignore generated Xcode projects
 *.xcodeproj
-# Ignore Data Xcode stores when opening the project directly
-/.swiftpm/xcode
+# Ignore SwiftPM state, such as the generated xcodeproj when opening the project directly
+.swiftpm
 # Ignore user state in Xcode Projects
 *.xcuserdatad
 UserInterfaceState.xcuserstate

--- a/CodeGeneration/.gitignore
+++ b/CodeGeneration/.gitignore
@@ -1,2 +1,0 @@
-# Ignore Data Xcode stores when opening the project directly
-/.swiftpm/xcode

--- a/Examples/.gitignore
+++ b/Examples/.gitignore
@@ -1,2 +1,0 @@
-# Ignore Data Xcode stores when opening the project directly
-/.swiftpm/xcode


### PR DESCRIPTION
By default Xcode saves an xctestplan directly in the `.swiftpm` directory if you change any of its default values (e.g when enabling code coverage). As such, ignore the entire `.swiftpm` directly, not just `.swiftpm/xcode`. Also ignore it for any child directories, avoiding the need to have separate `.gitignore`s for child SwiftPM projects.