### PR TITLE
[5.9] Add a compatibility layer for SwiftSyntax

### DIFF
--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -16,6 +16,7 @@ add_swift_host_library(SwiftSyntax
   SourceLength.swift
   SourceLocation.swift
   SourcePresence.swift
+  SwiftSyntaxCompatibility.swift
   Syntax.swift
   SyntaxArena.swift
   SyntaxChildren.swift

--- a/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
+++ b/Sources/SwiftSyntax/SwiftSyntaxCompatibility.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This file provides compatiblity aliases to keep dependents of SwiftSyntax building.
+// All users of the declarations in this file should transition away from them ASAP.
+
+public extension DeclGroupSyntax {
+  @available(*, deprecated, renamed: "memberBlock")
+  var members: MemberDeclBlockSyntax {
+    return self.memberBlock
+  }
+}

--- a/utils/group.json
+++ b/utils/group.json
@@ -61,5 +61,6 @@
     "SyntaxVerifier.swift",
     "BumpPtrAllocator.swift",
     "PlatformMutex.swift",
+    "SwiftSyntaxCompatibility.swift",
   ]
 }


### PR DESCRIPTION
When renaming methods this new file can contain deprecated declarations to keep clients building.