### PR TITLE
Don't guard assertions behind `#if DEBUG`

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
@@ -137,39 +137,29 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         internal init(_ data: SyntaxData)
         """
       ) {
-        IfConfigDeclSyntax(
-          clauses: IfConfigClauseListSyntax {
-            IfConfigClauseSyntax(
-              poundKeyword: .poundIfKeyword(),
-              condition: ExprSyntax("DEBUG"),
-              elements: .statements(
-                CodeBlockItemListSyntax {
-                  try! SwitchExprSyntax("switch data.raw.kind") {
-                    SwitchCaseSyntax(
-                      label: .case(
-                        SwitchCaseLabelSyntax {
-                          for childNode in SYNTAX_NODES where childNode.baseKind == node.syntaxKind {
-                            CaseItemSyntax(
-                              pattern: ExpressionPatternSyntax(
-                                expression: ExprSyntax(".\(raw: childNode.swiftSyntaxKind)")
-                              )
-                            )
-                          }
-                        }
+        CodeBlockItemListSyntax {
+          try! SwitchExprSyntax("switch data.raw.kind") {
+            SwitchCaseSyntax(
+              label: .case(
+                SwitchCaseLabelSyntax {
+                  for childNode in SYNTAX_NODES where childNode.baseKind == node.syntaxKind {
+                    CaseItemSyntax(
+                      pattern: ExpressionPatternSyntax(
+                        expression: ExprSyntax(".\(raw: childNode.swiftSyntaxKind)")
                       )
-                    ) {
-                      BreakStmtSyntax()
-                    }
-
-                    SwitchCaseSyntax("default:") {
-                      ExprSyntax("fatalError(\"Unable to create \(raw: node.name) from \\(data.raw.kind)\")")
-                    }
+                    )
                   }
                 }
               )
-            )
+            ) {
+              BreakStmtSyntax()
+            }
+
+            SwitchCaseSyntax("default:") {
+              ExprSyntax("preconditionFailure(\"Unable to create \(raw: node.name) from \\(data.raw.kind)\")")
+            }
           }
-        )
+        }
 
         ExprSyntax("self._syntaxNode = Syntax(data)")
       }

--- a/Sources/SwiftSyntax/SyntaxArena.swift
+++ b/Sources/SwiftSyntax/SyntaxArena.swift
@@ -19,7 +19,7 @@ public class SyntaxArena {
   /// are retained in `addChild()` and are released in `deinit`.
   private var childRefs: Set<SyntaxArenaRef>
 
-  #if DEBUG
+  #if DEBUG || SWIFTSYNTAX_ENABLE_ASSERTIONS
   /// Whether or not this arena has been added to other arenas as a child.
   /// Used to make sure we don’t introduce retain cycles between arenas.
   private var hasParent: Bool
@@ -32,7 +32,7 @@ public class SyntaxArena {
   fileprivate init(slabSize: Int) {
     self.allocator = BumpPtrAllocator(slabSize: slabSize)
     self.childRefs = []
-    #if DEBUG
+    #if DEBUG || SWIFTSYNTAX_ENABLE_ASSERTIONS
     self.hasParent = false
     #endif
   }
@@ -107,7 +107,7 @@ public class SyntaxArena {
   func addChild(_ otherRef: SyntaxArenaRef) {
     if SyntaxArenaRef(self) == otherRef { return }
 
-    #if DEBUG
+    #if DEBUG || SWIFTSYNTAX_ENABLE_ASSERTIONS
     precondition(
       !self.hasParent,
       "an arena can't have a new child once it's owned by other arenas"
@@ -116,7 +116,7 @@ public class SyntaxArena {
 
     if childRefs.insert(otherRef).inserted {
       otherRef.retain()
-      #if DEBUG
+      #if DEBUG || SWIFTSYNTAX_ENABLE_ASSERTIONS
       // FIXME: This may trigger a data race warning in Thread Sanitizer.
       // Can we use atomic bool here?
       otherRef.value.hasParent = true

--- a/Sources/SwiftSyntax/SyntaxChildren.swift
+++ b/Sources/SwiftSyntax/SyntaxChildren.swift
@@ -370,13 +370,9 @@ struct NonNilRawSyntaxChildren: BidirectionalCollection {
       {
         return reversedIndex
       }
-      #if DEBUG
       // Reversing any further would result in undefined behaviour of
       // index(before:)
-      if reversedIndex == children.startIndex {
-        fatalError("presentIndex(before:) must not be called if there is no " + "present index before the given one")
-      }
-      #endif
+      precondition(reversedIndex != children.startIndex, "presentIndex(before:) must not be called if there is no " + "present index before the given one")
       reversedIndex = children.index(before: reversedIndex)
     }
   }

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -82,14 +82,12 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    #if DEBUG
     switch data.raw.kind {
     case .accessorDecl, .actorDecl, .associatedtypeDecl, .classDecl, .deinitializerDecl, .editorPlaceholderDecl, .enumCaseDecl, .enumDecl, .extensionDecl, .functionDecl, .ifConfigDecl, .importDecl, .initializerDecl, .macroDecl, .macroExpansionDecl, .missingDecl, .operatorDecl, .poundSourceLocation, .precedenceGroupDecl, .protocolDecl, .structDecl, .subscriptDecl, .typealiasDecl, .variableDecl:
       break
     default:
-      fatalError("Unable to create DeclSyntax from \(data.raw.kind)")
+      preconditionFailure("Unable to create DeclSyntax from \(data.raw.kind)")
     }
-    #endif 
     self._syntaxNode = Syntax(data)
   }
   
@@ -227,14 +225,12 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    #if DEBUG
     switch data.raw.kind {
     case .arrayExpr, .arrowExpr, .asExpr, .assignmentExpr, .awaitExpr, .binaryOperatorExpr, .booleanLiteralExpr, .borrowExpr, .closureExpr, .dictionaryExpr, .discardAssignmentExpr, .editorPlaceholderExpr, .floatLiteralExpr, .forcedValueExpr, .functionCallExpr, .identifierExpr, .ifExpr, .inOutExpr, .infixOperatorExpr, .integerLiteralExpr, .isExpr, .keyPathExpr, .macroExpansionExpr, .memberAccessExpr, .missingExpr, .moveExpr, .nilLiteralExpr, .optionalChainingExpr, .packElementExpr, .packExpansionExpr, .postfixIfConfigExpr, .postfixUnaryExpr, .prefixOperatorExpr, .regexLiteralExpr, .sequenceExpr, .specializeExpr, .stringLiteralExpr, .subscriptExpr, .superRefExpr, .switchExpr, .ternaryExpr, .tryExpr, .tupleExpr, .typeExpr, .unresolvedAsExpr, .unresolvedIsExpr, .unresolvedPatternExpr, .unresolvedTernaryExpr:
       break
     default:
-      fatalError("Unable to create ExprSyntax from \(data.raw.kind)")
+      preconditionFailure("Unable to create ExprSyntax from \(data.raw.kind)")
     }
-    #endif 
     self._syntaxNode = Syntax(data)
   }
   
@@ -396,14 +392,12 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    #if DEBUG
     switch data.raw.kind {
     case .expressionPattern, .identifierPattern, .isTypePattern, .missingPattern, .tuplePattern, .valueBindingPattern, .wildcardPattern:
       break
     default:
-      fatalError("Unable to create PatternSyntax from \(data.raw.kind)")
+      preconditionFailure("Unable to create PatternSyntax from \(data.raw.kind)")
     }
-    #endif 
     self._syntaxNode = Syntax(data)
   }
   
@@ -524,14 +518,12 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    #if DEBUG
     switch data.raw.kind {
     case .breakStmt, .continueStmt, .deferStmt, .doStmt, .expressionStmt, .fallthroughStmt, .forInStmt, .forgetStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatWhileStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
       break
     default:
-      fatalError("Unable to create StmtSyntax from \(data.raw.kind)")
+      preconditionFailure("Unable to create StmtSyntax from \(data.raw.kind)")
     }
-    #endif 
     self._syntaxNode = Syntax(data)
   }
   
@@ -661,14 +653,12 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    #if DEBUG
     switch data.raw.kind {
     case .arrayType, .attributedType, .classRestrictionType, .compositionType, .constrainedSugarType, .dictionaryType, .functionType, .implicitlyUnwrappedOptionalType, .memberTypeIdentifier, .metatypeType, .missingType, .namedOpaqueReturnType, .optionalType, .packExpansionType, .packReferenceType, .simpleTypeIdentifier, .tupleType:
       break
     default:
-      fatalError("Unable to create TypeSyntax from \(data.raw.kind)")
+      preconditionFailure("Unable to create TypeSyntax from \(data.raw.kind)")
     }
-    #endif 
     self._syntaxNode = Syntax(data)
   }
   


### PR DESCRIPTION
Some assertions were still guarded by a `#if DEBUG`. Since we are now also enabling assertions in release builds if `SWIFTSYNTAX_ENABLE_ASSERTIONS` is set, this is no longer correct. Convert most of them to plain preconditions. I have measured and could not detect a performance difference when parsing MovieSwiftU.