### PR TITLE
Enable two swift-format rules that are now satisfied

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -9,9 +9,7 @@
     "rules": {
         "AlwaysUseLowerCamelCase": false,
         "AmbiguousTrailingClosureOverload": false,
-        "DontRepeatTypeInStaticProperties": false,
         "NoBlockComments": false,
-        "Spacing": false,
         "UseLetInEveryBoundCaseVariable": false,
         "UseSynthesizedInitializer": false
     }


### PR DESCRIPTION
I disabled all of those rules to make the introduction of swift-format easiser. Now I went through them again and these rules are satisfied. All the other rules that are disabled have good reasons for being diabled, so I want to keep them disabled.

rdar://103919185