### PR TITLE
[5.9] Add diagnostic for unexpected second identifier

### DIFF
--- a/Sources/SwiftParser/SyntaxUtils.swift
+++ b/Sources/SwiftParser/SyntaxUtils.swift
@@ -88,6 +88,14 @@ extension SyntaxText {
   var isEditorPlaceholder: Bool {
     return self.starts(with: SyntaxText("<#")) && self.hasSuffix(SyntaxText("#>"))
   }
+
+  var isStartingWithUppercase: Bool {
+    if !self.isEmpty, let firstCharacterByte = self.baseAddress?.pointee {
+      return 65 <= firstCharacterByte && firstCharacterByte <= 90
+    } else {
+      return false
+    }
+  }
 }
 
 extension RawTokenKind {

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -548,7 +548,7 @@ extension Parser {
         if let first = first,
           second == nil,
           colon?.isMissing == true,
-          first.tokenText.description.first?.isUppercase == true
+          first.tokenText.isStartingWithUppercase
         {
           elements.append(
             RawTupleTypeElementSyntax(

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -327,7 +327,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
         FixIt(
           message: .joinIdentifiers,
           changes: [
-            FixIt.MultiNodeChange(.replace(oldNode: Syntax(previousToken), newNode: Syntax(TokenSyntax(.identifier(joined), presence: .present)))),
+            FixIt.MultiNodeChange(.replace(oldNode: Syntax(previousToken), newNode: Syntax(TokenSyntax(.identifier(joined), trailingTrivia: tokens.last?.trailingTrivia ?? [], presence: .present)))),
             .makeMissing(tokens),
           ]
         )
@@ -338,7 +338,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
           FixIt(
             message: .joinIdentifiersWithCamelCase,
             changes: [
-              FixIt.MultiNodeChange(.replace(oldNode: Syntax(previousToken), newNode: Syntax(TokenSyntax(.identifier(joinedUsingCamelCase), presence: .present)))),
+              FixIt.MultiNodeChange(.replace(oldNode: Syntax(previousToken), newNode: Syntax(TokenSyntax(.identifier(joinedUsingCamelCase), trailingTrivia: tokens.last?.trailingTrivia ?? [], presence: .present)))),
               .makeMissing(tokens),
             ]
           )

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -383,9 +383,9 @@ public struct SpaceSeparatedIdentifiersError: ParserError {
     if let name = firstToken.parent?.ancestorOrSelf(mapping: {
       $0.nodeTypeNameForDiagnostics(allowBlockNames: false)
     }) {
-      return "found an unexpected second identifier in \(name)"
+      return "found an unexpected second identifier in \(name); is there an accidental break?"
     } else {
-      return "found an unexpected second identifier"
+      return "found an unexpected second identifier; is there an accidental break?"
     }
   }
 }

--- a/Tests/SwiftParserTest/ParserTests.swift
+++ b/Tests/SwiftParserTest/ParserTests.swift
@@ -54,7 +54,7 @@ public class ParserTests: XCTestCase {
     }
   }
 
-  /// Run parsr tests on all of the Swift files in the given path, recursively.
+  /// Run parser tests on all of the Swift files in the given path, recursively.
   func runParserTests(
     name: String,
     path: URL,

--- a/Tests/SwiftParserTest/TypeTests.swift
+++ b/Tests/SwiftParserTest/TypeTests.swift
@@ -15,15 +15,17 @@
 import XCTest
 
 final class TypeTests: XCTestCase {
-
   func testMissingColonInType() {
     assertParse(
       """
       var foo 1️⃣Bar = 1
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected ':' in type annotation")
-      ]
+        DiagnosticSpec(message: "expected ':' in type annotation", fixIts: ["insert ':'"])
+      ],
+      fixedSource: """
+        var foo: Bar = 1
+        """
     )
   }
 
@@ -65,7 +67,6 @@ final class TypeTests: XCTestCase {
   }
 
   func testClosureSignatures() {
-
     assertParse(
       """
       simple { [] str in

--- a/Tests/SwiftParserTest/translated/InvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidTests.swift
@@ -388,92 +388,85 @@ final class InvalidTests: XCTestCase {
     )
   }
 
-  func testInvalid23a() {
-    assertParse(
-      """
-      func dog 1️⃣cow() {}
-      """,
-      diagnostics: [
-        DiagnosticSpec(
-          message: "found an unexpected second identifier in function",
-          fixIts: [
-            "join the identifiers together",
-            "join the identifiers together with camel-case",
-          ]
-        )
-      ],
-      applyFixIts: ["join the identifiers together"],
-      fixedSource: "func dogcow() {}"
-    )
-  }
+  func testInvalid23() {
+    let testCases: [UInt: (fixIt: String, fixedSource: String)] = [
+      #line: ("join the identifiers together", "func dogcow() {}"),
+      #line: ("join the identifiers together with camel-case", "func dogCow() {}"),
+    ]
 
-  func testInvalid23b() {
-    assertParse(
-      """
-      func dog 1️⃣cow() {}
-      """,
-      diagnostics: [
-        DiagnosticSpec(
-          message: "found an unexpected second identifier in function",
-          fixIts: [
-            "join the identifiers together",
-            "join the identifiers together with camel-case",
-          ]
-        )
-      ],
-      applyFixIts: ["join the identifiers together with camel-case"],
-      fixedSource: "func dogCow() {}"
-    )
+    for (line, testCase) in testCases {
+      assertParse(
+        """
+        func dog 1️⃣cow() {}
+        """,
+        diagnostics: [
+          DiagnosticSpec(
+            message: "found an unexpected second identifier in function; is there an accidental break?",
+            fixIts: [
+              "join the identifiers together",
+              "join the identifiers together with camel-case",
+            ]
+          )
+        ],
+        applyFixIts: [testCase.fixIt],
+        fixedSource: testCase.fixedSource,
+        line: line
+      )
+    }
   }
 
   func testThreeIdentifersForFunctionName() {
-    assertParse(
-      """
-      func dog 1️⃣cow sheep() {}
-      """,
-      diagnostics: [
-        DiagnosticSpec(
-          message: "found an unexpected second identifier in function",
-          fixIts: [
-            "join the identifiers together",
-            "join the identifiers together with camel-case",
-          ]
-        )
-      ],
-      applyFixIts: ["join the identifiers together with camel-case"],
-      fixedSource: "func dogCowSheep() {}"
-    )
-  }
+    let testCases: [UInt: (fixIt: String, fixedSource: String)] = [
+      #line: ("join the identifiers together", "func dogcowsheep() {}"),
+      #line: ("join the identifiers together with camel-case", "func dogCowSheep() {}"),
+    ]
 
-  func testInvalid24() {
-    assertParse(
-      """
-      func cat 1️⃣Mouse() {}
-      """,
-      diagnostics: [
-        DiagnosticSpec(message: "found an unexpected second identifier in function", fixIts: ["join the identifiers together"])
-      ],
-      fixedSource: "func catMouse() {}"
-    )
+    for (line, testCase) in testCases {
+      assertParse(
+        """
+        func dog 1️⃣cow sheep() {}
+        """,
+        diagnostics: [
+          DiagnosticSpec(
+            message: "found an unexpected second identifier in function; is there an accidental break?",
+            fixIts: [
+              "join the identifiers together",
+              "join the identifiers together with camel-case",
+            ]
+          )
+        ],
+        applyFixIts: [testCase.fixIt],
+        fixedSource: testCase.fixedSource,
+        line: line
+      )
+    }
   }
 
   func testInvalid25() {
-    assertParse(
-      """
-      func friend 1️⃣ship<T>(x: T) {}
-      """,
-      diagnostics: [
-        DiagnosticSpec(
-          message: "found an unexpected second identifier in function",
-          fixIts: [
-            "join the identifiers together",
-            "join the identifiers together with camel-case",
-          ]
-        )
-      ],
-      applyFixIts: ["join the identifiers together with camel-case"],
-      fixedSource: "func friendShip<T>(x: T) {}"
-    )
+    let testCases: [UInt: (fixIt: String, fixedSource: String)] = [
+      #line: ("join the identifiers together", "func friendship<T>(x: T) {}"),
+      #line: ("join the identifiers together with camel-case", "func friendShip<T>(x: T) {}"),
+    ]
+
+    for (line, testCase) in testCases {
+      assertParse(
+        """
+        func friend 1️⃣ship<T>(x: T) {}
+        """,
+        diagnostics: [
+          DiagnosticSpec(
+            message: "found an unexpected second identifier in function; is there an accidental break?",
+            fixIts: [
+              "join the identifiers together",
+              "join the identifiers together with camel-case",
+            ]
+          )
+        ],
+        applyFixIts: [testCase.fixIt],
+        fixedSource: testCase.fixedSource,
+        line: line
+      )
+    }
   }
 
   func testInvalid26() {


### PR DESCRIPTION
* **Explanation**: If there is two identifiers separated by a space we diagnosed with a wrong diagnostic. This should come with a better diagnostic to helper the developer
* **Scope**: Parsing of identifiers
* **Risk**: Low, improves diagnostic
* **Testing**: CI didn’t find any issues
* **Issue**: N/A
* **Reviewer**: @ahoppen on https://github.com/apple/swift-syntax/pull/1382
