### PR TITLE
Change version dependency on `swift-argument-parser` to from `upToNextMinor` to `upToNextMajor`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -267,7 +267,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   // Building standalone.
   package.dependencies += [
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.2"))
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2")
   ]
 } else {
   package.dependencies += [


### PR DESCRIPTION
This will make SwiftSyntax more tolerant with regard to which swift-argument-parser version it needs, resulting in fewer version conflicts for users of SwiftSyntax.