### PR TITLE
Parse versions as three integer tokens

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/AvailabilityNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/AvailabilityNodes.swift
@@ -128,9 +128,21 @@ public let AVAILABILITY_NODES: [Node] = [
     kind: "Syntax",
     children: [
       Child(
-        name: "MajorMinor",
-        kind: .token(choices: [.token(tokenKind: "IntegerLiteralToken"), .token(tokenKind: "FloatingLiteralToken")]),
-        description: "In case the version consists only of the major version, an integer literal that specifies the major version. In case the version consists of major and minor version number, a floating literal in which the decimal part is interpreted as the minor version."
+        name: "Major",
+        kind: .token(choices: [.token(tokenKind: "IntegerLiteralToken")]),
+        description: "The major version."
+      ),
+      Child(
+        name: "MinorPeriod",
+        kind: .token(choices: [.token(tokenKind: "PeriodToken")]),
+        description: "If the version contains a minor number, the period separating the major from the minor number.",
+        isOptional: true
+      ),
+      Child(
+        name: "Minor",
+        kind: .token(choices: [.token(tokenKind: "IntegerLiteralToken")]),
+        description: "The minor version if specified.",
+        isOptional: true
       ),
       Child(
         name: "PatchPeriod",
@@ -139,7 +151,7 @@ public let AVAILABILITY_NODES: [Node] = [
         isOptional: true
       ),
       Child(
-        name: "PatchVersion",
+        name: "Patch",
         kind: .token(choices: [.token(tokenKind: "IntegerLiteralToken")]),
         description: "The patch version if specified.",
         isOptional: true

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -21031,55 +21031,79 @@ public struct RawVersionTupleSyntax: RawSyntaxNodeProtocol {
   }
   
   public init(
-      _ unexpectedBeforeMajorMinor: RawUnexpectedNodesSyntax? = nil, 
-      majorMinor: RawTokenSyntax, 
-      _ unexpectedBetweenMajorMinorAndPatchPeriod: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBeforeMajor: RawUnexpectedNodesSyntax? = nil, 
+      major: RawTokenSyntax, 
+      _ unexpectedBetweenMajorAndMinorPeriod: RawUnexpectedNodesSyntax? = nil, 
+      minorPeriod: RawTokenSyntax?, 
+      _ unexpectedBetweenMinorPeriodAndMinor: RawUnexpectedNodesSyntax? = nil, 
+      minor: RawTokenSyntax?, 
+      _ unexpectedBetweenMinorAndPatchPeriod: RawUnexpectedNodesSyntax? = nil, 
       patchPeriod: RawTokenSyntax?, 
-      _ unexpectedBetweenPatchPeriodAndPatchVersion: RawUnexpectedNodesSyntax? = nil, 
-      patchVersion: RawTokenSyntax?, 
-      _ unexpectedAfterPatchVersion: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenPatchPeriodAndPatch: RawUnexpectedNodesSyntax? = nil, 
+      patch: RawTokenSyntax?, 
+      _ unexpectedAfterPatch: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
-      kind: .versionTuple, uninitializedCount: 7, arena: arena) { layout in 
+      kind: .versionTuple, uninitializedCount: 11, arena: arena) { layout in 
       layout.initialize(repeating: nil)
-      layout[0] = unexpectedBeforeMajorMinor?.raw
-      layout[1] = majorMinor.raw
-      layout[2] = unexpectedBetweenMajorMinorAndPatchPeriod?.raw
-      layout[3] = patchPeriod?.raw
-      layout[4] = unexpectedBetweenPatchPeriodAndPatchVersion?.raw
-      layout[5] = patchVersion?.raw
-      layout[6] = unexpectedAfterPatchVersion?.raw
+      layout[0] = unexpectedBeforeMajor?.raw
+      layout[1] = major.raw
+      layout[2] = unexpectedBetweenMajorAndMinorPeriod?.raw
+      layout[3] = minorPeriod?.raw
+      layout[4] = unexpectedBetweenMinorPeriodAndMinor?.raw
+      layout[5] = minor?.raw
+      layout[6] = unexpectedBetweenMinorAndPatchPeriod?.raw
+      layout[7] = patchPeriod?.raw
+      layout[8] = unexpectedBetweenPatchPeriodAndPatch?.raw
+      layout[9] = patch?.raw
+      layout[10] = unexpectedAfterPatch?.raw
     }
     self.init(unchecked: raw)
   }
   
-  public var unexpectedBeforeMajorMinor: RawUnexpectedNodesSyntax? {
+  public var unexpectedBeforeMajor: RawUnexpectedNodesSyntax? {
     layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var majorMinor: RawTokenSyntax {
+  public var major: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
   }
   
-  public var unexpectedBetweenMajorMinorAndPatchPeriod: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenMajorAndMinorPeriod: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var patchPeriod: RawTokenSyntax? {
+  public var minorPeriod: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
   }
   
-  public var unexpectedBetweenPatchPeriodAndPatchVersion: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenMinorPeriodAndMinor: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var patchVersion: RawTokenSyntax? {
+  public var minor: RawTokenSyntax? {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))
   }
   
-  public var unexpectedAfterPatchVersion: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenMinorAndPatchPeriod: RawUnexpectedNodesSyntax? {
     layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var patchPeriod: RawTokenSyntax? {
+    layoutView.children[7].map(RawTokenSyntax.init(raw:))
+  }
+  
+  public var unexpectedBetweenPatchPeriodAndPatch: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var patch: RawTokenSyntax? {
+    layoutView.children[9].map(RawTokenSyntax.init(raw:))
+  }
+  
+  public var unexpectedAfterPatch: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -227,12 +227,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .accessPathComponent:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
-            .tokenKind(.identifier), 
-            .tokenKind(.binaryOperator), 
-            .tokenKind(.prefixOperator), 
-            .tokenKind(.postfixOperator)
-          ]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.identifier)]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.period)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -835,13 +830,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .declName:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
-            .tokenKind(.identifier), 
-            .tokenKind(.binaryOperator), 
-            .keyword("init"), 
-            .keyword("self"), 
-            .keyword("Self")
-          ]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.identifier), .tokenKind(.prefixOperator), .keyword("init")]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawDeclNameArgumentsSyntax?.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -962,7 +951,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .differentiableAttributeArguments:
     assert(layout.count == 11)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax?.self, tokenChoices: [.keyword("_forward"), .keyword("reverse"), .keyword("_linear")]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax?.self, tokenChoices: [.keyword("forward"), .keyword("reverse"), .keyword("linear")]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.comma)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -1019,12 +1008,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .editorPlaceholderExpr:
     assert(layout.count == 3)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
-            .tokenKind(.identifier), 
-            .keyword("self"), 
-            .keyword("Self"), 
-            .keyword("init")
-          ]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.identifier)]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
   case .effectsArguments:
     for (index, element) in layout.enumerated() {
@@ -1561,7 +1545,14 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .labeledSpecializeEntry:
     assert(layout.count == 9)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
+            .tokenKind(.identifier), 
+            .keyword("available"), 
+            .keyword("exported"), 
+            .keyword("kind"), 
+            .keyword("spi"), 
+            .keyword("spiModule")
+          ]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.colon)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -1786,7 +1777,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .objCSelectorPiece:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax?.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.identifier)]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.colon)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -2077,10 +2068,9 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self, tokenChoices: [
             .tokenKind(.identifier), 
-            .keyword("self"), 
-            .keyword("Self"), 
-            .keyword("init"), 
-            .tokenKind(.binaryOperator)
+            .tokenKind(.binaryOperator), 
+            .tokenKind(.prefixOperator), 
+            .tokenKind(.postfixOperator)
           ]))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 7, verify(layout[7], as: RawDeclNameArgumentsSyntax?.self))
@@ -2524,14 +2514,18 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 7, verify(layout[7], as: RawPatternBindingListSyntax.self))
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
   case .versionTuple:
-    assert(layout.count == 7)
+    assert(layout.count == 11)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.integerLiteral), .tokenKind(.floatingLiteral)]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.integerLiteral)]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.period)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.integerLiteral)]))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 7, verify(layout[7], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.period)]))
+    assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 9, verify(layout[9], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.integerLiteral)]))
+    assertNoError(kind, 10, verify(layout[10], as: RawUnexpectedNodesSyntax?.self))
   case .whereClause:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -19925,35 +19925,47 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   
   public init(
       leadingTrivia: Trivia? = nil, 
-      _ unexpectedBeforeMajorMinor: UnexpectedNodesSyntax? = nil, 
-      majorMinor: TokenSyntax, 
-      _ unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodesSyntax? = nil, 
+      _ unexpectedBeforeMajor: UnexpectedNodesSyntax? = nil, 
+      major: TokenSyntax = .integerLiteral("IntegerLiteralToken"), 
+      _ unexpectedBetweenMajorAndMinorPeriod: UnexpectedNodesSyntax? = nil, 
+      minorPeriod: TokenSyntax? = nil, 
+      _ unexpectedBetweenMinorPeriodAndMinor: UnexpectedNodesSyntax? = nil, 
+      minor: TokenSyntax? = nil, 
+      _ unexpectedBetweenMinorAndPatchPeriod: UnexpectedNodesSyntax? = nil, 
       patchPeriod: TokenSyntax? = nil, 
-      _ unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodesSyntax? = nil, 
-      patchVersion: TokenSyntax? = nil, 
-      _ unexpectedAfterPatchVersion: UnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenPatchPeriodAndPatch: UnexpectedNodesSyntax? = nil, 
+      patch: TokenSyntax? = nil, 
+      _ unexpectedAfterPatch: UnexpectedNodesSyntax? = nil, 
       trailingTrivia: Trivia? = nil
     
   ) {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
     let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (
-            unexpectedBeforeMajorMinor, 
-            majorMinor, 
-            unexpectedBetweenMajorMinorAndPatchPeriod, 
+            unexpectedBeforeMajor, 
+            major, 
+            unexpectedBetweenMajorAndMinorPeriod, 
+            minorPeriod, 
+            unexpectedBetweenMinorPeriodAndMinor, 
+            minor, 
+            unexpectedBetweenMinorAndPatchPeriod, 
             patchPeriod, 
-            unexpectedBetweenPatchPeriodAndPatchVersion, 
-            patchVersion, 
-            unexpectedAfterPatchVersion
+            unexpectedBetweenPatchPeriodAndPatch, 
+            patch, 
+            unexpectedAfterPatch
           ))) {(arena, _) in 
       let layout: [RawSyntax?] = [
-          unexpectedBeforeMajorMinor?.raw, 
-          majorMinor.raw, 
-          unexpectedBetweenMajorMinorAndPatchPeriod?.raw, 
+          unexpectedBeforeMajor?.raw, 
+          major.raw, 
+          unexpectedBetweenMajorAndMinorPeriod?.raw, 
+          minorPeriod?.raw, 
+          unexpectedBetweenMinorPeriodAndMinor?.raw, 
+          minor?.raw, 
+          unexpectedBetweenMinorAndPatchPeriod?.raw, 
           patchPeriod?.raw, 
-          unexpectedBetweenPatchPeriodAndPatchVersion?.raw, 
-          patchVersion?.raw, 
-          unexpectedAfterPatchVersion?.raw
+          unexpectedBetweenPatchPeriodAndPatch?.raw, 
+          patch?.raw, 
+          unexpectedAfterPatch?.raw
         ]
       let raw = RawSyntax.makeLayout(
           kind: SyntaxKind.versionTuple, 
@@ -19967,7 +19979,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
     self.init(data)
   }
   
-  public var unexpectedBeforeMajorMinor: UnexpectedNodesSyntax? {
+  public var unexpectedBeforeMajor: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -19976,8 +19988,8 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// In case the version consists only of the major version, an integer literal that specifies the major version. In case the version consists of major and minor version number, a floating literal in which the decimal part is interpreted as the minor version.
-  public var majorMinor: TokenSyntax {
+  /// The major version.
+  public var major: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)
     }
@@ -19986,7 +19998,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenMajorAndMinorPeriod: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 2, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -19995,8 +20007,8 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// If the version contains a patch number, the period separating the minor from the patch number.
-  public var patchPeriod: TokenSyntax? {
+  /// If the version contains a minor number, the period separating the major from the minor number.
+  public var minorPeriod: TokenSyntax? {
     get {
       return data.child(at: 3, parent: Syntax(self)).map(TokenSyntax.init)
     }
@@ -20005,7 +20017,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenMinorPeriodAndMinor: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -20014,8 +20026,8 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  /// The patch version if specified.
-  public var patchVersion: TokenSyntax? {
+  /// The minor version if specified.
+  public var minor: TokenSyntax? {
     get {
       return data.child(at: 5, parent: Syntax(self)).map(TokenSyntax.init)
     }
@@ -20024,7 +20036,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedAfterPatchVersion: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenMinorAndPatchPeriod: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 6, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -20033,15 +20045,57 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// If the version contains a patch number, the period separating the minor from the patch number.
+  public var patchPeriod: TokenSyntax? {
+    get {
+      return data.child(at: 7, parent: Syntax(self)).map(TokenSyntax.init)
+    }
+    set(value) {
+      self = VersionTupleSyntax(data.replacingChild(at: 7, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var unexpectedBetweenPatchPeriodAndPatch: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 8, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = VersionTupleSyntax(data.replacingChild(at: 8, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  /// The patch version if specified.
+  public var patch: TokenSyntax? {
+    get {
+      return data.child(at: 9, parent: Syntax(self)).map(TokenSyntax.init)
+    }
+    set(value) {
+      self = VersionTupleSyntax(data.replacingChild(at: 9, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var unexpectedAfterPatch: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 10, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = VersionTupleSyntax(data.replacingChild(at: 10, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
   public static var structure: SyntaxNodeStructure {
     return .layout([
-          \Self.unexpectedBeforeMajorMinor, 
-          \Self.majorMinor, 
-          \Self.unexpectedBetweenMajorMinorAndPatchPeriod, 
+          \Self.unexpectedBeforeMajor, 
+          \Self.major, 
+          \Self.unexpectedBetweenMajorAndMinorPeriod, 
+          \Self.minorPeriod, 
+          \Self.unexpectedBetweenMinorPeriodAndMinor, 
+          \Self.minor, 
+          \Self.unexpectedBetweenMinorAndPatchPeriod, 
           \Self.patchPeriod, 
-          \Self.unexpectedBetweenPatchPeriodAndPatchVersion, 
-          \Self.patchVersion, 
-          \Self.unexpectedAfterPatchVersion
+          \Self.unexpectedBetweenPatchPeriodAndPatch, 
+          \Self.patch, 
+          \Self.unexpectedAfterPatch
         ])
   }
   
@@ -20061,6 +20115,14 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 6:
       return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    case 10:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -20070,13 +20132,17 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
 extension VersionTupleSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-          "unexpectedBeforeMajorMinor": unexpectedBeforeMajorMinor.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
-          "majorMinor": Syntax(majorMinor).asProtocol(SyntaxProtocol.self), 
-          "unexpectedBetweenMajorMinorAndPatchPeriod": unexpectedBetweenMajorMinorAndPatchPeriod.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
+          "unexpectedBeforeMajor": unexpectedBeforeMajor.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
+          "major": Syntax(major).asProtocol(SyntaxProtocol.self), 
+          "unexpectedBetweenMajorAndMinorPeriod": unexpectedBetweenMajorAndMinorPeriod.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
+          "minorPeriod": minorPeriod.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
+          "unexpectedBetweenMinorPeriodAndMinor": unexpectedBetweenMinorPeriodAndMinor.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
+          "minor": minor.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
+          "unexpectedBetweenMinorAndPatchPeriod": unexpectedBetweenMinorAndPatchPeriod.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
           "patchPeriod": patchPeriod.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
-          "unexpectedBetweenPatchPeriodAndPatchVersion": unexpectedBetweenPatchPeriodAndPatchVersion.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
-          "patchVersion": patchVersion.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
-          "unexpectedAfterPatchVersion": unexpectedAfterPatchVersion.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any
+          "unexpectedBetweenPatchPeriodAndPatch": unexpectedBetweenPatchPeriodAndPatch.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
+          "patch": patch.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
+          "unexpectedAfterPatch": unexpectedAfterPatch.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any
         ])
   }
 }

--- a/Tests/SwiftParserTest/AvailabilityTests.swift
+++ b/Tests/SwiftParserTest/AvailabilityTests.swift
@@ -99,4 +99,93 @@ final class AvailabilityTests: XCTestCase {
       """
     )
   }
+
+  func testVersionParsing() {
+    assertParse(
+      """
+      @available(OSX 10)
+      func test() {}
+      """,
+      substructure: Syntax(
+        VersionTupleSyntax(
+          major: .integerLiteral("10")
+        )
+      )
+    )
+
+    assertParse(
+      """
+      @available(OSX 10.0)
+      func test() {}
+      """,
+      substructure: Syntax(
+        VersionTupleSyntax(
+          major: .integerLiteral("10"),
+          minorPeriod: .periodToken(),
+          minor: .integerLiteral("0")
+        )
+      )
+    )
+
+    assertParse(
+      """
+      @available(OSX 10.0.1)
+      func test() {}
+      """,
+      substructure: Syntax(
+        VersionTupleSyntax(
+          major: .integerLiteral("10"),
+          minorPeriod: .periodToken(),
+          minor: .integerLiteral("0"),
+          patchPeriod: .periodToken(),
+          patch: .integerLiteral("1")
+        )
+      )
+    )
+
+    assertParse(
+      """
+      @available(OSX 1️⃣10e10)
+      func test() {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected version tuple in version restriction"),
+        DiagnosticSpec(message: "unexpected code '10e10' in attribute"),
+      ]
+    )
+
+    assertParse(
+      """
+      @available(OSX 10.1️⃣0e10)
+      func test() {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected integer literal in version tuple"),
+        DiagnosticSpec(message: "unexpected code '0e10' in attribute"),
+      ]
+    )
+
+    assertParse(
+      """
+      @available(OSX 1️⃣0xff)
+      func test() {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected version tuple in version restriction"),
+        DiagnosticSpec(message: "unexpected code '0xff' in attribute"),
+      ]
+    )
+
+    assertParse(
+      """
+      @available(OSX 1.0.1️⃣0xff)
+      func test() {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected integer literal in version tuple"),
+        DiagnosticSpec(message: "unexpected code '0xff' in attribute"),
+      ]
+    )
+
+  }
 }


### PR DESCRIPTION
Previously, internals from the lexer leaked through by representing the major and minor part of the version as a float literal. Also, we accepted non-decimal numbers (eg. hex) for version number, which we don’t want.

Fixes apple/swift-syntax#1434
rdar://107152155