### PR TITLE
If no explicit highlight range was given, highlight the node the diagnostic is anchored at instead of highlighting nothing

### DIFF
--- a/Sources/SwiftDiagnostics/Diagnostic.swift
+++ b/Sources/SwiftDiagnostics/Diagnostic.swift
@@ -33,18 +33,20 @@ public struct Diagnostic: CustomDebugStringConvertible {
   /// Each Fix-It offers a different way to resolve the diagnostic. Usually, there's only one.
   public let fixIts: [FixIt]
 
+  /// If `highlights` is `nil` then `node` will be highlighted. This is a
+  /// reasonable default for almost all diagnostics.
   public init(
     node: Syntax,
     position: AbsolutePosition? = nil,
     message: DiagnosticMessage,
-    highlights: [Syntax] = [],
+    highlights: [Syntax]? = nil,
     notes: [Note] = [],
     fixIts: [FixIt] = []
   ) {
     self.node = node
     self.position = position ?? node.positionAfterSkippingLeadingTrivia
     self.diagMessage = message
-    self.highlights = highlights
+    self.highlights = highlights ?? [node]
     self.notes = notes
     self.fixIts = fixIts
   }

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -84,11 +84,12 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
   // MARK: - Private helper functions
 
   /// Produce a diagnostic.
+  /// If `highlights` is `nil` the `node` will be highlighted.
   func addDiagnostic<T: SyntaxProtocol>(
     _ node: T,
     position: AbsolutePosition? = nil,
     _ message: DiagnosticMessage,
-    highlights: [Syntax] = [],
+    highlights: [Syntax]? = nil,
     notes: [Note] = [],
     fixIts: [FixIt] = [],
     handledNodes: [SyntaxIdentifier] = []

--- a/Sources/SwiftSyntaxBuilder/ValidatingSyntaxNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/ValidatingSyntaxNodes.swift
@@ -32,7 +32,7 @@ extension SyntaxProtocol {
 }
 
 extension Trivia {
-  /// If `trivia` has contains no unexpected trivia, return `trivia`, otherwise
+  /// If `trivia` contains no unexpected trivia, return `trivia`, otherwise
   /// throw an error with diagnostics describing the unexpected trivia.
   public init(validating trivia: Trivia) throws {
     self = trivia

--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -765,7 +765,7 @@ final class RecoveryTests: XCTestCase {
       protocol Multi 1️⃣ident {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "found an unexpected second identifier in protocol")
+        DiagnosticSpec(message: "found an unexpected second identifier in protocol", highlight: "ident")
       ]
     )
   }


### PR DESCRIPTION
Especially for IDEs we should always report a highlight range whenever possible because it looks nicer if a token can be underlined instead of just underlining the character at which the diagnostic is anchored, which is what many IDEs default to.

rdar://104113111