### PR TITLE
Add space on leading and trailing equal

### DIFF
--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -1967,7 +1967,23 @@ extension Lexer.Cursor {
     if self.input.baseAddress! - tokStart.input.baseAddress! == 1 {
       switch tokStart.peek() {
       case UInt8(ascii: "="):
-        return Lexer.Result(.equal)
+        if leftBound != rightBound {
+          var errorPos = tokStart
+
+          if rightBound {
+            _ = errorPos.advance()
+          }
+
+          return Lexer.Result(
+            .equal,
+            error: LexingDiagnostic(
+              .equalMustHaveConsistentWhitespaceOnBothSides,
+              position: errorPos
+            )
+          )
+        } else {
+          return Lexer.Result(.equal)
+        }
       case UInt8(ascii: "&"):
         if leftBound == rightBound || leftBound {
           break

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -504,6 +504,9 @@ extension FixItMessage where Self == StaticParserFixIt {
   public static var insertNewline: Self {
     .init("insert newline")
   }
+  public static var insertWhitespace: Self {
+    .init("insert whitespace")
+  }
   public static var joinIdentifiers: Self {
     .init("join the identifiers together")
   }

--- a/Sources/SwiftSyntax/TokenDiagnostic.swift
+++ b/Sources/SwiftSyntax/TokenDiagnostic.swift
@@ -23,6 +23,7 @@ public struct TokenDiagnostic: Hashable {
     // Please order these alphabetically
 
     case editorPlaceholder
+    case equalMustHaveConsistentWhitespaceOnBothSides
     case expectedBinaryExponentInHexFloatLiteral
     case expectedClosingBraceInUnicodeEscape
     case expectedDigitInFloatLiteral
@@ -96,6 +97,7 @@ public struct TokenDiagnostic: Hashable {
   public var severity: Severity {
     switch kind {
     case .editorPlaceholder: return .error
+    case .equalMustHaveConsistentWhitespaceOnBothSides: return .error
     case .expectedBinaryExponentInHexFloatLiteral: return .error
     case .expectedClosingBraceInUnicodeEscape: return .error
     case .expectedDigitInFloatLiteral: return .error

--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -1958,34 +1958,46 @@ final class RecoveryTests: XCTestCase {
   }
 
   func testRecovery163() {
+    // <rdar://problem/22387625> QoI: Common errors: 'let x= 5' and 'let x =5' could use Fix-its
     assertParse(
       """
-      // <rdar://problem/22387625> QoI: Common errors: 'let x= 5' and 'let x =5' could use Fix-its
       func r22387625() {
-        let _= 5
-        let _ =5
+        let _1️⃣= 5
+        let _ =2️⃣5
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: '=' must have consistent whitespace on both sides, Fix-It replacements: 8 - 8 = ' '
-        // TODO: Old parser expected error on line 4: '=' must have consistent whitespace on both sides, Fix-It replacements: 10 - 10 = ' '
-      ]
+        DiagnosticSpec(locationMarker: "1️⃣", message: "'=' must have consistent whitespace on both sides", fixIts: ["insert whitespace"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "'=' must have consistent whitespace on both sides", fixIts: ["insert whitespace"]),
+      ],
+      fixedSource: """
+        func r22387625() {
+          let _ = 5
+          let _ = 5
+        }
+        """
     )
   }
 
   func testRecovery164() {
+    // https://github.com/apple/swift/issues/45723
     assertParse(
       """
-      // https://github.com/apple/swift/issues/45723
       do {
-        let _: Int= 5
-        let _: Array<Int>= []
+        let _: Int1️⃣= 5
+        let _: Array<Int>2️⃣= []
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: '=' must have consistent whitespace on both sides, Fix-It replacements: 13 - 13 = ' '
-        // TODO: Old parser expected error on line 4: '=' must have consistent whitespace on both sides, Fix-It replacements: 20 - 20 = ' '
-      ]
+        DiagnosticSpec(locationMarker: "1️⃣", message: "'=' must have consistent whitespace on both sides", fixIts: ["insert whitespace"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "'=' must have consistent whitespace on both sides", fixIts: ["insert whitespace"]),
+      ],
+      fixedSource: """
+        do {
+          let _: Int = 5
+          let _: Array<Int> = []
+        }
+        """
     )
   }
 


### PR DESCRIPTION
So the thing is that a rebased messed things up and closed my PR https://github.com/apple/swift-syntax/pull/1443 🫣