### PR TITLE
Fix missing diagnostics for multiple expressions on the same line in closures, switches, and getters

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1768,20 +1768,14 @@ extension Parser {
             )
           }
 
-          var body = [RawCodeBlockItemSyntax]()
-          var codeBlockProgress = LoopProgressCondition()
-          while !self.at(.rightBrace),
-            let newItem = self.parseCodeBlockItem(),
-            codeBlockProgress.evaluate(currentToken)
-          {
-            body.append(newItem)
-          }
+          let body = parseCodeBlockItemList(until: { $0.at(.rightBrace) })
+
           let (unexpectedBeforeRBrace, rbrace) = self.expect(.rightBrace)
           return .getter(
             RawCodeBlockSyntax(
               unexpectedBeforeLBrace,
               leftBrace: lbrace,
-              statements: RawCodeBlockItemListSyntax(elements: body, arena: self.arena),
+              statements: body,
               unexpectedBeforeRBrace,
               rightBrace: rbrace,
               arena: self.arena

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -229,7 +229,7 @@ extension Parser {
       // If config of attributes is parsed as part of declaration parsing as it
       // doesn't constitute its own code block item.
       let directive = self.parsePoundIfDirective { (parser, _) in
-        parser.parseCodeBlockItem(isAtTopLevel: false, allowInitDecl: true)
+        parser.parseCodeBlockItem(isAtTopLevel: isAtTopLevel, allowInitDecl: allowInitDecl)
       } addSemicolonIfNeeded: { lastElement, newItemAtStartOfLine, parser in
         if lastElement.semicolon == nil && !newItemAtStartOfLine {
           return RawCodeBlockItemSyntax(

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -59,7 +59,7 @@ extension Parser {
 }
 
 extension Parser {
-  mutating func parseCodeBlockItemList(isAtTopLevel: Bool, allowInitDecl: Bool = true, stopCondition: (inout Parser) -> Bool) -> RawCodeBlockItemListSyntax {
+  mutating func parseCodeBlockItemList(isAtTopLevel: Bool = false, allowInitDecl: Bool = true, until stopCondition: (inout Parser) -> Bool) -> RawCodeBlockItemListSyntax {
     var elements = [RawCodeBlockItemSyntax]()
     var loopProgress = LoopProgressCondition()
     while !stopCondition(&self), loopProgress.evaluate(currentToken) {
@@ -89,7 +89,7 @@ extension Parser {
   ///
   ///     top-level-declaration → statements?
   mutating func parseTopLevelCodeBlockItems() -> RawCodeBlockItemListSyntax {
-    return parseCodeBlockItemList(isAtTopLevel: true, stopCondition: { _ in false })
+    return parseCodeBlockItemList(isAtTopLevel: true, until: { _ in false })
   }
 
   /// The optional form of `parseCodeBlock` that checks to see if the parser has
@@ -116,7 +116,7 @@ extension Parser {
   /// indented to close this code block or a surrounding context. See `expectRightBrace`.
   mutating func parseCodeBlock(introducer: RawTokenSyntax? = nil, allowInitDecl: Bool = true) -> RawCodeBlockSyntax {
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
-    let itemList = parseCodeBlockItemList(isAtTopLevel: false, allowInitDecl: allowInitDecl, stopCondition: { $0.at(.rightBrace) })
+    let itemList = parseCodeBlockItemList(allowInitDecl: allowInitDecl, until: { $0.at(.rightBrace) })
     let (unexpectedBeforeRBrace, rbrace) = self.expectRightBrace(leftBrace: lbrace, introducer: introducer)
 
     return .init(
@@ -148,7 +148,7 @@ extension Parser {
   ///     statement → compiler-control-statement
   ///     statements → statement statements?
   @_spi(RawSyntax)
-  public mutating func parseCodeBlockItem(isAtTopLevel: Bool = false, allowInitDecl: Bool = true) -> RawCodeBlockItemSyntax? {
+  public mutating func parseCodeBlockItem(isAtTopLevel: Bool, allowInitDecl: Bool) -> RawCodeBlockItemSyntax? {
     if let remainingTokens = remainingTokensIfMaximumNestingLevelReached() {
       return RawCodeBlockItemSyntax(
         remainingTokens,
@@ -229,7 +229,7 @@ extension Parser {
       // If config of attributes is parsed as part of declaration parsing as it
       // doesn't constitute its own code block item.
       let directive = self.parsePoundIfDirective { (parser, _) in
-        parser.parseCodeBlockItem()
+        parser.parseCodeBlockItem(isAtTopLevel: false, allowInitDecl: true)
       } addSemicolonIfNeeded: { lastElement, newItemAtStartOfLine, parser in
         if lastElement.semicolon == nil && !newItemAtStartOfLine {
           return RawCodeBlockItemSyntax(

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -1839,7 +1839,7 @@ final class StatementExpressionTests: XCTestCase {
       ]
     )
   }
-  
+
   func testConsecutiveStatements2() {
     assertParse(
       "switch x {case y: a1️⃣ b2️⃣ c}",
@@ -1849,7 +1849,7 @@ final class StatementExpressionTests: XCTestCase {
       ]
     )
   }
-  
+
   func testConsecutiveStatements3() {
     assertParse(
       """
@@ -1861,7 +1861,7 @@ final class StatementExpressionTests: XCTestCase {
       ]
     )
   }
-  
+
   func testConsecutiveStatements4() {
     assertParse(
       """
@@ -1870,6 +1870,43 @@ final class StatementExpressionTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
+      ]
+    )
+  }
+
+  func testInitCallInPoundIf() {
+    // Make sure we parse 'init()' as an expr, not a decl.
+    assertParse(
+      """
+      class C {
+      init() {
+      #if true
+        init()
+      #endif
+      }
+      }
+      """,
+      substructure: Syntax(
+        FunctionCallExprSyntax(
+          calledExpression: IdentifierExprSyntax(identifier: .keyword(.init("init")!)),
+          leftParen: .leftParenToken(),
+          argumentList: TupleExprElementListSyntax([]),
+          rightParen: .rightParenToken()
+        )
+      )
+    )
+  }
+
+  func testUnexpectedCloseBraceInPoundIf() {
+    assertParse(
+      """
+      #if true
+      1️⃣}
+      class C {}
+      #endif
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "unexpected brace before class")
       ]
     )
   }

--- a/Tests/SwiftParserTest/ExpressionTests.swift
+++ b/Tests/SwiftParserTest/ExpressionTests.swift
@@ -1830,6 +1830,50 @@ final class StatementExpressionTests: XCTestCase {
     )
   }
 
+  func testConsecutiveStatements1() {
+    assertParse(
+      "{a1️⃣ b2️⃣ c}",
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
+      ]
+    )
+  }
+  
+  func testConsecutiveStatements2() {
+    assertParse(
+      "switch x {case y: a1️⃣ b2️⃣ c}",
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
+      ]
+    )
+  }
+  
+  func testConsecutiveStatements3() {
+    assertParse(
+      """
+      var i: Int { a1️⃣ b2️⃣ c }
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
+      ]
+    )
+  }
+  
+  func testConsecutiveStatements4() {
+    assertParse(
+      """
+      var i: Int { get {a1️⃣ b} set {c2️⃣ d} }
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
+      ]
+    )
+  }
+
   func testStringLiteralAfterKeyPath() {
     assertParse(
       #"""

--- a/Tests/SwiftParserTest/translated/InvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidTests.swift
@@ -162,7 +162,7 @@ final class InvalidTests: XCTestCase {
           1️⃣let y = "foo"
           switch y {
             case "bar":
-              blah blah // ignored
+              blah2️⃣ blah // ignored
           }
         case "baz":
           break
@@ -174,7 +174,8 @@ final class InvalidTests: XCTestCase {
       }
       """#,
       diagnostics: [
-        DiagnosticSpec(message: "all statements inside a switch must be covered by a 'case' or 'default' label")
+        DiagnosticSpec(locationMarker: "1️⃣", message: "all statements inside a switch must be covered by a 'case' or 'default' label"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
       ]
     )
   }


### PR DESCRIPTION
Switch loops that used `parseCodeBlockItem` without semicolon checking over to using `parseCodeBlockItemList`.

Resolves #1452
rdar://107265306