### PR TITLE
Rename children that refer to a `MemberDeclBlock` from `members` to `memberBlock`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -196,7 +196,7 @@ public let DECL_NODES: [Node] = [
         isOptional: true
       ),
       Child(
-        name: "Members",
+        name: "MemberBlock",
         kind: .node(kind: "MemberDeclBlock")
       ),
     ]
@@ -312,7 +312,7 @@ public let DECL_NODES: [Node] = [
         isOptional: true
       ),
       Child(
-        name: "Members",
+        name: "MemberBlock",
         kind: .node(kind: "MemberDeclBlock")
       ),
     ]
@@ -654,7 +654,7 @@ public let DECL_NODES: [Node] = [
         isOptional: true
       ),
       Child(
-        name: "Members",
+        name: "MemberBlock",
         kind: .node(kind: "MemberDeclBlock"),
         description: "The cases and other members of this enum."
       ),
@@ -709,7 +709,7 @@ public let DECL_NODES: [Node] = [
         isOptional: true
       ),
       Child(
-        name: "Members",
+        name: "MemberBlock",
         kind: .node(kind: "MemberDeclBlock")
       ),
     ]
@@ -1722,7 +1722,7 @@ public let DECL_NODES: [Node] = [
         isOptional: true
       ),
       Child(
-        name: "Members",
+        name: "MemberBlock",
         kind: .node(kind: "MemberDeclBlock")
       ),
     ]
@@ -1824,7 +1824,7 @@ public let DECL_NODES: [Node] = [
         isOptional: true
       ),
       Child(
-        name: "Members",
+        name: "MemberBlock",
         kind: .node(kind: "MemberDeclBlock")
       ),
     ]

--- a/CodeGeneration/Sources/SyntaxSupport/Traits.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/Traits.swift
@@ -41,7 +41,7 @@ public let TRAITS: [Trait] = [
     children: [
       Child(name: "Attributes", kind: .node(kind: "AttributeList"), isOptional: true),
       Child(name: "Modifiers", kind: .node(kind: "ModifierList"), isOptional: true),
-      Child(name: "Members", kind: .node(kind: "MemberDeclBlock")),
+      Child(name: "MemberBlock", kind: .node(kind: "MemberDeclBlock")),
     ]
   ),
   Trait(

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -419,7 +419,7 @@ extension Parser {
     } else {
       whereClause = nil
     }
-    let members = self.parseMemberDeclList(introducer: extensionKeyword)
+    let memberBlock = self.parseMemberDeclList(introducer: extensionKeyword)
     return RawExtensionDeclSyntax(
       attributes: attrs.attributes,
       modifiers: attrs.modifiers,
@@ -428,7 +428,7 @@ extension Parser {
       extendedType: type,
       inheritanceClause: inheritance,
       genericWhereClause: whereClause,
-      members: members,
+      memberBlock: memberBlock,
       arena: self.arena
     )
   }

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -25,7 +25,7 @@ protocol NominalTypeDeclarationTrait {
     primaryOrGenerics: PrimaryOrGenerics?,
     inheritanceClause: RawTypeInheritanceClauseSyntax?,
     genericWhereClause: RawGenericWhereClauseSyntax?,
-    members: RawMemberDeclBlockSyntax,
+    memberBlock: RawMemberDeclBlockSyntax,
     arena: __shared SyntaxArena
   )
 
@@ -43,10 +43,22 @@ extension RawProtocolDeclSyntax: NominalTypeDeclarationTrait {
     primaryOrGenerics: RawPrimaryAssociatedTypeClauseSyntax?,
     inheritanceClause: RawTypeInheritanceClauseSyntax?,
     genericWhereClause: RawGenericWhereClauseSyntax?,
-    members: RawMemberDeclBlockSyntax,
+    memberBlock: RawMemberDeclBlockSyntax,
     arena: __shared SyntaxArena
   ) {
-    self.init(attributes: attributes, modifiers: modifiers, unexpectedBeforeIntroducerKeyword, protocolKeyword: introducerKeyword, unexpectedBeforeIdentifier, identifier: identifier, primaryAssociatedTypeClause: primaryOrGenerics, inheritanceClause: inheritanceClause, genericWhereClause: genericWhereClause, members: members, arena: arena)
+    self.init(
+      attributes: attributes,
+      modifiers: modifiers,
+      unexpectedBeforeIntroducerKeyword,
+      protocolKeyword: introducerKeyword,
+      unexpectedBeforeIdentifier,
+      identifier: identifier,
+      primaryAssociatedTypeClause: primaryOrGenerics,
+      inheritanceClause: inheritanceClause,
+      genericWhereClause: genericWhereClause,
+      memberBlock: memberBlock,
+      arena: arena
+    )
   }
 
   static func parsePrimaryOrGenerics(_ parser: inout Parser) -> RawPrimaryAssociatedTypeClauseSyntax? {
@@ -65,10 +77,22 @@ extension RawClassDeclSyntax: NominalTypeDeclarationTrait {
     primaryOrGenerics: RawGenericParameterClauseSyntax?,
     inheritanceClause: RawTypeInheritanceClauseSyntax?,
     genericWhereClause: RawGenericWhereClauseSyntax?,
-    members: RawMemberDeclBlockSyntax,
+    memberBlock: RawMemberDeclBlockSyntax,
     arena: __shared SyntaxArena
   ) {
-    self.init(attributes: attributes, modifiers: modifiers, unexpectedBeforeIntroducerKeyword, classKeyword: introducerKeyword, unexpectedBeforeIdentifier, identifier: identifier, genericParameterClause: primaryOrGenerics, inheritanceClause: inheritanceClause, genericWhereClause: genericWhereClause, members: members, arena: arena)
+    self.init(
+      attributes: attributes,
+      modifiers: modifiers,
+      unexpectedBeforeIntroducerKeyword,
+      classKeyword: introducerKeyword,
+      unexpectedBeforeIdentifier,
+      identifier: identifier,
+      genericParameterClause: primaryOrGenerics,
+      inheritanceClause: inheritanceClause,
+      genericWhereClause: genericWhereClause,
+      memberBlock: memberBlock,
+      arena: arena
+    )
   }
 
   static func parsePrimaryOrGenerics(_ parser: inout Parser) -> RawGenericParameterClauseSyntax? {
@@ -87,10 +111,22 @@ extension RawActorDeclSyntax: NominalTypeDeclarationTrait {
     primaryOrGenerics: RawGenericParameterClauseSyntax?,
     inheritanceClause: RawTypeInheritanceClauseSyntax?,
     genericWhereClause: RawGenericWhereClauseSyntax?,
-    members: RawMemberDeclBlockSyntax,
+    memberBlock: RawMemberDeclBlockSyntax,
     arena: __shared SyntaxArena
   ) {
-    self.init(attributes: attributes, modifiers: modifiers, unexpectedBeforeIntroducerKeyword, actorKeyword: introducerKeyword, unexpectedBeforeIdentifier, identifier: identifier, genericParameterClause: primaryOrGenerics, inheritanceClause: inheritanceClause, genericWhereClause: genericWhereClause, members: members, arena: arena)
+    self.init(
+      attributes: attributes,
+      modifiers: modifiers,
+      unexpectedBeforeIntroducerKeyword,
+      actorKeyword: introducerKeyword,
+      unexpectedBeforeIdentifier,
+      identifier: identifier,
+      genericParameterClause: primaryOrGenerics,
+      inheritanceClause: inheritanceClause,
+      genericWhereClause: genericWhereClause,
+      memberBlock: memberBlock,
+      arena: arena
+    )
   }
 
   static func parsePrimaryOrGenerics(_ parser: inout Parser) -> RawGenericParameterClauseSyntax? {
@@ -109,10 +145,22 @@ extension RawStructDeclSyntax: NominalTypeDeclarationTrait {
     primaryOrGenerics: RawGenericParameterClauseSyntax?,
     inheritanceClause: RawTypeInheritanceClauseSyntax?,
     genericWhereClause: RawGenericWhereClauseSyntax?,
-    members: RawMemberDeclBlockSyntax,
+    memberBlock: RawMemberDeclBlockSyntax,
     arena: __shared SyntaxArena
   ) {
-    self.init(attributes: attributes, modifiers: modifiers, unexpectedBeforeIntroducerKeyword, structKeyword: introducerKeyword, unexpectedBeforeIdentifier, identifier: identifier, genericParameterClause: primaryOrGenerics, inheritanceClause: inheritanceClause, genericWhereClause: genericWhereClause, members: members, arena: arena)
+    self.init(
+      attributes: attributes,
+      modifiers: modifiers,
+      unexpectedBeforeIntroducerKeyword,
+      structKeyword: introducerKeyword,
+      unexpectedBeforeIdentifier,
+      identifier: identifier,
+      genericParameterClause: primaryOrGenerics,
+      inheritanceClause: inheritanceClause,
+      genericWhereClause: genericWhereClause,
+      memberBlock: memberBlock,
+      arena: arena
+    )
   }
 
   static func parsePrimaryOrGenerics(_ parser: inout Parser) -> RawGenericParameterClauseSyntax? {
@@ -131,10 +179,22 @@ extension RawEnumDeclSyntax: NominalTypeDeclarationTrait {
     primaryOrGenerics: RawGenericParameterClauseSyntax?,
     inheritanceClause: RawTypeInheritanceClauseSyntax?,
     genericWhereClause: RawGenericWhereClauseSyntax?,
-    members: RawMemberDeclBlockSyntax,
+    memberBlock: RawMemberDeclBlockSyntax,
     arena: __shared SyntaxArena
   ) {
-    self.init(attributes: attributes, modifiers: modifiers, unexpectedBeforeIntroducerKeyword, enumKeyword: introducerKeyword, unexpectedBeforeIdentifier, identifier: identifier, genericParameters: primaryOrGenerics, inheritanceClause: inheritanceClause, genericWhereClause: genericWhereClause, members: members, arena: arena)
+    self.init(
+      attributes: attributes,
+      modifiers: modifiers,
+      unexpectedBeforeIntroducerKeyword,
+      enumKeyword: introducerKeyword,
+      unexpectedBeforeIdentifier,
+      identifier: identifier,
+      genericParameters: primaryOrGenerics,
+      inheritanceClause: inheritanceClause,
+      genericWhereClause: genericWhereClause,
+      memberBlock: memberBlock,
+      arena: arena
+    )
   }
 
   static func parsePrimaryOrGenerics(_ parser: inout Parser) -> RawGenericParameterClauseSyntax? {
@@ -162,7 +222,7 @@ extension Parser {
         primaryOrGenerics: nil,
         inheritanceClause: nil,
         genericWhereClause: nil,
-        members: RawMemberDeclBlockSyntax(
+        memberBlock: RawMemberDeclBlockSyntax(
           leftBrace: RawTokenSyntax(missing: .leftBrace, arena: self.arena),
           members: RawMemberDeclListSyntax(elements: [], arena: self.arena),
           rightBrace: RawTokenSyntax(missing: .rightBrace, arena: self.arena),
@@ -194,7 +254,7 @@ extension Parser {
       whereClause = nil
     }
 
-    let members = self.parseMemberDeclList(introducer: introducerKeyword)
+    let memberBlock = self.parseMemberDeclList(introducer: introducerKeyword)
     return T.init(
       attributes: attrs.attributes,
       modifiers: attrs.modifiers,
@@ -205,7 +265,7 @@ extension Parser {
       primaryOrGenerics: primaryOrGenerics,
       inheritanceClause: inheritance,
       genericWhereClause: whereClause,
-      members: members,
+      memberBlock: memberBlock,
       arena: self.arena
     )
   }

--- a/Sources/SwiftParserDiagnostics/PresenceUtils.swift
+++ b/Sources/SwiftParserDiagnostics/PresenceUtils.swift
@@ -78,7 +78,7 @@ class PresentMaker: SyntaxRewriter {
         modifiers: node.modifiers,
         structKeyword: .keyword(.struct, presence: .missing),
         identifier: .identifier("<#declaration#>", leadingTrivia: leadingTriviaBeforePlaceholder),
-        members: MemberDeclBlockSyntax(
+        memberBlock: MemberDeclBlockSyntax(
           leftBrace: .leftBraceToken(presence: .missing),
           members: MemberDeclListSyntax([]),
           rightBrace: .rightBraceToken(presence: .missing)

--- a/Sources/SwiftSyntax/generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTraits.swift
@@ -102,7 +102,7 @@ public protocol DeclGroupSyntax: SyntaxProtocol {
     set 
   }
   
-  var members: MemberDeclBlockSyntax { 
+  var memberBlock: MemberDeclBlockSyntax { 
     get 
     set 
   }

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -593,9 +593,9 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol {
       inheritanceClause: RawTypeInheritanceClauseSyntax?, 
       _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil, 
       genericWhereClause: RawGenericWhereClauseSyntax?, 
-      _ unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? = nil, 
-      members: RawMemberDeclBlockSyntax, 
-      _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? = nil, 
+      memberBlock: RawMemberDeclBlockSyntax, 
+      _ unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
@@ -615,9 +615,9 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[11] = inheritanceClause?.raw
       layout[12] = unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw
       layout[13] = genericWhereClause?.raw
-      layout[14] = unexpectedBetweenGenericWhereClauseAndMembers?.raw
-      layout[15] = members.raw
-      layout[16] = unexpectedAfterMembers?.raw
+      layout[14] = unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw
+      layout[15] = memberBlock.raw
+      layout[16] = unexpectedAfterMemberBlock?.raw
     }
     self.init(unchecked: raw)
   }
@@ -678,15 +678,15 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol {
     layoutView.children[13].map(RawGenericWhereClauseSyntax.init(raw:))
   }
   
-  public var unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? {
     layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var members: RawMemberDeclBlockSyntax {
+  public var memberBlock: RawMemberDeclBlockSyntax {
     layoutView.children[15].map(RawMemberDeclBlockSyntax.init(raw:))!
   }
   
-  public var unexpectedAfterMembers: RawUnexpectedNodesSyntax? {
+  public var unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? {
     layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
@@ -3250,9 +3250,9 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol {
       inheritanceClause: RawTypeInheritanceClauseSyntax?, 
       _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil, 
       genericWhereClause: RawGenericWhereClauseSyntax?, 
-      _ unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? = nil, 
-      members: RawMemberDeclBlockSyntax, 
-      _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? = nil, 
+      memberBlock: RawMemberDeclBlockSyntax, 
+      _ unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
@@ -3272,9 +3272,9 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[11] = inheritanceClause?.raw
       layout[12] = unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw
       layout[13] = genericWhereClause?.raw
-      layout[14] = unexpectedBetweenGenericWhereClauseAndMembers?.raw
-      layout[15] = members.raw
-      layout[16] = unexpectedAfterMembers?.raw
+      layout[14] = unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw
+      layout[15] = memberBlock.raw
+      layout[16] = unexpectedAfterMemberBlock?.raw
     }
     self.init(unchecked: raw)
   }
@@ -3335,15 +3335,15 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol {
     layoutView.children[13].map(RawGenericWhereClauseSyntax.init(raw:))
   }
   
-  public var unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? {
     layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var members: RawMemberDeclBlockSyntax {
+  public var memberBlock: RawMemberDeclBlockSyntax {
     layoutView.children[15].map(RawMemberDeclBlockSyntax.init(raw:))!
   }
   
-  public var unexpectedAfterMembers: RawUnexpectedNodesSyntax? {
+  public var unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? {
     layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
@@ -8136,9 +8136,9 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol {
       inheritanceClause: RawTypeInheritanceClauseSyntax?, 
       _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil, 
       genericWhereClause: RawGenericWhereClauseSyntax?, 
-      _ unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? = nil, 
-      members: RawMemberDeclBlockSyntax, 
-      _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? = nil, 
+      memberBlock: RawMemberDeclBlockSyntax, 
+      _ unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
@@ -8158,9 +8158,9 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[11] = inheritanceClause?.raw
       layout[12] = unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw
       layout[13] = genericWhereClause?.raw
-      layout[14] = unexpectedBetweenGenericWhereClauseAndMembers?.raw
-      layout[15] = members.raw
-      layout[16] = unexpectedAfterMembers?.raw
+      layout[14] = unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw
+      layout[15] = memberBlock.raw
+      layout[16] = unexpectedAfterMemberBlock?.raw
     }
     self.init(unchecked: raw)
   }
@@ -8221,15 +8221,15 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol {
     layoutView.children[13].map(RawGenericWhereClauseSyntax.init(raw:))
   }
   
-  public var unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? {
     layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var members: RawMemberDeclBlockSyntax {
+  public var memberBlock: RawMemberDeclBlockSyntax {
     layoutView.children[15].map(RawMemberDeclBlockSyntax.init(raw:))!
   }
   
-  public var unexpectedAfterMembers: RawUnexpectedNodesSyntax? {
+  public var unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? {
     layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
@@ -8669,9 +8669,9 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol {
       inheritanceClause: RawTypeInheritanceClauseSyntax?, 
       _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil, 
       genericWhereClause: RawGenericWhereClauseSyntax?, 
-      _ unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? = nil, 
-      members: RawMemberDeclBlockSyntax, 
-      _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? = nil, 
+      memberBlock: RawMemberDeclBlockSyntax, 
+      _ unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
@@ -8689,9 +8689,9 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[9] = inheritanceClause?.raw
       layout[10] = unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw
       layout[11] = genericWhereClause?.raw
-      layout[12] = unexpectedBetweenGenericWhereClauseAndMembers?.raw
-      layout[13] = members.raw
-      layout[14] = unexpectedAfterMembers?.raw
+      layout[12] = unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw
+      layout[13] = memberBlock.raw
+      layout[14] = unexpectedAfterMemberBlock?.raw
     }
     self.init(unchecked: raw)
   }
@@ -8744,15 +8744,15 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol {
     layoutView.children[11].map(RawGenericWhereClauseSyntax.init(raw:))
   }
   
-  public var unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? {
     layoutView.children[12].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var members: RawMemberDeclBlockSyntax {
+  public var memberBlock: RawMemberDeclBlockSyntax {
     layoutView.children[13].map(RawMemberDeclBlockSyntax.init(raw:))!
   }
   
-  public var unexpectedAfterMembers: RawUnexpectedNodesSyntax? {
+  public var unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? {
     layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
@@ -17201,9 +17201,9 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol {
       inheritanceClause: RawTypeInheritanceClauseSyntax?, 
       _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil, 
       genericWhereClause: RawGenericWhereClauseSyntax?, 
-      _ unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? = nil, 
-      members: RawMemberDeclBlockSyntax, 
-      _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? = nil, 
+      memberBlock: RawMemberDeclBlockSyntax, 
+      _ unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
@@ -17223,9 +17223,9 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[11] = inheritanceClause?.raw
       layout[12] = unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw
       layout[13] = genericWhereClause?.raw
-      layout[14] = unexpectedBetweenGenericWhereClauseAndMembers?.raw
-      layout[15] = members.raw
-      layout[16] = unexpectedAfterMembers?.raw
+      layout[14] = unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw
+      layout[15] = memberBlock.raw
+      layout[16] = unexpectedAfterMemberBlock?.raw
     }
     self.init(unchecked: raw)
   }
@@ -17286,15 +17286,15 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol {
     layoutView.children[13].map(RawGenericWhereClauseSyntax.init(raw:))
   }
   
-  public var unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? {
     layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var members: RawMemberDeclBlockSyntax {
+  public var memberBlock: RawMemberDeclBlockSyntax {
     layoutView.children[15].map(RawMemberDeclBlockSyntax.init(raw:))!
   }
   
-  public var unexpectedAfterMembers: RawUnexpectedNodesSyntax? {
+  public var unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? {
     layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
@@ -18506,9 +18506,9 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol {
       inheritanceClause: RawTypeInheritanceClauseSyntax?, 
       _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil, 
       genericWhereClause: RawGenericWhereClauseSyntax?, 
-      _ unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? = nil, 
-      members: RawMemberDeclBlockSyntax, 
-      _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? = nil, 
+      memberBlock: RawMemberDeclBlockSyntax, 
+      _ unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
     let raw = RawSyntax.makeLayout(
@@ -18528,9 +18528,9 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol {
       layout[11] = inheritanceClause?.raw
       layout[12] = unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw
       layout[13] = genericWhereClause?.raw
-      layout[14] = unexpectedBetweenGenericWhereClauseAndMembers?.raw
-      layout[15] = members.raw
-      layout[16] = unexpectedAfterMembers?.raw
+      layout[14] = unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw
+      layout[15] = memberBlock.raw
+      layout[16] = unexpectedAfterMemberBlock?.raw
     }
     self.init(unchecked: raw)
   }
@@ -18591,15 +18591,15 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol {
     layoutView.children[13].map(RawGenericWhereClauseSyntax.init(raw:))
   }
   
-  public var unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenGenericWhereClauseAndMemberBlock: RawUnexpectedNodesSyntax? {
     layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var members: RawMemberDeclBlockSyntax {
+  public var memberBlock: RawMemberDeclBlockSyntax {
     layoutView.children[15].map(RawMemberDeclBlockSyntax.init(raw:))!
   }
   
-  public var unexpectedAfterMembers: RawUnexpectedNodesSyntax? {
+  public var unexpectedAfterMemberBlock: RawUnexpectedNodesSyntax? {
     layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -287,9 +287,9 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       inheritanceClause: TypeInheritanceClauseSyntax? = nil, 
       _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, 
       genericWhereClause: GenericWhereClauseSyntax? = nil, 
-      _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, 
-      members: MemberDeclBlockSyntax, 
-      _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil, 
+      memberBlock: MemberDeclBlockSyntax, 
+      _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil, 
       trailingTrivia: Trivia? = nil
     
   ) {
@@ -310,9 +310,9 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             inheritanceClause, 
             unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
             genericWhereClause, 
-            unexpectedBetweenGenericWhereClauseAndMembers, 
-            members, 
-            unexpectedAfterMembers
+            unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+            memberBlock, 
+            unexpectedAfterMemberBlock
           ))) {(arena, _) in 
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
@@ -329,9 +329,9 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           inheritanceClause?.raw, 
           unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw, 
           genericWhereClause?.raw, 
-          unexpectedBetweenGenericWhereClauseAndMembers?.raw, 
-          members.raw, 
-          unexpectedAfterMembers?.raw
+          unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw, 
+          memberBlock.raw, 
+          unexpectedAfterMemberBlock?.raw
         ]
       let raw = RawSyntax.makeLayout(
           kind: SyntaxKind.actorDecl, 
@@ -509,7 +509,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 14, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -518,7 +518,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var members: MemberDeclBlockSyntax {
+  public var memberBlock: MemberDeclBlockSyntax {
     get {
       return MemberDeclBlockSyntax(data.child(at: 15, parent: Syntax(self))!)
     }
@@ -527,7 +527,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
+  public var unexpectedAfterMemberBlock: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 16, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -552,9 +552,9 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           \Self.inheritanceClause, 
           \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
           \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMembers, 
-          \Self.members, 
-          \Self.unexpectedAfterMembers
+          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+          \Self.memberBlock, 
+          \Self.unexpectedAfterMemberBlock
         ])
   }
 }
@@ -879,9 +879,9 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       inheritanceClause: TypeInheritanceClauseSyntax? = nil, 
       _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, 
       genericWhereClause: GenericWhereClauseSyntax? = nil, 
-      _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, 
-      members: MemberDeclBlockSyntax, 
-      _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil, 
+      memberBlock: MemberDeclBlockSyntax, 
+      _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil, 
       trailingTrivia: Trivia? = nil
     
   ) {
@@ -902,9 +902,9 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             inheritanceClause, 
             unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
             genericWhereClause, 
-            unexpectedBetweenGenericWhereClauseAndMembers, 
-            members, 
-            unexpectedAfterMembers
+            unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+            memberBlock, 
+            unexpectedAfterMemberBlock
           ))) {(arena, _) in 
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
@@ -921,9 +921,9 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           inheritanceClause?.raw, 
           unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw, 
           genericWhereClause?.raw, 
-          unexpectedBetweenGenericWhereClauseAndMembers?.raw, 
-          members.raw, 
-          unexpectedAfterMembers?.raw
+          unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw, 
+          memberBlock.raw, 
+          unexpectedAfterMemberBlock?.raw
         ]
       let raw = RawSyntax.makeLayout(
           kind: SyntaxKind.classDecl, 
@@ -1101,7 +1101,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 14, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -1110,7 +1110,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var members: MemberDeclBlockSyntax {
+  public var memberBlock: MemberDeclBlockSyntax {
     get {
       return MemberDeclBlockSyntax(data.child(at: 15, parent: Syntax(self))!)
     }
@@ -1119,7 +1119,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
+  public var unexpectedAfterMemberBlock: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 16, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -1144,9 +1144,9 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           \Self.inheritanceClause, 
           \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
           \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMembers, 
-          \Self.members, 
-          \Self.unexpectedAfterMembers
+          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+          \Self.memberBlock, 
+          \Self.unexpectedAfterMemberBlock
         ])
   }
 }
@@ -1698,9 +1698,9 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       inheritanceClause: TypeInheritanceClauseSyntax? = nil, 
       _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, 
       genericWhereClause: GenericWhereClauseSyntax? = nil, 
-      _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, 
-      members: MemberDeclBlockSyntax, 
-      _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil, 
+      memberBlock: MemberDeclBlockSyntax, 
+      _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil, 
       trailingTrivia: Trivia? = nil
     
   ) {
@@ -1721,9 +1721,9 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             inheritanceClause, 
             unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
             genericWhereClause, 
-            unexpectedBetweenGenericWhereClauseAndMembers, 
-            members, 
-            unexpectedAfterMembers
+            unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+            memberBlock, 
+            unexpectedAfterMemberBlock
           ))) {(arena, _) in 
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
@@ -1740,9 +1740,9 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           inheritanceClause?.raw, 
           unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw, 
           genericWhereClause?.raw, 
-          unexpectedBetweenGenericWhereClauseAndMembers?.raw, 
-          members.raw, 
-          unexpectedAfterMembers?.raw
+          unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw, 
+          memberBlock.raw, 
+          unexpectedAfterMemberBlock?.raw
         ]
       let raw = RawSyntax.makeLayout(
           kind: SyntaxKind.enumDecl, 
@@ -1927,7 +1927,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 14, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -1937,7 +1937,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
   
   /// The cases and other members of this enum.
-  public var members: MemberDeclBlockSyntax {
+  public var memberBlock: MemberDeclBlockSyntax {
     get {
       return MemberDeclBlockSyntax(data.child(at: 15, parent: Syntax(self))!)
     }
@@ -1946,7 +1946,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
+  public var unexpectedAfterMemberBlock: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 16, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -1971,9 +1971,9 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           \Self.inheritanceClause, 
           \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
           \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMembers, 
-          \Self.members, 
-          \Self.unexpectedAfterMembers
+          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+          \Self.memberBlock, 
+          \Self.unexpectedAfterMemberBlock
         ])
   }
 }
@@ -2013,9 +2013,9 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       inheritanceClause: TypeInheritanceClauseSyntax? = nil, 
       _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, 
       genericWhereClause: GenericWhereClauseSyntax? = nil, 
-      _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, 
-      members: MemberDeclBlockSyntax, 
-      _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil, 
+      memberBlock: MemberDeclBlockSyntax, 
+      _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil, 
       trailingTrivia: Trivia? = nil
     
   ) {
@@ -2034,9 +2034,9 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             inheritanceClause, 
             unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
             genericWhereClause, 
-            unexpectedBetweenGenericWhereClauseAndMembers, 
-            members, 
-            unexpectedAfterMembers
+            unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+            memberBlock, 
+            unexpectedAfterMemberBlock
           ))) {(arena, _) in 
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
@@ -2051,9 +2051,9 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           inheritanceClause?.raw, 
           unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw, 
           genericWhereClause?.raw, 
-          unexpectedBetweenGenericWhereClauseAndMembers?.raw, 
-          members.raw, 
-          unexpectedAfterMembers?.raw
+          unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw, 
+          memberBlock.raw, 
+          unexpectedAfterMemberBlock?.raw
         ]
       let raw = RawSyntax.makeLayout(
           kind: SyntaxKind.extensionDecl, 
@@ -2213,7 +2213,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 12, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -2222,7 +2222,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var members: MemberDeclBlockSyntax {
+  public var memberBlock: MemberDeclBlockSyntax {
     get {
       return MemberDeclBlockSyntax(data.child(at: 13, parent: Syntax(self))!)
     }
@@ -2231,7 +2231,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
+  public var unexpectedAfterMemberBlock: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 14, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -2254,9 +2254,9 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           \Self.inheritanceClause, 
           \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
           \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMembers, 
-          \Self.members, 
-          \Self.unexpectedAfterMembers
+          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+          \Self.memberBlock, 
+          \Self.unexpectedAfterMemberBlock
         ])
   }
 }
@@ -4794,9 +4794,9 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       inheritanceClause: TypeInheritanceClauseSyntax? = nil, 
       _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, 
       genericWhereClause: GenericWhereClauseSyntax? = nil, 
-      _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, 
-      members: MemberDeclBlockSyntax, 
-      _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil, 
+      memberBlock: MemberDeclBlockSyntax, 
+      _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil, 
       trailingTrivia: Trivia? = nil
     
   ) {
@@ -4817,9 +4817,9 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             inheritanceClause, 
             unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
             genericWhereClause, 
-            unexpectedBetweenGenericWhereClauseAndMembers, 
-            members, 
-            unexpectedAfterMembers
+            unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+            memberBlock, 
+            unexpectedAfterMemberBlock
           ))) {(arena, _) in 
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
@@ -4836,9 +4836,9 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           inheritanceClause?.raw, 
           unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw, 
           genericWhereClause?.raw, 
-          unexpectedBetweenGenericWhereClauseAndMembers?.raw, 
-          members.raw, 
-          unexpectedAfterMembers?.raw
+          unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw, 
+          memberBlock.raw, 
+          unexpectedAfterMemberBlock?.raw
         ]
       let raw = RawSyntax.makeLayout(
           kind: SyntaxKind.protocolDecl, 
@@ -5016,7 +5016,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 14, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -5025,7 +5025,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var members: MemberDeclBlockSyntax {
+  public var memberBlock: MemberDeclBlockSyntax {
     get {
       return MemberDeclBlockSyntax(data.child(at: 15, parent: Syntax(self))!)
     }
@@ -5034,7 +5034,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
+  public var unexpectedAfterMemberBlock: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 16, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -5059,9 +5059,9 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           \Self.inheritanceClause, 
           \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
           \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMembers, 
-          \Self.members, 
-          \Self.unexpectedAfterMembers
+          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+          \Self.memberBlock, 
+          \Self.unexpectedAfterMemberBlock
         ])
   }
 }
@@ -5103,9 +5103,9 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       inheritanceClause: TypeInheritanceClauseSyntax? = nil, 
       _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, 
       genericWhereClause: GenericWhereClauseSyntax? = nil, 
-      _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, 
-      members: MemberDeclBlockSyntax, 
-      _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil, 
+      _ unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil, 
+      memberBlock: MemberDeclBlockSyntax, 
+      _ unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil, 
       trailingTrivia: Trivia? = nil
     
   ) {
@@ -5126,9 +5126,9 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
             inheritanceClause, 
             unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
             genericWhereClause, 
-            unexpectedBetweenGenericWhereClauseAndMembers, 
-            members, 
-            unexpectedAfterMembers
+            unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+            memberBlock, 
+            unexpectedAfterMemberBlock
           ))) {(arena, _) in 
       let layout: [RawSyntax?] = [
           unexpectedBeforeAttributes?.raw, 
@@ -5145,9 +5145,9 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           inheritanceClause?.raw, 
           unexpectedBetweenInheritanceClauseAndGenericWhereClause?.raw, 
           genericWhereClause?.raw, 
-          unexpectedBetweenGenericWhereClauseAndMembers?.raw, 
-          members.raw, 
-          unexpectedAfterMembers?.raw
+          unexpectedBetweenGenericWhereClauseAndMemberBlock?.raw, 
+          memberBlock.raw, 
+          unexpectedAfterMemberBlock?.raw
         ]
       let raw = RawSyntax.makeLayout(
           kind: SyntaxKind.structDecl, 
@@ -5325,7 +5325,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 14, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -5334,7 +5334,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var members: MemberDeclBlockSyntax {
+  public var memberBlock: MemberDeclBlockSyntax {
     get {
       return MemberDeclBlockSyntax(data.child(at: 15, parent: Syntax(self))!)
     }
@@ -5343,7 +5343,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
+  public var unexpectedAfterMemberBlock: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 16, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -5368,9 +5368,9 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           \Self.inheritanceClause, 
           \Self.unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
           \Self.genericWhereClause, 
-          \Self.unexpectedBetweenGenericWhereClauseAndMembers, 
-          \Self.members, 
-          \Self.unexpectedAfterMembers
+          \Self.unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+          \Self.memberBlock, 
+          \Self.unexpectedAfterMemberBlock
         ])
   }
 }

--- a/Sources/SwiftSyntaxBuilder/SyntaxNodeWithBody.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxNodeWithBody.swift
@@ -93,7 +93,7 @@ extension InitializerDeclSyntax: HasTrailingOptionalCodeBlock {}
 // MARK: HasTrailingMemberDeclBlock
 
 public protocol HasTrailingMemberDeclBlock {
-  var members: MemberDeclBlockSyntax { get set }
+  var memberBlock: MemberDeclBlockSyntax { get set }
 
   init(_ header: PartialSyntaxNodeString, @MemberDeclListBuilder membersBuilder: () throws -> MemberDeclListSyntax) throws
 }
@@ -105,7 +105,7 @@ public extension HasTrailingMemberDeclBlock where Self: DeclSyntaxProtocol {
       throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualNode: decl)
     }
     self = castedDecl
-    self.members = try MemberDeclBlockSyntax(members: membersBuilder())
+    self.memberBlock = try MemberDeclBlockSyntax(members: membersBuilder())
   }
 }
 

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -73,9 +73,9 @@ extension ActorDeclSyntax {
       inheritanceClause: TypeInheritanceClauseSyntax? = nil, 
       unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, 
       genericWhereClause: GenericWhereClauseSyntax? = nil, 
-      unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, 
-      unexpectedAfterMembers: UnexpectedNodesSyntax? = nil, 
-      @MemberDeclListBuilder membersBuilder: () throws -> MemberDeclListSyntax, 
+      unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil, 
+      unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil, 
+      @MemberDeclListBuilder memberBlockBuilder: () throws -> MemberDeclListSyntax, 
       trailingTrivia: Trivia? = nil
     ) rethrows {
     try self.init(
@@ -94,9 +94,9 @@ extension ActorDeclSyntax {
         inheritanceClause: inheritanceClause, 
         unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
         genericWhereClause: genericWhereClause, 
-        unexpectedBetweenGenericWhereClauseAndMembers, 
-        members: MemberDeclBlockSyntax(members: membersBuilder()), 
-        unexpectedAfterMembers, 
+        unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        memberBlock: MemberDeclBlockSyntax(members: memberBlockBuilder()), 
+        unexpectedAfterMemberBlock, 
         trailingTrivia: trailingTrivia
       )
   }
@@ -174,9 +174,9 @@ extension ClassDeclSyntax {
       inheritanceClause: TypeInheritanceClauseSyntax? = nil, 
       unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, 
       genericWhereClause: GenericWhereClauseSyntax? = nil, 
-      unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, 
-      unexpectedAfterMembers: UnexpectedNodesSyntax? = nil, 
-      @MemberDeclListBuilder membersBuilder: () throws -> MemberDeclListSyntax, 
+      unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil, 
+      unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil, 
+      @MemberDeclListBuilder memberBlockBuilder: () throws -> MemberDeclListSyntax, 
       trailingTrivia: Trivia? = nil
     ) rethrows {
     try self.init(
@@ -195,9 +195,9 @@ extension ClassDeclSyntax {
         inheritanceClause: inheritanceClause, 
         unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
         genericWhereClause: genericWhereClause, 
-        unexpectedBetweenGenericWhereClauseAndMembers, 
-        members: MemberDeclBlockSyntax(members: membersBuilder()), 
-        unexpectedAfterMembers, 
+        unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        memberBlock: MemberDeclBlockSyntax(members: memberBlockBuilder()), 
+        unexpectedAfterMemberBlock, 
         trailingTrivia: trailingTrivia
       )
   }
@@ -422,9 +422,9 @@ extension EnumDeclSyntax {
       inheritanceClause: TypeInheritanceClauseSyntax? = nil, 
       unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, 
       genericWhereClause: GenericWhereClauseSyntax? = nil, 
-      unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, 
-      unexpectedAfterMembers: UnexpectedNodesSyntax? = nil, 
-      @MemberDeclListBuilder membersBuilder: () throws -> MemberDeclListSyntax, 
+      unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil, 
+      unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil, 
+      @MemberDeclListBuilder memberBlockBuilder: () throws -> MemberDeclListSyntax, 
       trailingTrivia: Trivia? = nil
     ) rethrows {
     try self.init(
@@ -443,9 +443,9 @@ extension EnumDeclSyntax {
         inheritanceClause: inheritanceClause, 
         unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
         genericWhereClause: genericWhereClause, 
-        unexpectedBetweenGenericWhereClauseAndMembers, 
-        members: MemberDeclBlockSyntax(members: membersBuilder()), 
-        unexpectedAfterMembers, 
+        unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        memberBlock: MemberDeclBlockSyntax(members: memberBlockBuilder()), 
+        unexpectedAfterMemberBlock, 
         trailingTrivia: trailingTrivia
       )
   }
@@ -502,9 +502,9 @@ extension ExtensionDeclSyntax {
       inheritanceClause: TypeInheritanceClauseSyntax? = nil, 
       unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, 
       genericWhereClause: GenericWhereClauseSyntax? = nil, 
-      unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, 
-      unexpectedAfterMembers: UnexpectedNodesSyntax? = nil, 
-      @MemberDeclListBuilder membersBuilder: () throws -> MemberDeclListSyntax, 
+      unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil, 
+      unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil, 
+      @MemberDeclListBuilder memberBlockBuilder: () throws -> MemberDeclListSyntax, 
       trailingTrivia: Trivia? = nil
     ) rethrows {
     try self.init(
@@ -521,9 +521,9 @@ extension ExtensionDeclSyntax {
         inheritanceClause: inheritanceClause, 
         unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
         genericWhereClause: genericWhereClause, 
-        unexpectedBetweenGenericWhereClauseAndMembers, 
-        members: MemberDeclBlockSyntax(members: membersBuilder()), 
-        unexpectedAfterMembers, 
+        unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        memberBlock: MemberDeclBlockSyntax(members: memberBlockBuilder()), 
+        unexpectedAfterMemberBlock, 
         trailingTrivia: trailingTrivia
       )
   }
@@ -1069,9 +1069,9 @@ extension ProtocolDeclSyntax {
       inheritanceClause: TypeInheritanceClauseSyntax? = nil, 
       unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, 
       genericWhereClause: GenericWhereClauseSyntax? = nil, 
-      unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, 
-      unexpectedAfterMembers: UnexpectedNodesSyntax? = nil, 
-      @MemberDeclListBuilder membersBuilder: () throws -> MemberDeclListSyntax, 
+      unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil, 
+      unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil, 
+      @MemberDeclListBuilder memberBlockBuilder: () throws -> MemberDeclListSyntax, 
       trailingTrivia: Trivia? = nil
     ) rethrows {
     try self.init(
@@ -1090,9 +1090,9 @@ extension ProtocolDeclSyntax {
         inheritanceClause: inheritanceClause, 
         unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
         genericWhereClause: genericWhereClause, 
-        unexpectedBetweenGenericWhereClauseAndMembers, 
-        members: MemberDeclBlockSyntax(members: membersBuilder()), 
-        unexpectedAfterMembers, 
+        unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        memberBlock: MemberDeclBlockSyntax(members: memberBlockBuilder()), 
+        unexpectedAfterMemberBlock, 
         trailingTrivia: trailingTrivia
       )
   }
@@ -1189,9 +1189,9 @@ extension StructDeclSyntax {
       inheritanceClause: TypeInheritanceClauseSyntax? = nil, 
       unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, 
       genericWhereClause: GenericWhereClauseSyntax? = nil, 
-      unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, 
-      unexpectedAfterMembers: UnexpectedNodesSyntax? = nil, 
-      @MemberDeclListBuilder membersBuilder: () throws -> MemberDeclListSyntax, 
+      unexpectedBetweenGenericWhereClauseAndMemberBlock: UnexpectedNodesSyntax? = nil, 
+      unexpectedAfterMemberBlock: UnexpectedNodesSyntax? = nil, 
+      @MemberDeclListBuilder memberBlockBuilder: () throws -> MemberDeclListSyntax, 
       trailingTrivia: Trivia? = nil
     ) rethrows {
     try self.init(
@@ -1210,9 +1210,9 @@ extension StructDeclSyntax {
         inheritanceClause: inheritanceClause, 
         unexpectedBetweenInheritanceClauseAndGenericWhereClause, 
         genericWhereClause: genericWhereClause, 
-        unexpectedBetweenGenericWhereClauseAndMembers, 
-        members: MemberDeclBlockSyntax(members: membersBuilder()), 
-        unexpectedAfterMembers, 
+        unexpectedBetweenGenericWhereClauseAndMemberBlock, 
+        memberBlock: MemberDeclBlockSyntax(members: memberBlockBuilder()), 
+        unexpectedAfterMemberBlock, 
         trailingTrivia: trailingTrivia
       )
   }

--- a/Sources/SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacros/MacroSystem.swift
@@ -249,9 +249,9 @@ class MacroApplication<Context: MacroExpansionContext>: SyntaxRewriter {
     let expandedDeclGroup = expandMembers(of: declGroup)
 
     // Recurse into member decls.
-    let newMembers = visit(expandedDeclGroup.members)
+    let newMembers = visit(expandedDeclGroup.memberBlock)
 
-    return DeclSyntax(expandedDeclGroup.with(\.members, newMembers))
+    return DeclSyntax(expandedDeclGroup.with(\.memberBlock, newMembers))
   }
 
   override func visit(_ node: ActorDeclSyntax) -> DeclSyntax {
@@ -400,8 +400,8 @@ extension MacroApplication {
 
     // FIXME: Is there a better way to add N members to a decl?
     return decl.with(
-      \.members,
-      newMembers.reduce(decl.members) { partialMembers, newMember in
+      \.memberBlock,
+      newMembers.reduce(decl.memberBlock) { partialMembers, newMember in
         partialMembers.addMember(.init(decl: newMember))
       }
     )

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1273,7 +1273,7 @@ final class DeclarationTests: XCTestCase {
               ClassDeclSyntax(
                 classKeyword: .keyword(.class),
                 identifier: .identifier("A"),
-                members: MemberDeclBlockSyntax(
+                memberBlock: MemberDeclBlockSyntax(
                   leftBrace: .leftBraceToken(),
                   members: MemberDeclListSyntax([
                     MemberDeclListItemSyntax(
@@ -1302,7 +1302,7 @@ final class DeclarationTests: XCTestCase {
               ClassDeclSyntax(
                 classKeyword: .keyword(.class),
                 identifier: .identifier("B"),
-                members: MemberDeclBlockSyntax(
+                memberBlock: MemberDeclBlockSyntax(
                   leftBrace: .leftBraceToken(),
                   members: MemberDeclListSyntax([]),
                   rightBrace: .rightBraceToken()

--- a/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
+++ b/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
@@ -41,7 +41,7 @@ final class HashbangLibraryTests: XCTestCase {
                       trailingTrivia: .space
                     ),
                     identifier: .identifier("Foo", trailingTrivia: .space),
-                    members: MemberDeclBlockSyntax(
+                    memberBlock: MemberDeclBlockSyntax(
                       members: MemberDeclListSyntax([])
                     )
                   )

--- a/Tests/SwiftSyntaxBuilderTest/ExtensionDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ExtensionDeclTests.swift
@@ -37,7 +37,7 @@ final class ExtensionDeclTests: XCTestCase {
     let members = MemberDeclListSyntax(keywords.map { MemberDeclListItemSyntax(decl: $0) })
     let buildable = ExtensionDeclSyntax(
       extendedType: TypeSyntax("TokenSyntax"),
-      members: MemberDeclBlockSyntax(members: members)
+      memberBlock: MemberDeclBlockSyntax(members: members)
     )
 
     assertBuildResult(

--- a/Tests/SwiftSyntaxBuilderTest/SourceFileTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/SourceFileTests.swift
@@ -22,7 +22,7 @@ final class SourceFileTests: XCTestCase {
       ClassDeclSyntax(
         classKeyword: .keyword(.class),
         identifier: "SomeViewController",
-        membersBuilder: {
+        memberBlockBuilder: {
           DeclSyntax("let tableView: UITableView")
         }
       )

--- a/Tests/SwiftSyntaxBuilderTest/StructTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StructTests.swift
@@ -46,7 +46,7 @@ final class StructTests: XCTestCase {
       ],
       structKeyword: .keyword(.struct),
       identifier: "CarriateReturnsStruct",
-      members: MemberDeclBlockSyntax(members: [])
+      memberBlock: MemberDeclBlockSyntax(members: [])
     )
     let carriageReturnFormFeedsStruct = StructDeclSyntax(
       leadingTrivia: [
@@ -57,7 +57,7 @@ final class StructTests: XCTestCase {
       ],
       structKeyword: .keyword(.struct),
       identifier: "CarriageReturnFormFeedsStruct",
-      members: MemberDeclBlockSyntax(members: [])
+      memberBlock: MemberDeclBlockSyntax(members: [])
     )
     let testStruct = try StructDeclSyntax("public struct TestStruct") {
       nestedStruct

--- a/Tests/SwiftSyntaxParserTest/ParseFileTests.swift
+++ b/Tests/SwiftSyntaxParserTest/ParseFileTests.swift
@@ -54,7 +54,7 @@ public class ParseFileTests: XCTestCase {
       var cases: [EnumCaseDeclSyntax] = []
       override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
         cases.append(
-          contentsOf: node.members.members.compactMap {
+          contentsOf: node.memberBlock.members.compactMap {
             $0.decl.as(EnumCaseDeclSyntax.self)
           }
         )

--- a/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
@@ -46,7 +46,7 @@ fileprivate func cannedStructDecl(arena: SyntaxArena) -> RawStructDeclSyntax {
     presence: .present,
     arena: arena
   )
-  let members = RawMemberDeclBlockSyntax(
+  let memberBlock = RawMemberDeclBlockSyntax(
     leftBrace: lBrace,
     members: RawMemberDeclListSyntax(elements: [], arena: arena),
     rightBrace: rBrace,
@@ -60,7 +60,7 @@ fileprivate func cannedStructDecl(arena: SyntaxArena) -> RawStructDeclSyntax {
     genericParameterClause: nil,
     inheritanceClause: nil,
     genericWhereClause: nil,
-    members: members,
+    memberBlock: memberBlock,
     arena: arena
   )
 }
@@ -85,8 +85,8 @@ final class RawSyntaxTests: XCTestCase {
       let structDecl = cannedStructDecl(arena: arena)
       XCTAssertEqual(structDecl.identifier.tokenKind, .identifier)
       XCTAssertEqual(structDecl.structKeyword.tokenText, "struct")
-      XCTAssertEqual(structDecl.members.leftBrace.tokenText, "{")
-      XCTAssertEqual(structDecl.members.members.elements.count, 0)
+      XCTAssertEqual(structDecl.memberBlock.leftBrace.tokenText, "{")
+      XCTAssertEqual(structDecl.memberBlock.members.elements.count, 0)
 
       XCTAssert(structDecl.is(RawDeclSyntax.self))
       XCTAssertNotNil(structDecl.as(RawDeclSyntax.self))

--- a/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
@@ -17,7 +17,7 @@ fileprivate func cannedStructDecl() -> StructDeclSyntax {
   let structKW = TokenSyntax.keyword(.struct, trailingTrivia: .space)
   let fooID = TokenSyntax.identifier("Foo", trailingTrivia: .space)
   let rBrace = TokenSyntax.rightBraceToken(leadingTrivia: .newline)
-  let members = MemberDeclBlockSyntax(
+  let memberBlock = MemberDeclBlockSyntax(
     leftBrace: .leftBraceToken(),
     members: MemberDeclListSyntax([]),
     rightBrace: rBrace
@@ -25,7 +25,7 @@ fileprivate func cannedStructDecl() -> StructDeclSyntax {
   return StructDeclSyntax(
     structKeyword: structKW,
     identifier: fooID,
-    members: members
+    memberBlock: memberBlock
   )
 }
 
@@ -48,8 +48,8 @@ public class SyntaxCreationTests: XCTestCase {
 
     let renamed = structDecl.with(\.identifier, forType)
       .with(
-        \.members,
-        structDecl.members
+        \.memberBlock,
+        structDecl.memberBlock
           .with(\.rightBrace, newBrace)
       )
 
@@ -62,14 +62,14 @@ public class SyntaxCreationTests: XCTestCase {
       """
     )
 
-    XCTAssertNotEqual(structDecl.members, renamed.members)
+    XCTAssertNotEqual(structDecl.memberBlock, renamed.memberBlock)
     XCTAssertEqual(structDecl, StructDeclSyntax(structDecl.root))
     XCTAssertNil(structDecl.parent)
-    XCTAssertNotNil(structDecl.members.parent)
-    XCTAssertEqual(structDecl.members.parent.map(StructDeclSyntax.init), structDecl)
+    XCTAssertNotNil(structDecl.memberBlock.parent)
+    XCTAssertEqual(structDecl.memberBlock.parent.map(StructDeclSyntax.init), structDecl)
 
     XCTAssertEqual(
-      "\(structDecl.members.rightBrace)",
+      "\(structDecl.memberBlock.rightBrace)",
       """
 
       }

--- a/Tests/SwiftSyntaxTest/SyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTests.swift
@@ -42,10 +42,10 @@ public class SyntaxTests: XCTestCase {
     let s = StructDeclSyntax(
       structKeyword: .keyword(.struct),
       identifier: .identifier("someStruct"),
-      members: MemberDeclBlockSyntax(leftBrace: .leftBraceToken(), members: [], rightBrace: .rightBraceToken())
+      memberBlock: MemberDeclBlockSyntax(leftBrace: .leftBraceToken(), members: [], rightBrace: .rightBraceToken())
     )
 
-    XCTAssertEqual(Syntax(s), s.members.parent)
-    XCTAssertNil(s.members.detach().parent)
+    XCTAssertEqual(Syntax(s), s.memberBlock.parent)
+    XCTAssertNil(s.memberBlock.detach().parent)
   }
 }


### PR DESCRIPTION
Previously, we frequently had patterns where we did `node.members.members`, which doesn’t read very nice. `node.memberBlock.members` is much nicer.