### PR TITLE
[5.9] Add a function to merge trivia from a node into an existing trivia

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/GenerateSwiftSyntax.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/GenerateSwiftSyntax.swift
@@ -106,7 +106,7 @@ struct GenerateSwiftSyntax: ParsableCommand {
         GeneratedFileSpec(swiftSyntaxGeneratedDir + ["SyntaxVisitor.swift"], syntaxVisitorFile),
         GeneratedFileSpec(swiftSyntaxGeneratedDir + ["TokenKind.swift"], tokenKindFile),
         GeneratedFileSpec(swiftSyntaxGeneratedDir + ["Tokens.swift"], tokensFile),
-        GeneratedFileSpec(swiftSyntaxGeneratedDir + ["Trivia.swift"], triviaFile),
+        GeneratedFileSpec(swiftSyntaxGeneratedDir + ["TriviaPieces.swift"], triviaPiecesFile),
 
         // SwiftSyntaxBuilder
         GeneratedFileSpec(swiftSyntaxBuilderGeneratedDir + ["BuildableCollectionNodes.swift"], buildableCollectionNodesFile),

--- a/Sources/SwiftParserDiagnostics/MultiLineStringLiteralDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/MultiLineStringLiteralDiagnosticsGenerator.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftDiagnostics
-import SwiftSyntax
+@_spi(RawSyntax) import SwiftSyntax
 
 /// A diagnostic that `MultiLineStringLiteralIndentatinDiagnosticsGenerator` is building.
 /// As indentation errors are found on more lines, this diagnostic is modified

--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -12,6 +12,7 @@ add_swift_host_library(SwiftSyntax
   BumpPtrAllocator.swift
   CommonAncestor.swift
   IncrementalParseTransition.swift
+  Trivia.swift
   SourceLength.swift
   SourceLocation.swift
   SourcePresence.swift
@@ -46,7 +47,7 @@ add_swift_host_library(SwiftSyntax
   generated/SyntaxVisitor.swift
   generated/TokenKind.swift
   generated/Tokens.swift
-  generated/Trivia.swift
+  generated/TriviaPieces.swift
 
   generated/syntaxNodes/SyntaxDeclNodes.swift
   generated/syntaxNodes/SyntaxExprNodes.swift

--- a/Sources/SwiftSyntax/Trivia.swift
+++ b/Sources/SwiftSyntax/Trivia.swift
@@ -1,0 +1,159 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public enum TriviaPosition {
+  case leading
+  case trailing
+}
+
+/// A collection of leading or trailing trivia. This is the main data structure
+/// for thinking about trivia.
+public struct Trivia {
+  public let pieces: [TriviaPiece]
+
+  /// Creates Trivia with the provided underlying pieces.
+  public init<S: Sequence>(pieces: S) where S.Element == TriviaPiece {
+    self.pieces = Array(pieces)
+  }
+
+  /// Creates Trivia with no pieces.
+  public static var zero: Trivia {
+    return Trivia(pieces: [])
+  }
+
+  /// Whether the Trivia contains no pieces.
+  public var isEmpty: Bool {
+    pieces.isEmpty
+  }
+
+  /// Creates a new `Trivia` by appending the provided `TriviaPiece` to the end.
+  public func appending(_ piece: TriviaPiece) -> Trivia {
+    var copy = pieces
+    copy.append(piece)
+    return Trivia(pieces: copy)
+  }
+
+  public var sourceLength: SourceLength {
+    return pieces.map({ $0.sourceLength }).reduce(.zero, +)
+  }
+
+  /// Get the byteSize of this trivia
+  public var byteSize: Int {
+    return sourceLength.utf8Length
+  }
+
+  /// Concatenates two collections of `Trivia` into one collection.
+  public static func +(lhs: Trivia, rhs: Trivia) -> Trivia {
+    return Trivia(pieces: lhs.pieces + rhs.pieces)
+  }
+
+  /// Concatenates two collections of `Trivia` into the left-hand side.
+  public static func +=(lhs: inout Trivia, rhs: Trivia) {
+    lhs = lhs + rhs
+  }
+}
+
+extension Trivia: Equatable {}
+
+extension Trivia: Collection {
+  public var startIndex: Int {
+    return pieces.startIndex
+  }
+
+  public var endIndex: Int {
+    return pieces.endIndex
+  }
+
+  public func index(after i: Int) -> Int {
+    return pieces.index(after: i)
+  }
+
+  public subscript(_ index: Int) -> TriviaPiece {
+    return pieces[index]
+  }
+}
+
+extension Trivia: ExpressibleByArrayLiteral {
+  /// Creates Trivia from the provided pieces.
+  public init(arrayLiteral elements: TriviaPiece...) {
+    self.pieces = elements
+  }
+}
+
+extension Trivia: TextOutputStreamable {
+  /// Prints the provided trivia as they would be written in a source file.
+  ///
+  /// - Parameter stream: The stream to which to print the trivia.
+  public func write<Target>(to target: inout Target)
+  where Target: TextOutputStream {
+    for piece in pieces {
+      piece.write(to: &target)
+    }
+  }
+}
+
+extension Trivia: CustomStringConvertible {
+  public var description: String {
+    var description = ""
+    self.write(to: &description)
+    return description
+  }
+}
+
+extension Trivia: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    if count == 1, let first = first {
+      return first.debugDescription
+    }
+    return "[" + map(\.debugDescription).joined(separator: ", ") + "]"
+  }
+}
+
+extension TriviaPiece {
+  /// Returns true if the trivia is `.newlines`, `.carriageReturns` or `.carriageReturnLineFeeds`
+  public var isNewline: Bool {
+    switch self {
+    case .newlines,
+        .carriageReturns,
+        .carriageReturnLineFeeds:
+      return true
+    default:
+      return false
+    }
+  }
+}
+
+extension RawTriviaPiece {
+  /// Returns true if the trivia is `.newlines`, `.carriageReturns` or `.carriageReturnLineFeeds`
+  public var isNewline: Bool {
+    switch self {
+    case .newlines,
+        .carriageReturns,
+        .carriageReturnLineFeeds:
+      return true
+    default:
+      return false
+    }
+  }
+}
+
+extension RawTriviaPiece: TextOutputStreamable {
+  public func write<Target: TextOutputStream>(to target: inout Target) {
+    TriviaPiece(raw: self).write(to: &target)
+  }
+}
+
+extension RawTriviaPiece: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    TriviaPiece(raw: self).debugDescription
+  }
+}

--- a/Sources/SwiftSyntax/generated/TriviaPieces.swift
+++ b/Sources/SwiftSyntax/generated/TriviaPieces.swift
@@ -12,11 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-public enum TriviaPosition {
-  case leading
-  case trailing
-}
-
 /// A contiguous stretch of a single kind of trivia. The constituent part of
 /// a `Trivia` collection.
 ///
@@ -141,53 +136,7 @@ extension TriviaPiece: CustomDebugStringConvertible {
   }
 }
 
-extension TriviaPiece {
-  /// Returns true if the trivia is `.newlines`, `.carriageReturns` or `.carriageReturnLineFeeds`
-  public var isNewline: Bool {
-    switch self {
-    case .newlines, 
-        .carriageReturns, 
-        .carriageReturnLineFeeds:
-      return true
-    default:
-      return false
-    }
-  }
-}
-
-/// A collection of leading or trailing trivia. This is the main data structure
-/// for thinking about trivia.
-public struct Trivia {
-  public let pieces: [TriviaPiece]
-  
-  /// Creates Trivia with the provided underlying pieces.
-  public init<S: Sequence>(pieces: S) where S.Element == TriviaPiece {
-    self.pieces = Array(pieces)
-  }
-  
-  /// Whether the Trivia contains no pieces.
-  public var isEmpty: Bool {
-    pieces.isEmpty
-  }
-  
-  /// Creates a new `Trivia` by appending the provided `TriviaPiece` to the end.
-  public func appending(_ piece: TriviaPiece) -> Trivia {
-    var copy = pieces
-    copy.append(piece)
-    return Trivia(pieces: copy)
-  }
-  
-  public var sourceLength: SourceLength {
-    return pieces.map({ 
-        $0.sourceLength 
-      }).reduce(.zero, + )
-  }
-  
-  /// Get the byteSize of this trivia
-  public var byteSize: Int {
-    return sourceLength.utf8Length
-  }
-  
+extension Trivia {
   /// Returns a piece of trivia for some number of #"\"# characters.
   public static func backslashes(_ count: Int) -> Trivia {
     return [.backslashes(count)]
@@ -309,79 +258,6 @@ public struct Trivia {
   }
 }
 
-extension Trivia: CustomDebugStringConvertible {
-  public var debugDescription: String {
-    if count == 1, let first = first {
-      return first.debugDescription
-    }
-    return "[" + map(\.debugDescription).joined(separator: ", ") + "]"
-  }
-}
-
-extension Trivia: Equatable {}
-
-/// Conformance for Trivia to the Collection protocol.
-extension Trivia: Collection {
-  public var startIndex: Int {
-    return pieces.startIndex
-  }
-  
-
-  public var endIndex: Int {
-    return pieces.endIndex
-  }
-  
-
-  public func index(after i: Int) -> Int {
-    return pieces.index(after: i)
-  }
-  
-
-  public subscript (_ index: Int) -> TriviaPiece {
-    return pieces[index]
-  }
-}
-
-extension Trivia: ExpressibleByArrayLiteral {
-  /// Creates Trivia from the provided pieces.
-  public init(arrayLiteral elements: TriviaPiece...) {
-    self.pieces = elements
-  }
-}
-
-extension Trivia: TextOutputStreamable {
-  /// Prints the provided trivia as they would be written in a source file.
-  ///
-  /// - Parameter stream: The stream to which to print the trivia.
-  public func write<Target>(to target: inout Target)
-  where Target: TextOutputStream {
-    for piece in pieces {
-      piece.write(to: &target)
-    }
-  }
-}
-
-extension Trivia: CustomStringConvertible {
-  public var description: String {
-    var description = ""
-    self.write(to: &description)
-    return description
-  }
-}
-
-extension Trivia {
-  /// Concatenates two collections of `Trivia` into one collection.
-  public static func + (lhs: Trivia, rhs: Trivia) -> Trivia {
-    return Trivia(pieces: lhs.pieces + rhs.pieces)
-  }
-  
-
-  /// Concatenates two collections of `Trivia` into the left-hand side.
-  public static func += (lhs: inout Trivia, rhs: Trivia) {
-    lhs = lhs + rhs
-  }
-}
-
 extension TriviaPiece: Equatable {}
 
 extension TriviaPiece {
@@ -476,18 +352,6 @@ public enum RawTriviaPiece: Equatable {
     case let .verticalTabs(count):
       return .verticalTabs(count)
     }
-  }
-}
-
-extension RawTriviaPiece: TextOutputStreamable {
-  public func write<Target: TextOutputStream>(to target: inout Target) {
-    TriviaPiece(raw: self).write(to: &target)
-  }
-}
-
-extension RawTriviaPiece: CustomDebugStringConvertible {
-  public var debugDescription: String {
-    TriviaPiece(raw: self).debugDescription
   }
 }
 
@@ -596,20 +460,6 @@ extension RawTriviaPiece {
       return text
     case .verticalTabs(_):
       return nil
-    }
-  }
-}
-
-extension RawTriviaPiece {
-  /// Returns true if the trivia is `.newlines`, `.carriageReturns` or `.carriageReturnLineFeeds`
-  public var isNewline: Bool {
-    switch self {
-    case .newlines, 
-        .carriageReturns, 
-        .carriageReturnLineFeeds:
-      return true
-    default:
-      return false
     }
   }
 }

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -227,7 +227,12 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .accessPathComponent:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.identifier)]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
+            .tokenKind(.identifier), 
+            .tokenKind(.binaryOperator), 
+            .tokenKind(.prefixOperator), 
+            .tokenKind(.postfixOperator)
+          ]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.period)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -862,7 +867,13 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .declName:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.identifier), .tokenKind(.prefixOperator), .keyword("init")]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
+            .tokenKind(.identifier), 
+            .tokenKind(.binaryOperator), 
+            .keyword("init"), 
+            .keyword("self"), 
+            .keyword("Self")
+          ]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawDeclNameArgumentsSyntax?.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -983,7 +994,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .differentiableAttributeArguments:
     assert(layout.count == 11)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax?.self, tokenChoices: [.keyword("forward"), .keyword("reverse"), .keyword("linear")]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax?.self, tokenChoices: [.keyword("_forward"), .keyword("reverse"), .keyword("_linear")]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.comma)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -1607,14 +1618,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .labeledSpecializeEntry:
     assert(layout.count == 9)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
-            .tokenKind(.identifier), 
-            .keyword("available"), 
-            .keyword("exported"), 
-            .keyword("kind"), 
-            .keyword("spi"), 
-            .keyword("spiModule")
-          ]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.colon)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -1838,7 +1842,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   case .objCSelectorPiece:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.identifier)]))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax?.self))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.colon)]))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
@@ -2129,9 +2133,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 5, verify(layout[5], as: RawTokenSyntax.self, tokenChoices: [
             .tokenKind(.identifier), 
-            .tokenKind(.binaryOperator), 
-            .tokenKind(.prefixOperator), 
-            .tokenKind(.postfixOperator)
+            .keyword("self"), 
+            .keyword("Self"), 
+            .keyword("init"), 
+            .tokenKind(.binaryOperator)
           ]))
     assertNoError(kind, 6, verify(layout[6], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 7, verify(layout[7], as: RawDeclNameArgumentsSyntax?.self))

--- a/utils/group.json
+++ b/utils/group.json
@@ -18,6 +18,7 @@
     "TokenKind.swift",
     "SyntaxTreeViewMode.swift",
     "Trivia.swift",
+    "TriviaPieces.swift",
     "Tokens.swift",
   ],
   "Syntax nodes": [


### PR DESCRIPTION
* Explanation: Adds new methods for merging trivia from a node, dropping the matching prefix from the RHS. Also cleans up `Trivia` so only the parts that have to be generated are.
* Scope: New functionality, no clients are impacted
* Risk: Low, this introduces new `Trivia.merging` methods
* Original PR: https://github.com/apple/swift-syntax/pull/1478