### PR TITLE
Simplify MacroDecl syntax to match the accepted proposals 

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -1026,18 +1026,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "Signature",
-        kind: .nodeChoices(choices: [
-          Child(
-            name: "FunctionLike",
-            kind: .node(kind: "FunctionSignature"),
-            nameForDiagnostics: "macro signature"
-          ),
-          Child(
-            name: "ValueLike",
-            kind: .node(kind: "TypeAnnotation"),
-            nameForDiagnostics: "macro signature"
-          ),
-        ]),
+        kind: .node(kind: "FunctionSignature"),
         nameForDiagnostics: "macro signature"
       ),
       Child(

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -2158,15 +2158,7 @@ extension Parser {
     }
 
     // Macro signature, which is either value-like or function-like.
-    let signature: RawMacroDeclSyntax.Signature
-    if let colon = self.consume(if: .colon) {
-      let type = self.parseType()
-      signature = .valueLike(
-        RawTypeAnnotationSyntax(colon: colon, type: type, arena: self.arena)
-      )
-    } else {
-      signature = .functionLike(self.parseFunctionSignature())
-    }
+    let signature = self.parseFunctionSignature()
 
     // Initializer, if any.
     let definition: RawInitializerClauseSyntax?

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -11746,37 +11746,6 @@ public struct RawLayoutRequirementSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawMacroDeclSyntax: RawDeclSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
-  public enum Signature: RawSyntaxNodeProtocol {
-    case `functionLike`(RawFunctionSignatureSyntax)
-    case `valueLike`(RawTypeAnnotationSyntax)
-    
-    public static func isKindOf(_ raw: RawSyntax) -> Bool {
-      return RawFunctionSignatureSyntax.isKindOf(raw) || RawTypeAnnotationSyntax.isKindOf(raw)
-    }
-    
-    public var raw: RawSyntax {
-      switch self {
-      case .functionLike(let node): 
-        return node.raw
-      case .valueLike(let node): 
-        return node.raw
-      }
-    }
-    
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
-      if let node = RawFunctionSignatureSyntax(other) {
-        self = .functionLike(node)
-        return 
-      }
-      if let node = RawTypeAnnotationSyntax(other) {
-        self = .valueLike(node)
-        return 
-      }
-      return nil
-    }
-  }
-  
   @_spi(RawSyntax)
   public var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!
@@ -11812,7 +11781,7 @@ public struct RawMacroDeclSyntax: RawDeclSyntaxNodeProtocol {
       _ unexpectedBetweenIdentifierAndGenericParameterClause: RawUnexpectedNodesSyntax? = nil, 
       genericParameterClause: RawGenericParameterClauseSyntax?, 
       _ unexpectedBetweenGenericParameterClauseAndSignature: RawUnexpectedNodesSyntax? = nil, 
-      signature: Signature, 
+      signature: RawFunctionSignatureSyntax, 
       _ unexpectedBetweenSignatureAndDefinition: RawUnexpectedNodesSyntax? = nil, 
       definition: RawInitializerClauseSyntax?, 
       _ unexpectedBetweenDefinitionAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil, 
@@ -11888,8 +11857,8 @@ public struct RawMacroDeclSyntax: RawDeclSyntaxNodeProtocol {
     layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var signature: RawSyntax {
-    layoutView.children[11]!
+  public var signature: RawFunctionSignatureSyntax {
+    layoutView.children[11].map(RawFunctionSignatureSyntax.init(raw:))!
   }
   
   public var unexpectedBetweenSignatureAndDefinition: RawUnexpectedNodesSyntax? {

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -1402,8 +1402,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 9, verify(layout[9], as: RawGenericParameterClauseSyntax?.self))
     assertNoError(kind, 10, verify(layout[10], as: RawUnexpectedNodesSyntax?.self))
-    assertAnyHasNoError(kind, 11, [
-        verify(layout[11], as: RawSyntax.self)])
+    assertNoError(kind, 11, verify(layout[11], as: RawFunctionSignatureSyntax.self))
     assertNoError(kind, 12, verify(layout[12], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 13, verify(layout[13], as: RawInitializerClauseSyntax?.self))
     assertNoError(kind, 14, verify(layout[14], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -3943,48 +3943,6 @@ extension InitializerDeclSyntax: CustomReflectable {
 
 
 public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  public enum Signature: SyntaxChildChoices {
-    case `functionLike`(FunctionSignatureSyntax)
-    case `valueLike`(TypeAnnotationSyntax)
-    
-    public var _syntaxNode: Syntax {
-      switch self {
-      case .functionLike(let node):
-        return node._syntaxNode
-      case .valueLike(let node):
-        return node._syntaxNode
-      }
-    }
-    
-    init(_ data: SyntaxData) { 
-      self.init(Syntax(data))! 
-    }
-    
-    public init(_ node: FunctionSignatureSyntax) {
-      self = .functionLike(node)
-    }
-    
-    public init(_ node: TypeAnnotationSyntax) {
-      self = .valueLike(node)
-    }
-    
-    public init?<S: SyntaxProtocol>(_ node: S) {
-      if let node = node.as(FunctionSignatureSyntax.self) {
-        self = .functionLike(node)
-        return 
-      }
-      if let node = node.as(TypeAnnotationSyntax.self) {
-        self = .valueLike(node)
-        return 
-      }
-      return nil
-    }
-    
-    public static var structure: SyntaxNodeStructure {
-      return .choices([.node(FunctionSignatureSyntax.self), .node(TypeAnnotationSyntax.self)])
-    }
-  }
-  
   public let _syntaxNode: Syntax
   
   public init?<S: SyntaxProtocol>(_ node: S) {
@@ -4015,7 +3973,7 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, 
       genericParameterClause: GenericParameterClauseSyntax? = nil, 
       _ unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? = nil, 
-      signature: Signature, 
+      signature: FunctionSignatureSyntax, 
       _ unexpectedBetweenSignatureAndDefinition: UnexpectedNodesSyntax? = nil, 
       definition: InitializerClauseSyntax? = nil, 
       _ unexpectedBetweenDefinitionAndGenericWhereClause: UnexpectedNodesSyntax? = nil, 
@@ -4213,9 +4171,9 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var signature: Signature {
+  public var signature: FunctionSignatureSyntax {
     get {
-      return Signature(data.child(at: 11, parent: Syntax(self))!)
+      return FunctionSignatureSyntax(data.child(at: 11, parent: Syntax(self))!)
     }
     set(value) {
       self = MacroDeclSyntax(data.replacingChild(at: 11, with: value.raw, arena: SyntaxArena()))

--- a/Sources/SwiftSyntaxMacros/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacros/MacroReplacement.swift
@@ -114,11 +114,7 @@ fileprivate class ParameterReplacementVisitor: SyntaxAnyVisitor {
   // of a macro.
   override func visit(_ node: IdentifierExprSyntax) -> SyntaxVisitorContinueKind {
     let identifier = node.identifier
-
-    // FIXME: This will go away.
-    guard case let .functionLike(signature) = macro.signature else {
-      return .visitChildren
-    }
+    let signature = macro.signature
 
     let matchedParameter = signature.input.parameterList.enumerated().first { (index, parameter) in
       if identifier.text == "_" {

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1334,12 +1334,18 @@ final class DeclarationTests: XCTestCase {
   func testMacroDecl() {
     assertParse(
       """
-      macro m1: Int = A.M1
+      macro m11️⃣: Int = A.M1
       macro m2(_: Int) = A.M2
       macro m3(a b: Int) -> Int = A.M3
-      macro m4<T>: T = A.M4 where T.Assoc: P
+      macro m4<T>2️⃣: T = A.M4 where T.Assoc: P
       macro m5<T: P>(_: T)
-      """
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected parameter clause in function signature"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code ': Int = A.M1' before macro"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected parameter clause in function signature"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code ': T = A.M4 where T.Assoc: P' before macro")
+      ]
     )
 
     assertParse(

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1344,7 +1344,7 @@ final class DeclarationTests: XCTestCase {
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected parameter clause in function signature"),
         DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected code ': Int = A.M1' before macro"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected parameter clause in function signature"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code ': T = A.M4 where T.Assoc: P' before macro")
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected code ': T = A.M4 where T.Assoc: P' before macro"),
       ]
     )
 


### PR DESCRIPTION
* *Explanation*: Early macro proposals differentiated syntax between "function-like" and "value-like" macros. However, we settled on always making macros "function-like", so remove the "value-like" syntax, which causes the parser and syntax tree to be more complex than necessary (and not represent the actual language grammar).
* Scope: Parser and syntax tree are affected, but no clients ever used this syntax.
* Risk: Very low; it's eliminating parsing and syntax tree support for an experimental syntax that is no longer in use.
* Reviewer: @ahoppen  