### PR TITLE
Remove check for `endOfFile` in `advance`

### DIFF
--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -1772,6 +1772,8 @@ extension Lexer.Cursor {
   }
 
   mutating func lexInStringLiteral(stringLiteralKind: StringLiteralKind, delimiterLength: Int) -> Lexer.Result {
+    if self.isAtEndOfFile { return .init(.eof) }
+
     var error: LexingDiagnostic? = nil
 
     while true {

--- a/Sources/SwiftParser/Lexer/LexemeSequence.swift
+++ b/Sources/SwiftParser/Lexer/LexemeSequence.swift
@@ -43,20 +43,7 @@ extension Lexer {
 
     mutating func advance() -> Lexer.Lexeme {
       defer {
-        if self.cursor.isAtEndOfFile {
-          self.nextToken = Lexeme(
-            tokenKind: .eof,
-            flags: [],
-            diagnostic: nil,
-            start: self.cursor.pointer,
-            leadingTriviaLength: 0,
-            textLength: 0,
-            trailingTriviaLength: 0,
-            cursor: self.cursor
-          )
-        } else {
-          self.nextToken = self.cursor.nextToken(sourceBufferStart: self.sourceBufferStart, stateAllocator: lexerStateAllocator)
-        }
+        self.nextToken = self.cursor.nextToken(sourceBufferStart: self.sourceBufferStart, stateAllocator: lexerStateAllocator)
       }
       return self.nextToken
     }


### PR DESCRIPTION
Instead, let the lexer produce `.eof` itself. This will be needed for regex literal lexing, where the lexer may still want to produce an empty regex literal pattern when at the end of the file, before the `.eof` token.