### PR TITLE
Fix cases where syntax nodes were constructed with incorrect token kinds

### DIFF
--- a/Sources/SwiftOperators/SyntaxSynthesis.swift
+++ b/Sources/SwiftOperators/SyntaxSynthesis.swift
@@ -12,16 +12,26 @@
 
 import SwiftSyntax
 
+fileprivate extension OperatorKind {
+  var keyword: Keyword {
+    switch self {
+    case .infix: return .infix
+    case .prefix: return .prefix
+    case .postfix: return .postfix
+    }
+  }
+}
+
 extension Operator {
   /// Synthesize a syntactic representation of this operator based on its
   /// semantic definition.
   public func synthesizedSyntax() -> OperatorDeclSyntax {
     let modifiers = ModifierListSyntax(
-      [DeclModifierSyntax(name: .identifier("\(kind)"))]
+      [DeclModifierSyntax(name: .keyword(kind.keyword))]
     )
     let operatorKeyword = TokenSyntax.keyword(.operator, leadingTrivia: .space)
     let identifierSyntax =
-      TokenSyntax.identifier(name, leadingTrivia: .space)
+      TokenSyntax.binaryOperator(name, leadingTrivia: .space)
     let precedenceGroupSyntax = precedenceGroup.map { groupName in
       OperatorPrecedenceAndTypesSyntax(
         colon: .colonToken(),
@@ -64,6 +74,16 @@ extension PrecedenceRelation {
   }
 }
 
+fileprivate extension Associativity {
+  var keyword: Keyword {
+    switch self {
+    case .none: return .none
+    case .left: return .left
+    case .right: return .right
+    }
+  }
+}
+
 extension PrecedenceGroup {
   /// Synthesize a syntactic representation of this precedence group based on
   /// its semantic definition.
@@ -83,12 +103,12 @@ extension PrecedenceGroup {
         .init(
           PrecedenceGroupAssociativitySyntax(
             associativityKeyword:
-              .identifier(
-                "associativity",
+              .keyword(
+                .associativity,
                 leadingTrivia: [.newlines(1), .spaces(indentation)]
               ),
             colon: .colonToken(),
-            value: .identifier("\(associativity)", leadingTrivia: .space)
+            value: .keyword(associativity.keyword, leadingTrivia: .space)
           )
         )
       )
@@ -103,8 +123,8 @@ extension PrecedenceGroup {
         .init(
           PrecedenceGroupAssignmentSyntax(
             assignmentKeyword:
-              .identifier(
-                "assignment",
+              .keyword(
+                .assignment,
                 leadingTrivia: [.newlines(1), .spaces(indentation)]
               ),
             colon: .colonToken(),

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -265,7 +265,7 @@ extension ExpressibleByLiteralSyntax where Self: FloatingPoint, Self: LosslessSt
     case .negativeInfinity, .negativeZero:
       return ExprSyntax(
         PrefixOperatorExprSyntax(
-          operatorToken: "-",
+          operatorToken: .prefixOperator("-"),
           postfixExpression: (-self).makeLiteralSyntax()
         )
       )

--- a/Tests/SwiftSyntaxBuilderTest/FloatLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FloatLiteralTests.swift
@@ -19,8 +19,8 @@ final class FloatLiteralTests: XCTestCase {
     let testCases: [UInt: (FloatLiteralExprSyntax, String)] = [
       #line: (FloatLiteralExprSyntax(floatingDigits: .floatingLiteral(String(123.321))), "123.321"),
       #line: (FloatLiteralExprSyntax(floatingDigits: .floatingLiteral(String(-123.321))), "-123.321"),
-      #line: (FloatLiteralExprSyntax(floatingDigits: "2_123.321"), "2_123.321"),
-      #line: (FloatLiteralExprSyntax(floatingDigits: "-2_123.321"), "-2_123.321"),
+      #line: (FloatLiteralExprSyntax(floatingDigits: .floatingLiteral("2_123.321")), "2_123.321"),
+      #line: (FloatLiteralExprSyntax(floatingDigits: .floatingLiteral("-2_123.321")), "-2_123.321"),
       #line: (FloatLiteralExprSyntax(2_123.321), "2123.321"),
       #line: (FloatLiteralExprSyntax(-2_123.321), "-2123.321"),
       #line: (2_123.321, "2123.321"),

--- a/Tests/SwiftSyntaxBuilderTest/IntegerLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/IntegerLiteralTests.swift
@@ -19,8 +19,8 @@ final class IntegerLiteralTests: XCTestCase {
     let testCases: [UInt: (IntegerLiteralExprSyntax, String)] = [
       #line: (IntegerLiteralExprSyntax(digits: .integerLiteral(String(123))), "123"),
       #line: (IntegerLiteralExprSyntax(digits: .integerLiteral(String(-123))), "-123"),
-      #line: (IntegerLiteralExprSyntax(digits: "1_000"), "1_000"),
-      #line: (IntegerLiteralExprSyntax(digits: "-1_000"), "-1_000"),
+      #line: (IntegerLiteralExprSyntax(digits: .integerLiteral("1_000")), "1_000"),
+      #line: (IntegerLiteralExprSyntax(digits: .integerLiteral("-1_000")), "-1_000"),
       #line: (IntegerLiteralExprSyntax(1_000), "1000"),
       #line: (IntegerLiteralExprSyntax(-1_000), "-1000"),
       #line: (1_000, "1000"),

--- a/Tests/SwiftSyntaxParserTest/SyntaxComparisonTests.swift
+++ b/Tests/SwiftSyntaxParserTest/SyntaxComparisonTests.swift
@@ -41,13 +41,13 @@ public class SyntaxComparisonTests: XCTestCase {
   }
 
   public func testDifferentTokenKind() throws {
-    let expected = Syntax(makeFunc(identifier: .identifier("f"), keyword: .keyword(.class)))
+    let expected = Syntax(makeFunc(identifier: .binaryOperator("f")))
 
     func expectations(_ diff: TreeDifference?, file: StaticString = #filePath, line: UInt = #line) throws {
       let diff = try XCTUnwrap(diff, file: file, line: line)
       XCTAssertEqual(diff.reason, .token)
-      XCTAssertEqual(Syntax(diff.baseline).as(TokenSyntax.self)?.tokenKind, .keyword(.class))
-      XCTAssertEqual(Syntax(diff.node).as(TokenSyntax.self)?.tokenKind, .keyword(.func))
+      XCTAssertEqual(Syntax(diff.baseline).as(TokenSyntax.self)?.tokenKind, .binaryOperator("f"))
+      XCTAssertEqual(Syntax(diff.node).as(TokenSyntax.self)?.tokenKind, .identifier("f"))
     }
 
     let actual = Syntax(makeFunc(identifier: .identifier("f")))
@@ -98,7 +98,7 @@ public class SyntaxComparisonTests: XCTestCase {
         body: CodeBlockSyntax(
           leftBrace: .leftBraceToken(presence: .missing),
           statements: CodeBlockItemListSyntax([]),
-          rightBrace: .leftBraceToken(presence: .missing)
+          rightBrace: .rightBraceToken(presence: .missing)
         )
       )
     )


### PR DESCRIPTION
This fixes all remaining cases that were caught by https://github.com/apple/swift-syntax/pull/1466.