### PR TITLE
Make leading/trailing trivia required fields

### DIFF
--- a/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
@@ -96,7 +96,7 @@ extension FixIt.Changes {
         ),
         .replaceLeadingTrivia(token: nextToken, newTrivia: []),
       ]
-    } else if node.leadingTrivia?.isEmpty ?? true,
+    } else if node.leadingTrivia.isEmpty,
       let previousToken = node.previousToken(viewMode: .fixedUp),
       previousToken.presence == .present,
       previousToken.trailingTrivia.isEmpty,

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -821,7 +821,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
             message: RemoveNodesFixIt(unexpectedName),
             changes: [
               .makeMissing(unexpectedName),
-              FixIt.Changes(changes: [.replaceTrailingTrivia(token: previous, newTrivia: .zero)]),
+              FixIt.Changes(changes: [.replaceTrailingTrivia(token: previous, newTrivia: [])]),
             ]
           )
         ],
@@ -1008,7 +1008,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
         message: ReplaceTokensFixIt(replaceTokens: [singleQuote], replacement: node.openQuote),
         changes: [
           .makeMissing(singleQuote, transferTrivia: false),
-          .makePresent(node.openQuote, leadingTrivia: singleQuote.leadingTrivia ?? []),
+          .makePresent(node.openQuote, leadingTrivia: singleQuote.leadingTrivia),
           .makeMissing(node.unexpectedBetweenSegmentsAndCloseQuote, transferTrivia: false),
           .makePresent(node.closeQuote, trailingTrivia: node.unexpectedBetweenSegmentsAndCloseQuote?.trailingTrivia ?? []),
         ]

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -474,12 +474,12 @@ extension RawSyntax {
     }
   }
 
-  func formLeadingTrivia() -> Trivia? {
-    firstToken(viewMode: .sourceAccurate)?.formLeadingTrivia()
+  func formLeadingTrivia() -> Trivia {
+    firstToken(viewMode: .sourceAccurate)?.formLeadingTrivia() ?? []
   }
 
-  func formTrailingTrivia() -> Trivia? {
-    lastToken(viewMode: .sourceAccurate)?.formTrailingTrivia()
+  func formTrailingTrivia() -> Trivia {
+    lastToken(viewMode: .sourceAccurate)?.formTrailingTrivia() ?? []
   }
 }
 

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -471,24 +471,24 @@ public extension SyntaxProtocol {
   /// The leading trivia of this syntax node. Leading trivia is attached to
   /// the first token syntax contained by this node. Without such token, this
   /// property will return nil.
-  var leadingTrivia: Trivia? {
+  var leadingTrivia: Trivia {
     get {
       return raw.formLeadingTrivia()
     }
     set {
-      self = Self(Syntax(data.withLeadingTrivia(newValue ?? [], arena: SyntaxArena())))!
+      self = Self(Syntax(data.withLeadingTrivia(newValue, arena: SyntaxArena())))!
     }
   }
 
   /// The trailing trivia of this syntax node. Trailing trivia is attached to
   /// the last token syntax contained by this node. Without such token, this
   /// property will return nil.
-  var trailingTrivia: Trivia? {
+  var trailingTrivia: Trivia {
     get {
       return raw.formTrailingTrivia()
     }
     set {
-      self = Self(Syntax(data.withTrailingTrivia(newValue ?? [], arena: SyntaxArena())))!
+      self = Self(Syntax(data.withTrailingTrivia(newValue, arena: SyntaxArena())))!
     }
   }
 
@@ -510,7 +510,7 @@ public extension SyntaxProtocol {
   /// When isImplicit is true, the syntax node doesn't include any
   /// underlying tokens, e.g. an empty CodeBlockItemList.
   var isImplicit: Bool {
-    return leadingTrivia == nil
+    return raw.isEmpty
   }
 
   /// The textual byte length of this node exluding leading and trailing trivia.
@@ -636,10 +636,10 @@ public extension SyntaxProtocol {
     if let token = Syntax(self).as(TokenSyntax.self) {
       target.write(String(describing: token.tokenKind))
       if includeTrivia {
-        if let leadingTrivia = leadingTrivia, !leadingTrivia.isEmpty {
+        if !leadingTrivia.isEmpty {
           target.write(" leadingTrivia=\(leadingTrivia.debugDescription)")
         }
-        if let trailingTrivia = trailingTrivia, !trailingTrivia.isEmpty {
+        if !trailingTrivia.isEmpty {
           target.write(" trailingTrivia=\(trailingTrivia.debugDescription)")
         }
       }

--- a/Sources/SwiftSyntax/generated/Trivia.swift
+++ b/Sources/SwiftSyntax/generated/Trivia.swift
@@ -165,11 +165,6 @@ public struct Trivia {
     self.pieces = Array(pieces)
   }
   
-  /// Creates Trivia with no pieces.
-  public static var zero: Trivia {
-    return Trivia(pieces: [])
-  }
-  
   /// Whether the Trivia contains no pieces.
   public var isEmpty: Bool {
     pieces.isEmpty

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
@@ -23,10 +23,10 @@ private class InitializerExprFormat: BasicFormat {
       self.visit($0).as(SyntaxType.self)!
     }
     formattedChildren = formattedChildren.map {
-      if $0.leadingTrivia?.first?.isNewline == true {
+      if $0.leadingTrivia.first?.isNewline == true {
         return $0
       } else {
-        return $0.with(\.leadingTrivia, indentedNewline + ($0.leadingTrivia ?? []))
+        return $0.with(\.leadingTrivia, indentedNewline + $0.leadingTrivia)
       }
     }
     indentationLevel -= 1

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolationTests.swift
@@ -230,8 +230,8 @@ final class StringInterpolationTests: XCTestCase {
     class Rewriter: SyntaxRewriter {
       override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
         let newFunc = DeclSyntax("func newName() {}")
-          .with(\.leadingTrivia, node.leadingTrivia!)
-          .with(\.trailingTrivia, node.trailingTrivia!)
+          .with(\.leadingTrivia, node.leadingTrivia)
+          .with(\.trailingTrivia, node.trailingTrivia)
         return DeclSyntax(newFunc)
       }
     }

--- a/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
+++ b/Tests/SwiftSyntaxMacrosTest/MacroSystemTests.swift
@@ -75,10 +75,7 @@ public struct ColorLiteralMacro: ExpressionMacro {
       with: "_colorLiteralRed"
     )
     let initSyntax: ExprSyntax = ".init(\(argList))"
-    if let leadingTrivia = macro.leadingTrivia {
-      return initSyntax.with(\.leadingTrivia, leadingTrivia)
-    }
-    return initSyntax
+    return initSyntax.with(\.leadingTrivia, macro.leadingTrivia)
   }
 }
 
@@ -95,10 +92,7 @@ public struct FileLiteralMacro: ExpressionMacro {
       with: "fileReferenceLiteralResourceName"
     )
     let initSyntax: ExprSyntax = ".init(\(argList))"
-    if let leadingTrivia = macro.leadingTrivia {
-      return initSyntax.with(\.leadingTrivia, leadingTrivia)
-    }
-    return initSyntax
+    return initSyntax.with(\.leadingTrivia, macro.leadingTrivia)
   }
 }
 
@@ -115,10 +109,7 @@ public struct ImageLiteralMacro: ExpressionMacro {
       with: "imageLiteralResourceName"
     )
     let initSyntax: ExprSyntax = ".init(\(argList))"
-    if let leadingTrivia = macro.leadingTrivia {
-      return initSyntax.with(\.leadingTrivia, leadingTrivia)
-    }
-    return initSyntax
+    return initSyntax.with(\.leadingTrivia, macro.leadingTrivia)
   }
 }
 
@@ -134,11 +125,7 @@ public struct ColumnMacro: ExpressionMacro {
     else {
       throw CustomError.message("can't find location for macro")
     }
-
-    if let leadingTrivia = macro.leadingTrivia {
-      return sourceLoc.column.with(\.leadingTrivia, leadingTrivia)
-    }
-    return sourceLoc.column
+    return sourceLoc.column.with(\.leadingTrivia, macro.leadingTrivia)
   }
 }
 
@@ -154,11 +141,7 @@ public struct FileIDMacro: ExpressionMacro {
     else {
       throw CustomError.message("can't find location for macro")
     }
-
-    if let leadingTrivia = macro.leadingTrivia {
-      return sourceLoc.file.with(\.leadingTrivia, leadingTrivia)
-    }
-    return sourceLoc.file
+    return sourceLoc.file.with(\.leadingTrivia, macro.leadingTrivia)
   }
 }
 

--- a/Tests/SwiftSyntaxParserTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftSyntaxParserTest/AbsolutePositionTests.swift
@@ -149,14 +149,14 @@ public class AbsolutePositionTests: XCTestCase {
   public func testTrivias() {
     let idx = 5
     let root = self.createSourceFile(idx + 1)
-    XCTAssertEqual(3, root.leadingTrivia!.count)
-    XCTAssertEqual(0, root.trailingTrivia!.count)
+    XCTAssertEqual(3, root.leadingTrivia.count)
+    XCTAssertEqual(0, root.trailingTrivia.count)
     let state = root.statements[idx]
-    XCTAssertEqual(3, state.leadingTrivia!.count)
-    XCTAssertEqual(2, state.trailingTrivia!.count)
+    XCTAssertEqual(3, state.leadingTrivia.count)
+    XCTAssertEqual(2, state.trailingTrivia.count)
     XCTAssertEqual(
       state.byteSize,
-      state.leadingTrivia!.byteSize + state.trailingTrivia!.byteSize
+      state.leadingTrivia.byteSize + state.trailingTrivia.byteSize
         + state.byteSizeAfterTrimmingTrivia
     )
     XCTAssertFalse(root.statements.isImplicit)

--- a/Tests/SwiftSyntaxParserTest/SyntaxVisitorTests.swift
+++ b/Tests/SwiftSyntaxParserTest/SyntaxVisitorTests.swift
@@ -122,7 +122,7 @@ public class SyntaxVisitorTests: XCTestCase {
   public func testRewriteTrivia() {
     class TriviaRemover: SyntaxRewriter {
       override func visit(_ token: TokenSyntax) -> TokenSyntax {
-        return token.with(\.trailingTrivia, .zero)
+        return token.with(\.trailingTrivia, [])
       }
     }
 


### PR DESCRIPTION
Rather than having the possibility of `nil` trivia and requiring all clients to check every use, just return empty trivia when there are no nodes present.