### PR TITLE
[5.9] Add diagnostic for wrong where requirements separation

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -759,9 +759,21 @@ extension Parser {
         }
 
         keepGoing = self.consume(if: .comma)
+        let unexpectedBetweenBodyAndTrailingComma: RawUnexpectedNodesSyntax?
+
+        // If there's a comma, keep parsing the list.
+        // If there's a "&&", diagnose replace with a comma and keep parsing
+        if let token = self.consumeIfContextualPunctuator("&&") {
+          keepGoing = self.missingToken(.comma)
+          unexpectedBetweenBodyAndTrailingComma = RawUnexpectedNodesSyntax([token], arena: self.arena)
+        } else {
+          unexpectedBetweenBodyAndTrailingComma = nil
+        }
+
         elements.append(
           RawGenericRequirementSyntax(
             body: requirement,
+            unexpectedBetweenBodyAndTrailingComma,
             trailingComma: keepGoing,
             arena: self.arena
           )

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -131,6 +131,9 @@ extension DiagnosticMessage where Self == StaticParserError {
   public static var expectedAssignmentInsteadOfComparisonOperator: Self {
     .init("expected '=' instead of '==' to assign default value for parameter")
   }
+  public static var expectedCommaInWhereClause: Self {
+    .init("expected ',' to separate the requirements of this 'where' clause")
+  }
   public static var expectedLeftBraceOrIfAfterElse: Self {
     .init("expected '{' or 'if' after 'else'")
   }

--- a/Tests/SwiftParserTest/translated/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryTests.swift
@@ -2174,15 +2174,17 @@ final class RecoveryTests: XCTestCase {
   }
 
   func testRecovery177() {
+    // rdar://38225184
     assertParse(
       """
-      // rdar://38225184
       extension Collection where Element == Int 1️⃣&& Index == Int {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "unexpected code '&& Index == Int' in extension")
-        // TODO: Old parser expected error on line 1: expected ',' to separate the requirements of this 'where' clause, Fix-It replacements: 43 - 45 = ','
-      ]
+        DiagnosticSpec(message: "expected ',' to separate the requirements of this 'where' clause", fixIts: ["replace '&&' with ','"])
+      ],
+      fixedSource: """
+        extension Collection where Element == Int, Index == Int {}
+        """
     )
   }
 


### PR DESCRIPTION
* **Explanation**: If there is a`&&` in a generic where requirement the parser didn't recover correctly and emitted a wrong diagnostic. This fix ensures we recover well and have a correct diagnostic and fix-it.
* **Scope**: Parsing of generic where requirements 
* **Risk**: Low, improves diagnostic
* **Testing**: CI didn’t find any issues
* **Issue**: N/A
* **Reviewer**: @ahoppen on https://github.com/apple/swift-syntax/pull/1513