### PR TITLE
[5.9] Fix a precondition failure if a generic parameter clause had an additional closing right angle

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -544,7 +544,7 @@ extension Parser {
 
     let rangle: RawTokenSyntax
     if self.currentToken.starts(with: ">") {
-      rangle = self.consumeAnyToken(remapping: .rightAngle)
+      rangle = self.consumePrefix(">", as: .rightAngle)
     } else {
       rangle = RawTokenSyntax(missing: .rightAngle, arena: self.arena)
     }

--- a/Tests/SwiftParserTest/DeclarationTests.swift
+++ b/Tests/SwiftParserTest/DeclarationTests.swift
@@ -1552,6 +1552,15 @@ final class DeclarationTests: XCTestCase {
       """
     )
   }
+
+  func testDoubleRightAngle() {
+    assertParse(
+      "func foo<A>1️⃣> test()",
+      diagnostics: [
+        DiagnosticSpec(message: "unexpected code '> test' before parameter clause")
+      ]
+    )
+  }
 }
 
 extension Parser.DeclAttributes {


### PR DESCRIPTION
* **Explanation**: If a generic argument clause has an additional closing `>`, we performed a misparse, causing a precondition failure because we were consuming `>>` as a right angle, which doesn’t match the expected text.
* **Scope**: Parsing of generic argument argument clauses
* **Risk**: Very low. The old code was obviously wrong
* **Testing**: Added regression test
* **Issue**: rdar://108624264
* **Reviewer**: @bnbarham on https://github.com/apple/swift-syntax/pull/1595