### PR TITLE
[Macros] Centralize "unwrapping" of errors into diagnostics

### DIFF
--- a/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
@@ -62,14 +62,8 @@ extension CompilerPluginMessageHandler {
         throw MacroExpansionError.unmathedMacroRole
       }
     } catch {
-      let diagMessage: DiagnosticMessage
-      if let message = error as? DiagnosticMessage, message.severity == .error {
-        diagMessage = message
-      } else {
-        diagMessage = ThrownErrorDiagnostic(message: String(describing: error))
-      }
+      context.addDiagnostics(from: error, node: syntax)
       expandedSource = ""
-      context.diagnose(Diagnostic(node: syntax, message: diagMessage))
     }
 
     let diagnostics = context.diagnostics.map {
@@ -221,14 +215,8 @@ extension CompilerPluginMessageHandler {
         throw MacroExpansionError.unmathedMacroRole
       }
     } catch {
-      let diagMessage: DiagnosticMessage
-      if let message = error as? DiagnosticMessage, message.severity == .error {
-        diagMessage = message
-      } else {
-        diagMessage = ThrownErrorDiagnostic(message: String(describing: error))
-      }
+      context.addDiagnostics(from: error, node: attributeNode)
       expandedSources = []
-      context.diagnose(Diagnostic(node: Syntax(attributeNode), message: diagMessage))
     }
 
     let diagnostics = context.diagnostics.map {
@@ -237,16 +225,5 @@ extension CompilerPluginMessageHandler {
     try self.sendMessage(
       .expandAttachedMacroResult(expandedSources: expandedSources, diagnostics: diagnostics)
     )
-  }
-}
-
-/// Diagnostic message used for thrown errors.
-fileprivate struct ThrownErrorDiagnostic: DiagnosticMessage {
-  let message: String
-
-  var severity: DiagnosticSeverity { .error }
-
-  var diagnosticID: MessageID {
-    .init(domain: "SwiftSyntaxMacros", id: "ThrownErrorDiagnostic")
   }
 }

--- a/Sources/SwiftSyntaxMacros/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacros/MacroReplacement.swift
@@ -14,7 +14,7 @@ enum MacroExpanderError: DiagnosticMessage {
       return "macro expansion requires a definition"
 
     case .definitionNotMacroExpansion:
-      return "macro definition must itself by a macro expansion expression (starting with '#')"
+      return "macro must itself be defined by a macro expansion expression (starting with '#')"
 
     case .nonParameterReference(let name):
       return "reference to value '\(name.text)' that is not a macro parameter in expansion"


### PR DESCRIPTION
We had a few different implementations of "take an error thrown from a
macro and turn it into diagnostics". Improve the implementation in
`MacroExpansionContext.addDiagnostics` to properly handle both
`DiagnosticsError` and `DiagnosticsMessage`, as well as fall back
gracefully if either of those is missing an error diagnostic. Then,
use that implementation for the compiler plugin message handler.

Another part of fixing rdar://107289985, where diagnostics provided by
throwing `DiagnosticsError` aren't coming through well.