### PR TITLE
Fix a precondition failure if a generic parameter clause had an additional closing right angle

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -544,7 +544,7 @@ extension Parser {
 
     let rangle: RawTokenSyntax
     if self.currentToken.starts(with: ">") {
-      rangle = self.consumeAnyToken(remapping: .rightAngle)
+      rangle = self.consumePrefix(">", as: .rightAngle)
     } else {
       rangle = RawTokenSyntax(missing: .rightAngle, arena: self.arena)
     }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1610,6 +1610,15 @@ final class DeclarationTests: XCTestCase {
         )
     )
   }
+
+  func testDoubleRightAngle() {
+    assertParse(
+      "func foo<A>1️⃣> test()",
+      diagnostics: [
+        DiagnosticSpec(message: "unexpected code '> test' before parameter clause")
+      ]
+    )
+  }
 }
 
 extension Parser.DeclAttributes {


### PR DESCRIPTION
rdar://108624264