### PR TITLE
Fix a couple cases where the formatting in CodeGeneration was off

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserEntryFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftparser/ParserEntryFile.swift
@@ -88,10 +88,10 @@ let parserEntryFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
         let existingUnexpected: [RawSyntax]
         if let unexpectedNode = layout.children[layout.children.count - 1] {
-           precondition(unexpectedNode.is(RawUnexpectedNodesSyntax.self))
-           existingUnexpected = unexpectedNode.as(RawUnexpectedNodesSyntax.self).elements
+          precondition(unexpectedNode.is(RawUnexpectedNodesSyntax.self))
+          existingUnexpected = unexpectedNode.as(RawUnexpectedNodesSyntax.self).elements
         } else {
-           existingUnexpected = []
+          existingUnexpected = []
         }
         let unexpected = RawUnexpectedNodesSyntax(elements: existingUnexpected + remainingTokens, arena: self.arena)
 

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
@@ -169,11 +169,11 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           public init(elements: [\(raw: element)], arena: __shared SyntaxArena) {
             let raw = RawSyntax.makeLayout(
               kind: .\(raw: node.swiftSyntaxKind), uninitializedCount: elements.count, arena: arena) { layout in
-                  guard var ptr = layout.baseAddress else { return }
-                  for elem in elements {
-                    ptr.initialize(to: elem.raw)
-                    ptr += 1
-                  }
+                guard var ptr = layout.baseAddress else { return }
+                for elem in elements {
+                  ptr.initialize(to: elem.raw)
+                  ptr += 1
+                }
             }
             self.init(unchecked: raw)
           }
@@ -183,7 +183,7 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         DeclSyntax(
           """
           public var elements: [Raw\(raw: node.collectionElementType.syntaxBaseName)] {
-              layoutView.children.map { Raw\(raw: node.collectionElementType.syntaxBaseName)(raw: $0!) }
+            layoutView.children.map { Raw\(raw: node.collectionElementType.syntaxBaseName)(raw: $0!) }
           }
           """
         )

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxValidationFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxValidationFile.swift
@@ -35,18 +35,18 @@ let rawSyntaxValidationFile = try! SourceFileSyntax(leadingTrivia: copyrightHead
               DeclSyntax(
                 #"""
                 enum TokenChoice: CustomStringConvertible {
-                   case keyword(StaticString)
-                   case tokenKind(RawTokenKind)
+                  case keyword(StaticString)
+                  case tokenKind(RawTokenKind)
 
-                   var description: String {
-                     switch self {
-                     case .keyword(let keyword):
-                       return "keyword('\(keyword)')"
-                     case .tokenKind(let kind):
-                       return "\(kind)"
-                     }
-                   }
-                 }
+                  var description: String {
+                    switch self {
+                    case .keyword(let keyword):
+                      return "keyword('\(keyword)')"
+                    case .tokenKind(let kind):
+                      return "\(kind)"
+                    }
+                  }
+                }
                 """#
               )
 
@@ -76,7 +76,7 @@ let rawSyntaxValidationFile = try! SourceFileSyntax(leadingTrivia: copyrightHead
                       return (file, line)
                     case .tokenMismatch(expectedTokenChoices: _, actualKind: _, actualText: _, file: let file, line: let line):
                       return (file, line)
-                  }
+                    }
                   }
                 }
                 """#
@@ -156,13 +156,13 @@ let rawSyntaxValidationFile = try! SourceFileSyntax(leadingTrivia: copyrightHead
 
               DeclSyntax(
                 #"""
-                 func assertNoError(_ nodeKind: SyntaxKind, _ index: Int, _ error: ValidationError?) {
-                   if let error = error {
-                     let (file, line) = error.fileAndLine
-                     assertionFailure("""
-                       Error validating child at index \(index) of \(nodeKind):
-                       \(error.description)
-                       """, file: file, line: line)
+                func assertNoError(_ nodeKind: SyntaxKind, _ index: Int, _ error: ValidationError?) {
+                  if let error = error {
+                    let (file, line) = error.fileAndLine
+                    assertionFailure("""
+                      Error validating child at index \(index) of \(nodeKind):
+                      \(error.description)
+                      """, file: file, line: line)
                   }
                 }
                 """#

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -191,13 +191,12 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         /// - Parameter layout: The new list of raw syntax nodes underlying this
         ///                     collection.
         /// - Returns: A new `\(raw: node.name)` with the new layout underlying it.
-        internal func replacingLayout(
-          _ layout: [RawSyntax?]) -> \(raw: node.name) {
-            let arena = SyntaxArena()
-            let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
-            let newData = data.replacingSelf(newRaw, arena: arena)
-            return \(raw: node.name)(newData)
-          }
+        internal func replacingLayout(_ layout: [RawSyntax?]) -> \(raw: node.name) {
+          let arena = SyntaxArena()
+          let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+          let newData = data.replacingSelf(newRaw, arena: arena)
+          return \(raw: node.name)(newData)
+        }
         """
       )
 

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodeFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxNodeFile.swift
@@ -109,8 +109,12 @@ func syntaxNode(emitKind: String) -> SourceFileSyntax {
                 DeclSyntax(
                   """
                   let raw = RawSyntax.makeLayout(
-                    kind: SyntaxKind.\(raw: node.swiftSyntaxKind), from: layout, arena: arena,
-                    leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
+                    kind: SyntaxKind.\(raw: node.swiftSyntaxKind),
+                    from: layout,
+                    arena: arena,
+                    leadingTrivia: leadingTrivia,
+                    trailingTrivia: trailingTrivia
+                  )
                   """
                 )
               }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TriviaPiecesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TriviaPiecesFile.swift
@@ -181,7 +181,7 @@ let triviaPiecesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   ) {
     for trivia in TRIVIAS {
       if trivia.isCollection {
-        DeclSyntax(" case \(raw: trivia.enumCaseName)(Int)")
+        DeclSyntax("case \(raw: trivia.enumCaseName)(Int)")
 
       } else {
         DeclSyntax("case \(raw: trivia.enumCaseName)(SyntaxText)")

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -75,8 +75,7 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `AccessPathSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> AccessPathSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> AccessPathSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -285,8 +284,7 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `AccessorListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> AccessorListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> AccessorListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -495,8 +493,7 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `ArrayElementListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> ArrayElementListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> ArrayElementListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -748,8 +745,7 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `AttributeListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> AttributeListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> AttributeListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -958,8 +954,7 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `AvailabilitySpecListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> AvailabilitySpecListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> AvailabilitySpecListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -1168,8 +1163,7 @@ public struct AvailabilityVersionRestrictionListSyntax: SyntaxCollection, Syntax
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `AvailabilityVersionRestrictionListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> AvailabilityVersionRestrictionListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> AvailabilityVersionRestrictionListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -1378,8 +1372,7 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `CaseItemListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> CaseItemListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> CaseItemListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -1588,8 +1581,7 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `CatchClauseListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> CatchClauseListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> CatchClauseListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -1798,8 +1790,7 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `CatchItemListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> CatchItemListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> CatchItemListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -2008,8 +1999,7 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `ClosureCaptureItemListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> ClosureCaptureItemListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> ClosureCaptureItemListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -2218,8 +2208,7 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `ClosureParamListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> ClosureParamListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> ClosureParamListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -2428,8 +2417,7 @@ public struct ClosureParameterListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `ClosureParameterListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> ClosureParameterListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> ClosureParameterListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -2638,8 +2626,7 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `CodeBlockItemListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> CodeBlockItemListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> CodeBlockItemListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -2848,8 +2835,7 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `CompositionTypeElementListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> CompositionTypeElementListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> CompositionTypeElementListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -3058,8 +3044,7 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `ConditionElementListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> ConditionElementListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> ConditionElementListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -3268,8 +3253,7 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `DeclNameArgumentListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> DeclNameArgumentListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> DeclNameArgumentListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -3478,8 +3462,7 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `DesignatedTypeListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> DesignatedTypeListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> DesignatedTypeListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -3688,8 +3671,7 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `DictionaryElementListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> DictionaryElementListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> DictionaryElementListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -3898,8 +3880,7 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `DifferentiabilityParamListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> DifferentiabilityParamListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> DifferentiabilityParamListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -4105,8 +4086,7 @@ public struct DocumentationAttributeArgumentsSyntax: SyntaxCollection, SyntaxHas
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `DocumentationAttributeArgumentsSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> DocumentationAttributeArgumentsSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> DocumentationAttributeArgumentsSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -4312,8 +4292,7 @@ public struct EffectsArgumentsSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `EffectsArgumentsSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> EffectsArgumentsSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> EffectsArgumentsSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -4519,8 +4498,7 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `EnumCaseElementListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> EnumCaseElementListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> EnumCaseElementListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -4729,8 +4707,7 @@ public struct EnumCaseParameterListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `EnumCaseParameterListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> EnumCaseParameterListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> EnumCaseParameterListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -4936,8 +4913,7 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `ExprListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> ExprListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> ExprListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -5146,8 +5122,7 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `FunctionParameterListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> FunctionParameterListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> FunctionParameterListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -5356,8 +5331,7 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `GenericArgumentListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> GenericArgumentListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> GenericArgumentListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -5566,8 +5540,7 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `GenericParameterListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> GenericParameterListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> GenericParameterListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -5776,8 +5749,7 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `GenericRequirementListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> GenericRequirementListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> GenericRequirementListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -5986,8 +5958,7 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `IfConfigClauseListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> IfConfigClauseListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> IfConfigClauseListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -6196,8 +6167,7 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `InheritedTypeListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> InheritedTypeListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> InheritedTypeListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -6406,8 +6376,7 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `KeyPathComponentListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> KeyPathComponentListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> KeyPathComponentListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -6616,8 +6585,7 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `MemberDeclListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> MemberDeclListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> MemberDeclListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -6826,8 +6794,7 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `ModifierListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> ModifierListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> ModifierListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -7036,8 +7003,7 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `MultipleTrailingClosureElementListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> MultipleTrailingClosureElementListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> MultipleTrailingClosureElementListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -7246,8 +7212,7 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `ObjCSelectorSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> ObjCSelectorSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> ObjCSelectorSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -7456,8 +7421,7 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `PatternBindingListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> PatternBindingListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> PatternBindingListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -7721,8 +7685,7 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `PrecedenceGroupAttributeListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> PrecedenceGroupAttributeListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> PrecedenceGroupAttributeListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -7931,8 +7894,7 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `PrecedenceGroupNameListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> PrecedenceGroupNameListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> PrecedenceGroupNameListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -8141,8 +8103,7 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `PrimaryAssociatedTypeListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> PrimaryAssociatedTypeListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> PrimaryAssociatedTypeListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -8416,8 +8377,7 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `SpecializeAttributeSpecListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> SpecializeAttributeSpecListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> SpecializeAttributeSpecListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -8669,8 +8629,7 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `StringLiteralSegmentsSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> StringLiteralSegmentsSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> StringLiteralSegmentsSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -8922,8 +8881,7 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `SwitchCaseListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> SwitchCaseListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> SwitchCaseListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -9132,8 +9090,7 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `TupleExprElementListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> TupleExprElementListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> TupleExprElementListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -9342,8 +9299,7 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `TuplePatternElementListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> TuplePatternElementListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> TuplePatternElementListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -9552,8 +9508,7 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `TupleTypeElementListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> TupleTypeElementListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> TupleTypeElementListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -9759,8 +9714,7 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `UnexpectedNodesSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> UnexpectedNodesSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> UnexpectedNodesSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)
@@ -9969,8 +9923,7 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
   /// - Returns: A new `YieldExprListSyntax` with the new layout underlying it.
-  internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> YieldExprListSyntax {
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> YieldExprListSyntax {
     let arena = SyntaxArena()
     let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
     let newData = data.replacingSelf(newRaw, arena: arena)

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -129,13 +129,13 @@ public struct RawAccessPathSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawAccessPathComponentSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .accessPath, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -449,13 +449,13 @@ public struct RawAccessorListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawAccessorDeclSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .accessorList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -723,13 +723,13 @@ public struct RawArrayElementListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawArrayElementSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .arrayElementList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -1390,13 +1390,13 @@ public struct RawAttributeListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [Element], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .attributeList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -2194,13 +2194,13 @@ public struct RawAvailabilitySpecListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawAvailabilityArgumentSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .availabilitySpecList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -2314,13 +2314,13 @@ public struct RawAvailabilityVersionRestrictionListSyntax: RawSyntaxNodeProtocol
   public init(elements: [RawAvailabilityVersionRestrictionListEntrySyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .availabilityVersionRestrictionList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -2842,13 +2842,13 @@ public struct RawCaseItemListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawCaseItemSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .caseItemList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -2974,13 +2974,13 @@ public struct RawCatchClauseListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawCatchClauseSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .catchClauseList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -3106,13 +3106,13 @@ public struct RawCatchItemListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawCatchItemSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .catchItemList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -3438,13 +3438,13 @@ public struct RawClosureCaptureItemListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawClosureCaptureItemSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .closureCaptureItemList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -3864,13 +3864,13 @@ public struct RawClosureParamListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawClosureParamSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .closureParamList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -4066,13 +4066,13 @@ public struct RawClosureParameterListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawClosureParameterSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .closureParameterList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -4407,13 +4407,13 @@ public struct RawCodeBlockItemListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawCodeBlockItemSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .codeBlockItemList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -4647,13 +4647,13 @@ public struct RawCompositionTypeElementListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawCompositionTypeElementSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .compositionTypeElementList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -4825,13 +4825,13 @@ public struct RawConditionElementListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawConditionElementSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .conditionElementList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -5552,13 +5552,13 @@ public struct RawDeclNameArgumentListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawDeclNameArgumentSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .declNameArgumentList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -6227,13 +6227,13 @@ public struct RawDesignatedTypeListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawDesignatedTypeElementSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .designatedTypeList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -6277,13 +6277,13 @@ public struct RawDictionaryElementListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawDictionaryElementSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .dictionaryElementList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -6640,13 +6640,13 @@ public struct RawDifferentiabilityParamListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawDifferentiabilityParamSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .differentiabilityParamList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -7326,13 +7326,13 @@ public struct RawDocumentationAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawDocumentationAttributeArgumentSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .documentationAttributeArguments, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -7574,13 +7574,13 @@ public struct RawEffectsArgumentsSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawTokenSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .effectsArguments, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -7718,13 +7718,13 @@ public struct RawEnumCaseElementListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawEnumCaseElementSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .enumCaseElementList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -7944,13 +7944,13 @@ public struct RawEnumCaseParameterListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawEnumCaseParameterSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .enumCaseParameterList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -8348,13 +8348,13 @@ public struct RawExprListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawExprSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .exprList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -9541,13 +9541,13 @@ public struct RawFunctionParameterListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawFunctionParameterSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .functionParameterList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -10015,13 +10015,13 @@ public struct RawGenericArgumentListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawGenericArgumentSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .genericArgumentList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -10229,13 +10229,13 @@ public struct RawGenericParameterListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawGenericParameterSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .genericParameterList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -10397,13 +10397,13 @@ public struct RawGenericRequirementListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawGenericRequirementSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .genericRequirementList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -10847,13 +10847,13 @@ public struct RawIfConfigClauseListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawIfConfigClauseSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .ifConfigClauseList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -11660,13 +11660,13 @@ public struct RawInheritedTypeListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawInheritedTypeSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .inheritedTypeList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -12214,13 +12214,13 @@ public struct RawKeyPathComponentListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawKeyPathComponentSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .keyPathComponentList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -13760,13 +13760,13 @@ public struct RawMemberDeclListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawMemberDeclListItemSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .memberDeclList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -14271,13 +14271,13 @@ public struct RawModifierListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawDeclModifierSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .modifierList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -14391,13 +14391,13 @@ public struct RawMultipleTrailingClosureElementListSyntax: RawSyntaxNodeProtocol
   public init(elements: [RawMultipleTrailingClosureElementSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .multipleTrailingClosureElementList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -14721,13 +14721,13 @@ public struct RawObjCSelectorSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawObjCSelectorPieceSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .objCSelector, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -15743,13 +15743,13 @@ public struct RawPatternBindingListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawPatternBindingSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .patternBindingList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -16535,13 +16535,13 @@ public struct RawPrecedenceGroupAttributeListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [Element], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .precedenceGroupAttributeList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -16785,13 +16785,13 @@ public struct RawPrecedenceGroupNameListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawPrecedenceGroupNameElementSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .precedenceGroupNameList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -17069,13 +17069,13 @@ public struct RawPrimaryAssociatedTypeListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawPrimaryAssociatedTypeSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .primaryAssociatedTypeList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -18090,13 +18090,13 @@ public struct RawSpecializeAttributeSpecListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [Element], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .specializeAttributeSpecList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -18386,13 +18386,13 @@ public struct RawStringLiteralSegmentsSyntax: RawSyntaxNodeProtocol {
   public init(elements: [Element], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .stringLiteralSegments, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -19098,13 +19098,13 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [Element], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .switchCaseList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -19789,13 +19789,13 @@ public struct RawTupleExprElementListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawTupleExprElementSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .tupleExprElementList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -20015,13 +20015,13 @@ public struct RawTuplePatternElementListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawTuplePatternElementSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .tuplePatternElementList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -20241,13 +20241,13 @@ public struct RawTupleTypeElementListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawTupleTypeElementSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .tupleTypeElementList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -21186,13 +21186,13 @@ public struct RawUnexpectedNodesSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .unexpectedNodes, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }
@@ -22066,13 +22066,13 @@ public struct RawYieldExprListSyntax: RawSyntaxNodeProtocol {
   public init(elements: [RawYieldExprListElementSyntax], arena: __shared SyntaxArena) {
     let raw = RawSyntax.makeLayout(
       kind: .yieldExprList, uninitializedCount: elements.count, arena: arena) { layout in 
-        guard var ptr = layout.baseAddress else { 
+      guard var ptr = layout.baseAddress else { 
         return 
       }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
     }
     self.init(unchecked: raw)
   }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -89,7 +89,8 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -339,7 +340,8 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -642,7 +644,8 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -931,7 +934,8 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1216,7 +1220,8 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1395,7 +1400,8 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1498,7 +1504,8 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1750,7 +1757,8 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2061,7 +2069,8 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2350,7 +2359,8 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2623,7 +2633,8 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2775,7 +2786,8 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3050,7 +3062,8 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3367,7 +3380,8 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3676,7 +3690,8 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3950,7 +3965,8 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4121,7 +4137,8 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4349,7 +4366,8 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4534,7 +4552,8 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4846,7 +4865,8 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5155,7 +5175,8 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5506,7 +5527,8 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5809,7 +5831,8 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6074,7 +6097,8 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -71,7 +71,8 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -225,7 +226,8 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -352,7 +354,8 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -493,7 +496,8 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -584,7 +588,8 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -685,7 +690,8 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -762,7 +768,8 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -853,7 +860,8 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -980,7 +988,8 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1202,7 +1211,8 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1323,7 +1333,8 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1400,7 +1411,8 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1477,7 +1489,8 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1568,7 +1581,8 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1707,7 +1721,8 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1940,7 +1955,8 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2115,7 +2131,8 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2309,7 +2326,8 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2430,7 +2448,8 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2551,7 +2570,8 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2648,7 +2668,8 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2789,7 +2810,8 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3014,7 +3036,8 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3300,7 +3323,8 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3477,7 +3501,8 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3550,7 +3575,8 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3651,7 +3677,8 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3742,7 +3769,8 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3857,7 +3885,8 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3972,7 +4001,8 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4087,7 +4117,8 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4233,7 +4264,8 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4348,7 +4380,8 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4481,7 +4514,8 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4642,7 +4676,8 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4752,7 +4787,8 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4885,7 +4921,8 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5103,7 +5140,8 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5322,7 +5360,8 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5431,7 +5470,8 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5643,7 +5683,8 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5824,7 +5865,8 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5965,7 +6007,8 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6105,7 +6148,8 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6196,7 +6240,8 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6297,7 +6342,8 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6374,7 +6420,8 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6471,7 +6518,8 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -65,7 +65,8 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -186,7 +187,8 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -340,7 +342,8 @@ public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -461,7 +464,8 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -596,7 +600,8 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -990,7 +995,8 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1223,7 +1229,8 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1352,7 +1359,8 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1538,7 +1546,8 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1762,7 +1771,8 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1900,7 +1910,8 @@ public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, Syn
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2016,7 +2027,8 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2138,7 +2150,8 @@ public struct BackDeployedAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashabl
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2301,7 +2314,8 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2442,7 +2456,8 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2602,7 +2617,8 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2784,7 +2800,8 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2957,7 +2974,8 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3138,7 +3156,8 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3292,7 +3311,8 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3413,7 +3433,8 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -3606,7 +3627,8 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4006,7 +4028,8 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4273,7 +4296,8 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4396,7 +4420,8 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4550,7 +4575,8 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4734,7 +4760,8 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -4855,7 +4882,8 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5008,7 +5036,8 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5190,7 +5219,8 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5331,7 +5361,8 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5466,7 +5497,8 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5581,7 +5613,8 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5702,7 +5735,8 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -5856,7 +5890,8 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6003,7 +6038,8 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6223,7 +6259,8 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6350,7 +6387,8 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6505,7 +6543,8 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6668,7 +6707,8 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6811,7 +6851,8 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -6984,7 +7025,8 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7215,7 +7257,8 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7377,7 +7420,8 @@ public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable 
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7524,7 +7568,8 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7689,7 +7734,8 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -7876,7 +7922,8 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -8120,7 +8167,8 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -8273,7 +8321,8 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -8467,7 +8516,8 @@ public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -8624,7 +8674,8 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -8923,7 +8974,8 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -9064,7 +9116,8 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -9218,7 +9271,8 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -9345,7 +9399,8 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -9543,7 +9598,8 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -9857,7 +9913,8 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -9972,7 +10029,8 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -10193,7 +10251,8 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -10375,7 +10434,8 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -10540,7 +10600,8 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -10675,7 +10736,8 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -10843,7 +10905,8 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -10944,7 +11007,8 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -11041,7 +11105,8 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -11182,7 +11247,8 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -11348,7 +11414,8 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -11543,7 +11610,8 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -11790,7 +11858,8 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -11951,7 +12020,8 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -12105,7 +12175,8 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -12205,7 +12276,8 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -12284,7 +12356,8 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -12419,7 +12492,8 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -12540,7 +12614,8 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -12683,7 +12758,8 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -12851,7 +12927,8 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -13024,7 +13101,8 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -13224,7 +13302,8 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -13438,7 +13517,8 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -13643,7 +13723,8 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -13864,7 +13945,8 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -14006,7 +14088,8 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -14142,7 +14225,8 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -14263,7 +14347,8 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -14425,7 +14510,8 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -14579,7 +14665,8 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -14706,7 +14793,8 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -14903,7 +14991,8 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -15024,7 +15113,8 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -15159,7 +15249,8 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -15279,7 +15370,8 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -15376,7 +15468,8 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -15578,7 +15671,8 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -15732,7 +15826,8 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -15859,7 +15954,8 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -16030,7 +16126,8 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -16197,7 +16294,8 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -16388,7 +16486,8 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -16623,7 +16722,8 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -16738,7 +16838,8 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -16853,7 +16954,8 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -16987,7 +17089,8 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -17108,7 +17211,8 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -17249,7 +17353,8 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -17402,7 +17507,8 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -17582,7 +17688,8 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -17697,7 +17804,8 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -17818,7 +17926,8 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
@@ -51,7 +51,8 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -128,7 +129,8 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -219,7 +221,8 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -317,7 +320,8 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -396,7 +400,8 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -550,7 +555,8 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -665,7 +671,8 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -65,7 +65,8 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -180,7 +181,8 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -295,7 +297,8 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -416,7 +419,8 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -556,7 +560,8 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -633,7 +638,8 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -772,7 +778,8 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1047,7 +1054,8 @@ public struct ForgetStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1174,7 +1182,8 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1354,7 +1363,8 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1472,7 +1482,8 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1557,7 +1568,8 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1712,7 +1724,8 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1858,7 +1871,8 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1979,7 +1993,8 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2175,7 +2190,8 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
@@ -71,7 +71,8 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -212,7 +213,8 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -352,7 +354,8 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -429,7 +432,8 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -539,7 +543,8 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -672,7 +677,8 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -865,7 +871,8 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1059,7 +1066,8 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1186,7 +1194,8 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1347,7 +1356,8 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1465,7 +1475,8 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1538,7 +1549,8 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1653,7 +1665,8 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1768,7 +1781,8 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1883,7 +1897,8 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -1998,7 +2013,8 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
@@ -2119,7 +2135,8 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
           arena: arena, 
           leadingTrivia: leadingTrivia, 
           trailingTrivia: trailingTrivia
-        )
+        
+      )
       return SyntaxData.forRoot(raw)
     }
     self.init(data)


### PR DESCRIPTION
With the new BasicFormat from https://github.com/apple/swift-syntax/pull/1558, these cases will be formatted weirdly, so I want to update them now.