### PR TITLE
Validate token choices in CI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,13 +5,13 @@ import Foundation
 
 /// If we are in a controlled CI environment, we can use internal compiler flags
 /// to speed up the build or improve it.
-let swiftSyntaxSwiftSettings: [SwiftSetting]
+var swiftSyntaxSwiftSettings: [SwiftSetting] = []
 if ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] != nil {
   let groupFile = URL(fileURLWithPath: #file)
     .deletingLastPathComponent()
     .appendingPathComponent("utils")
     .appendingPathComponent("group.json")
-  swiftSyntaxSwiftSettings = [
+  swiftSyntaxSwiftSettings += [
     .define("SWIFTSYNTAX_ENABLE_ASSERTIONS"),
     .unsafeFlags([
       "-Xfrontend", "-group-info-path",
@@ -21,8 +21,11 @@ if ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] != nil 
       "-enforce-exclusivity=unchecked",
     ]),
   ]
-} else {
-  swiftSyntaxSwiftSettings = []
+}
+if ProcessInfo.processInfo.environment["SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION"] != nil {
+  swiftSyntaxSwiftSettings += [
+    .define("SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION")
+  ]
 }
 
 let package = Package(

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -17,7 +17,7 @@
 /// Note that this only validates the immediate children.
 /// Results in an assertion failure if the layout is invalid.
 func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
-  #if DEBUG
+  #if SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION
   enum TokenChoice: CustomStringConvertible {
     case keyword(StaticString)
     case tokenKind(RawTokenKind)
@@ -140,7 +140,6 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     // the list of expected token choices in the syntax tree doesn't match those
     // the parser generates. Disable the verification for now until all issues
     // regarding it are fixed.
-    #if VALIDATE_TOKEN_CHOICES
     if raw != nil {
       return verify(
           raw, 
@@ -151,9 +150,6 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
         )
     }
     return nil
-    #else 
-    return verify(raw, as: RawTokenSyntax?.self)
-    #endif 
   }
   func verify(
       _ raw: RawSyntax?, 
@@ -166,7 +162,6 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     // the list of expected token choices in the syntax tree doesn't match those
     // the parser generates. Disable the verification for now until all issues
     // regarding it are fixed.
-    #if VALIDATE_TOKEN_CHOICES
     guard let raw = raw else {
       return .expectedNonNil(expectedKind: RawTokenSyntax.self, file: file, line: line)
     }
@@ -193,9 +188,6 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
         file: file, 
         line: line
       )
-    #else 
-    return verify(raw, as: RawTokenSyntax.self)
-    #endif 
   }
   func assertNoError(_ nodeKind: SyntaxKind, _ index: Int, _ error: ValidationError?) {
     if let error = error {


### PR DESCRIPTION
This changes the the paradigm around token validation in SwiftSyntax. Previously, we always validated that the `RawSyntax` tree layout was as expected in debug builds (independent of whether we forced assertions on). This property should always be guaranteed by our API unless you are replacing children manually. Verification that the tokens in the tree matched the token choices, on the other hand, was always disabled unless you specifically enabled it by modifying Package.swift.

This changes the paradigm by enabling `RawSyntax` layout and token validation whenever the `SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION` conditional compilation flag is set. I am planning to set this compilation flag on SwiftSyntax’s PR testing jobs at first and, after considering the performance impact, also on Swift’s PR jobs. This should give us two advantages:
- In CI we get more extensive tree validation because we are now also validate the token choices
- If we are just building SwiftSyntax as a package dependency in SwiftPM, we get faster performance because we skip the `RawSyntax` layout validation (which is really just a way to debug serious issues while working on SwiftSyntax itself).