### PR TITLE
Only output number of executed instructions in `swift-parser-cli` on macOS

### DIFF
--- a/Sources/_InstructionCounter/include/InstructionsExecuted.h
+++ b/Sources/_InstructionCounter/include/InstructionsExecuted.h
@@ -12,6 +12,6 @@
 
 #include <unistd.h>
 
-/// Returns the number of instructions the process has executed since it was
-/// launched.
+/// On macOS returns the number of instructions the process has executed since
+/// it was launched, on all other platforms returns 0.
 uint64_t getInstructionsExecuted();

--- a/Sources/_InstructionCounter/src/InstructionsExecuted.c
+++ b/Sources/_InstructionCounter/src/InstructionsExecuted.c
@@ -10,7 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if __APPLE__
+#include <TargetConditionals.h>
+#if TARGET_OS_MAC && !TARGET_OS_IPHONE
+#define TARGET_IS_MACOS 1
+#endif
+#endif
+
 #include "InstructionsExecuted.h"
+
+#ifdef TARGET_IS_MACOS
 #include <libproc.h>
 #include <sys/resource.h>
 
@@ -21,3 +30,8 @@ uint64_t getInstructionsExecuted() {
   }
   return 0;
 }
+#else
+uint64_t getInstructionsExecuted() {
+  return 0;
+}
+#endif

--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -190,7 +190,11 @@ class PerformanceTest: ParsableCommand {
     let endDate = Date()
 
     print("Time:         \(endDate.timeIntervalSince(start) / Double(self.iterations) * 1000)ms")
-    print("Instructions: \(Double(endInstructions - startInstructions) / Double(self.iterations))")
+    if endInstructions != startInstructions {
+      // endInstructions == startInstructions only happens if we are on non-macOS
+      // platforms that don't support `getInstructionsExecuted`. Don't display anything.
+      print("Instructions: \(Double(endInstructions - startInstructions) / Double(self.iterations))")
+    }
   }
 }
 


### PR DESCRIPTION
`libproc.h` is not available on iOS and I’m not sure how it behaves on Linux. Since `swift-parser-cli` is only a testing utility, take the safe approach and only output the number of executed instructions on macOS.