### PR TITLE
[5.9] Fix debugInitCall

### DIFF
--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/ChildNameForKeyPathFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/ChildNameForKeyPathFile.swift
@@ -20,7 +20,8 @@ let childNameForKeyPathFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     """
     /// If the keyPath is one from a layout structure, return the property name
     /// of it.
-    internal func childName(_ keyPath: AnyKeyPath) -> String?
+    @_spi(RawSyntax)
+    public func childName(_ keyPath: AnyKeyPath) -> String?
     """
   ) {
     try! SwitchExprSyntax("switch keyPath") {

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -14,7 +14,8 @@
 
 /// If the keyPath is one from a layout structure, return the property name
 /// of it.
-internal func childName(_ keyPath: AnyKeyPath) -> String? {
+@_spi(RawSyntax)
+public func childName(_ keyPath: AnyKeyPath) -> String? {
   switch keyPath {
   case \AccessPathComponentSyntax.unexpectedBeforeName:
     return "unexpectedBeforeName"


### PR DESCRIPTION
* **Explanation**: I broke `debugInitCall` when I removed the custom mirrors for syntax nodes. Fix it again, also fixing some more issues along the way that previously caused us to generate Swift code that didn’t compile.
* **Scope**: A method that is only intended for debugging purposes
* **Risk**: Zero, this methods is never called in any production code
* **Testing**: Manual 
* **Issue**: rdar://108756044
* **Reviewer**: @bnbarham on https://github.com/apple/swift-syntax/pull/1543