### PR TITLE
[5.9] Add spacing between first and second parameter name

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -809,7 +809,7 @@ public let DECL_NODES: [Node] = [
       // name to avoid backtracking.
       Child(
         name: "SecondName",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .token(tokenKind: "WildcardToken")]),
+        kind: .token(choices: [.token(tokenKind: "IdentifierToken"), .token(tokenKind: "WildcardToken")], requiresLeadingSpace: true),
         nameForDiagnostics: "internal name",
         isOptional: true
       ),

--- a/Sources/SwiftBasicFormat/generated/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat.swift
@@ -170,6 +170,8 @@ open class BasicFormat: SyntaxRewriter {
     switch keyPath {
     case \AvailabilityArgumentSyntax.entry:
       return false
+    case \FunctionParameterSyntax.secondName:
+      return true
     default:
       return nil
     }

--- a/Tests/SwiftSyntaxBuilderTest/FunctionParameterSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionParameterSyntaxTests.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+final class FunctionParameterSyntaxTests: XCTestCase {
+  func testFunctionParameterSyntaxSpacing() {
+    let builder = FunctionParameterSyntax(firstName: "on", secondName: "eventLoop", type: TypeSyntax("EventLoop"))
+    assertBuildResult(
+      builder,
+      """
+      on eventLoop: EventLoop
+      """
+    )
+  }
+}


### PR DESCRIPTION
Fixes #1505 in 5.9