### PR TITLE
Fix escape handling for emoji `#️⃣` in string literals

### DIFF
--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
@@ -249,7 +249,7 @@ extension StringLiteralExprSyntax {
         continue
 
       // Special mode: counting a sequence of pounds until we reach its end.
-      case (true, "#"):
+      case (true, _) where c.unicodeScalars.contains("#"):
         consecutivePounds += 1
         maxPounds = max(maxPounds, consecutivePounds)
       case (true, _):

--- a/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
@@ -71,6 +71,15 @@ final class StringLiteralTests: XCTestCase {
     )
   }
 
+  func testEscapePoundEmojis() {
+    assertBuildResult(
+      StringLiteralExprSyntax(content: ##"foo"#️⃣"bar"##),
+      """
+      ##"foo"#️⃣"bar"##
+      """
+    )
+  }
+
   func testEscapeInteropolation() {
     assertBuildResult(
       StringLiteralExprSyntax(content: ###"\##(foobar)\#(foobar)"###),


### PR DESCRIPTION
This pull request addresses an issue with the escape handling when counting the number of `#` characters in string literals. Previously, the code didn't consider the emoji `#️⃣` presence. This resulted in incorrect escape counts.

For example, the string literal generated from the string `foo "#️⃣"bar` would be `##"foo "#️⃣"bar "##`, but the current implementation generates `#"foo "#️⃣"bar "#`. This literal will result in a compile error because the escape is incomplete.