### PR TITLE
Add documentation for DeinitializerDeclSyntax and all its children

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -398,6 +398,14 @@ public let DECL_NODES: [Node] = [
   Node(
     name: "DeinitializerDecl",
     nameForDiagnostics: "deinitializer",
+    description: """
+      A deinitializer declaration like the following.
+
+      ```swift
+      deinit {
+      }
+      ```
+      """,
     kind: "Decl",
     traits: [
       "Attributed"
@@ -407,21 +415,25 @@ public let DECL_NODES: [Node] = [
         name: "Attributes",
         kind: .collection(kind: "AttributeList", collectionElementName: "Attribute"),
         nameForDiagnostics: "attributes",
+        description: "Attributes that are attached to the deinitializer.",
         isOptional: true
       ),
       Child(
         name: "Modifiers",
         kind: .collection(kind: "ModifierList", collectionElementName: "Modifier"),
         nameForDiagnostics: "modifiers",
+        description: "Modifiers that are attached to the deinitializer.",
         isOptional: true
       ),
       Child(
         name: "DeinitKeyword",
-        kind: .token(choices: [.keyword(text: "deinit")])
+        kind: .token(choices: [.keyword(text: "deinit")]),
+        description: "The deinit keyword."
       ),
       Child(
         name: "Body",
         kind: .node(kind: "CodeBlock"),
+        description: "The deinitializer's body.",
         isOptional: true
       ),
     ]

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -1157,7 +1157,12 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - DeinitializerDeclSyntax
 
-
+/// A deinitializer declaration like the following.
+/// 
+/// ```swift
+/// deinit {
+/// }
+/// ```
 public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -1236,6 +1241,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// Attributes that are attached to the deinitializer.
   public var attributes: AttributeListSyntax? {
     get {
       return data.child(at: 1, parent: Syntax(self)).map(AttributeListSyntax.init)
@@ -1273,6 +1279,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// Modifiers that are attached to the deinitializer.
   public var modifiers: ModifierListSyntax? {
     get {
       return data.child(at: 3, parent: Syntax(self)).map(ModifierListSyntax.init)
@@ -1310,6 +1317,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The deinit keyword.
   public var deinitKeyword: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 5, parent: Syntax(self))!)
@@ -1328,6 +1336,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The deinitializer's body.
   public var body: CodeBlockSyntax? {
     get {
       return data.child(at: 7, parent: Syntax(self)).map(CodeBlockSyntax.init)


### PR DESCRIPTION
As part of #1528, documentation should be added to `DeinitializerDeclSyntax` and all it's children.