### PR TITLE
[5.9] Change included header for uint64_t in InstructionsExecuted.h

### DIFF
--- a/Sources/_InstructionCounter/include/InstructionsExecuted.h
+++ b/Sources/_InstructionCounter/include/InstructionsExecuted.h
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <unistd.h>
+#include <stdint.h>
 
 /// On macOS returns the number of instructions the process has executed since
 /// it was launched, on all other platforms returns 0.

--- a/Sources/_InstructionCounter/src/InstructionsExecuted.c
+++ b/Sources/_InstructionCounter/src/InstructionsExecuted.c
@@ -22,6 +22,7 @@
 #ifdef TARGET_IS_MACOS
 #include <libproc.h>
 #include <sys/resource.h>
+#include <unistd.h>
 
 uint64_t getInstructionsExecuted() {
   struct rusage_info_v4 ru;


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-syntax/pull/1489 to release/5.9.

---

The Linux build on swiftpackageindex.com said it couldn’t find uint64_t in InstructiosnExecuted.h. I think we need to include `stdint.h` instead. Let’s try that.