### PR TITLE
Fix spacing between multiple `@_spi(...)` attributes.

### DIFF
--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -12,7 +12,7 @@
 
 import XCTest
 @_spi(RawSyntax) import SwiftSyntax
-@_spi(Testing)@_spi(RawSyntax) import SwiftParser
+@_spi(Testing) @_spi(RawSyntax) import SwiftParser
 @_spi(RawSyntax) import SwiftParserDiagnostics
 import SwiftDiagnostics
 import _SwiftSyntaxTestSupport

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @_spi(RawSyntax) import SwiftSyntax
-@_spi(Testing)@_spi(RawSyntax) import SwiftParser
+@_spi(Testing) @_spi(RawSyntax) import SwiftParser
 import SwiftSyntaxBuilder
 import SwiftBasicFormat
 import XCTest


### PR DESCRIPTION
This is a companion to https://github.com/apple/swift-format/pull/501, which tweaks the breaking behavior for `import` decls (and also fixes this existing mis-styling).