### PR TITLE
add parsing for ~ (the 'without' operator)

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -906,6 +906,14 @@ public let DECL_NODES: [Node] = [
       "WithTrailingComma"
     ],
     children: [
+      /// Indicates whether the 'without' operator was applied to the type to
+      /// indicate the suppression of implicit conformance to this type.
+      /// This child stores the token representing the 'without' operator.
+      Child(
+        name: "HasWithout",
+        kind: .token(choices: [.token(tokenKind: "PrefixOperatorToken")]),
+        isOptional: true
+      ),
       Child(
         name: "TypeName",
         kind: .node(kind: "Type")

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -219,6 +219,7 @@ extension Parser {
       var keepGoing: RawTokenSyntax? = nil
       var loopProgress = LoopProgressCondition()
       repeat {
+        var withoutToken: RawTokenSyntax? = nil
         let type: RawTypeSyntax
         if let classKeyword = self.consume(if: .keyword(.class)) {
           type = RawTypeSyntax(
@@ -228,12 +229,16 @@ extension Parser {
             )
           )
         } else {
+          if self.currentToken.starts(with: "~") {
+            withoutToken = self.consumePrefix("~", as: .prefixOperator)
+          }
           type = self.parseType()
         }
 
         keepGoing = self.consume(if: .comma)
         elements.append(
           RawInheritedTypeSyntax(
+            hasWithout: withoutToken,
             typeName: type,
             trailingComma: keepGoing,
             arena: self.arena

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -11102,7 +11102,9 @@ public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol {
   }
   
   public init(
-      _ unexpectedBeforeTypeName: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBeforeHasWithout: RawUnexpectedNodesSyntax? = nil, 
+      hasWithout: RawTokenSyntax?, 
+      _ unexpectedBetweenHasWithoutAndTypeName: RawUnexpectedNodesSyntax? = nil, 
       typeName: RawTypeSyntax, 
       _ unexpectedBetweenTypeNameAndTrailingComma: RawUnexpectedNodesSyntax? = nil, 
       trailingComma: RawTokenSyntax?, 
@@ -11110,35 +11112,45 @@ public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol {
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
-      kind: .inheritedType, uninitializedCount: 5, arena: arena) { layout in 
+      kind: .inheritedType, uninitializedCount: 7, arena: arena) { layout in 
       layout.initialize(repeating: nil)
-      layout[0] = unexpectedBeforeTypeName?.raw
-      layout[1] = typeName.raw
-      layout[2] = unexpectedBetweenTypeNameAndTrailingComma?.raw
-      layout[3] = trailingComma?.raw
-      layout[4] = unexpectedAfterTrailingComma?.raw
+      layout[0] = unexpectedBeforeHasWithout?.raw
+      layout[1] = hasWithout?.raw
+      layout[2] = unexpectedBetweenHasWithoutAndTypeName?.raw
+      layout[3] = typeName.raw
+      layout[4] = unexpectedBetweenTypeNameAndTrailingComma?.raw
+      layout[5] = trailingComma?.raw
+      layout[6] = unexpectedAfterTrailingComma?.raw
     }
     self.init(unchecked: raw)
   }
   
-  public var unexpectedBeforeTypeName: RawUnexpectedNodesSyntax? {
+  public var unexpectedBeforeHasWithout: RawUnexpectedNodesSyntax? {
     layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var typeName: RawTypeSyntax {
-    layoutView.children[1].map(RawTypeSyntax.init(raw:))!
+  public var hasWithout: RawTokenSyntax? {
+    layoutView.children[1].map(RawTokenSyntax.init(raw:))
   }
   
-  public var unexpectedBetweenTypeNameAndTrailingComma: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenHasWithoutAndTypeName: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
+  public var typeName: RawTypeSyntax {
+    layoutView.children[3].map(RawTypeSyntax.init(raw:))!
+  }
+  
+  public var unexpectedBetweenTypeNameAndTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
   public var trailingComma: RawTokenSyntax? {
-    layoutView.children[3].map(RawTokenSyntax.init(raw:))
+    layoutView.children[5].map(RawTokenSyntax.init(raw:))
   }
   
   public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
-    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -227,12 +227,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .accessPathComponent:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
-            .tokenKind(.identifier), 
-            .tokenKind(.binaryOperator), 
-            .tokenKind(.prefixOperator), 
-            .tokenKind(.postfixOperator)
-          ]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.identifier)]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.period)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -835,13 +830,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .declName:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
-            .tokenKind(.identifier), 
-            .tokenKind(.binaryOperator), 
-            .keyword("init"), 
-            .keyword("self"), 
-            .keyword("Self")
-          ]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.identifier), .tokenKind(.prefixOperator), .keyword("init")]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawDeclNameArgumentsSyntax?.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -962,7 +951,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .differentiableAttributeArguments:
     assert(layout.count == 11)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax?.self, tokenChoices: [.keyword("_forward"), .keyword("reverse"), .keyword("_linear")]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax?.self, tokenChoices: [.keyword("forward"), .keyword("reverse"), .keyword("linear")]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.comma)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -1019,12 +1008,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .editorPlaceholderExpr:
     assert(layout.count == 3)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
-            .tokenKind(.identifier), 
-            .keyword("self"), 
-            .keyword("Self"), 
-            .keyword("init")
-          ]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.identifier)]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
   case .effectsArguments:
     for (index, element) in layout.enumerated() {
@@ -1455,12 +1439,14 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
       assertNoError(kind, index, verify(element, as: RawInheritedTypeSyntax.self))
     }
   case .inheritedType:
-    assert(layout.count == 5)
+    assert(layout.count == 7)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTypeSyntax.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.prefixOperator)]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.comma)]))
+    assertNoError(kind, 3, verify(layout[3], as: RawTypeSyntax.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.comma)]))
+    assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
   case .initializerClause:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
@@ -1561,7 +1547,14 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .labeledSpecializeEntry:
     assert(layout.count == 9)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
+            .tokenKind(.identifier), 
+            .keyword("available"), 
+            .keyword("exported"), 
+            .keyword("kind"), 
+            .keyword("spi"), 
+            .keyword("spiModule")
+          ]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.colon)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -1785,7 +1778,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .objCSelectorPiece:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax?.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.identifier)]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.colon)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -2076,10 +2069,9 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self, tokenChoices: [
             .tokenKind(.identifier), 
-            .keyword("self"), 
-            .keyword("Self"), 
-            .keyword("init"), 
-            .tokenKind(.binaryOperator)
+            .tokenKind(.binaryOperator), 
+            .tokenKind(.prefixOperator), 
+            .tokenKind(.postfixOperator)
           ]))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 7, verify(layout[7], as: RawDeclNameArgumentsSyntax?.self))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -11505,7 +11505,9 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   
   public init<T: TypeSyntaxProtocol>(
       leadingTrivia: Trivia? = nil, 
-      _ unexpectedBeforeTypeName: UnexpectedNodesSyntax? = nil, 
+      _ unexpectedBeforeHasWithout: UnexpectedNodesSyntax? = nil, 
+      hasWithout: TokenSyntax? = nil, 
+      _ unexpectedBetweenHasWithoutAndTypeName: UnexpectedNodesSyntax? = nil, 
       typeName: T, 
       _ unexpectedBetweenTypeNameAndTrailingComma: UnexpectedNodesSyntax? = nil, 
       trailingComma: TokenSyntax? = nil, 
@@ -11516,14 +11518,18 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
     let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (
-            unexpectedBeforeTypeName, 
+            unexpectedBeforeHasWithout, 
+            hasWithout, 
+            unexpectedBetweenHasWithoutAndTypeName, 
             typeName, 
             unexpectedBetweenTypeNameAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
           ))) {(arena, _) in 
       let layout: [RawSyntax?] = [
-          unexpectedBeforeTypeName?.raw, 
+          unexpectedBeforeHasWithout?.raw, 
+          hasWithout?.raw, 
+          unexpectedBetweenHasWithoutAndTypeName?.raw, 
           typeName.raw, 
           unexpectedBetweenTypeNameAndTrailingComma?.raw, 
           trailingComma?.raw, 
@@ -11541,7 +11547,7 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     self.init(data)
   }
   
-  public var unexpectedBeforeTypeName: UnexpectedNodesSyntax? {
+  public var unexpectedBeforeHasWithout: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -11550,16 +11556,16 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var typeName: TypeSyntax {
+  public var hasWithout: TokenSyntax? {
     get {
-      return TypeSyntax(data.child(at: 1, parent: Syntax(self))!)
+      return data.child(at: 1, parent: Syntax(self)).map(TokenSyntax.init)
     }
     set(value) {
-      self = InheritedTypeSyntax(data.replacingChild(at: 1, with: value.raw, arena: SyntaxArena()))
+      self = InheritedTypeSyntax(data.replacingChild(at: 1, with: value?.raw, arena: SyntaxArena()))
     }
   }
   
-  public var unexpectedBetweenTypeNameAndTrailingComma: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenHasWithoutAndTypeName: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 2, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -11568,16 +11574,16 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var trailingComma: TokenSyntax? {
+  public var typeName: TypeSyntax {
     get {
-      return data.child(at: 3, parent: Syntax(self)).map(TokenSyntax.init)
+      return TypeSyntax(data.child(at: 3, parent: Syntax(self))!)
     }
     set(value) {
-      self = InheritedTypeSyntax(data.replacingChild(at: 3, with: value?.raw, arena: SyntaxArena()))
+      self = InheritedTypeSyntax(data.replacingChild(at: 3, with: value.raw, arena: SyntaxArena()))
     }
   }
   
-  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenTypeNameAndTrailingComma: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -11586,9 +11592,29 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
+  public var trailingComma: TokenSyntax? {
+    get {
+      return data.child(at: 5, parent: Syntax(self)).map(TokenSyntax.init)
+    }
+    set(value) {
+      self = InheritedTypeSyntax(data.replacingChild(at: 5, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 6, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = InheritedTypeSyntax(data.replacingChild(at: 6, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
   public static var structure: SyntaxNodeStructure {
     return .layout([
-          \Self.unexpectedBeforeTypeName, 
+          \Self.unexpectedBeforeHasWithout, 
+          \Self.hasWithout, 
+          \Self.unexpectedBetweenHasWithoutAndTypeName, 
           \Self.typeName, 
           \Self.unexpectedBetweenTypeNameAndTrailingComma, 
           \Self.trailingComma, 
@@ -11608,6 +11634,10 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 4:
       return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -11617,7 +11647,9 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 extension InheritedTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-          "unexpectedBeforeTypeName": unexpectedBeforeTypeName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
+          "unexpectedBeforeHasWithout": unexpectedBeforeHasWithout.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
+          "hasWithout": hasWithout.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
+          "unexpectedBetweenHasWithoutAndTypeName": unexpectedBetweenHasWithoutAndTypeName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
           "typeName": Syntax(typeName).asProtocol(SyntaxProtocol.self), 
           "unexpectedBetweenTypeNameAndTrailingComma": unexpectedBetweenTypeNameAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 
           "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any , 

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1551,6 +1551,16 @@ final class DeclarationTests: XCTestCase {
       """
     )
   }
+
+  func testSuppressedImplicitConformance() {
+    assertParse(
+      """
+      struct Hello: ~Copyable {}
+
+      enum Whatever: Int, ~ Hashable, Equatable {}
+      """
+    )
+  }
 }
 
 extension Parser.DeclAttributes {


### PR DESCRIPTION
see the primary PR https://github.com/apple/swift/pull/64699 for more details. This companion PR implements the parsing for the "without operator" `~` used for conformance suppression. For example, `~Copyable`.

rdar://106775103