### PR TITLE
[5.9] Slightly clean up `FixIt.Change` and `FixIt.Changes`

### DIFF
--- a/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Diagnostics.swift
@@ -84,7 +84,7 @@ extension PluginMessage.Diagnostic {
     self.fixIts = syntaxDiag.fixIts.compactMap {
       PluginMessage.Diagnostic.FixIt(
         message: $0.message.message,
-        changes: $0.changes.changes.compactMap {
+        changes: $0.changes.compactMap {
           let range: SourceManager.SourceRange?
           let text: String
           switch $0 {

--- a/Sources/SwiftDiagnostics/FixIt.swift
+++ b/Sources/SwiftDiagnostics/FixIt.swift
@@ -25,22 +25,6 @@ public protocol FixItMessage {
 
 /// A Fix-It that can be applied to resolve a diagnostic.
 public struct FixIt {
-  public struct Changes: ExpressibleByArrayLiteral {
-    public var changes: [Change]
-
-    public init(changes: [Change]) {
-      self.changes = changes
-    }
-
-    public init(arrayLiteral elements: FixIt.Change...) {
-      self.init(changes: elements)
-    }
-
-    public init(combining: [Changes]) {
-      self.init(changes: combining.flatMap(\.changes))
-    }
-  }
-
   public enum Change {
     /// Replace `oldNode` by `newNode`.
     case replace(oldNode: Syntax, newNode: Syntax)
@@ -54,10 +38,10 @@ public struct FixIt {
   public let message: FixItMessage
 
   /// The changes that need to be performed when the Fix-It is applied.
-  public let changes: Changes
+  public let changes: [Change]
 
-  public init(message: FixItMessage, changes: Changes) {
-    precondition(!changes.changes.isEmpty, "A Fix-It must have at least one change associated with it")
+  public init(message: FixItMessage, changes: [Change]) {
+    precondition(!changes.isEmpty, "A Fix-It must have at least one change associated with it")
     self.message = message
     self.changes = changes
   }

--- a/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/LexerDiagnosticMessages.swift
@@ -192,7 +192,7 @@ public extension SwiftSyntax.TokenDiagnostic {
         .with(\.leadingTrivia, Trivia(pieces: token.leadingTrivia.map(replaceNonBreakingSpace)))
         .with(\.trailingTrivia, Trivia(pieces: token.trailingTrivia.map(replaceNonBreakingSpace)))
       return [
-        FixIt(message: .replaceNonBreakingSpaceBySpace, changes: [[.replace(oldNode: Syntax(token), newNode: Syntax(fixedToken))]])
+        FixIt(message: .replaceNonBreakingSpaceBySpace, changes: [.replace(oldNode: Syntax(token), newNode: Syntax(fixedToken))])
       ]
     case .unicodeCurlyQuote:
       let (rawKind, text) = token.tokenKind.decomposeToRaw()
@@ -206,7 +206,7 @@ public extension SwiftSyntax.TokenDiagnostic {
 
       let fixedToken = token.withKind(TokenKind.fromRaw(kind: rawKind, text: replacedText))
       return [
-        FixIt(message: .replaceCurlyQuoteByNormalQuote, changes: [[.replace(oldNode: Syntax(token), newNode: Syntax(fixedToken))]])
+        FixIt(message: .replaceCurlyQuoteByNormalQuote, changes: [.replace(oldNode: Syntax(token), newNode: Syntax(fixedToken))])
       ]
     case .equalMustHaveConsistentWhitespaceOnBothSides:
       let hasLeadingSpace = token.previousToken(viewMode: .all)?.trailingTrivia.contains(where: { $0.isSpaceOrTab }) ?? false
@@ -226,7 +226,7 @@ public extension SwiftSyntax.TokenDiagnostic {
       }
 
       return [
-        FixIt(message: .insertWhitespace, changes: FixIt.Changes(changes: changes))
+        FixIt(message: .insertWhitespace, changes: changes)
       ]
     default:
       return []

--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -316,7 +316,7 @@ extension ParseDiagnosticsGenerator {
   func handleMissingSyntax<T: SyntaxProtocol>(
     _ node: T,
     overridePosition: AbsolutePosition? = nil,
-    additionalChanges: [FixIt.Changes] = [],
+    additionalChanges: [FixIt.MultiNodeChange] = [],
     additionalHandledNodes: [SyntaxIdentifier] = []
   ) -> SyntaxVisitorContinueKind {
     if shouldSkip(node) {
@@ -356,7 +356,7 @@ extension ParseDiagnosticsGenerator {
       }
     }
 
-    let changes = missingNodes.enumerated().map { (index, missingNode) -> FixIt.Changes in
+    let changes = missingNodes.enumerated().map { (index, missingNode) -> FixIt.MultiNodeChange in
       if index == 0,
         let token = missingNode.as(TokenSyntax.self),
         let previousTokenKind = missingNode.previousToken(viewMode: .sourceAccurate)?.tokenKind

--- a/Sources/SwiftParserDiagnostics/MissingTokenError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingTokenError.swift
@@ -97,7 +97,7 @@ extension ParseDiagnosticsGenerator {
 
   private func handleInvalidPeriod(invalidToken: TokenSyntax, missingToken: TokenSyntax, invalidTokenContainer: UnexpectedNodesSyntax) -> Bool {
     // Trailing trivia is the cause of this diagnostic, don't transfer it.
-    let changes: [FixIt.Changes] = [
+    let changes: [FixIt.MultiNodeChange] = [
       .makeMissing(invalidToken, transferTrivia: false),
       .makePresent(missingToken),
     ]

--- a/Sources/SwiftParserDiagnostics/MultiLineStringLiteralDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/MultiLineStringLiteralDiagnosticsGenerator.swift
@@ -115,7 +115,7 @@ final class MultiLineStringLiteralIndentatinDiagnosticsGenerator: SyntaxVisitor 
       message: InvalidIndentationInMultiLineStringLiteralError(kind: currentDiagnostic.kind, lines: currentDiagnostic.lines),
       highlights: [],
       notes: [Note(node: Syntax(closeQuote), message: .shouldMatchIndentationOfClosingQuote)],
-      fixIts: [FixIt(message: .changeIndentationToMatchClosingDelimiter, changes: FixIt.Changes(changes: currentDiagnostic.changes))]
+      fixIts: [FixIt(message: .changeIndentationToMatchClosingDelimiter, changes: currentDiagnostic.changes)]
     )
 
     finishedDiagnostics.append((diagnostic, currentDiagnostic.handledNodes))

--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -19,10 +19,10 @@ add_swift_host_library(SwiftSyntax
   SyntaxArena.swift
   SyntaxChildren.swift
   SyntaxData.swift
-  SyntaxOtherNodes.swift
   SyntaxText.swift
   SyntaxTreeViewMode.swift
   TokenDiagnostic.swift
+  TokenSyntax.swift
   Utils.swift
 
   Raw/RawSyntax.swift

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -197,6 +197,21 @@ public struct RawSyntaxTokenView {
     }
   }
 
+  /// Returns a `RawSyntax` node with the presence changed to `newValue`.
+  @_spi(RawSyntax)
+  public func withPresence(_ newValue: SourcePresence, arena: SyntaxArena) -> RawSyntax {
+    switch raw.rawData.payload {
+    case .parsedToken(var payload):
+      payload.presence = newValue
+      return RawSyntax(arena: arena, payload: .parsedToken(payload))
+    case .materializedToken(var payload):
+      payload.presence = newValue
+      return RawSyntax(arena: arena, payload: .materializedToken(payload))
+    default:
+      preconditionFailure("'withKind()' is called on non-token raw syntax")
+    }
+  }
+
   /// The length of the token without leading or trailing trivia, assuming this
   /// is a token node.
   @_spi(RawSyntax)

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -336,6 +336,14 @@ struct SyntaxData {
       return self
     }
   }
+
+  func withPresence(_ presence: SourcePresence, arena: SyntaxArena) -> SyntaxData {
+    if let raw = raw.tokenView?.withPresence(presence, arena: arena) {
+      return replacingSelf(raw, arena: arena)
+    } else {
+      return self
+    }
+  }
 }
 
 #if DEBUG

--- a/Sources/SwiftSyntax/TokenSyntax.swift
+++ b/Sources/SwiftSyntax/TokenSyntax.swift
@@ -55,7 +55,12 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   }
 
   public var presence: SourcePresence {
-    return tokenView.presence
+    get {
+      return tokenView.presence
+    }
+    set {
+      self = TokenSyntax(data.withPresence(newValue, arena: SyntaxArena()))
+    }
   }
 
   /// The text of the token as written in the source code, without any trivia.

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -285,7 +285,7 @@ class FixItApplier: SyntaxRewriter {
           return true
         }
       }
-      .flatMap { $0.changes.changes }
+      .flatMap { $0.changes }
   }
 
   public override func visitAny(_ node: Syntax) -> Syntax? {

--- a/utils/group.json
+++ b/utils/group.json
@@ -27,10 +27,10 @@
     "SyntaxDeclNodes.swift",
     "SyntaxExprNodes.swift",
     "SyntaxNodes.swift",
-    "SyntaxOtherNodes.swift",
     "SyntaxPatternNodes.swift",
     "SyntaxStmtNodes.swift",
     "SyntaxTypeNodes.swift",
+    "TokenSyntax.swift",
   ],
   "Utils": [
     "CommonAncestor.swift",


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-syntax/pull/1460 to release/5.9

---

The existing API with `FixIt.Change` and `FixIt.Changes` and the fact that we passed `[FixIt.Changes]` around what fairly weird.

Ideally, we would only have `FixIt.Change` and make it powerful enough to represent all the trivia transfer that `FixIt.Changes` is doing. But given that that will be a larger effort, let’s make some smaller changes now that reduce the badness of the public API impact:

- Move `FixIt.Changes` to `SwiftParserDiagnostics`, make it internal and rename it to `MultiNodeChange`. That way this type is no longer exposed in the public API, so we can iterate on it or remove it without breaking clients. The only thing that remains exposed is `FixIt.Change`, which we want to continue to support. We will probably add more cases to it in the future.
- Make `FixIt.Changes` no longer conform to `ExpressibleByArrayLiteral`. That just makes everything a lot more explicit and easier to follow.
- Remove some unecessary initializations of `FixIt.Changes` where `FixIt.Change` was sufficient.
- Make `presence` on `TokenSyntax` settable so you can do `token.with(\.presence, .missing)`
- Slightly unrelated: Rename SyntaxOtherNodes.swift to TokenSyntax.swift because that’s the only node it contains.