### PR TITLE
[5.9] Automatically format expanded macros

### DIFF
--- a/Sources/SwiftCompilerPluginMessageHandling/CMakeLists.txt
+++ b/Sources/SwiftCompilerPluginMessageHandling/CMakeLists.txt
@@ -16,6 +16,7 @@ add_swift_host_library(SwiftCompilerPluginMessageHandling
 
 target_link_libraries(SwiftCompilerPluginMessageHandling PUBLIC
   SwiftSyntax
+  SwiftBasicFormat
   SwiftDiagnostics
   SwiftParser
   SwiftSyntaxMacros

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -541,12 +541,34 @@ public extension SyntaxProtocol {
     return self.with(\.leadingTrivia, []).with(\.trailingTrivia, [])
   }
 
-  /// The description of this node without the leading trivia of the first token
-  /// in the node and the trailing trivia of the last token in the node.
+  /// A copy of this node with pieces that match `matching` trimmed from the
+  /// leading trivia of the first token and trailing trivia of the last token.
+  func trimmed(matching filter: (TriviaPiece) -> Bool) -> Self {
+    // TODO: Should only need one new node here
+    return self.with(
+      \.leadingTrivia,
+      Trivia(pieces: leadingTrivia.pieces.drop(while: filter))
+    ).with(
+      \.trailingTrivia,
+      Trivia(pieces: trailingTrivia.pieces.reversed().drop(while: filter).reversed())
+    )
+  }
+
+  /// The description of this node with leading whitespace of the first token
+  /// and trailing whitespace of the last token removed.
   var trimmedDescription: String {
-    // TODO: We shouldn't need to create to copies just to get the description
-    // without trivia.
+    // TODO: We shouldn't need to create to copies just to get the trimmed
+    // description.
     return self.trimmed.description
+  }
+
+  /// The description of this node with pieces that match `matching` removed
+  /// from the leading trivia of the first token and trailing trivia of the
+  /// last token.
+  func trimmedDescription(matching filter: (TriviaPiece) -> Bool) -> String {
+    // TODO: We shouldn't need to create to copies just to get the trimmed
+    // description.
+    return self.trimmed(matching: filter).description
   }
 }
 

--- a/Sources/SwiftSyntaxMacros/CMakeLists.txt
+++ b/Sources/SwiftSyntaxMacros/CMakeLists.txt
@@ -15,6 +15,7 @@ add_swift_host_library(SwiftSyntaxMacros
   MacroProtocols/ExpressionMacro.swift
   MacroProtocols/FreestandingMacro.swift
   MacroProtocols/Macro.swift
+  MacroProtocols/Macro+Format.swift
   MacroProtocols/MemberAttributeMacro.swift
   MacroProtocols/MemberMacro.swift
   MacroProtocols/PeerMacro.swift

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/Macro+Format.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/Macro+Format.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Describes the mode to use to format the result of an expansion.
+public enum FormatMode {
+  /// Perform a basic format of the expansion. This is primarily for inserting
+  /// whitespace as required (eg. between two keywords), but also adds simple
+  /// newline and indentation.
+  case auto
+
+  /// Disable automatically formatting the expanded macro. Trivia must be
+  /// manually inserted where required (eg. adding spaces between keywords).
+  case disabled
+}
+
+public extension Macro {
+  static var formatMode: FormatMode {
+    return .auto
+  }
+}

--- a/Sources/SwiftSyntaxMacros/MacroProtocols/Macro.swift
+++ b/Sources/SwiftSyntaxMacros/MacroProtocols/Macro.swift
@@ -11,4 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 /// Describes a macro.
-public protocol Macro {}
+public protocol Macro {
+  /// How the resulting expansion should be formatted, `.auto` by default.
+  /// Use `.disabled` for the expansion to be used as is.
+  static var formatMode: FormatMode { get }
+}

--- a/lit_tests/compiler_plugin_basic.swift
+++ b/lit_tests/compiler_plugin_basic.swift
@@ -23,7 +23,9 @@ class MyClass {
 }
 
 // For '@Metadata'
-// CHECK: static var __metadata__: [String: String] { ["name": "MyClass"] }
+// CHECK: {{^}}static var __metadata__: [String: String] {
+// CHECK-NEXT: {{^}}    ["name": "MyClass"]
+// CHECK-NEXT: {{^}}}
 
 // For '#echo(12)'
 // CHECK: /* echo */12


### PR DESCRIPTION
* Explanation: Macro formatting patch. Primarily this is aimed to reduce the previous burden on expansions having to add required trivia and to be at least *somewhat* formatted. We now basic format all macro expansions, which both adds required trivia and adds some basic newlines and indentation. Macros can opt-out by implementing `formatMode` and setting to `.disabled`.
* Scope: All macro expansions
* Risk: Low; we may end up with some oddly-formatted macros, but implementors can always disable it if they want
* Testing: Swift-repo tests for formatted macros
* Original PR: https://github.com/apple/swift-syntax/pull/1591