### PR TITLE
[bazel] Update main version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "swift-syntax",
-    version = "0.50800.0",
+    version = "0",  # Update on release/* branches
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
This version doesn't matter except when the repo is part of the [bazel-central-registry](https://github.com/bazelbuild/bazel-central-registry/). Because of this we can just null out this version on main and update it on release/* branches so that eventual release archives have the right version info (technically that isn't required because we can include patches in the BCR but it's ideal to not have to do that).