### PR TITLE
improve implementation of without operator

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -1033,7 +1033,7 @@ public let DECL_NODES: [Node] = [
       /// indicate the suppression of implicit conformance to this type.
       /// This child stores the token representing the 'without' operator.
       Child(
-        name: "HasWithout",
+        name: "WithoutTilde",
         kind: .token(choices: [.token(tokenKind: "PrefixOperatorToken")]),
         isOptional: true
       ),

--- a/Sources/SwiftParser/Nominals.swift
+++ b/Sources/SwiftParser/Nominals.swift
@@ -289,16 +289,14 @@ extension Parser {
             )
           )
         } else {
-          if self.currentToken.starts(with: "~") {
-            withoutToken = self.consumePrefix("~", as: .prefixOperator)
-          }
+          withoutToken = self.consumeIfContextualPunctuator("~", remapping: .prefixOperator)
           type = self.parseType()
         }
 
         keepGoing = self.consume(if: .comma)
         elements.append(
           RawInheritedTypeSyntax(
-            hasWithout: withoutToken,
+            withoutTilde: withoutToken,
             typeName: type,
             trailingComma: keepGoing,
             arena: self.arena

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -1712,12 +1712,12 @@ internal func childName(_ keyPath: AnyKeyPath) -> String? {
     return "rightOperand"
   case \InfixOperatorExprSyntax.unexpectedAfterRightOperand:
     return "unexpectedAfterRightOperand"
-  case \InheritedTypeSyntax.unexpectedBeforeHasWithout:
-    return "unexpectedBeforeHasWithout"
-  case \InheritedTypeSyntax.hasWithout:
-    return "hasWithout"
-  case \InheritedTypeSyntax.unexpectedBetweenHasWithoutAndTypeName:
-    return "unexpectedBetweenHasWithoutAndTypeName"
+  case \InheritedTypeSyntax.unexpectedBeforeWithoutTilde:
+    return "unexpectedBeforeWithoutTilde"
+  case \InheritedTypeSyntax.withoutTilde:
+    return "withoutTilde"
+  case \InheritedTypeSyntax.unexpectedBetweenWithoutTildeAndTypeName:
+    return "unexpectedBetweenWithoutTildeAndTypeName"
   case \InheritedTypeSyntax.typeName:
     return "typeName"
   case \InheritedTypeSyntax.unexpectedBetweenTypeNameAndTrailingComma:

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -11708,9 +11708,9 @@ public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol {
   }
   
   public init(
-      _ unexpectedBeforeHasWithout: RawUnexpectedNodesSyntax? = nil, 
-      hasWithout: RawTokenSyntax?, 
-      _ unexpectedBetweenHasWithoutAndTypeName: RawUnexpectedNodesSyntax? = nil, 
+      _ unexpectedBeforeWithoutTilde: RawUnexpectedNodesSyntax? = nil, 
+      withoutTilde: RawTokenSyntax?, 
+      _ unexpectedBetweenWithoutTildeAndTypeName: RawUnexpectedNodesSyntax? = nil, 
       typeName: RawTypeSyntax, 
       _ unexpectedBetweenTypeNameAndTrailingComma: RawUnexpectedNodesSyntax? = nil, 
       trailingComma: RawTokenSyntax?, 
@@ -11720,9 +11720,9 @@ public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol {
     let raw = RawSyntax.makeLayout(
       kind: .inheritedType, uninitializedCount: 7, arena: arena) { layout in 
       layout.initialize(repeating: nil)
-      layout[0] = unexpectedBeforeHasWithout?.raw
-      layout[1] = hasWithout?.raw
-      layout[2] = unexpectedBetweenHasWithoutAndTypeName?.raw
+      layout[0] = unexpectedBeforeWithoutTilde?.raw
+      layout[1] = withoutTilde?.raw
+      layout[2] = unexpectedBetweenWithoutTildeAndTypeName?.raw
       layout[3] = typeName.raw
       layout[4] = unexpectedBetweenTypeNameAndTrailingComma?.raw
       layout[5] = trailingComma?.raw
@@ -11731,15 +11731,15 @@ public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol {
     self.init(unchecked: raw)
   }
   
-  public var unexpectedBeforeHasWithout: RawUnexpectedNodesSyntax? {
+  public var unexpectedBeforeWithoutTilde: RawUnexpectedNodesSyntax? {
     layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var hasWithout: RawTokenSyntax? {
+  public var withoutTilde: RawTokenSyntax? {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))
   }
   
-  public var unexpectedBetweenHasWithoutAndTypeName: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenWithoutTildeAndTypeName: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -10504,9 +10504,9 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   
   public init<T: TypeSyntaxProtocol>(
       leadingTrivia: Trivia? = nil, 
-      _ unexpectedBeforeHasWithout: UnexpectedNodesSyntax? = nil, 
-      hasWithout: TokenSyntax? = nil, 
-      _ unexpectedBetweenHasWithoutAndTypeName: UnexpectedNodesSyntax? = nil, 
+      _ unexpectedBeforeWithoutTilde: UnexpectedNodesSyntax? = nil, 
+      withoutTilde: TokenSyntax? = nil, 
+      _ unexpectedBetweenWithoutTildeAndTypeName: UnexpectedNodesSyntax? = nil, 
       typeName: T, 
       _ unexpectedBetweenTypeNameAndTrailingComma: UnexpectedNodesSyntax? = nil, 
       trailingComma: TokenSyntax? = nil, 
@@ -10517,18 +10517,18 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     // Extend the lifetime of all parameters so their arenas don't get destroyed
     // before they can be added as children of the new arena.
     let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (
-            unexpectedBeforeHasWithout, 
-            hasWithout, 
-            unexpectedBetweenHasWithoutAndTypeName, 
+            unexpectedBeforeWithoutTilde, 
+            withoutTilde, 
+            unexpectedBetweenWithoutTildeAndTypeName, 
             typeName, 
             unexpectedBetweenTypeNameAndTrailingComma, 
             trailingComma, 
             unexpectedAfterTrailingComma
           ))) {(arena, _) in 
       let layout: [RawSyntax?] = [
-          unexpectedBeforeHasWithout?.raw, 
-          hasWithout?.raw, 
-          unexpectedBetweenHasWithoutAndTypeName?.raw, 
+          unexpectedBeforeWithoutTilde?.raw, 
+          withoutTilde?.raw, 
+          unexpectedBetweenWithoutTildeAndTypeName?.raw, 
           typeName.raw, 
           unexpectedBetweenTypeNameAndTrailingComma?.raw, 
           trailingComma?.raw, 
@@ -10546,7 +10546,7 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     self.init(data)
   }
   
-  public var unexpectedBeforeHasWithout: UnexpectedNodesSyntax? {
+  public var unexpectedBeforeWithoutTilde: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -10555,7 +10555,7 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var hasWithout: TokenSyntax? {
+  public var withoutTilde: TokenSyntax? {
     get {
       return data.child(at: 1, parent: Syntax(self)).map(TokenSyntax.init)
     }
@@ -10564,7 +10564,7 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     }
   }
   
-  public var unexpectedBetweenHasWithoutAndTypeName: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenWithoutTildeAndTypeName: UnexpectedNodesSyntax? {
     get {
       return data.child(at: 2, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
     }
@@ -10611,9 +10611,9 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   
   public static var structure: SyntaxNodeStructure {
     return .layout([
-          \Self.unexpectedBeforeHasWithout, 
-          \Self.hasWithout, 
-          \Self.unexpectedBetweenHasWithoutAndTypeName, 
+          \Self.unexpectedBeforeWithoutTilde, 
+          \Self.withoutTilde, 
+          \Self.unexpectedBetweenWithoutTildeAndTypeName, 
           \Self.typeName, 
           \Self.unexpectedBetweenTypeNameAndTrailingComma, 
           \Self.trailingComma, 

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1577,9 +1577,37 @@ final class DeclarationTests: XCTestCase {
     assertParse(
       """
       struct Hello: ~Copyable {}
+      """,
+      substructure: Syntax(
+        InheritedTypeSyntax(
+          withoutTilde: .prefixOperator("~"),
+          typeName: TypeSyntax(stringLiteral: "Copyable")
+        )
+      )
+    )
 
-      enum Whatever: Int, ~ Hashable, Equatable {}
+    assertParse(
       """
+      enum Whatever: Int, ~ Hashable, Equatable {}
+      """,
+      substructure:
+        Syntax(
+          TypeInheritanceClauseSyntax(
+            colon: .colonToken(),
+            inheritedTypeCollection: InheritedTypeListSyntax([
+              InheritedTypeSyntax(
+                typeName: TypeSyntax(stringLiteral: "Int"),
+                trailingComma: .commaToken()
+              ),
+              InheritedTypeSyntax(
+                withoutTilde: .prefixOperator("~"),
+                typeName: TypeSyntax(stringLiteral: "Hashable"),
+                trailingComma: .commaToken()
+              ),
+              InheritedTypeSyntax(typeName: TypeSyntax(stringLiteral: "Equatable")),
+            ])
+          )
+        )
     )
   }
 }


### PR DESCRIPTION
- changes "hasWithout" to "withoutTilde" for now, though the tilde is likely to change to the contextual keyword `without` soon.
- improves a test with structural verification
- simplifies parsing a bit

this addresses the post-merge review in https://github.com/apple/swift-syntax/pull/1461