### PR TITLE
Use a different unicode character for the corner diagnostics

### DIFF
--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -304,7 +304,7 @@ public struct DiagnosticsFormatter {
         for diag in diags.dropLast(1) {
           annotatedSource.append("\(preMessage)├─ \(colorizeIfRequested(diag.diagMessage))\n")
         }
-        annotatedSource.append("\(preMessage)╰─ \(colorizeIfRequested(diags.last!.diagMessage))\n")
+        annotatedSource.append("\(preMessage)└─ \(colorizeIfRequested(diags.last!.diagMessage))\n")
       }
 
       // Add suffix text.

--- a/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
+++ b/Sources/SwiftDiagnostics/GroupedDiagnostics.swift
@@ -183,8 +183,8 @@ extension GroupedDiagnostics {
         boxSuffix = ""
       }
 
-      prefixString = colorizeBufferOutline(padding + "╭─── ") + sourceFile.displayName + " " + boxSuffix + "\n"
-      suffixString = colorizeBufferOutline(padding + "╰───" + String(repeating: "─", count: sourceFile.displayName.count + 2)) + boxSuffix + "\n"
+      prefixString = colorizeBufferOutline(padding + "┌─── ") + sourceFile.displayName + " " + boxSuffix + "\n"
+      suffixString = colorizeBufferOutline(padding + "└───" + String(repeating: "─", count: sourceFile.displayName.count + 2)) + boxSuffix + "\n"
     }
 
     // Render the buffer.

--- a/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
@@ -30,7 +30,7 @@ final class DiagnosticsFormatterTests: XCTestCase {
       """
     let expectedOutput = """
       1 │ var foo = bar +
-        │                ╰─ error: expected expression after operator
+        │                └─ error: expected expression after operator
 
       """
     assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
@@ -42,9 +42,9 @@ final class DiagnosticsFormatterTests: XCTestCase {
       """
     let expectedOutput = """
       1 │ foo.[].[].[]
-        │     │  │  ╰─ error: expected name in member access
-        │     │  ╰─ error: expected name in member access
-        │     ╰─ error: expected name in member access
+        │     │  │  └─ error: expected name in member access
+        │     │  └─ error: expected name in member access
+        │     └─ error: expected name in member access
 
       """
     assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
@@ -68,14 +68,14 @@ final class DiagnosticsFormatterTests: XCTestCase {
        2 │ i = 2
        3 │ i = foo(
        4 │ i = 4
-         │      ╰─ error: expected ')' to end function call
+         │      └─ error: expected ')' to end function call
        5 │ i = 5
        6 │ i = 6
          ┆
        9 │ i = 9
       10 │ i = 10
       11 │ i = bar(
-         │         ╰─ error: expected value and ')' to end function call
+         │         └─ error: expected value and ')' to end function call
 
       """
     assertStringsEqualWithDiff(annotate(source: source), expectedOutput)
@@ -87,7 +87,7 @@ final class DiagnosticsFormatterTests: XCTestCase {
     let expectedOutput = """
       1 │ t as (..)
         │       ├─ error: expected type in tuple type
-        │       ╰─ error: unexpected code '..' in tuple type
+        │       └─ error: unexpected code '..' in tuple type
 
       """
 
@@ -101,7 +101,7 @@ final class DiagnosticsFormatterTests: XCTestCase {
 
     let expectedOutput = """
       \u{001B}[0;36m1 │\u{001B}[0;0m var foo = bar +
-        \u{001B}[0;36m│\u{001B}[0;0m                ╰─ \u{001B}[1;31merror: expected expression after operator\u{001B}[0;0m
+        \u{001B}[0;36m│\u{001B}[0;0m                └─ \u{001B}[1;31merror: expected expression after operator\u{001B}[0;0m
 
       """
     assertStringsEqualWithDiff(annotate(source: source, colorize: true), expectedOutput)
@@ -113,9 +113,9 @@ final class DiagnosticsFormatterTests: XCTestCase {
       """
     let expectedOutput = """
       \u{001B}[0;36m1 │\u{001B}[0;0m foo.[].[].[]
-        \u{001B}[0;36m│\u{001B}[0;0m     │  │  ╰─ \u{001B}[1;31merror: expected name in member access\u{001B}[0;0m
-        \u{001B}[0;36m│\u{001B}[0;0m     │  ╰─ \u{001B}[1;31merror: expected name in member access\u{001B}[0;0m
-        \u{001B}[0;36m│\u{001B}[0;0m     ╰─ \u{001B}[1;31merror: expected name in member access\u{001B}[0;0m
+        \u{001B}[0;36m│\u{001B}[0;0m     │  │  └─ \u{001B}[1;31merror: expected name in member access\u{001B}[0;0m
+        \u{001B}[0;36m│\u{001B}[0;0m     │  └─ \u{001B}[1;31merror: expected name in member access\u{001B}[0;0m
+        \u{001B}[0;36m│\u{001B}[0;0m     └─ \u{001B}[1;31merror: expected name in member access\u{001B}[0;0m
 
       """
     assertStringsEqualWithDiff(annotate(source: source, colorize: true), expectedOutput)
@@ -128,8 +128,8 @@ final class DiagnosticsFormatterTests: XCTestCase {
 
     let expectedOutput = """
       \u{001B}[0;36m1 │\u{001B}[0;0m for \u{001B}[4;39m(i\u{001B}[0;0m \u{001B}[4;39m= 🐮; i != 👩‍👩‍👦‍👦; i += 1)\u{001B}[0;0m { }
-        \u{001B}[0;36m│\u{001B}[0;0m │      ╰─ \u{001B}[1;31merror: expected ')' to end tuple pattern\u{001B}[0;0m
-        \u{001B}[0;36m│\u{001B}[0;0m ╰─ \u{001B}[1;31merror: C-style for statement has been removed in Swift 3\u{001B}[0;0m
+        \u{001B}[0;36m│\u{001B}[0;0m │      └─ \u{001B}[1;31merror: expected ')' to end tuple pattern\u{001B}[0;0m
+        \u{001B}[0;36m│\u{001B}[0;0m └─ \u{001B}[1;31merror: C-style for statement has been removed in Swift 3\u{001B}[0;0m
 
       """
 

--- a/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/GroupDiagnosticsFormatterTests.swift
@@ -117,17 +117,17 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
       3 │ // test
       4 │ let pi = 3.14159
       5 │ #myAssert(pi == 3)
-        │ ╰─ note: in expansion of macro 'myAssert' here
-        ╭─── #myAssert ───────────────────────────────────────────────────────
+        │ └─ note: in expansion of macro 'myAssert' here
+        ┌─── #myAssert ───────────────────────────────────────────────────────
         │1 │ let __a = pi
         │2 │ let __b = 3
         │3 │ if !(__a == __b) {
-        │  │          ╰─ error: no matching operator '==' for types 'Double' and 'Int'
+        │  │          └─ error: no matching operator '==' for types 'Double' and 'Int'
         │4 │   fatalError("assertion failed: pi != 3")
         │5 │ }
-        ╰─────────────────────────────────────────────────────────────────────
+        └─────────────────────────────────────────────────────────────────────
       6 │ print("hello"
-        │              ╰─ error: expected ')' to end function call
+        │              └─ error: expected ')' to end function call
 
       """
     )
@@ -184,21 +184,21 @@ final class GroupedDiagnosticsFormatterTests: XCTestCase {
       === main.swift:2 ===
       1 │ let pi = 3.14159
       2 │ #myAssert(pi == 3)
-        │ ╰─ note: in expansion of macro 'myAssert' here
-        ╭─── #myAssert ───────────────────────────────────────────────────────
+        │ └─ note: in expansion of macro 'myAssert' here
+        ┌─── #myAssert ───────────────────────────────────────────────────────
         │1 │ let __a = pi
         │2 │ let __b = 3
         │3 │ if #invertedEqualityCheck(__a, __b) {
-        │  │    ╰─ note: in expansion of macro 'invertedEqualityCheck' here
-        │  ╭─── #invertedEqualityCheck ───────────────────────────────────────
+        │  │    └─ note: in expansion of macro 'invertedEqualityCheck' here
+        │  ┌─── #invertedEqualityCheck ───────────────────────────────────────
         │  │1 │ !(__a == __b)
-        │  │  │       ╰─ error: no matching operator '==' for types 'Double' and 'Int'
-        │  ╰──────────────────────────────────────────────────────────────────
+        │  │  │       └─ error: no matching operator '==' for types 'Double' and 'Int'
+        │  └──────────────────────────────────────────────────────────────────
         │4 │   fatalError("assertion failed: pi != 3")
         │5 │ }
-        ╰─────────────────────────────────────────────────────────────────────
+        └─────────────────────────────────────────────────────────────────────
       3 │ print("hello"
-        │              ╰─ error: expected ')' to end function call
+        │              └─ error: expected ')' to end function call
 
       """
     )

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -418,7 +418,7 @@ final class StringInterpolationTests: XCTestCase {
         """
 
         1 │ /*comment*/ invalid /*comm*/
-          │             ╰─ error: unexpected trivia 'invalid'
+          │             └─ error: unexpected trivia 'invalid'
 
         """
       )
@@ -435,8 +435,8 @@ final class StringInterpolationTests: XCTestCase {
         """
 
         1 │ return 1
-          │ │       ╰─ error: expected declaration
-          │ ╰─ error: unexpected code 'return 1' before declaration
+          │ │       └─ error: expected declaration
+          │ └─ error: unexpected code 'return 1' before declaration
 
         """
       )
@@ -453,8 +453,8 @@ final class StringInterpolationTests: XCTestCase {
         """
 
         1 │ struct Foo {}
-          │ │            ╰─ error: expected statement
-          │ ╰─ error: unexpected code 'struct Foo {}' before statement
+          │ │            └─ error: expected statement
+          │ └─ error: unexpected code 'struct Foo {}' before statement
 
         """
       )


### PR DESCRIPTION
The current character there wasn't aligning properly and this new one aligns like intended.