### PR TITLE
Update SwiftSyntax to Swift 5.7

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
@@ -48,7 +48,7 @@ public class TokenSpec {
     self.name = name
     self.kind = kind
     self.nameForDiagnostics = nameForDiagnostics
-    if let unprefixedKind = unprefixedKind {
+    if let unprefixedKind {
       self.unprefixedKind = unprefixedKind
     } else {
       self.unprefixedKind = kind

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
@@ -50,7 +50,11 @@ public extension Child {
   /// function parameter. Otherwise, return `nil`.
   var defaultInitialization: InitializerClauseSyntax? {
     if isOptional || isUnexpectedNodes {
-      return InitializerClauseSyntax(value: NilLiteralExprSyntax())
+      if type.isBaseType && kind.isNodeChoicesEmpty {
+        return InitializerClauseSyntax(value: ExprSyntax("\(type.buildable).none"))
+      } else {
+        return InitializerClauseSyntax(value: NilLiteralExprSyntax())
+      }
     }
     guard let token = token, isToken else {
       return type.defaultValue.map { InitializerClauseSyntax(value: $0) }

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
@@ -160,7 +160,7 @@ public struct SyntaxBuildableType: Hashable {
   }
 
   /// Wraps a type in an optional depending on whether `isOptional` is true.
-  public func optionalWrapped<TypeNode: TypeSyntaxProtocol>(type: TypeNode) -> TypeSyntax {
+  public func optionalWrapped(type: some TypeSyntaxProtocol) -> TypeSyntax {
     if isOptional {
       return TypeSyntax(OptionalTypeSyntax(wrappedType: type))
     } else {
@@ -169,7 +169,7 @@ public struct SyntaxBuildableType: Hashable {
   }
 
   /// Wraps a type in an optional chaining depending on whether `isOptional` is true.
-  public func optionalChained<ExprNode: ExprSyntaxProtocol>(expr: ExprNode) -> ExprSyntax {
+  public func optionalChained(expr: some ExprSyntaxProtocol) -> ExprSyntax {
     if isOptional {
       return ExprSyntax(OptionalChainingExprSyntax(expression: expr))
     } else {
@@ -178,7 +178,7 @@ public struct SyntaxBuildableType: Hashable {
   }
 
   /// Wraps a type in a force unwrap expression depending on whether `isOptional` is true.
-  public func forceUnwrappedIfNeeded<ExprNode: ExprSyntaxProtocol>(expr: ExprNode) -> ExprSyntax {
+  public func forceUnwrappedIfNeeded(expr: some ExprSyntaxProtocol) -> ExprSyntax {
     if isOptional {
       return ExprSyntax(ForcedValueExprSyntax(expression: expr))
     } else {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/KeywordFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/KeywordFile.swift
@@ -24,7 +24,6 @@ let lookupTable = ArrayExprSyntax(leftSquare: .leftSquareBracketToken(trailingTr
 let keywordFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   try! EnumDeclSyntax(
     """
-    @frozen  // FIXME: Not actually stable, works around a miscompile
     public enum Keyword: UInt8, Hashable
     """
   ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
@@ -72,7 +72,7 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             }
           }
 
-          try InitializerDeclSyntax("public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol") {
+          try InitializerDeclSyntax("public init?(_ other: some RawSyntaxNodeProtocol)") {
             for (swiftName, typeName) in choices {
               StmtSyntax(
                 """
@@ -145,7 +145,7 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
       DeclSyntax(
         """
-        public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+        public init?(_ other: some RawSyntaxNodeProtocol) {
           guard Self.isKindOf(other.raw) else { return nil }
           self.init(unchecked: other.raw)
         }
@@ -155,7 +155,7 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       if node.isBase {
         DeclSyntax(
           """
-          public init<Node: Raw\(raw: node.name)NodeProtocol>(_ other: Node) {
+          public init(_ other: some Raw\(raw: node.name)NodeProtocol) {
             self.init(unchecked: other.raw)
           }
           """

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxNodesFile.swift
@@ -48,7 +48,6 @@ let rawSyntaxNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       for (name, choices) in enums {
         try EnumDeclSyntax(
           """
-          @frozen // FIXME: Not actually stable, works around a miscompile
           public enum \(raw: name): RawSyntaxNodeProtocol
           """
         ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxValidationFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxValidationFile.swift
@@ -157,7 +157,7 @@ let rawSyntaxValidationFile = try! SourceFileSyntax(leadingTrivia: copyrightHead
               DeclSyntax(
                 #"""
                 func assertNoError(_ nodeKind: SyntaxKind, _ index: Int, _ error: ValidationError?) {
-                  if let error = error {
+                  if let error {
                     let (file, line) = error.fileAndLine
                     assertionFailure("""
                       Error validating child at index \(index) of \(nodeKind):

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxBaseNodesFile.swift
@@ -63,7 +63,7 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       DeclSyntax(
         """
         /// Create a `\(raw: node.name)` node from a specialized syntax node.
-        public init<S: \(raw: node.name)Protocol>(_ syntax: S) {
+        public init(_ syntax: some \(raw: node.name)Protocol) {
           // We know this cast is going to succeed. Go through init(_: SyntaxData)
           // to do a sanity check and verify the kind matches in debug builds and get
           // maximum performance in release builds.
@@ -75,7 +75,7 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       DeclSyntax(
         """
         /// Create a `\(raw: node.name)` node from a specialized optional syntax node.
-        public init?<S: \(raw: node.name)Protocol>(_ syntax: S?) {
+        public init?(_ syntax: (some \(raw: node.name)Protocol)?) {
           guard let syntax = syntax else { return nil }
           self.init(syntax)
         }
@@ -103,7 +103,7 @@ let syntaxBaseNodesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
         """
       )
 
-      try InitializerDeclSyntax("public init?<S: SyntaxProtocol>(_ node: S)") {
+      try InitializerDeclSyntax("public init?(_ node: some SyntaxProtocol)") {
         try SwitchExprSyntax("switch node.raw.kind") {
           SwitchCaseListSyntax {
             SwitchCaseSyntax(

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -54,7 +54,6 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       if let collectionElementChoices = node.collectionElementChoices, !collectionElementChoices.isEmpty {
         try EnumDeclSyntax(
           """
-          @frozen // FIXME: Not actually stable, works around a miscompile
           public enum Element: SyntaxChildChoices
           """
         ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxCollectionsFile.swift
@@ -81,7 +81,7 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             if choiceNode.isBase {
               DeclSyntax(
                 """
-                public init<Node: \(raw: choiceNode.name)Protocol>(_ node: Node) {
+                public init(_ node: some \(raw: choiceNode.name)Protocol) {
                   self = .\(raw: choiceNode.swiftSyntaxKind)(\(raw: choiceNode.name)(node))
                 }
                 """
@@ -98,7 +98,7 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
             }
           }
 
-          try InitializerDeclSyntax("public init?<S: SyntaxProtocol>(_ node: S)") {
+          try InitializerDeclSyntax("public init?(_ node: some SyntaxProtocol)") {
             for choiceName in node.collectionElementChoices ?? [] {
               let choiceNode = SYNTAX_NODE_MAP[choiceName]!
               StmtSyntax(
@@ -144,7 +144,7 @@ let syntaxCollectionsFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
       DeclSyntax(
         """
-        public init?<S: SyntaxProtocol>(_ node: S) {
+        public init?(_ node: some SyntaxProtocol) {
           guard node.raw.kind == .\(raw: node.swiftSyntaxKind) else { return nil }
           self._syntaxNode = node._syntaxNode
         }

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxEnumFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxEnumFile.swift
@@ -19,7 +19,6 @@ let syntaxEnumFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   try! EnumDeclSyntax(
     """
     /// Enum to exhaustively switch over all different syntax nodes.
-    @frozen // FIXME: Not actually stable, works around a miscompile
     public enum SyntaxEnum
     """
   ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxKindFile.swift
@@ -19,7 +19,6 @@ let syntaxKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   try! EnumDeclSyntax(
     """
     /// Enumerates the known kinds of Syntax represented in the Syntax tree.
-    @frozen // FIXME: Not actually stable, works around a miscompile
     public enum SyntaxKind
     """
   ) {

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -316,7 +316,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           }
         }
         
-        if let newLayout = newLayout {
+        if let newLayout {
           // A child node was rewritten. Build the updated node.
           
           // Sanity check, ensure the new children are the same length.

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTransformFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxTransformFile.swift
@@ -96,7 +96,7 @@ let syntaxTransformFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     DeclSyntax(
       """
-      public func visit<T: SyntaxChildChoices>(_ node: T) -> ResultType {
+      public func visit(_ node: some SyntaxChildChoices) -> ResultType {
         return visit(Syntax(node))
       }
       """
@@ -104,7 +104,7 @@ let syntaxTransformFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     DeclSyntax(
       """
-      public func visitChildren<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) -> [ResultType] {
+      public func visitChildren(_ node: some SyntaxProtocol) -> [ResultType] {
         let syntaxNode = Syntax(node)
         return NonNilRawSyntaxChildren(syntaxNode, viewMode: .sourceAccurate).map { rawChild in
           let child = Syntax(SyntaxData(rawChild, parent: syntaxNode))

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxVisitorFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxVisitorFile.swift
@@ -44,7 +44,7 @@ let syntaxVisitorFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       """
       /// Walk all nodes of the given syntax tree, calling the corresponding `visit`
       /// function for every node that is being visited.
-      public func walk<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) {
+      public func walk(_ node: some SyntaxProtocol) {
         visit(node.data)
       }
       """
@@ -135,7 +135,7 @@ let syntaxVisitorFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
 
     DeclSyntax(
       """
-      private func visitChildren<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) {
+      private func visitChildren(_ node: some SyntaxProtocol) {
         let syntaxNode = Syntax(node)
         for childRaw in NonNilRawSyntaxChildren(syntaxNode, viewMode: viewMode) {
           let childData = SyntaxData(childRaw, parent: syntaxNode)

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TokenKindFile.swift
@@ -19,7 +19,6 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
   try! EnumDeclSyntax(
     """
     /// Enumerates the kinds of tokens in the Swift language.
-    @frozen // FIXME: Not actually stable, works around a miscompile
     public enum TokenKind: Hashable
     """
   ) {
@@ -152,7 +151,6 @@ let tokenKindFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
     // because it significantly improves performance when comparing two
     // `RawTokenBaseKind` for equality. With the raw value, it compiles down to
     // a primitive integer compare, without, it calls into `__derived_enum_equals`.
-    @frozen // FIXME: Not actually stable, works around a miscompile
     @_spi(RawSyntax)
     public enum RawTokenKind: UInt8, Equatable, Hashable
     """

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TriviaPiecesFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/TriviaPiecesFile.swift
@@ -55,7 +55,7 @@ let triviaPiecesFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
       /// Prints the provided trivia as they would be written in a source file.
       ///
       /// - Parameter stream: The stream to which to print the trivia.
-      public func write<Target>(to target: inout Target) where Target: TextOutputStream
+      public func write(to target: inout some TextOutputStream)
       """
     ) {
       DeclSyntax(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 
 import PackageDescription
 import Foundation

--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -55,7 +55,7 @@ open class BasicFormat: SyntaxRewriter {
   // MARK: - Updating indentation level
 
   public func increaseIndentationLevel(to userDefinedIndentation: Trivia? = nil) {
-    if let userDefinedIndentation = userDefinedIndentation {
+    if let userDefinedIndentation {
       indentationStack.append((indentation: userDefinedIndentation, isUserDefined: true))
     } else {
       indentationStack.append((indentation: currentIndentationLevel + indentationWidth, isUserDefined: false))

--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -139,7 +139,7 @@ open class BasicFormat: SyntaxRewriter {
   // MARK: - Customization points
 
   /// Whether a leading newline on `token` should be added.
-  open func requiresIndent<T: SyntaxProtocol>(_ node: T) -> Bool {
+  open func requiresIndent(_ node: some SyntaxProtocol) -> Bool {
     return node.requiresIndent
   }
 

--- a/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/Macros.swift
@@ -46,21 +46,21 @@ extension CompilerPluginMessageHandler {
 
       switch macroDefinition {
       case let exprMacroDef as ExpressionMacro.Type:
-        func _expand<Node: FreestandingMacroExpansionSyntax>(node: Node) throws -> ExprSyntax {
+        func _expand(node: some FreestandingMacroExpansionSyntax) throws -> ExprSyntax {
           try exprMacroDef.expansion(of: node, in: context)
         }
         let rewritten = try _openExistential(macroSyntax, do: _expand)
         expandedSource = rewritten.formattedExpansion(macroDefinition.formatMode)
 
       case let declMacroDef as DeclarationMacro.Type:
-        func _expand<Node: FreestandingMacroExpansionSyntax>(node: Node) throws -> [DeclSyntax] {
+        func _expand(node: some FreestandingMacroExpansionSyntax) throws -> [DeclSyntax] {
           try declMacroDef.expansion(of: node, in: context)
         }
         let rewritten = try _openExistential(macroSyntax, do: _expand)
         expandedSource = CodeBlockItemListSyntax(rewritten.map { CodeBlockItemSyntax(item: .decl($0)) }).formattedExpansion(macroDefinition.formatMode)
 
       case let codeItemMacroDef as CodeItemMacro.Type:
-        func _expand<Node: FreestandingMacroExpansionSyntax>(node: Node) throws -> [CodeBlockItemSyntax] {
+        func _expand(node: some FreestandingMacroExpansionSyntax) throws -> [CodeBlockItemSyntax] {
           try codeItemMacroDef.expansion(of: node, in: context)
         }
         let rewritten = try _openExistential(macroSyntax, do: _expand)
@@ -128,8 +128,8 @@ extension CompilerPluginMessageHandler {
 
         // Local function to expand a member atribute macro once we've opened up
         // the existential.
-        func expandMemberAttributeMacro<Node: DeclGroupSyntax>(
-          _ node: Node
+        func expandMemberAttributeMacro(
+          _ node: some DeclGroupSyntax
         ) throws -> [AttributeSyntax] {
           return try attachedMacro.expansion(
             of: attributeNode,
@@ -158,8 +158,8 @@ extension CompilerPluginMessageHandler {
 
         // Local function to expand a member macro once we've opened up
         // the existential.
-        func expandMemberMacro<Node: DeclGroupSyntax>(
-          _ node: Node
+        func expandMemberMacro(
+          _ node: some DeclGroupSyntax
         ) throws -> [DeclSyntax] {
           return try attachedMacro.expansion(
             of: attributeNode,
@@ -196,8 +196,8 @@ extension CompilerPluginMessageHandler {
 
         // Local function to expand a conformance macro once we've opened up
         // the existential.
-        func expandConformanceMacro<Node: DeclGroupSyntax>(
-          _ node: Node
+        func expandConformanceMacro(
+          _ node: some DeclGroupSyntax
         ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] {
           return try attachedMacro.expansion(
             of: attributeNode,

--- a/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
+++ b/Sources/SwiftCompilerPluginMessageHandling/PluginMacroExpansionContext.swift
@@ -242,8 +242,8 @@ extension PluginMacroExpansionContext: MacroExpansionContext {
     diagnostics.append(diagnostic)
   }
 
-  public func location<Node: SyntaxProtocol>(
-    of node: Node,
+  public func location(
+    of node: some SyntaxProtocol,
     at positionMode: PositionInSyntaxNode,
     filePathMode: SourceLocationFilePathMode
   ) -> AbstractSourceLocation? {

--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -81,8 +81,8 @@ public struct DiagnosticsFormatter {
     self.colorize = colorize
   }
 
-  public static func annotatedSource<SyntaxType: SyntaxProtocol>(
-    tree: SyntaxType,
+  public static func annotatedSource(
+    tree: some SyntaxProtocol,
     diags: [Diagnostic],
     contextSize: Int = 2,
     colorize: Bool = false
@@ -92,10 +92,10 @@ public struct DiagnosticsFormatter {
   }
 
   /// Colorize the given source line by applying highlights from diagnostics.
-  private func colorizeSourceLine<SyntaxType: SyntaxProtocol>(
+  private func colorizeSourceLine(
     _ annotatedLine: AnnotatedSourceLine,
     lineNumber: Int,
-    tree: SyntaxType,
+    tree: some SyntaxProtocol,
     sourceLocationConverter slc: SourceLocationConverter
   ) -> String {
     guard colorize, !annotatedLine.diagnostics.isEmpty else {
@@ -181,9 +181,9 @@ public struct DiagnosticsFormatter {
   /// - Parameters:
   ///   - suffixTexts: suffix text to be printed at the given absolute
   ///                  locations within the source file.
-  func annotatedSource<SyntaxType: SyntaxProtocol>(
+  func annotatedSource(
     fileName: String?,
-    tree: SyntaxType,
+    tree: some SyntaxProtocol,
     diags: [Diagnostic],
     indentString: String,
     suffixTexts: [AbsolutePosition: String],
@@ -313,8 +313,8 @@ public struct DiagnosticsFormatter {
   }
 
   /// Print given diagnostics for a given syntax tree on the command line
-  public func annotatedSource<SyntaxType: SyntaxProtocol>(
-    tree: SyntaxType,
+  public func annotatedSource(
+    tree: some SyntaxProtocol,
     diags: [Diagnostic]
   ) -> String {
     return annotatedSource(

--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -221,7 +221,7 @@ public struct DiagnosticsFormatter {
     var annotatedSource = ""
 
     // If there was a filename, add it first.
-    if let fileName = fileName {
+    if let fileName {
       let header = colorizeBufferOutline("===")
       let firstLine =
         1

--- a/Sources/SwiftOperators/OperatorTable+Folding.swift
+++ b/Sources/SwiftOperators/OperatorTable+Folding.swift
@@ -413,8 +413,8 @@ extension OperatorTable {
         //   - missing precedence groups,
         //   - have unordered precedence groups, or
         //   - have the same precedence group with no associativity.
-        if let op1Precedence = op1Precedence,
-          let op2Precedence = op2Precedence
+        if let op1Precedence,
+          let op2Precedence
         {
           try errorHandler(
             .incomparableOperators(

--- a/Sources/SwiftOperators/OperatorTable+Folding.swift
+++ b/Sources/SwiftOperators/OperatorTable+Folding.swift
@@ -529,8 +529,8 @@ extension OperatorTable {
   /// function, a throwing error handler will end up being called twice with
   /// the first error that causes it to be thrown. The first call will stop
   /// the operation, then the second must also throw.
-  public func foldAll<Node: SyntaxProtocol>(
-    _ node: Node,
+  public func foldAll(
+    _ node: some SyntaxProtocol,
     errorHandler: OperatorErrorHandler = { throw $0 }
   ) rethrows -> Syntax {
     return try withoutActuallyEscaping(errorHandler) { errorHandler in

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1130,7 +1130,7 @@ extension Parser {
 
 extension Parser {
   /// If a `throws` keyword appears right in front of the `arrow`, it is returned as `misplacedThrowsKeyword` so it can be synthesized in front of the arrow.
-  mutating func parseFunctionReturnClause<S: RawEffectSpecifiersTrait>(effectSpecifiers: inout S?, allowNamedOpaqueResultType: Bool) -> RawReturnClauseSyntax {
+  mutating func parseFunctionReturnClause(effectSpecifiers: inout (some RawEffectSpecifiersTrait)?, allowNamedOpaqueResultType: Bool) -> RawReturnClauseSyntax {
     let (unexpectedBeforeArrow, arrow) = self.expect(.arrow)
     let unexpectedBeforeReturnType = self.parseMisplacedEffectSpecifiers(&effectSpecifiers)
     let result: RawTypeSyntax

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -614,7 +614,7 @@ extension Parser {
   }
 
   @_spi(RawSyntax)
-  public mutating func parseDottedExpressionSuffix<R: RawSyntaxNodeProtocol>(previousNode: R?) -> (
+  public mutating func parseDottedExpressionSuffix(previousNode: (some RawSyntaxNodeProtocol)?) -> (
     unexpectedPeriod: RawUnexpectedNodesSyntax?,
     period: RawTokenSyntax,
     name: RawTokenSyntax,

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -173,7 +173,7 @@ extension Parser {
       elements.append(lastElement)
       elements.append(operatorExpr)
 
-      if let rhsExpr = rhsExpr {
+      if let rhsExpr {
         // Operator parsing returned the RHS.
         lastElement = rhsExpr
       } else if forDirective && self.currentToken.isAtStartOfLine {
@@ -1447,7 +1447,7 @@ extension Parser {
     let (unexpectedBeforeSlash, openSlash) = self.expect(.regexSlash)
 
     // If we had opening pounds, there should be no trivia for the slash.
-    if let openPounds = openPounds {
+    if let openPounds {
       precondition(openPounds.trailingTriviaByteLength == 0 && openSlash.leadingTriviaByteLength == 0)
     }
 

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -264,8 +264,7 @@ extension Lexer {
       self.stateStack.perform(stateTransition: stateTransition, stateAllocator: stateAllocator)
     }
 
-    public func starts<PossiblePrefix>(with possiblePrefix: PossiblePrefix) -> Bool
-    where PossiblePrefix: Sequence, PossiblePrefix.Element == UInt8 {
+    public func starts(with possiblePrefix: some Sequence<UInt8>) -> Bool {
       return self.input.starts(with: possiblePrefix)
     }
 

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -172,7 +172,7 @@ extension Lexer.Cursor {
     mutating func perform(stateTransition: Lexer.StateTransition, stateAllocator: BumpPtrAllocator) {
       switch stateTransition {
       case .push(newState: let newState):
-        if let topState = topState {
+        if let topState {
           if let stateStack = stateStack {
             let newStateStack = stateAllocator.allocate(State.self, count: stateStack.count + 1)
             let (_, existingStateStackEndIndex) = newStateStack.initialize(from: stateStack)
@@ -190,7 +190,7 @@ extension Lexer.Cursor {
       case .replace(newState: let newState):
         topState = newState
       case .pop:
-        if let stateStack = stateStack {
+        if let stateStack {
           topState = stateStack.last!
           if stateStack.count == 1 {
             self.stateStack = nil
@@ -756,7 +756,7 @@ extension Lexer.Cursor {
     // Test for single-line string literals that resemble multiline delimiter.
     var sameLineCloseCheck = self
     _ = sameLineCloseCheck.advance()
-    if let openingRawStringDelimiters = openingRawStringDelimiters, openingRawStringDelimiters != 0 {
+    if let openingRawStringDelimiters, openingRawStringDelimiters != 0 {
       // Scan if the current line contains `"` followed by `openingRawStringDelimiters` `#` characters
       while sameLineCloseCheck.is(notAt: "\r", "\n") {
         if sameLineCloseCheck.advance(matching: #"""#) {

--- a/Sources/SwiftParser/Lexer/RegexLiteralLexer.swift
+++ b/Sources/SwiftParser/Lexer/RegexLiteralLexer.swift
@@ -174,7 +174,7 @@ fileprivate struct RegexLiteralLexer {
 
     // If we have a multi-line literal, make sure the closing delimiter
     // appears alone on a newline.
-    if let lastNewlineEnd = lastNewlineEnd {
+    if let lastNewlineEnd {
       var delimScan = lastNewlineEnd
       while delimScan.pointer < slashBegin.pointer {
         if !delimScan.advance(matching: " ", "\t") {
@@ -809,7 +809,7 @@ extension Lexer.Cursor {
 
     // Compute the new transition.
     let transition: Lexer.StateTransition?
-    if let existingPtr = existingPtr {
+    if let existingPtr {
       transition = lexemes.isEmpty ? .pop : .replace(newState: .inRegexLiteral(index: index, lexemes: existingPtr))
     } else {
       transition = lexemes.isEmpty ? nil : .pushRegexLexemes(index: index, lexemes: lexemes.base)

--- a/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
+++ b/Sources/SwiftParser/Lexer/UnicodeScalarExtensions.swift
@@ -226,7 +226,7 @@ extension Unicode.Scalar {
   }
 
   /// Returns the first unicode scalar in `byteSequence`, which may span multiple bytes.
-  public static func lexing<S: Collection>(from byteSequence: S) -> Self? where S.Element == UInt8 {
+  public static func lexing(from byteSequence: some Collection<UInt8>) -> Self? {
     var index = byteSequence.startIndex
     let peek = { () -> UInt8? in
       if index < byteSequence.endIndex {

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -185,7 +185,7 @@ extension Parser {
       } else {
         generics = nil
       }
-      if let keepGoing = keepGoing {
+      if let keepGoing {
         result = RawTypeSyntax(
           RawMemberTypeIdentifierSyntax(
             baseType: result!,

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -602,7 +602,7 @@ extension Parser {
   ///     unexpected period (with the extraneous whitespace) and a missing
   ///     period. If there is a newline also set `skipMember` to inform
   ///     callers to not parse any futher member names.
-  mutating func consumeMemberPeriod<R: RawSyntaxNodeProtocol>(previousNode: R?) -> (unexpected: RawUnexpectedNodesSyntax?, period: RawTokenSyntax, skipMemberName: Bool) {
+  mutating func consumeMemberPeriod(previousNode: (some RawSyntaxNodeProtocol)?) -> (unexpected: RawUnexpectedNodesSyntax?, period: RawTokenSyntax, skipMemberName: Bool) {
     precondition(self.at(.period))
 
     let beforePeriodWhitespace = previousNode?.raw.trailingTriviaByteLength ?? 0 > 0 || self.currentToken.leadingTriviaByteLength > 0

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -148,7 +148,7 @@ public struct Parser {
     self.maximumNestingLevel = maximumNestingLevel ?? Self.defaultMaximumNestingLevel
 
     var sourceBuffer: UnsafeBufferPointer<UInt8>
-    if let arena = arena {
+    if let arena {
       self.arena = arena
       sourceBuffer = input
       precondition(arena.contains(text: SyntaxText(baseAddress: input.baseAddress, count: input.count)))

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -164,7 +164,7 @@ extension Parser {
     let colon = self.consume(if: .colon)
     var lookahead = self.lookahead()
     var type: RawTypeAnnotationSyntax?
-    if let colon = colon {
+    if let colon {
       let result = self.parseResultType()
       type = RawTypeAnnotationSyntax(
         colon: colon,

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -92,7 +92,7 @@ extension Parser.Lookahead {
       default:
         matchedSpec = nil
       }
-      if let matchedSpec = matchedSpec {
+      if let matchedSpec {
         return RecoveryConsumptionHandle(
           unexpectedTokens: self.tokensConsumed - initialTokensConsumed,
           tokenConsumptionHandle: TokenConsumptionHandle(spec: matchedSpec)

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -72,7 +72,7 @@ fileprivate class StringLiteralExpressionIndentationChecker {
     var hasRewrittenChild = false
     var rewrittenChildren: [RawSyntax?] = []
     for child in layoutView.children {
-      if let child = child, let rewrittenChild = visit(node: child) {
+      if let child, let rewrittenChild = visit(node: child) {
         hasRewrittenChild = true
         rewrittenChildren.append(rewrittenChild)
       } else {
@@ -360,7 +360,7 @@ extension Parser {
     // -------------------------------------------------------------------------
     // Parse indentation of the closing quote
 
-    if let lastSegment = lastSegment,
+    if let lastSegment,
       let parsedTrivia = parseIndentationTrivia(text: lastSegment.content.tokenText)
     {
       indentationTrivia = parsedTrivia

--- a/Sources/SwiftParser/SyntaxUtils.swift
+++ b/Sources/SwiftParser/SyntaxUtils.swift
@@ -73,11 +73,11 @@ extension RawTokenSyntax: UnexpectedNodesCombinable {
 extension RawUnexpectedNodesSyntax: UnexpectedNodesCombinable {}
 
 extension RawUnexpectedNodesSyntax {
-  init?<T1: UnexpectedNodesCombinable, T2: UnexpectedNodesCombinable>(combining syntax1: T1, _ syntax2: T2, arena: __shared SyntaxArena) {
+  init?(combining syntax1: some UnexpectedNodesCombinable, _ syntax2: some UnexpectedNodesCombinable, arena: __shared SyntaxArena) {
     self.init(syntax1.elements + syntax2.elements, arena: arena)
   }
 
-  init?<T1: UnexpectedNodesCombinable, T2: UnexpectedNodesCombinable, T3: UnexpectedNodesCombinable>(combining syntax1: T1, _ syntax2: T2, _ syntax3: T3, arena: __shared SyntaxArena) {
+  init?(combining syntax1: some UnexpectedNodesCombinable, _ syntax2: some UnexpectedNodesCombinable, _ syntax3: some UnexpectedNodesCombinable, arena: __shared SyntaxArena) {
     self.init(syntax1.elements + syntax2.elements + syntax3.elements, arena: arena)
   }
 }

--- a/Sources/SwiftParser/SyntaxUtils.swift
+++ b/Sources/SwiftParser/SyntaxUtils.swift
@@ -56,7 +56,7 @@ extension Array: UnexpectedNodesCombinable where Element: UnexpectedNodesCombina
 
 extension Optional: UnexpectedNodesCombinable where Wrapped: UnexpectedNodesCombinable {
   var elements: [RawSyntax] {
-    if let self = self {
+    if let self {
       return self.elements
     } else {
       return []

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -156,7 +156,7 @@ extension Parser {
 
     var base = self.parseSimpleType()
     guard self.atContextualPunctuator("&") else {
-      if let someOrAny = someOrAny {
+      if let someOrAny {
         return RawTypeSyntax(
           RawConstrainedSugarTypeSyntax(
             someOrAnySpecifier: someOrAny,
@@ -201,7 +201,7 @@ extension Parser {
       )
     }
 
-    if let someOrAny = someOrAny {
+    if let someOrAny {
       return RawTypeSyntax(
         RawConstrainedSugarTypeSyntax(
           someOrAnySpecifier: someOrAny,
@@ -545,7 +545,7 @@ extension Parser {
 
         // In the case that the input is "(foo bar)" we have to decide whether we parse it as "(foo: bar)" or "(foo, bar)".
         // As most people write identifiers lowercase and types capitalized, we decide on the first character of the first token
-        if let first = first,
+        if let first,
           second == nil,
           colon?.isMissing == true,
           first.tokenText.isStartingWithUppercase

--- a/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
@@ -42,21 +42,6 @@ extension FixIt {
   init(message: FixItMessage, changes: MultiNodeChange) {
     self.init(message: message, changes: changes.primitiveChanges)
   }
-
-  // These overloads shouldn't be needed, but are currently required for the
-  // Swift 5.5 compiler to handle non-trivial FixIt initializations using
-  // leading-dot syntax.
-  // TODO: These can be dropped once we require a minimum of Swift 5.6 to
-  // compile the library.
-  init(message: StaticParserFixIt, changes: MultiNodeChange) {
-    self.init(message: message as FixItMessage, changes: changes.primitiveChanges)
-  }
-  init(message: StaticParserFixIt, changes: [MultiNodeChange]) {
-    self.init(message: message as FixItMessage, changes: MultiNodeChange(combining: changes).primitiveChanges)
-  }
-  public init(message: StaticParserFixIt, changes: [Change]) {
-    self.init(message: message as FixItMessage, changes: changes)
-  }
 }
 
 // MARK: - Make missing

--- a/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
@@ -89,7 +89,7 @@ extension FixIt.MultiNodeChange {
 
   /// If `transferTrivia` is `true`, the leading and trailing trivia of the
   /// removed node will be transferred to the trailing trivia of the previous token.
-  static func makeMissing<SyntaxType: SyntaxProtocol>(_ node: SyntaxType?, transferTrivia: Bool = true) -> Self {
+  static func makeMissing(_ node: (some SyntaxProtocol)?, transferTrivia: Bool = true) -> Self {
     guard let node = node else {
       return FixIt.MultiNodeChange(primitiveChanges: [])
     }
@@ -104,7 +104,7 @@ extension FixIt.MultiNodeChange {
   /// While doing this, it tries to be smart, merging trivia where it makes sense
   /// and refusing to add e.g. a space after punctuation, where it usually
   /// doesn't make sense.
-  private static func transferTriviaAtSides<SyntaxType: SyntaxProtocol>(from nodes: [SyntaxType]) -> Self {
+  private static func transferTriviaAtSides(from nodes: [some SyntaxProtocol]) -> Self {
     let removedTriviaAtSides = (nodes.first?.leadingTrivia ?? []).merging(nodes.last?.trailingTrivia ?? [])
     if !removedTriviaAtSides.isEmpty, let previousToken = nodes.first?.previousToken(viewMode: .sourceAccurate) {
       let mergedTrivia = previousToken.trailingTrivia.merging(removedTriviaAtSides)
@@ -133,8 +133,8 @@ class MissingNodesBasicFormatter: BasicFormat {
 extension FixIt.MultiNodeChange {
   /// Make a node present. If `leadingTrivia` or `trailingTrivia` is specified,
   /// override the default leading/trailing trivia inferred from `BasicFormat`.
-  static func makePresent<T: SyntaxProtocol>(
-    _ node: T,
+  static func makePresent(
+    _ node: some SyntaxProtocol,
     leadingTrivia: Trivia? = nil,
     trailingTrivia: Trivia? = nil
   ) -> Self {

--- a/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
@@ -141,10 +141,10 @@ extension FixIt.MultiNodeChange {
     var presentNode = MissingNodesBasicFormatter(viewMode: .fixedUp).visit(Syntax(node))
     presentNode = PresentMaker().rewrite(presentNode)
 
-    if let leadingTrivia = leadingTrivia {
+    if let leadingTrivia {
       presentNode = presentNode.with(\.leadingTrivia, leadingTrivia)
     }
-    if let trailingTrivia = trailingTrivia {
+    if let trailingTrivia {
       presentNode = presentNode.with(\.trailingTrivia, trailingTrivia)
     }
 

--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -66,7 +66,7 @@ fileprivate enum NodesDescriptionPart {
     }
   }
 
-  static func descriptionParts<S: Sequence>(for nodes: S) -> [NodesDescriptionPart] where S.Element == Syntax {
+  static func descriptionParts(for nodes: some Sequence<Syntax>) -> [NodesDescriptionPart] {
     var parts: [NodesDescriptionPart] = []
     for missingNode in nodes {
       if let token = missingNode.as(TokenSyntax.self) {
@@ -110,12 +110,12 @@ fileprivate enum NodesDescriptionPart {
 /// Returns a string that describes `missingNodes`.
 /// If `commonParent` is not `nil`, `missingNodes` are expected to all be children of `commonParent`.
 /// If `format` is `true`, `BasicFormat` will be used to format the tokens prior to printing. This is useful if the nodes have been synthesized.
-func nodesDescription<SyntaxType: SyntaxProtocol>(_ nodes: [SyntaxType], format: Bool) -> String {
+func nodesDescription(_ nodes: [some SyntaxProtocol], format: Bool) -> String {
   return nodesDescriptionAndCommonParent(nodes, format: format).description
 }
 
 /// Same as `nodesDescription` but if a common ancestor was used to describe `missingNodes`, also return that `commonAncestor`
-func nodesDescriptionAndCommonParent<SyntaxType: SyntaxProtocol>(_ nodes: [SyntaxType], format: Bool) -> (commonAncestor: Syntax?, description: String) {
+func nodesDescriptionAndCommonParent(_ nodes: [some SyntaxProtocol], format: Bool) -> (commonAncestor: Syntax?, description: String) {
   let missingSyntaxNodes = nodes.map(Syntax.init)
 
   let isOnlyTokenWithNonMissingText: Bool
@@ -329,8 +329,8 @@ public struct InsertTokenFixIt: ParserFixIt {
 // MARK: - Generate Error
 
 extension ParseDiagnosticsGenerator {
-  func handleMissingSyntax<T: SyntaxProtocol>(
-    _ node: T,
+  func handleMissingSyntax(
+    _ node: some SyntaxProtocol,
     overridePosition: AbsolutePosition? = nil,
     additionalChanges: [FixIt.MultiNodeChange] = [],
     additionalHandledNodes: [SyntaxIdentifier] = []

--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -249,7 +249,7 @@ public struct MissingNodesError: ParserError {
     } else {
       missingExpr = nil
     }
-    if let missingExpr = missingExpr,
+    if let missingExpr,
       let exprList = missingExpr.parent?.as(ExprListSyntax.self),
       exprList.parent?.is(SequenceExprSyntax.self) ?? false,
       let previousSiblingIndex = exprList.index(missingExpr.index, offsetBy: -1, limitedBy: exprList.startIndex)
@@ -296,7 +296,7 @@ public struct MissingNodesError: ParserError {
   public var message: String {
     let (anchor, description) = nodesDescriptionAndCommonParent(missingNodes, format: true)
     var message = "expected \(description)"
-    if let afterClause = afterClause {
+    if let afterClause {
       message += " \(afterClause)"
     } else if let parentContextClause = parentContextClause(anchor: anchor?.parent ?? findCommonAncestor(missingNodes)) {
       message += " \(parentContextClause)"
@@ -389,7 +389,7 @@ extension ParseDiagnosticsGenerator {
     }
 
     let position: AbsolutePosition
-    if let overridePosition = overridePosition {
+    if let overridePosition {
       position = overridePosition
     } else if node.shouldBeInsertedAfterNextTokenTrivia, let nextToken = node.nextToken(viewMode: .sourceAccurate) {
       position = nextToken.positionAfterSkippingLeadingTrivia

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -1051,7 +1051,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
       } else {
         message = nil
       }
-      if let message = message {
+      if let message {
         let fixIts: [FixIt]
         if node.identifier.presence == .present {
           fixIts = [FixIt(message: RemoveNodesFixIt(unexpected), changes: .makeMissing(unexpected))]

--- a/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParserDiagnostics/ParserDiagnosticMessages.swift
@@ -615,11 +615,11 @@ public struct RemoveRedundantFixIt: ParserFixIt {
 public struct RemoveNodesFixIt: ParserFixIt {
   public let nodesToRemove: [Syntax]
 
-  init<SyntaxType: SyntaxProtocol>(_ nodesToRemove: [SyntaxType]) {
+  init(_ nodesToRemove: [some SyntaxProtocol]) {
     self.nodesToRemove = nodesToRemove.map(Syntax.init)
   }
 
-  init<SyntaxType: SyntaxProtocol>(_ nodeToRemove: SyntaxType) {
+  init(_ nodeToRemove: some SyntaxProtocol) {
     self.nodesToRemove = [Syntax(nodeToRemove)]
   }
 

--- a/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
+++ b/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
@@ -133,7 +133,7 @@ public struct OpaqueParameterToGeneric: RefactoringProvider {
     }
 
     var newGenericParams: [GenericParameterSyntax] = []
-    if let genericParams = genericParams {
+    if let genericParams {
       newGenericParams.append(contentsOf: genericParams.genericParameterList)
     }
 
@@ -152,7 +152,7 @@ public struct OpaqueParameterToGeneric: RefactoringProvider {
 
     let newGenericParamSyntax = GenericParameterListSyntax(newGenericParams)
     let newGenericParamClause: GenericParameterClauseSyntax
-    if let genericParams = genericParams {
+    if let genericParams {
       newGenericParamClause = genericParams.with(
         \.genericParameterList,
         newGenericParamSyntax

--- a/Sources/SwiftSyntax/IncrementalParseTransition.swift
+++ b/Sources/SwiftSyntax/IncrementalParseTransition.swift
@@ -238,7 +238,7 @@ public struct IncrementalParseLookup {
     }
     let prevPosition = AbsolutePosition(utf8Offset: prevOffset)
     let node = cursorLookup(prevPosition: prevPosition, kind: kind)
-    if let delegate = reusedDelegate, let node = node {
+    if let delegate = reusedDelegate, let node {
       delegate.parserReusedNode(
         range: ByteSourceRange(offset: newOffset, length: node.byteSize),
         previousNode: node

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -797,13 +797,13 @@ extension RawSyntax {
     )
   }
 
-  static func makeLayout<C: Collection>(
+  static func makeLayout(
     kind: SyntaxKind,
-    from collection: C,
+    from collection: some Collection<RawSyntax?>,
     arena: __shared SyntaxArena,
     leadingTrivia: Trivia? = nil,
     trailingTrivia: Trivia? = nil
-  ) -> RawSyntax where C.Element == RawSyntax? {
+  ) -> RawSyntax {
     if leadingTrivia != nil || trailingTrivia != nil {
       var layout = Array(collection)
       if let leadingTrivia = leadingTrivia,
@@ -829,7 +829,7 @@ extension RawSyntax {
 
 extension RawSyntax: CustomDebugStringConvertible {
 
-  private func debugWrite<Target: TextOutputStream>(to target: inout Target, indent: Int, withChildren: Bool = false) {
+  private func debugWrite(to target: inout some TextOutputStream, indent: Int, withChildren: Bool = false) {
     let childIndent = indent + 2
     switch rawData.payload {
     case .parsedToken(let dat):

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -76,7 +76,7 @@ internal struct RawSyntaxData {
         }
       }
       set {
-        if let newValue = newValue {
+        if let newValue {
           self.tokenDiagnosticKind = newValue.kind
           self.tokenDiagnosticByteOffset = newValue.byteOffset
         } else {
@@ -130,7 +130,7 @@ internal struct RawSyntaxData {
         }
       }
       set {
-        if let newValue = newValue {
+        if let newValue {
           self.tokenDiagnosticKind = newValue.kind
           self.tokenDiagnosticByteOffset = newValue.byteOffset
         } else {

--- a/Sources/SwiftSyntax/Raw/RawSyntaxLayoutView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxLayoutView.swift
@@ -55,10 +55,10 @@ public struct RawSyntaxLayoutView {
 
   /// Creates a new node of the same kind but with children replaced by `elements`.
   @_spi(RawSyntax)
-  public func replacingLayout<C: Collection>(
-    with elements: C,
+  public func replacingLayout(
+    with elements: some Collection<RawSyntax?>,
     arena: SyntaxArena
-  ) -> RawSyntax where C.Element == RawSyntax? {
+  ) -> RawSyntax {
     return .makeLayout(
       kind: raw.kind,
       uninitializedCount: elements.count,
@@ -124,11 +124,11 @@ public struct RawSyntaxLayoutView {
   }
 
   @_spi(RawSyntax)
-  public func replacingChildSubrange<C: Collection>(
+  public func replacingChildSubrange(
     _ range: Range<Int>,
-    with elements: C,
+    with elements: some Collection<RawSyntax?>,
     arena: SyntaxArena
-  ) -> RawSyntax where C.Element == RawSyntax? {
+  ) -> RawSyntax {
     precondition(!raw.isToken)
     let newCount = children.count - range.count + elements.count
     return .makeLayout(

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -21,7 +21,7 @@ public protocol RawSyntaxNodeProtocol: CustomStringConvertible, TextOutputStream
   var raw: RawSyntax { get }
 
   /// Create the typed raw syntax if `other` can be cast to `Self`
-  init?<T: RawSyntaxNodeProtocol>(_ other: T)
+  init?(_ other: some RawSyntaxNodeProtocol)
 }
 
 public extension RawSyntaxNodeProtocol {
@@ -39,7 +39,7 @@ public extension RawSyntaxNodeProtocol {
     raw.description
   }
 
-  func write<Target>(to target: inout Target) where Target: TextOutputStream {
+  func write(to target: inout some TextOutputStream) {
     raw.write(to: &target)
   }
 
@@ -67,7 +67,7 @@ extension RawSyntax: RawSyntaxNodeProtocol {
     self = raw
   }
 
-  public init<T: RawSyntaxNodeProtocol>(_ other: T) {
+  public init(_ other: some RawSyntaxNodeProtocol) {
     self.init(raw: other.raw)
   }
 }
@@ -112,7 +112,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
 
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else { return nil }
     self.init(unchecked: other.raw)
   }

--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -73,7 +73,7 @@ public final class SourceLocationConverter {
   /// - Parameters:
   ///   - file: The file path associated with the syntax tree.
   ///   - tree: The root of the syntax tree to convert positions to line/columns for.
-  public init<SyntaxType: SyntaxProtocol>(file: String, tree: SyntaxType) {
+  public init(file: String, tree: some SyntaxProtocol) {
     precondition(tree.parent == nil, "SourceLocationConverter must be passed the root of the syntax tree")
     self.file = file
     self.source = tree.syntaxTextBytes

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -68,7 +68,7 @@ public struct Syntax: SyntaxProtocol, SyntaxHashable {
   }
 
   /// Create a `Syntax` node from a specialized syntax node.
-  public init<S: SyntaxProtocol>(_ syntax: S) {
+  public init(_ syntax: some SyntaxProtocol) {
     self = syntax._syntaxNode
   }
 
@@ -158,7 +158,7 @@ public protocol SyntaxProtocol: CustomStringConvertible,
 
   /// Converts the given specialized node to this type. Returns `nil` if the
   /// conversion is not possible.
-  init?<S: SyntaxProtocol>(_ node: S)
+  init?(_ node: some SyntaxProtocol)
 
   /// The statically allowed structure of the syntax node.
   static var structure: SyntaxNodeStructure { get }

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -619,7 +619,7 @@ public extension SyntaxProtocol {
     mark: SyntaxProtocol? = nil,
     indentString: String
   ) {
-    if let mark = mark, self.id == mark.id {
+    if let mark, self.id == mark.id {
       target.write("*** ")
     }
 
@@ -639,7 +639,7 @@ public extension SyntaxProtocol {
 
     let allChildren = children(viewMode: .all)
 
-    if let converter = converter {
+    if let converter {
       let range = sourceRange(converter: converter)
       target.write(" [\(range.start)...\(range.end)]")
     }
@@ -648,7 +648,7 @@ public extension SyntaxProtocol {
       target.write(" MISSING")
     }
 
-    if let mark = mark, self.id == mark.id {
+    if let mark, self.id == mark.id {
       target.write(" ***")
     }
 

--- a/Sources/SwiftSyntax/SyntaxChildren.swift
+++ b/Sources/SwiftSyntax/SyntaxChildren.swift
@@ -302,7 +302,7 @@ struct NonNilRawSyntaxChildren: BidirectionalCollection {
         guard let (node, info) = self.iterator.next() else {
           return nil
         }
-        if let node = node, viewMode.shouldTraverse(node: node) {
+        if let node, viewMode.shouldTraverse(node: node) {
           return AbsoluteRawSyntax(raw: node, info: info)
         }
       }

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -295,7 +295,7 @@ struct SyntaxData {
   func replacingSelf(_ newRaw: RawSyntax, arena: SyntaxArena) -> SyntaxData {
     // If we have a parent already, then ask our current parent to copy itself
     // recursively up to the root.
-    if let parent = parent {
+    if let parent {
       let parentData = parent.replacingChild(at: indexInParent, with: newRaw, arena: arena)
       let newParent = Syntax(parentData)
       return SyntaxData(absoluteRaw.replacingSelf(newRaw, newRootId: parentData.nodeId.rootId), parent: newParent)

--- a/Sources/SwiftSyntax/Trivia.swift
+++ b/Sources/SwiftSyntax/Trivia.swift
@@ -21,7 +21,7 @@ public struct Trivia {
   public let pieces: [TriviaPiece]
 
   /// Creates Trivia with the provided underlying pieces.
-  public init<S: Sequence>(pieces: S) where S.Element == TriviaPiece {
+  public init(pieces: some Sequence<TriviaPiece>) {
     self.pieces = Array(pieces)
   }
 
@@ -69,7 +69,7 @@ public struct Trivia {
   /// Creates a new `Trivia` by merging the leading and trailing `Trivia`
   /// of `triviaOf` into the end of `self`. Only includes one copy of any
   /// common prefixes.
-  public func merging<T: SyntaxProtocol>(triviaOf node: T) -> Trivia {
+  public func merging(triviaOf node: some SyntaxProtocol) -> Trivia {
     return merging(node.leadingTrivia).merging(node.trailingTrivia)
   }
 
@@ -115,8 +115,7 @@ extension Trivia: TextOutputStreamable {
   /// Prints the provided trivia as they would be written in a source file.
   ///
   /// - Parameter stream: The stream to which to print the trivia.
-  public func write<Target>(to target: inout Target)
-  where Target: TextOutputStream {
+  public func write(to target: inout some TextOutputStream) {
     for piece in pieces {
       piece.write(to: &target)
     }
@@ -173,7 +172,7 @@ extension Trivia {
 }
 
 extension RawTriviaPiece: TextOutputStreamable {
-  public func write<Target: TextOutputStream>(to target: inout Target) {
+  public func write(to target: inout some TextOutputStream) {
     TriviaPiece(raw: self).write(to: &target)
   }
 }

--- a/Sources/SwiftSyntax/Trivia.swift
+++ b/Sources/SwiftSyntax/Trivia.swift
@@ -133,7 +133,7 @@ extension Trivia: CustomStringConvertible {
 
 extension Trivia: CustomDebugStringConvertible {
   public var debugDescription: String {
-    if count == 1, let first = first {
+    if count == 1, let first {
       return first.debugDescription
     }
     return "[" + map(\.debugDescription).joined(separator: ", ") + "]"

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-@frozen  // FIXME: Not actually stable, works around a miscompile
 public enum Keyword: UInt8, Hashable {
   case __consuming
   case __owned

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -39,7 +39,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
   /// Create a `DeclSyntax` node from a specialized syntax node.
-  public init<S: DeclSyntaxProtocol>(_ syntax: S) {
+  public init(_ syntax: some DeclSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -47,7 +47,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a `DeclSyntax` node from a specialized optional syntax node.
-  public init?<S: DeclSyntaxProtocol>(_ syntax: S?) {
+  public init?(_ syntax: (some DeclSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
     }
@@ -69,7 +69,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     switch node.raw.kind {
     case .accessorDecl, .actorDecl, .associatedtypeDecl, .classDecl, .deinitializerDecl, .editorPlaceholderDecl, .enumCaseDecl, .enumDecl, .extensionDecl, .functionDecl, .ifConfigDecl, .importDecl, .initializerDecl, .macroDecl, .macroExpansionDecl, .missingDecl, .operatorDecl, .poundSourceLocation, .precedenceGroupDecl, .protocolDecl, .structDecl, .subscriptDecl, .typealiasDecl, .variableDecl:
       self._syntaxNode = node._syntaxNode
@@ -174,7 +174,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
   /// Create a `ExprSyntax` node from a specialized syntax node.
-  public init<S: ExprSyntaxProtocol>(_ syntax: S) {
+  public init(_ syntax: some ExprSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -182,7 +182,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a `ExprSyntax` node from a specialized optional syntax node.
-  public init?<S: ExprSyntaxProtocol>(_ syntax: S?) {
+  public init?(_ syntax: (some ExprSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
     }
@@ -204,7 +204,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     switch node.raw.kind {
     case .arrayExpr, .arrowExpr, .asExpr, .assignmentExpr, .awaitExpr, .binaryOperatorExpr, .booleanLiteralExpr, .borrowExpr, .closureExpr, .dictionaryExpr, .discardAssignmentExpr, .editorPlaceholderExpr, .floatLiteralExpr, .forcedValueExpr, .functionCallExpr, .identifierExpr, .ifExpr, .inOutExpr, .infixOperatorExpr, .integerLiteralExpr, .isExpr, .keyPathExpr, .macroExpansionExpr, .memberAccessExpr, .missingExpr, .moveExpr, .nilLiteralExpr, .optionalChainingExpr, .packElementExpr, .packExpansionExpr, .postfixIfConfigExpr, .postfixUnaryExpr, .prefixOperatorExpr, .regexLiteralExpr, .sequenceExpr, .specializeExpr, .stringLiteralExpr, .subscriptExpr, .superRefExpr, .switchExpr, .ternaryExpr, .tryExpr, .tupleExpr, .typeExpr, .unresolvedAsExpr, .unresolvedIsExpr, .unresolvedPatternExpr, .unresolvedTernaryExpr:
       self._syntaxNode = node._syntaxNode
@@ -333,7 +333,7 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
   /// Create a `PatternSyntax` node from a specialized syntax node.
-  public init<S: PatternSyntaxProtocol>(_ syntax: S) {
+  public init(_ syntax: some PatternSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -341,7 +341,7 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a `PatternSyntax` node from a specialized optional syntax node.
-  public init?<S: PatternSyntaxProtocol>(_ syntax: S?) {
+  public init?(_ syntax: (some PatternSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
     }
@@ -363,7 +363,7 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     switch node.raw.kind {
     case .expressionPattern, .identifierPattern, .isTypePattern, .missingPattern, .tuplePattern, .valueBindingPattern, .wildcardPattern:
       self._syntaxNode = node._syntaxNode
@@ -451,7 +451,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
   /// Create a `StmtSyntax` node from a specialized syntax node.
-  public init<S: StmtSyntaxProtocol>(_ syntax: S) {
+  public init(_ syntax: some StmtSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -459,7 +459,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a `StmtSyntax` node from a specialized optional syntax node.
-  public init?<S: StmtSyntaxProtocol>(_ syntax: S?) {
+  public init?(_ syntax: (some StmtSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
     }
@@ -481,7 +481,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     switch node.raw.kind {
     case .breakStmt, .continueStmt, .deferStmt, .doStmt, .expressionStmt, .fallthroughStmt, .forInStmt, .forgetStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatWhileStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
       self._syntaxNode = node._syntaxNode
@@ -578,7 +578,7 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
   /// Create a `TypeSyntax` node from a specialized syntax node.
-  public init<S: TypeSyntaxProtocol>(_ syntax: S) {
+  public init(_ syntax: some TypeSyntaxProtocol) {
     // We know this cast is going to succeed. Go through init(_: SyntaxData)
     // to do a sanity check and verify the kind matches in debug builds and get
     // maximum performance in release builds.
@@ -586,7 +586,7 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   }
   
   /// Create a `TypeSyntax` node from a specialized optional syntax node.
-  public init?<S: TypeSyntaxProtocol>(_ syntax: S?) {
+  public init?(_ syntax: (some TypeSyntaxProtocol)?) {
     guard let syntax = syntax else {
       return nil
     }
@@ -608,7 +608,7 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self.init(fromProtocol: syntax)
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     switch node.raw.kind {
     case .arrayType, .attributedType, .classRestrictionType, .compositionType, .constrainedSugarType, .dictionaryType, .functionType, .implicitlyUnwrappedOptionalType, .memberTypeIdentifier, .metatypeType, .missingType, .namedOpaqueReturnType, .optionalType, .packExpansionType, .packReferenceType, .simpleTypeIdentifier, .suppressedType, .tupleType:
       self._syntaxNode = node._syntaxNode

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -38,7 +38,7 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .accessPath else {
       return nil
     }
@@ -247,7 +247,7 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .accessorList else {
       return nil
     }
@@ -456,7 +456,7 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .arrayElementList else {
       return nil
     }
@@ -683,7 +683,7 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
       self = .ifConfigDecl(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(AttributeSyntax.self) {
         self = .attribute(node)
         return
@@ -708,7 +708,7 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .attributeList else {
       return nil
     }
@@ -917,7 +917,7 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilitySpecList else {
       return nil
     }
@@ -1126,7 +1126,7 @@ public struct AvailabilityVersionRestrictionListSyntax: SyntaxCollection, Syntax
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilityVersionRestrictionList else {
       return nil
     }
@@ -1335,7 +1335,7 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .caseItemList else {
       return nil
     }
@@ -1544,7 +1544,7 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .catchClauseList else {
       return nil
     }
@@ -1753,7 +1753,7 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .catchItemList else {
       return nil
     }
@@ -1962,7 +1962,7 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureCaptureItemList else {
       return nil
     }
@@ -2171,7 +2171,7 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureParamList else {
       return nil
     }
@@ -2380,7 +2380,7 @@ public struct ClosureParameterListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureParameterList else {
       return nil
     }
@@ -2589,7 +2589,7 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .codeBlockItemList else {
       return nil
     }
@@ -2798,7 +2798,7 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .compositionTypeElementList else {
       return nil
     }
@@ -3007,7 +3007,7 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .conditionElementList else {
       return nil
     }
@@ -3216,7 +3216,7 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .declNameArgumentList else {
       return nil
     }
@@ -3425,7 +3425,7 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .designatedTypeList else {
       return nil
     }
@@ -3634,7 +3634,7 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .dictionaryElementList else {
       return nil
     }
@@ -3843,7 +3843,7 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .differentiabilityParamList else {
       return nil
     }
@@ -4049,7 +4049,7 @@ public struct DocumentationAttributeArgumentsSyntax: SyntaxCollection, SyntaxHas
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .documentationAttributeArguments else {
       return nil
     }
@@ -4255,7 +4255,7 @@ public struct EffectsArgumentsSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .effectsArguments else {
       return nil
     }
@@ -4461,7 +4461,7 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseElementList else {
       return nil
     }
@@ -4670,7 +4670,7 @@ public struct EnumCaseParameterListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseParameterList else {
       return nil
     }
@@ -4876,7 +4876,7 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .exprList else {
       return nil
     }
@@ -5085,7 +5085,7 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .functionParameterList else {
       return nil
     }
@@ -5294,7 +5294,7 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericArgumentList else {
       return nil
     }
@@ -5503,7 +5503,7 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericParameterList else {
       return nil
     }
@@ -5712,7 +5712,7 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericRequirementList else {
       return nil
     }
@@ -5921,7 +5921,7 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .ifConfigClauseList else {
       return nil
     }
@@ -6130,7 +6130,7 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .inheritedTypeList else {
       return nil
     }
@@ -6339,7 +6339,7 @@ public struct KeyPathComponentListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .keyPathComponentList else {
       return nil
     }
@@ -6548,7 +6548,7 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .memberDeclList else {
       return nil
     }
@@ -6757,7 +6757,7 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .modifierList else {
       return nil
     }
@@ -6966,7 +6966,7 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .multipleTrailingClosureElementList else {
       return nil
     }
@@ -7175,7 +7175,7 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .objCSelector else {
       return nil
     }
@@ -7384,7 +7384,7 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .patternBindingList else {
       return nil
     }
@@ -7618,7 +7618,7 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
       self = .precedenceGroupAssociativity(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(PrecedenceGroupRelationSyntax.self) {
         self = .precedenceGroupRelation(node)
         return
@@ -7648,7 +7648,7 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupAttributeList else {
       return nil
     }
@@ -7857,7 +7857,7 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupNameList else {
       return nil
     }
@@ -8066,7 +8066,7 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .primaryAssociatedTypeList else {
       return nil
     }
@@ -8304,7 +8304,7 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
       self = .genericWhereClause(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(LabeledSpecializeEntrySyntax.self) {
         self = .labeledSpecializeEntry(node)
         return
@@ -8340,7 +8340,7 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .specializeAttributeSpecList else {
       return nil
     }
@@ -8567,7 +8567,7 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
       self = .expressionSegment(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(StringSegmentSyntax.self) {
         self = .stringSegment(node)
         return
@@ -8592,7 +8592,7 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .stringLiteralSegments else {
       return nil
     }
@@ -8819,7 +8819,7 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
       self = .ifConfigDecl(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(SwitchCaseSyntax.self) {
         self = .switchCase(node)
         return
@@ -8844,7 +8844,7 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .switchCaseList else {
       return nil
     }
@@ -9053,7 +9053,7 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tupleExprElementList else {
       return nil
     }
@@ -9262,7 +9262,7 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tuplePatternElementList else {
       return nil
     }
@@ -9471,7 +9471,7 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tupleTypeElementList else {
       return nil
     }
@@ -9677,7 +9677,7 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .unexpectedNodes else {
       return nil
     }
@@ -9886,7 +9886,7 @@ public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
     data.raw.layoutView!
   }
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .yieldExprList else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -657,7 +657,6 @@ extension ArrayElementListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: SyntaxChildChoices {
     case `attribute`(AttributeSyntax)
     case `ifConfigDecl`(IfConfigDeclSyntax)
@@ -7585,7 +7584,6 @@ extension PatternBindingListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashable {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: SyntaxChildChoices {
     case `precedenceGroupRelation`(PrecedenceGroupRelationSyntax)
     case `precedenceGroupAssignment`(PrecedenceGroupAssignmentSyntax)
@@ -8264,7 +8262,6 @@ extension PrimaryAssociatedTypeListSyntax: BidirectionalCollection {
 
 /// A collection of arguments for the `@_specialize` attribute
 public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashable {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: SyntaxChildChoices {
     case `labeledSpecializeEntry`(LabeledSpecializeEntrySyntax)
     case `availabilityEntry`(AvailabilityEntrySyntax)
@@ -8541,7 +8538,6 @@ extension SpecializeAttributeSpecListSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: SyntaxChildChoices {
     case `stringSegment`(StringSegmentSyntax)
     case `expressionSegment`(ExpressionSegmentSyntax)
@@ -8793,7 +8789,6 @@ extension StringLiteralSegmentsSyntax: BidirectionalCollection {
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
 public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: SyntaxChildChoices {
     case `switchCase`(SwitchCaseSyntax)
     case `ifConfigDecl`(IfConfigDeclSyntax)

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 /// Enum to exhaustively switch over all different syntax nodes.
-@frozen // FIXME: Not actually stable, works around a miscompile
 public enum SyntaxEnum {
   case token(TokenSyntax)
   case accessPathComponent(AccessPathComponentSyntax)

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 /// Enumerates the known kinds of Syntax represented in the Syntax tree.
-@frozen // FIXME: Not actually stable, works around a miscompile
 public enum SyntaxKind {
   case token
   case accessPathComponent

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -6949,7 +6949,7 @@ open class SyntaxRewriter {
       }
     }
 
-    if let newLayout = newLayout {
+    if let newLayout {
       // A child node was rewritten. Build the updated node.
 
       // Sanity check, ensure the new children are the same length.

--- a/Sources/SwiftSyntax/generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTransform.swift
@@ -3810,11 +3810,11 @@ extension SyntaxTransformVisitor {
     visit(Syntax(node))
   }
   
-  public func visit<T: SyntaxChildChoices>(_ node: T) -> ResultType {
+  public func visit(_ node: some SyntaxChildChoices) -> ResultType {
     return visit(Syntax(node))
   }
   
-  public func visitChildren<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) -> [ResultType] {
+  public func visitChildren(_ node: some SyntaxProtocol) -> [ResultType] {
     let syntaxNode = Syntax(node)
     return NonNilRawSyntaxChildren(syntaxNode, viewMode: .sourceAccurate).map { rawChild in
       let child = Syntax(SyntaxData(rawChild, parent: syntaxNode))

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -30,7 +30,7 @@ open class SyntaxVisitor {
   
   /// Walk all nodes of the given syntax tree, calling the corresponding `visit`
   /// function for every node that is being visited.
-  public func walk<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) {
+  public func walk(_ node: some SyntaxProtocol) {
     visit(node.data)
   }
   
@@ -6781,7 +6781,7 @@ open class SyntaxVisitor {
     }
   }
   
-  private func visitChildren<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) {
+  private func visitChildren(_ node: some SyntaxProtocol) {
     let syntaxNode = Syntax(node)
     for childRaw in NonNilRawSyntaxChildren(syntaxNode, viewMode: viewMode) {
       let childData = SyntaxData(childRaw, parent: syntaxNode)

--- a/Sources/SwiftSyntax/generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/generated/TokenKind.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 /// Enumerates the kinds of tokens in the Swift language.
-@frozen // FIXME: Not actually stable, works around a miscompile
 public enum TokenKind: Hashable {
   case eof
   case arrow
@@ -473,7 +472,6 @@ extension TokenKind: Equatable {
 // because it significantly improves performance when comparing two
 // `RawTokenBaseKind` for equality. With the raw value, it compiles down to
 // a primitive integer compare, without, it calls into `__derived_enum_equals`.
-@frozen // FIXME: Not actually stable, works around a miscompile
 @_spi(RawSyntax)
 public enum RawTokenKind: UInt8, Equatable, Hashable {
   case eof

--- a/Sources/SwiftSyntax/generated/TriviaPieces.swift
+++ b/Sources/SwiftSyntax/generated/TriviaPieces.swift
@@ -57,7 +57,7 @@ extension TriviaPiece: TextOutputStreamable {
   /// Prints the provided trivia as they would be written in a source file.
   ///
   /// - Parameter stream: The stream to which to print the trivia.
-  public func write<Target>(to target: inout Target) where Target: TextOutputStream {
+  public func write(to target: inout some TextOutputStream) {
     func printRepeated(_ character: String, count: Int) {
       for _ in 0 ..< count {
         target.write(character)

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -1329,7 +1329,6 @@ public struct RawAssociatedtypeDeclSyntax: RawDeclSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawAttributeListSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: RawSyntaxNodeProtocol {
     case `attribute`(RawAttributeSyntax)
     case `ifConfigDecl`(RawIfConfigDeclSyntax)
@@ -1410,7 +1409,6 @@ public struct RawAttributeListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Argument: RawSyntaxNodeProtocol {
     case `argumentList`(RawTupleExprElementListSyntax)
     case `token`(RawTokenSyntax)
@@ -1755,7 +1753,6 @@ public struct RawAttributedTypeSyntax: RawTypeSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Entry: RawSyntaxNodeProtocol {
     case `token`(RawTokenSyntax)
     case `availabilityVersionRestriction`(RawAvailabilityVersionRestrictionSyntax)
@@ -2051,7 +2048,6 @@ public struct RawAvailabilityEntrySyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Value: RawSyntaxNodeProtocol {
     case `string`(RawStringLiteralExprSyntax)
     case `version`(RawVersionTupleSyntax)
@@ -4228,7 +4224,6 @@ public struct RawClosureParameterSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Input: RawSyntaxNodeProtocol {
     case `simpleInput`(RawClosureParamListSyntax)
     case `input`(RawClosureParameterClauseSyntax)
@@ -4427,7 +4422,6 @@ public struct RawCodeBlockItemListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Item: RawSyntaxNodeProtocol {
     case `decl`(RawDeclSyntax)
     case `stmt`(RawStmtSyntax)
@@ -4845,7 +4839,6 @@ public struct RawConditionElementListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawConditionElementSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Condition: RawSyntaxNodeProtocol {
     case `expression`(RawExprSyntax)
     case `availability`(RawAvailabilityConditionSyntax)
@@ -6391,7 +6384,6 @@ public struct RawDictionaryElementSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Content: RawSyntaxNodeProtocol {
     case `colon`(RawTokenSyntax)
     case `elements`(RawDictionaryElementListSyntax)
@@ -6730,7 +6722,6 @@ public struct RawDifferentiabilityParamSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Parameters: RawSyntaxNodeProtocol {
     case `parameter`(RawDifferentiabilityParamSyntax)
     case `parameterList`(RawDifferentiabilityParamsSyntax)
@@ -7171,7 +7162,6 @@ public struct RawDoStmtSyntax: RawStmtSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawDocumentationAttributeArgumentSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Value: RawSyntaxNodeProtocol {
     case `token`(RawTokenSyntax)
     case `string`(RawStringLiteralExprSyntax)
@@ -10417,7 +10407,6 @@ public struct RawGenericRequirementListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Body: RawSyntaxNodeProtocol {
     case `sameTypeRequirement`(RawSameTypeRequirementSyntax)
     case `conformanceRequirement`(RawConformanceRequirementSyntax)
@@ -10867,7 +10856,6 @@ public struct RawIfConfigClauseListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Elements: RawSyntaxNodeProtocol {
     case `statements`(RawCodeBlockItemListSyntax)
     case `switchCases`(RawSwitchCaseListSyntax)
@@ -11071,7 +11059,6 @@ public struct RawIfConfigDeclSyntax: RawDeclSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawIfExprSyntax: RawExprSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum ElseBody: RawSyntaxNodeProtocol {
     case `ifExpr`(RawIfExprSyntax)
     case `codeBlock`(RawCodeBlockSyntax)
@@ -12222,7 +12209,6 @@ public struct RawKeyPathComponentListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Component: RawSyntaxNodeProtocol {
     case `property`(RawKeyPathPropertyComponentSyntax)
     case `subscript`(RawKeyPathSubscriptComponentSyntax)
@@ -15838,7 +15824,6 @@ public struct RawPatternBindingListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Accessor: RawSyntaxNodeProtocol {
     case `accessors`(RawAccessorBlockSyntax)
     case `getter`(RawCodeBlockSyntax)
@@ -16542,7 +16527,6 @@ public struct RawPrecedenceGroupAssociativitySyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawPrecedenceGroupAttributeListSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: RawSyntaxNodeProtocol {
     case `precedenceGroupRelation`(RawPrecedenceGroupRelationSyntax)
     case `precedenceGroupAssignment`(RawPrecedenceGroupAssignmentSyntax)
@@ -18090,7 +18074,6 @@ public struct RawSourceFileSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawSpecializeAttributeSpecListSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: RawSyntaxNodeProtocol {
     case `labeledSpecializeEntry`(RawLabeledSpecializeEntrySyntax)
     case `availabilityEntry`(RawAvailabilityEntrySyntax)
@@ -18400,7 +18383,6 @@ public struct RawStringLiteralExprSyntax: RawExprSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawStringLiteralSegmentsSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: RawSyntaxNodeProtocol {
     case `stringSegment`(RawStringSegmentSyntax)
     case `expressionSegment`(RawExpressionSegmentSyntax)
@@ -18681,7 +18663,6 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Accessor: RawSyntaxNodeProtocol {
     case `accessors`(RawAccessorBlockSyntax)
     case `getter`(RawCodeBlockSyntax)
@@ -19182,7 +19163,6 @@ public struct RawSwitchCaseLabelSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Element: RawSyntaxNodeProtocol {
     case `switchCase`(RawSwitchCaseSyntax)
     case `ifConfigDecl`(RawIfConfigDeclSyntax)
@@ -19263,7 +19243,6 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Label: RawSyntaxNodeProtocol {
     case `default`(RawSwitchDefaultLabelSyntax)
     case `case`(RawSwitchCaseLabelSyntax)
@@ -22313,7 +22292,6 @@ public struct RawYieldListSyntax: RawSyntaxNodeProtocol {
 
 @_spi(RawSyntax)
 public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol {
-  @frozen // FIXME: Not actually stable, works around a miscompile
   public enum Yields: RawSyntaxNodeProtocol {
     case `yieldList`(RawYieldListSyntax)
     case `simpleYield`(RawExprSyntax)

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -49,7 +49,7 @@ public struct RawAccessPathComponentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -119,7 +119,7 @@ public struct RawAccessPathSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -169,7 +169,7 @@ public struct RawAccessorBlockSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -251,7 +251,7 @@ public struct RawAccessorDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -369,7 +369,7 @@ public struct RawAccessorEffectSpecifiersSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -439,7 +439,7 @@ public struct RawAccessorListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -489,7 +489,7 @@ public struct RawAccessorParameterSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -571,7 +571,7 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -713,7 +713,7 @@ public struct RawArrayElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -763,7 +763,7 @@ public struct RawArrayElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -833,7 +833,7 @@ public struct RawArrayExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -915,7 +915,7 @@ public struct RawArrayTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -997,7 +997,7 @@ public struct RawArrowExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1067,7 +1067,7 @@ public struct RawAsExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1161,7 +1161,7 @@ public struct RawAssignmentExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1219,7 +1219,7 @@ public struct RawAssociatedtypeDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1347,7 +1347,7 @@ public struct RawAttributeListSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawAttributeSyntax(other) {
         self = .attribute(node)
         return
@@ -1380,7 +1380,7 @@ public struct RawAttributeListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1482,7 +1482,7 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawTupleExprElementListSyntax(other) {
         self = .argumentList(node)
         return
@@ -1587,7 +1587,7 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1693,7 +1693,7 @@ public struct RawAttributedTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1776,7 +1776,7 @@ public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawTokenSyntax(other) {
         self = .token(node)
         return
@@ -1813,7 +1813,7 @@ public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1883,7 +1883,7 @@ public struct RawAvailabilityConditionSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -1977,7 +1977,7 @@ public struct RawAvailabilityEntrySyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2069,7 +2069,7 @@ public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawStringLiteralExprSyntax(other) {
         self = .string(node)
         return
@@ -2102,7 +2102,7 @@ public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2184,7 +2184,7 @@ public struct RawAvailabilitySpecListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2234,7 +2234,7 @@ public struct RawAvailabilityVersionRestrictionListEntrySyntax: RawSyntaxNodePro
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2304,7 +2304,7 @@ public struct RawAvailabilityVersionRestrictionListSyntax: RawSyntaxNodeProtocol
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2354,7 +2354,7 @@ public struct RawAvailabilityVersionRestrictionSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2424,7 +2424,7 @@ public struct RawAwaitExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2494,7 +2494,7 @@ public struct RawBackDeployedAttributeSpecListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2576,7 +2576,7 @@ public struct RawBinaryOperatorExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2634,7 +2634,7 @@ public struct RawBooleanLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2692,7 +2692,7 @@ public struct RawBorrowExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2762,7 +2762,7 @@ public struct RawBreakStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2832,7 +2832,7 @@ public struct RawCaseItemListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2882,7 +2882,7 @@ public struct RawCaseItemSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -2964,7 +2964,7 @@ public struct RawCatchClauseListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3014,7 +3014,7 @@ public struct RawCatchClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3096,7 +3096,7 @@ public struct RawCatchItemListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3146,7 +3146,7 @@ public struct RawCatchItemSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3228,7 +3228,7 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3370,7 +3370,7 @@ public struct RawClassRestrictionTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3428,7 +3428,7 @@ public struct RawClosureCaptureItemListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3478,7 +3478,7 @@ public struct RawClosureCaptureItemSpecifierSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3572,7 +3572,7 @@ public struct RawClosureCaptureItemSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3678,7 +3678,7 @@ public struct RawClosureCaptureSignatureSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3760,7 +3760,7 @@ public struct RawClosureExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3854,7 +3854,7 @@ public struct RawClosureParamListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3904,7 +3904,7 @@ public struct RawClosureParamSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -3974,7 +3974,7 @@ public struct RawClosureParameterClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4056,7 +4056,7 @@ public struct RawClosureParameterListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4106,7 +4106,7 @@ public struct RawClosureParameterSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4246,7 +4246,7 @@ public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawClosureParamListSyntax(other) {
         self = .simpleInput(node)
         return
@@ -4279,7 +4279,7 @@ public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4397,7 +4397,7 @@ public struct RawCodeBlockItemListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4448,7 +4448,7 @@ public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawDeclSyntax(other) {
         self = .decl(node)
         return
@@ -4485,7 +4485,7 @@ public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4555,7 +4555,7 @@ public struct RawCodeBlockSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4637,7 +4637,7 @@ public struct RawCompositionTypeElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4687,7 +4687,7 @@ public struct RawCompositionTypeElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4757,7 +4757,7 @@ public struct RawCompositionTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4815,7 +4815,7 @@ public struct RawConditionElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4869,7 +4869,7 @@ public struct RawConditionElementSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawExprSyntax(other) {
         self = .expression(node)
         return
@@ -4910,7 +4910,7 @@ public struct RawConditionElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -4980,7 +4980,7 @@ public struct RawConformanceRequirementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5062,7 +5062,7 @@ public struct RawConstrainedSugarTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5132,7 +5132,7 @@ public struct RawContinueStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5202,7 +5202,7 @@ public struct RawConventionAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5308,7 +5308,7 @@ public struct RawConventionWitnessMethodAttributeArgumentsSyntax: RawSyntaxNodeP
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5390,7 +5390,7 @@ public struct RawDeclModifierDetailSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5472,7 +5472,7 @@ public struct RawDeclModifierSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5542,7 +5542,7 @@ public struct RawDeclNameArgumentListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5592,7 +5592,7 @@ public struct RawDeclNameArgumentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5662,7 +5662,7 @@ public struct RawDeclNameArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5744,7 +5744,7 @@ public struct RawDeclNameSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5819,14 +5819,14 @@ public struct RawDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
     self.init(unchecked: other.raw)
   }
   
-  public init<Node: RawDeclSyntaxNodeProtocol>(_ other: Node) {
+  public init(_ other: some RawDeclSyntaxNodeProtocol) {
     self.init(unchecked: other.raw)
   }
 }
@@ -5853,7 +5853,7 @@ public struct RawDeferStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -5923,7 +5923,7 @@ public struct RawDeinitializerDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6017,7 +6017,7 @@ public struct RawDerivativeRegistrationAttributeArgumentsSyntax: RawSyntaxNodePr
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6147,7 +6147,7 @@ public struct RawDesignatedTypeElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6217,7 +6217,7 @@ public struct RawDesignatedTypeListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6267,7 +6267,7 @@ public struct RawDictionaryElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6317,7 +6317,7 @@ public struct RawDictionaryElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6409,7 +6409,7 @@ public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawTokenSyntax(other) {
         self = .colon(node)
         return
@@ -6442,7 +6442,7 @@ public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6524,7 +6524,7 @@ public struct RawDictionaryTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6630,7 +6630,7 @@ public struct RawDifferentiabilityParamListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6680,7 +6680,7 @@ public struct RawDifferentiabilityParamSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6748,7 +6748,7 @@ public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawDifferentiabilityParamSyntax(other) {
         self = .parameter(node)
         return
@@ -6781,7 +6781,7 @@ public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6863,7 +6863,7 @@ public struct RawDifferentiabilityParamsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -6945,7 +6945,7 @@ public struct RawDifferentiableAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7051,7 +7051,7 @@ public struct RawDiscardAssignmentExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7109,7 +7109,7 @@ public struct RawDoStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7189,7 +7189,7 @@ public struct RawDocumentationAttributeArgumentSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawTokenSyntax(other) {
         self = .token(node)
         return
@@ -7222,7 +7222,7 @@ public struct RawDocumentationAttributeArgumentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7316,7 +7316,7 @@ public struct RawDocumentationAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7366,7 +7366,7 @@ public struct RawDynamicReplacementArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7448,7 +7448,7 @@ public struct RawEditorPlaceholderDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7506,7 +7506,7 @@ public struct RawEditorPlaceholderExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7564,7 +7564,7 @@ public struct RawEffectsArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7614,7 +7614,7 @@ public struct RawEnumCaseDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7708,7 +7708,7 @@ public struct RawEnumCaseElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7758,7 +7758,7 @@ public struct RawEnumCaseElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7852,7 +7852,7 @@ public struct RawEnumCaseParameterClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7934,7 +7934,7 @@ public struct RawEnumCaseParameterListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -7984,7 +7984,7 @@ public struct RawEnumCaseParameterSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8114,7 +8114,7 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8256,7 +8256,7 @@ public struct RawExposeAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8338,7 +8338,7 @@ public struct RawExprListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8393,14 +8393,14 @@ public struct RawExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
     self.init(unchecked: other.raw)
   }
   
-  public init<Node: RawExprSyntaxNodeProtocol>(_ other: Node) {
+  public init(_ other: some RawExprSyntaxNodeProtocol) {
     self.init(unchecked: other.raw)
   }
 }
@@ -8427,7 +8427,7 @@ public struct RawExpressionPatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8485,7 +8485,7 @@ public struct RawExpressionSegmentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8591,7 +8591,7 @@ public struct RawExpressionStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8649,7 +8649,7 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8779,7 +8779,7 @@ public struct RawFallthroughStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8837,7 +8837,7 @@ public struct RawFloatLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -8895,7 +8895,7 @@ public struct RawForInStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9061,7 +9061,7 @@ public struct RawForcedValueExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9131,7 +9131,7 @@ public struct RawForgetStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9201,7 +9201,7 @@ public struct RawFunctionCallExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9319,7 +9319,7 @@ public struct RawFunctionDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9461,7 +9461,7 @@ public struct RawFunctionEffectSpecifiersSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9531,7 +9531,7 @@ public struct RawFunctionParameterListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9581,7 +9581,7 @@ public struct RawFunctionParameterSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9735,7 +9735,7 @@ public struct RawFunctionSignatureSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9817,7 +9817,7 @@ public struct RawFunctionTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -9923,7 +9923,7 @@ public struct RawGenericArgumentClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10005,7 +10005,7 @@ public struct RawGenericArgumentListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10055,7 +10055,7 @@ public struct RawGenericArgumentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10125,7 +10125,7 @@ public struct RawGenericParameterClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10219,7 +10219,7 @@ public struct RawGenericParameterListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10269,7 +10269,7 @@ public struct RawGenericParameterSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10387,7 +10387,7 @@ public struct RawGenericRequirementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10438,7 +10438,7 @@ public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawSameTypeRequirementSyntax(other) {
         self = .sameTypeRequirement(node)
         return
@@ -10475,7 +10475,7 @@ public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10545,7 +10545,7 @@ public struct RawGenericWhereClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10615,7 +10615,7 @@ public struct RawGuardStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10709,7 +10709,7 @@ public struct RawIdentifierExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10779,7 +10779,7 @@ public struct RawIdentifierPatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10837,7 +10837,7 @@ public struct RawIfConfigClauseListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -10894,7 +10894,7 @@ public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawCodeBlockItemListSyntax(other) {
         self = .statements(node)
         return
@@ -10939,7 +10939,7 @@ public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11021,7 +11021,7 @@ public struct RawIfConfigDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11089,7 +11089,7 @@ public struct RawIfExprSyntax: RawExprSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawIfExprSyntax(other) {
         self = .ifExpr(node)
         return
@@ -11122,7 +11122,7 @@ public struct RawIfExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11228,7 +11228,7 @@ public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11322,7 +11322,7 @@ public struct RawImplicitlyUnwrappedOptionalTypeSyntax: RawTypeSyntaxNodeProtoco
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11392,7 +11392,7 @@ public struct RawImportDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11498,7 +11498,7 @@ public struct RawInOutExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11568,7 +11568,7 @@ public struct RawInfixOperatorExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11650,7 +11650,7 @@ public struct RawInheritedTypeListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11700,7 +11700,7 @@ public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11770,7 +11770,7 @@ public struct RawInitializerClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11840,7 +11840,7 @@ public struct RawInitializerDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -11982,7 +11982,7 @@ public struct RawIntegerLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12040,7 +12040,7 @@ public struct RawIsExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12122,7 +12122,7 @@ public struct RawIsTypePatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12192,7 +12192,7 @@ public struct RawKeyPathComponentListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12243,7 +12243,7 @@ public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawKeyPathPropertyComponentSyntax(other) {
         self = .property(node)
         return
@@ -12280,7 +12280,7 @@ public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12350,7 +12350,7 @@ public struct RawKeyPathExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12432,7 +12432,7 @@ public struct RawKeyPathOptionalComponentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12490,7 +12490,7 @@ public struct RawKeyPathPropertyComponentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12572,7 +12572,7 @@ public struct RawKeyPathSubscriptComponentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12654,7 +12654,7 @@ public struct RawLabeledSpecializeEntrySyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12748,7 +12748,7 @@ public struct RawLabeledStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12830,7 +12830,7 @@ public struct RawLayoutRequirementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -12972,7 +12972,7 @@ public struct RawMacroDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13114,7 +13114,7 @@ public struct RawMacroExpansionDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13256,7 +13256,7 @@ public struct RawMacroExpansionExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13398,7 +13398,7 @@ public struct RawMatchingPatternConditionSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13492,7 +13492,7 @@ public struct RawMemberAccessExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13586,7 +13586,7 @@ public struct RawMemberDeclBlockSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13668,7 +13668,7 @@ public struct RawMemberDeclListItemSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13738,7 +13738,7 @@ public struct RawMemberDeclListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13788,7 +13788,7 @@ public struct RawMemberTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13882,7 +13882,7 @@ public struct RawMetatypeTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -13964,7 +13964,7 @@ public struct RawMissingDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14046,7 +14046,7 @@ public struct RawMissingExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14104,7 +14104,7 @@ public struct RawMissingPatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14162,7 +14162,7 @@ public struct RawMissingStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14220,7 +14220,7 @@ public struct RawMissingSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14278,7 +14278,7 @@ public struct RawMissingTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14336,7 +14336,7 @@ public struct RawModifierListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14386,7 +14386,7 @@ public struct RawMoveExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14456,7 +14456,7 @@ public struct RawMultipleTrailingClosureElementListSyntax: RawSyntaxNodeProtocol
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14506,7 +14506,7 @@ public struct RawMultipleTrailingClosureElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14588,7 +14588,7 @@ public struct RawNamedOpaqueReturnTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14658,7 +14658,7 @@ public struct RawNilLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14716,7 +14716,7 @@ public struct RawObjCSelectorPieceSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14786,7 +14786,7 @@ public struct RawObjCSelectorSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14836,7 +14836,7 @@ public struct RawOpaqueReturnTypeOfAttributeArgumentsSyntax: RawSyntaxNodeProtoc
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -14918,7 +14918,7 @@ public struct RawOperatorDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15024,7 +15024,7 @@ public struct RawOperatorPrecedenceAndTypesSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15106,7 +15106,7 @@ public struct RawOptionalBindingConditionSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15200,7 +15200,7 @@ public struct RawOptionalChainingExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15270,7 +15270,7 @@ public struct RawOptionalTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15340,7 +15340,7 @@ public struct RawOriginallyDefinedInArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15446,7 +15446,7 @@ public struct RawPackElementExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15516,7 +15516,7 @@ public struct RawPackExpansionExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15586,7 +15586,7 @@ public struct RawPackExpansionTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15656,7 +15656,7 @@ public struct RawPackReferenceTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15726,7 +15726,7 @@ public struct RawParameterClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15808,7 +15808,7 @@ public struct RawPatternBindingListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -15856,7 +15856,7 @@ public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawAccessorBlockSyntax(other) {
         self = .accessors(node)
         return
@@ -15889,7 +15889,7 @@ public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16000,14 +16000,14 @@ public struct RawPatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
     self.init(unchecked: other.raw)
   }
   
-  public init<Node: RawPatternSyntaxNodeProtocol>(_ other: Node) {
+  public init(_ other: some RawPatternSyntaxNodeProtocol) {
     self.init(unchecked: other.raw)
   }
 }
@@ -16034,7 +16034,7 @@ public struct RawPostfixIfConfigExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16104,7 +16104,7 @@ public struct RawPostfixUnaryExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16174,7 +16174,7 @@ public struct RawPoundSourceLocationArgsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16304,7 +16304,7 @@ public struct RawPoundSourceLocationSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16398,7 +16398,7 @@ public struct RawPrecedenceGroupAssignmentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16480,7 +16480,7 @@ public struct RawPrecedenceGroupAssociativitySyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16563,7 +16563,7 @@ public struct RawPrecedenceGroupAttributeListSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawPrecedenceGroupRelationSyntax(other) {
         self = .precedenceGroupRelation(node)
         return
@@ -16600,7 +16600,7 @@ public struct RawPrecedenceGroupAttributeListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16650,7 +16650,7 @@ public struct RawPrecedenceGroupDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16780,7 +16780,7 @@ public struct RawPrecedenceGroupNameElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16850,7 +16850,7 @@ public struct RawPrecedenceGroupNameListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16900,7 +16900,7 @@ public struct RawPrecedenceGroupRelationSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -16982,7 +16982,7 @@ public struct RawPrefixOperatorExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17052,7 +17052,7 @@ public struct RawPrimaryAssociatedTypeClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17134,7 +17134,7 @@ public struct RawPrimaryAssociatedTypeListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17184,7 +17184,7 @@ public struct RawPrimaryAssociatedTypeSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17254,7 +17254,7 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17396,7 +17396,7 @@ public struct RawQualifiedDeclNameSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17490,7 +17490,7 @@ public struct RawRegexLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17596,7 +17596,7 @@ public struct RawRepeatWhileStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17690,7 +17690,7 @@ public struct RawReturnClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17760,7 +17760,7 @@ public struct RawReturnStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17830,7 +17830,7 @@ public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17912,7 +17912,7 @@ public struct RawSequenceExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -17970,7 +17970,7 @@ public struct RawSimpleTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18040,7 +18040,7 @@ public struct RawSourceFileSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18114,7 +18114,7 @@ public struct RawSpecializeAttributeSpecListSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawLabeledSpecializeEntrySyntax(other) {
         self = .labeledSpecializeEntry(node)
         return
@@ -18155,7 +18155,7 @@ public struct RawSpecializeAttributeSpecListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18205,7 +18205,7 @@ public struct RawSpecializeExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18280,14 +18280,14 @@ public struct RawStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
     self.init(unchecked: other.raw)
   }
   
-  public init<Node: RawStmtSyntaxNodeProtocol>(_ other: Node) {
+  public init(_ other: some RawStmtSyntaxNodeProtocol) {
     self.init(unchecked: other.raw)
   }
 }
@@ -18314,7 +18314,7 @@ public struct RawStringLiteralExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18418,7 +18418,7 @@ public struct RawStringLiteralSegmentsSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawStringSegmentSyntax(other) {
         self = .stringSegment(node)
         return
@@ -18451,7 +18451,7 @@ public struct RawStringLiteralSegmentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18501,7 +18501,7 @@ public struct RawStringSegmentSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18559,7 +18559,7 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18699,7 +18699,7 @@ public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawAccessorBlockSyntax(other) {
         self = .accessors(node)
         return
@@ -18732,7 +18732,7 @@ public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18874,7 +18874,7 @@ public struct RawSubscriptExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -18992,7 +18992,7 @@ public struct RawSuperRefExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19050,7 +19050,7 @@ public struct RawSuppressedTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19120,7 +19120,7 @@ public struct RawSwitchCaseLabelSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19200,7 +19200,7 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawSwitchCaseSyntax(other) {
         self = .switchCase(node)
         return
@@ -19233,7 +19233,7 @@ public struct RawSwitchCaseListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19281,7 +19281,7 @@ public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawSwitchDefaultLabelSyntax(other) {
         self = .default(node)
         return
@@ -19314,7 +19314,7 @@ public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19396,7 +19396,7 @@ public struct RawSwitchDefaultLabelSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19466,7 +19466,7 @@ public struct RawSwitchExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19572,7 +19572,7 @@ public struct RawTargetFunctionEntrySyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19666,7 +19666,7 @@ public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19772,7 +19772,7 @@ public struct RawThrowStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19842,7 +19842,7 @@ public struct RawTryExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19924,7 +19924,7 @@ public struct RawTupleExprElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -19974,7 +19974,7 @@ public struct RawTupleExprElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20068,7 +20068,7 @@ public struct RawTupleExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20150,7 +20150,7 @@ public struct RawTuplePatternElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20200,7 +20200,7 @@ public struct RawTuplePatternElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20294,7 +20294,7 @@ public struct RawTuplePatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20376,7 +20376,7 @@ public struct RawTupleTypeElementListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20426,7 +20426,7 @@ public struct RawTupleTypeElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20568,7 +20568,7 @@ public struct RawTupleTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20650,7 +20650,7 @@ public struct RawTypeAnnotationSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20720,7 +20720,7 @@ public struct RawTypeEffectSpecifiersSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20790,7 +20790,7 @@ public struct RawTypeExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20848,7 +20848,7 @@ public struct RawTypeInheritanceClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20918,7 +20918,7 @@ public struct RawTypeInitializerClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -20993,14 +20993,14 @@ public struct RawTypeSyntax: RawTypeSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
     self.init(unchecked: other.raw)
   }
   
-  public init<Node: RawTypeSyntaxNodeProtocol>(_ other: Node) {
+  public init(_ other: some RawTypeSyntaxNodeProtocol) {
     self.init(unchecked: other.raw)
   }
 }
@@ -21027,7 +21027,7 @@ public struct RawTypealiasDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21157,7 +21157,7 @@ public struct RawUnavailableFromAsyncArgumentsSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21239,7 +21239,7 @@ public struct RawUnderscorePrivateAttributeArgumentsSyntax: RawSyntaxNodeProtoco
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21321,7 +21321,7 @@ public struct RawUnexpectedNodesSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21371,7 +21371,7 @@ public struct RawUnresolvedAsExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21441,7 +21441,7 @@ public struct RawUnresolvedIsExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21499,7 +21499,7 @@ public struct RawUnresolvedPatternExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21557,7 +21557,7 @@ public struct RawUnresolvedTernaryExprSyntax: RawExprSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21639,7 +21639,7 @@ public struct RawValueBindingPatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21709,7 +21709,7 @@ public struct RawVariableDeclSyntax: RawDeclSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21803,7 +21803,7 @@ public struct RawVersionTupleSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21909,7 +21909,7 @@ public struct RawWhereClauseSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -21979,7 +21979,7 @@ public struct RawWhileStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -22061,7 +22061,7 @@ public struct RawWildcardPatternSyntax: RawPatternSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -22131,7 +22131,7 @@ public struct RawYieldExprListElementSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -22201,7 +22201,7 @@ public struct RawYieldExprListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -22251,7 +22251,7 @@ public struct RawYieldListSyntax: RawSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }
@@ -22331,7 +22331,7 @@ public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol {
       }
     }
     
-    public init?<T>(_ other: T) where T : RawSyntaxNodeProtocol {
+    public init?(_ other: some RawSyntaxNodeProtocol) {
       if let node = RawYieldListSyntax(other) {
         self = .yieldList(node)
         return
@@ -22364,7 +22364,7 @@ public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol {
     self.raw = raw
   }
   
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+  public init?(_ other: some RawSyntaxNodeProtocol) {
     guard Self.isKindOf(other.raw) else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -179,7 +179,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
       )
   }
   func assertNoError(_ nodeKind: SyntaxKind, _ index: Int, _ error: ValidationError?) {
-    if let error = error {
+    if let error {
       let (file, line) = error.fileAndLine
       assertionFailure("""
         Error validating child at index \(index) of \(nodeKind):

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -18,7 +18,7 @@
 public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .accessorDecl else {
       return nil
     }
@@ -257,7 +257,7 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .actorDecl else {
       return nil
     }
@@ -567,7 +567,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .associatedtypeDecl else {
       return nil
     }
@@ -851,7 +851,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .classDecl else {
       return nil
     }
@@ -1166,7 +1166,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .deinitializerDecl else {
       return nil
     }
@@ -1376,7 +1376,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .editorPlaceholderDecl else {
       return nil
     }
@@ -1454,7 +1454,7 @@ public struct EditorPlaceholderDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseDecl else {
       return nil
     }
@@ -1683,7 +1683,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .enumDecl else {
       return nil
     }
@@ -2001,7 +2001,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .extensionDecl else {
       return nil
     }
@@ -2016,7 +2016,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
       attributes: AttributeListSyntax? = nil,
@@ -2025,7 +2025,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenModifiersAndExtensionKeyword: UnexpectedNodesSyntax? = nil,
       extensionKeyword: TokenSyntax = .keyword(.extension),
       _ unexpectedBetweenExtensionKeywordAndExtendedType: UnexpectedNodesSyntax? = nil,
-      extendedType: E,
+      extendedType: some TypeSyntaxProtocol,
       _ unexpectedBetweenExtendedTypeAndInheritanceClause: UnexpectedNodesSyntax? = nil,
       inheritanceClause: TypeInheritanceClauseSyntax? = nil,
       _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
@@ -2285,7 +2285,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .functionDecl else {
       return nil
     }
@@ -2595,7 +2595,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .ifConfigDecl else {
       return nil
     }
@@ -2730,7 +2730,7 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .importDecl else {
       return nil
     }
@@ -2988,7 +2988,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .initializerDecl else {
       return nil
     }
@@ -3306,7 +3306,7 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .macroDecl else {
       return nil
     }
@@ -3616,7 +3616,7 @@ public struct MacroDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .macroExpansionDecl else {
       return nil
     }
@@ -3927,7 +3927,7 @@ public struct MacroExpansionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .missingDecl else {
       return nil
     }
@@ -4110,7 +4110,7 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .operatorDecl else {
       return nil
     }
@@ -4345,7 +4345,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .poundSourceLocation else {
       return nil
     }
@@ -4513,7 +4513,7 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupDecl else {
       return nil
     }
@@ -4820,7 +4820,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .protocolDecl else {
       return nil
     }
@@ -5184,7 +5184,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .structDecl else {
       return nil
     }
@@ -5525,7 +5525,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       self = .getter(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(AccessorBlockSyntax.self) {
         self = .accessors(node)
         return
@@ -5544,7 +5544,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .subscriptDecl else {
       return nil
     }
@@ -5854,7 +5854,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .typealiasDecl else {
       return nil
     }
@@ -6138,7 +6138,7 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .variableDecl else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -2777,7 +2777,7 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       _ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil,
       backslash: TokenSyntax = .backslashToken(),
       _ unexpectedBetweenBackslashAndRoot: UnexpectedNodesSyntax? = nil,
-      root: (some TypeSyntaxProtocol)? = nil,
+      root: (some TypeSyntaxProtocol)? = TypeSyntax?.none,
       _ unexpectedBetweenRootAndComponents: UnexpectedNodesSyntax? = nil,
       components: KeyPathComponentListSyntax,
       _ unexpectedAfterComponents: UnexpectedNodesSyntax? = nil,
@@ -2815,41 +2815,6 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
-  }
-  
-  /// This initializer exists solely because Swift 5.6 does not support
-  /// `Optional<ConcreteType>.none` as a default value of a generic parameter.
-  /// The above initializer thus defaults to `nil` instead, but that means it
-  /// is not actually callable when either not passing the defaulted parameter,
-  /// or passing `nil`.
-  ///
-  /// Hack around that limitation using this initializer, which takes a
-  /// `Missing*` syntax node instead. `Missing*` is used over the base type as
-  /// the base type would allow implicit conversion from a string literal,
-  /// which the above initializer doesn't support.
-  public init(
-      leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil,
-      backslash: TokenSyntax = .backslashToken(),
-      _ unexpectedBetweenBackslashAndRoot: UnexpectedNodesSyntax? = nil,
-      root: MissingTypeSyntax? = nil,
-      _ unexpectedBetweenRootAndComponents: UnexpectedNodesSyntax? = nil,
-      components: KeyPathComponentListSyntax,
-      _ unexpectedAfterComponents: UnexpectedNodesSyntax? = nil,
-      trailingTrivia: Trivia? = nil
-    
-  ) {
-    self.init(
-        leadingTrivia: leadingTrivia,
-        unexpectedBeforeBackslash,
-        backslash: backslash,
-        unexpectedBetweenBackslashAndRoot,
-        root: Optional<TypeSyntax> .none,
-        unexpectedBetweenRootAndComponents,
-        components: components,
-        unexpectedAfterComponents, 
-        trailingTrivia: trailingTrivia
-      )
   }
   
   public var unexpectedBeforeBackslash: UnexpectedNodesSyntax? {
@@ -3282,7 +3247,7 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil,
-      base: (some ExprSyntaxProtocol)? = nil,
+      base: (some ExprSyntaxProtocol)? = ExprSyntax?.none,
       _ unexpectedBetweenBaseAndDot: UnexpectedNodesSyntax? = nil,
       dot: TokenSyntax = .periodToken(),
       _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil,
@@ -3328,45 +3293,6 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
-  }
-  
-  /// This initializer exists solely because Swift 5.6 does not support
-  /// `Optional<ConcreteType>.none` as a default value of a generic parameter.
-  /// The above initializer thus defaults to `nil` instead, but that means it
-  /// is not actually callable when either not passing the defaulted parameter,
-  /// or passing `nil`.
-  ///
-  /// Hack around that limitation using this initializer, which takes a
-  /// `Missing*` syntax node instead. `Missing*` is used over the base type as
-  /// the base type would allow implicit conversion from a string literal,
-  /// which the above initializer doesn't support.
-  public init(
-      leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil,
-      base: MissingExprSyntax? = nil,
-      _ unexpectedBetweenBaseAndDot: UnexpectedNodesSyntax? = nil,
-      dot: TokenSyntax = .periodToken(),
-      _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil,
-      name: TokenSyntax,
-      _ unexpectedBetweenNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
-      declNameArguments: DeclNameArgumentsSyntax? = nil,
-      _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil,
-      trailingTrivia: Trivia? = nil
-    
-  ) {
-    self.init(
-        leadingTrivia: leadingTrivia,
-        unexpectedBeforeBase,
-        base: Optional<ExprSyntax> .none,
-        unexpectedBetweenBaseAndDot,
-        dot: dot,
-        unexpectedBetweenDotAndName,
-        name: name,
-        unexpectedBetweenNameAndDeclNameArguments,
-        declNameArguments: declNameArguments,
-        unexpectedAfterDeclNameArguments, 
-        trailingTrivia: trailingTrivia
-      )
   }
   
   public var unexpectedBeforeBase: UnexpectedNodesSyntax? {
@@ -4110,7 +4036,7 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil,
-      base: (some ExprSyntaxProtocol)? = nil,
+      base: (some ExprSyntaxProtocol)? = ExprSyntax?.none,
       _ unexpectedBetweenBaseAndConfig: UnexpectedNodesSyntax? = nil,
       config: IfConfigDeclSyntax,
       _ unexpectedAfterConfig: UnexpectedNodesSyntax? = nil,
@@ -4144,37 +4070,6 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
-  }
-  
-  /// This initializer exists solely because Swift 5.6 does not support
-  /// `Optional<ConcreteType>.none` as a default value of a generic parameter.
-  /// The above initializer thus defaults to `nil` instead, but that means it
-  /// is not actually callable when either not passing the defaulted parameter,
-  /// or passing `nil`.
-  ///
-  /// Hack around that limitation using this initializer, which takes a
-  /// `Missing*` syntax node instead. `Missing*` is used over the base type as
-  /// the base type would allow implicit conversion from a string literal,
-  /// which the above initializer doesn't support.
-  public init(
-      leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil,
-      base: MissingExprSyntax? = nil,
-      _ unexpectedBetweenBaseAndConfig: UnexpectedNodesSyntax? = nil,
-      config: IfConfigDeclSyntax,
-      _ unexpectedAfterConfig: UnexpectedNodesSyntax? = nil,
-      trailingTrivia: Trivia? = nil
-    
-  ) {
-    self.init(
-        leadingTrivia: leadingTrivia,
-        unexpectedBeforeBase,
-        base: Optional<ExprSyntax> .none,
-        unexpectedBetweenBaseAndConfig,
-        config: config,
-        unexpectedAfterConfig, 
-        trailingTrivia: trailingTrivia
-      )
   }
   
   public var unexpectedBeforeBase: UnexpectedNodesSyntax? {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -18,7 +18,7 @@
 public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .arrayExpr else {
       return nil
     }
@@ -179,7 +179,7 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .arrowExpr else {
       return nil
     }
@@ -295,7 +295,7 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .asExpr else {
       return nil
     }
@@ -310,16 +310,16 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol, T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndAsTok: UnexpectedNodesSyntax? = nil,
       asTok: TokenSyntax = .keyword(.as),
       _ unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil,
       questionOrExclamationMark: TokenSyntax? = nil,
       _ unexpectedBetweenQuestionOrExclamationMarkAndTypeName: UnexpectedNodesSyntax? = nil,
-      typeName: T,
+      typeName: some TypeSyntaxProtocol,
       _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -463,7 +463,7 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .assignmentExpr else {
       return nil
     }
@@ -541,7 +541,7 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .awaitExpr else {
       return nil
     }
@@ -556,12 +556,12 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeAwaitKeyword: UnexpectedNodesSyntax? = nil,
       awaitKeyword: TokenSyntax = .keyword(.await),
       _ unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -657,7 +657,7 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .binaryOperatorExpr else {
       return nil
     }
@@ -735,7 +735,7 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .booleanLiteralExpr else {
       return nil
     }
@@ -813,7 +813,7 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .borrowExpr else {
       return nil
     }
@@ -828,12 +828,12 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBorrowKeyword: UnexpectedNodesSyntax? = nil,
       borrowKeyword: TokenSyntax = .keyword(._borrow),
       _ unexpectedBetweenBorrowKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -929,7 +929,7 @@ public struct BorrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureExpr else {
       return nil
     }
@@ -1139,7 +1139,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       self = .elements(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(TokenSyntax.self) {
         self = .colon(node)
         return
@@ -1158,7 +1158,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .dictionaryExpr else {
       return nil
     }
@@ -1300,7 +1300,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .discardAssignmentExpr else {
       return nil
     }
@@ -1378,7 +1378,7 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .editorPlaceholderExpr else {
       return nil
     }
@@ -1456,7 +1456,7 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .floatLiteralExpr else {
       return nil
     }
@@ -1534,7 +1534,7 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .forcedValueExpr else {
       return nil
     }
@@ -1549,10 +1549,10 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndExclamationMark: UnexpectedNodesSyntax? = nil,
       exclamationMark: TokenSyntax = .exclamationMarkToken(),
       _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil,
@@ -1650,7 +1650,7 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .functionCallExpr else {
       return nil
     }
@@ -1665,10 +1665,10 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<C: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeCalledExpression: UnexpectedNodesSyntax? = nil,
-      calledExpression: C,
+      calledExpression: some ExprSyntaxProtocol,
       _ unexpectedBetweenCalledExpressionAndLeftParen: UnexpectedNodesSyntax? = nil,
       leftParen: TokenSyntax? = nil,
       _ unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? = nil,
@@ -1908,7 +1908,7 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .identifierExpr else {
       return nil
     }
@@ -2047,7 +2047,7 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       self = .codeBlock(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(IfExprSyntax.self) {
         self = .ifExpr(node)
         return
@@ -2066,7 +2066,7 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .ifExpr else {
       return nil
     }
@@ -2279,7 +2279,7 @@ public struct IfExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .inOutExpr else {
       return nil
     }
@@ -2294,12 +2294,12 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeAmpersand: UnexpectedNodesSyntax? = nil,
       ampersand: TokenSyntax = .prefixAmpersandToken(),
       _ unexpectedBetweenAmpersandAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -2395,7 +2395,7 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .infixOperatorExpr else {
       return nil
     }
@@ -2410,14 +2410,14 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<L: ExprSyntaxProtocol, O: ExprSyntaxProtocol, R: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLeftOperand: UnexpectedNodesSyntax? = nil,
-      leftOperand: L,
+      leftOperand: some ExprSyntaxProtocol,
       _ unexpectedBetweenLeftOperandAndOperatorOperand: UnexpectedNodesSyntax? = nil,
-      operatorOperand: O,
+      operatorOperand: some ExprSyntaxProtocol,
       _ unexpectedBetweenOperatorOperandAndRightOperand: UnexpectedNodesSyntax? = nil,
-      rightOperand: R,
+      rightOperand: some ExprSyntaxProtocol,
       _ unexpectedAfterRightOperand: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -2537,7 +2537,7 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .integerLiteralExpr else {
       return nil
     }
@@ -2615,7 +2615,7 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .isExpr else {
       return nil
     }
@@ -2630,14 +2630,14 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol, T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndIsTok: UnexpectedNodesSyntax? = nil,
       isTok: TokenSyntax = .keyword(.is),
       _ unexpectedBetweenIsTokAndTypeName: UnexpectedNodesSyntax? = nil,
-      typeName: T,
+      typeName: some TypeSyntaxProtocol,
       _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -2757,7 +2757,7 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .keyPathExpr else {
       return nil
     }
@@ -2772,12 +2772,12 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<R: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil,
       backslash: TokenSyntax = .backslashToken(),
       _ unexpectedBetweenBackslashAndRoot: UnexpectedNodesSyntax? = nil,
-      root: R? = nil,
+      root: (some TypeSyntaxProtocol)? = nil,
       _ unexpectedBetweenRootAndComponents: UnexpectedNodesSyntax? = nil,
       components: KeyPathComponentListSyntax,
       _ unexpectedAfterComponents: UnexpectedNodesSyntax? = nil,
@@ -2953,7 +2953,7 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .macroExpansionExpr else {
       return nil
     }
@@ -3264,7 +3264,7 @@ public struct MacroExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .memberAccessExpr else {
       return nil
     }
@@ -3279,10 +3279,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil,
-      base: B? = nil,
+      base: (some ExprSyntaxProtocol)? = nil,
       _ unexpectedBetweenBaseAndDot: UnexpectedNodesSyntax? = nil,
       dot: TokenSyntax = .periodToken(),
       _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil,
@@ -3471,7 +3471,7 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .missingExpr else {
       return nil
     }
@@ -3550,7 +3550,7 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .moveExpr else {
       return nil
     }
@@ -3565,12 +3565,12 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeMoveKeyword: UnexpectedNodesSyntax? = nil,
       moveKeyword: TokenSyntax,
       _ unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -3666,7 +3666,7 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .nilLiteralExpr else {
       return nil
     }
@@ -3744,7 +3744,7 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .optionalChainingExpr else {
       return nil
     }
@@ -3759,10 +3759,10 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndQuestionMark: UnexpectedNodesSyntax? = nil,
       questionMark: TokenSyntax = .postfixQuestionMarkToken(),
       _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil,
@@ -3860,7 +3860,7 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .packElementExpr else {
       return nil
     }
@@ -3875,12 +3875,12 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeEachKeyword: UnexpectedNodesSyntax? = nil,
       eachKeyword: TokenSyntax = .keyword(.each),
       _ unexpectedBetweenEachKeywordAndPackRefExpr: UnexpectedNodesSyntax? = nil,
-      packRefExpr: P,
+      packRefExpr: some ExprSyntaxProtocol,
       _ unexpectedAfterPackRefExpr: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -3976,7 +3976,7 @@ public struct PackElementExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .packExpansionExpr else {
       return nil
     }
@@ -3991,12 +3991,12 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeRepeatKeyword: UnexpectedNodesSyntax? = nil,
       repeatKeyword: TokenSyntax = .keyword(.repeat),
       _ unexpectedBetweenRepeatKeywordAndPatternExpr: UnexpectedNodesSyntax? = nil,
-      patternExpr: P,
+      patternExpr: some ExprSyntaxProtocol,
       _ unexpectedAfterPatternExpr: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -4092,7 +4092,7 @@ public struct PackExpansionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .postfixIfConfigExpr else {
       return nil
     }
@@ -4107,10 +4107,10 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil,
-      base: B? = nil,
+      base: (some ExprSyntaxProtocol)? = nil,
       _ unexpectedBetweenBaseAndConfig: UnexpectedNodesSyntax? = nil,
       config: IfConfigDeclSyntax,
       _ unexpectedAfterConfig: UnexpectedNodesSyntax? = nil,
@@ -4239,7 +4239,7 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .postfixUnaryExpr else {
       return nil
     }
@@ -4254,10 +4254,10 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndOperatorToken: UnexpectedNodesSyntax? = nil,
       operatorToken: TokenSyntax,
       _ unexpectedAfterOperatorToken: UnexpectedNodesSyntax? = nil,
@@ -4355,7 +4355,7 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .prefixOperatorExpr else {
       return nil
     }
@@ -4370,12 +4370,12 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeOperatorToken: UnexpectedNodesSyntax? = nil,
       operatorToken: TokenSyntax? = nil,
       _ unexpectedBetweenOperatorTokenAndPostfixExpression: UnexpectedNodesSyntax? = nil,
-      postfixExpression: P,
+      postfixExpression: some ExprSyntaxProtocol,
       _ unexpectedAfterPostfixExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -4471,7 +4471,7 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .regexLiteralExpr else {
       return nil
     }
@@ -4665,7 +4665,7 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .sequenceExpr else {
       return nil
     }
@@ -4762,7 +4762,7 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .specializeExpr else {
       return nil
     }
@@ -4777,10 +4777,10 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
       genericArgumentClause: GenericArgumentClauseSyntax,
       _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil,
@@ -4878,7 +4878,7 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .stringLiteralExpr else {
       return nil
     }
@@ -5091,7 +5091,7 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .subscriptExpr else {
       return nil
     }
@@ -5106,10 +5106,10 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<C: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeCalledExpression: UnexpectedNodesSyntax? = nil,
-      calledExpression: C,
+      calledExpression: some ExprSyntaxProtocol,
       _ unexpectedBetweenCalledExpressionAndLeftBracket: UnexpectedNodesSyntax? = nil,
       leftBracket: TokenSyntax = .leftSquareBracketToken(),
       _ unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodesSyntax? = nil,
@@ -5349,7 +5349,7 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .superRefExpr else {
       return nil
     }
@@ -5427,7 +5427,7 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .switchExpr else {
       return nil
     }
@@ -5442,12 +5442,12 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeSwitchKeyword: UnexpectedNodesSyntax? = nil,
       switchKeyword: TokenSyntax = .keyword(.switch),
       _ unexpectedBetweenSwitchKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndLeftBrace: UnexpectedNodesSyntax? = nil,
       leftBrace: TokenSyntax = .leftBraceToken(),
       _ unexpectedBetweenLeftBraceAndCases: UnexpectedNodesSyntax? = nil,
@@ -5640,7 +5640,7 @@ public struct SwitchExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .ternaryExpr else {
       return nil
     }
@@ -5655,18 +5655,18 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<C: ExprSyntaxProtocol, F: ExprSyntaxProtocol, S: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeConditionExpression: UnexpectedNodesSyntax? = nil,
-      conditionExpression: C,
+      conditionExpression: some ExprSyntaxProtocol,
       _ unexpectedBetweenConditionExpressionAndQuestionMark: UnexpectedNodesSyntax? = nil,
       questionMark: TokenSyntax = .infixQuestionMarkToken(),
       _ unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? = nil,
-      firstChoice: F,
+      firstChoice: some ExprSyntaxProtocol,
       _ unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? = nil,
       colonMark: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonMarkAndSecondChoice: UnexpectedNodesSyntax? = nil,
-      secondChoice: S,
+      secondChoice: some ExprSyntaxProtocol,
       _ unexpectedAfterSecondChoice: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -5834,7 +5834,7 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tryExpr else {
       return nil
     }
@@ -5849,14 +5849,14 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeTryKeyword: UnexpectedNodesSyntax? = nil,
       tryKeyword: TokenSyntax = .keyword(.try),
       _ unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil,
       questionOrExclamationMark: TokenSyntax? = nil,
       _ unexpectedBetweenQuestionOrExclamationMarkAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -5976,7 +5976,7 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tupleExpr else {
       return nil
     }
@@ -6137,7 +6137,7 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .typeExpr else {
       return nil
     }
@@ -6152,10 +6152,10 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedAfterType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -6215,7 +6215,7 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .unresolvedAsExpr else {
       return nil
     }
@@ -6331,7 +6331,7 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .unresolvedIsExpr else {
       return nil
     }
@@ -6409,7 +6409,7 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .unresolvedPatternExpr else {
       return nil
     }
@@ -6424,10 +6424,10 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil,
-      pattern: P,
+      pattern: some PatternSyntaxProtocol,
       _ unexpectedAfterPattern: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -6487,7 +6487,7 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .unresolvedTernaryExpr else {
       return nil
     }
@@ -6502,12 +6502,12 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<F: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeQuestionMark: UnexpectedNodesSyntax? = nil,
       questionMark: TokenSyntax = .infixQuestionMarkToken(),
       _ unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? = nil,
-      firstChoice: F,
+      firstChoice: some ExprSyntaxProtocol,
       _ unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? = nil,
       colonMark: TokenSyntax = .colonToken(),
       _ unexpectedAfterColonMark: UnexpectedNodesSyntax? = nil,

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -18,7 +18,7 @@
 public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .accessPathComponent else {
       return nil
     }
@@ -134,7 +134,7 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .accessorBlock else {
       return nil
     }
@@ -295,7 +295,7 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
 public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .accessorEffectSpecifiers else {
       return nil
     }
@@ -411,7 +411,7 @@ public struct AccessorEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .accessorParameter else {
       return nil
     }
@@ -553,7 +553,7 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .arrayElement else {
       return nil
     }
@@ -568,10 +568,10 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -818,7 +818,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       self = .documentationArguments(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(TupleExprElementListSyntax.self) {
         self = .argumentList(node)
         return
@@ -930,7 +930,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .attribute else {
       return nil
     }
@@ -945,12 +945,12 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<A: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeAtSignToken: UnexpectedNodesSyntax? = nil,
       atSignToken: TokenSyntax = .atSignToken(),
       _ unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodesSyntax? = nil,
-      attributeName: A,
+      attributeName: some TypeSyntaxProtocol,
       _ unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodesSyntax? = nil,
       leftParen: TokenSyntax? = nil,
       _ unexpectedBetweenLeftParenAndArgument: UnexpectedNodesSyntax? = nil,
@@ -1159,7 +1159,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
       self = .availabilityLabeledArgument(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(TokenSyntax.self) {
         self = .token(node)
         return
@@ -1182,7 +1182,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilityArgument else {
       return nil
     }
@@ -1300,7 +1300,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilityCondition else {
       return nil
     }
@@ -1487,7 +1487,7 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
 public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilityEntry else {
       return nil
     }
@@ -1699,7 +1699,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
       self = .version(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(StringLiteralExprSyntax.self) {
         self = .string(node)
         return
@@ -1718,7 +1718,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilityLabeledArgument else {
       return nil
     }
@@ -1863,7 +1863,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
 public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilityVersionRestrictionListEntry else {
       return nil
     }
@@ -1980,7 +1980,7 @@ public struct AvailabilityVersionRestrictionListEntrySyntax: SyntaxProtocol, Syn
 public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .availabilityVersionRestriction else {
       return nil
     }
@@ -2097,7 +2097,7 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
 public struct BackDeployedAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .backDeployedAttributeSpecList else {
       return nil
     }
@@ -2261,7 +2261,7 @@ public struct BackDeployedAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashabl
 public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .caseItem else {
       return nil
     }
@@ -2276,10 +2276,10 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil,
-      pattern: P,
+      pattern: some PatternSyntaxProtocol,
       _ unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? = nil,
       whereClause: WhereClauseSyntax? = nil,
       _ unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -2403,7 +2403,7 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
 public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .catchClause else {
       return nil
     }
@@ -2564,7 +2564,7 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .catchItem else {
       return nil
     }
@@ -2579,10 +2579,10 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil,
-      pattern: P? = nil,
+      pattern: (some PatternSyntaxProtocol)? = nil,
       _ unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? = nil,
       whereClause: WhereClauseSyntax? = nil,
       _ unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -2741,7 +2741,7 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureCaptureItemSpecifier else {
       return nil
     }
@@ -2909,7 +2909,7 @@ public struct ClosureCaptureItemSpecifierSyntax: SyntaxProtocol, SyntaxHashable 
 public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureCaptureItem else {
       return nil
     }
@@ -2924,7 +2924,7 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeSpecifier: UnexpectedNodesSyntax? = nil,
       specifier: ClosureCaptureItemSpecifierSyntax? = nil,
@@ -2933,7 +2933,7 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenNameAndAssignToken: UnexpectedNodesSyntax? = nil,
       assignToken: TokenSyntax? = nil,
       _ unexpectedBetweenAssignTokenAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -3103,7 +3103,7 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureCaptureSignature else {
       return nil
     }
@@ -3264,7 +3264,7 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureParam else {
       return nil
     }
@@ -3380,7 +3380,7 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureParameterClause else {
       return nil
     }
@@ -3544,7 +3544,7 @@ public struct ClosureParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureParameter else {
       return nil
     }
@@ -3559,7 +3559,7 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
       attributes: AttributeListSyntax? = nil,
@@ -3572,7 +3572,7 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax? = nil,
       _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil,
-      type: T? = nil,
+      type: (some TypeSyntaxProtocol)? = nil,
       _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil,
       ellipsis: TokenSyntax? = nil,
       _ unexpectedBetweenEllipsisAndTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -3938,7 +3938,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       self = .input(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(ClosureParamListSyntax.self) {
         self = .simpleInput(node)
         return
@@ -3957,7 +3957,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .closureSignature else {
       return nil
     }
@@ -4214,19 +4214,19 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
       self.init(Syntax(data))!
     }
     
-    public init<Node: DeclSyntaxProtocol>(_ node: Node) {
+    public init(_ node: some DeclSyntaxProtocol) {
       self = .decl(DeclSyntax(node))
     }
     
-    public init<Node: StmtSyntaxProtocol>(_ node: Node) {
+    public init(_ node: some StmtSyntaxProtocol) {
       self = .stmt(StmtSyntax(node))
     }
     
-    public init<Node: ExprSyntaxProtocol>(_ node: Node) {
+    public init(_ node: some ExprSyntaxProtocol) {
       self = .expr(ExprSyntax(node))
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(DeclSyntax.self) {
         self = .decl(node)
         return
@@ -4249,7 +4249,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .codeBlockItem else {
       return nil
     }
@@ -4367,7 +4367,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
 public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .codeBlock else {
       return nil
     }
@@ -4528,7 +4528,7 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
 public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .compositionTypeElement else {
       return nil
     }
@@ -4543,10 +4543,10 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeAndAmpersand: UnexpectedNodesSyntax? = nil,
       ampersand: TokenSyntax? = nil,
       _ unexpectedAfterAmpersand: UnexpectedNodesSyntax? = nil,
@@ -4665,7 +4665,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
       self.init(Syntax(data))!
     }
     
-    public init<Node: ExprSyntaxProtocol>(_ node: Node) {
+    public init(_ node: some ExprSyntaxProtocol) {
       self = .expression(ExprSyntax(node))
     }
     
@@ -4681,7 +4681,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
       self = .optionalBinding(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(ExprSyntax.self) {
         self = .expression(node)
         return
@@ -4713,7 +4713,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .conditionElement else {
       return nil
     }
@@ -4829,7 +4829,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .conformanceRequirement else {
       return nil
     }
@@ -4844,14 +4844,14 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<L: TypeSyntaxProtocol, R: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLeftTypeIdentifier: UnexpectedNodesSyntax? = nil,
-      leftTypeIdentifier: L,
+      leftTypeIdentifier: some TypeSyntaxProtocol,
       _ unexpectedBetweenLeftTypeIdentifierAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndRightTypeIdentifier: UnexpectedNodesSyntax? = nil,
-      rightTypeIdentifier: R,
+      rightTypeIdentifier: some TypeSyntaxProtocol,
       _ unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -4971,7 +4971,7 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .conventionAttributeArguments else {
       return nil
     }
@@ -5166,7 +5166,7 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .conventionWitnessMethodAttributeArguments else {
       return nil
     }
@@ -5308,7 +5308,7 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
 public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .declModifierDetail else {
       return nil
     }
@@ -5450,7 +5450,7 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .declModifier else {
       return nil
     }
@@ -5566,7 +5566,7 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .declNameArgument else {
       return nil
     }
@@ -5682,7 +5682,7 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .declNameArguments else {
       return nil
     }
@@ -5843,7 +5843,7 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .declName else {
       return nil
     }
@@ -5961,7 +5961,7 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .derivativeRegistrationAttributeArguments else {
       return nil
     }
@@ -6212,7 +6212,7 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
 public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .designatedTypeElement else {
       return nil
     }
@@ -6328,7 +6328,7 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .dictionaryElement else {
       return nil
     }
@@ -6343,14 +6343,14 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<K: ExprSyntaxProtocol, V: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeKeyExpression: UnexpectedNodesSyntax? = nil,
-      keyExpression: K,
+      keyExpression: some ExprSyntaxProtocol,
       _ unexpectedBetweenKeyExpressionAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndValueExpression: UnexpectedNodesSyntax? = nil,
-      valueExpression: V,
+      valueExpression: some ExprSyntaxProtocol,
       _ unexpectedBetweenValueExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -6496,7 +6496,7 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .differentiabilityParam else {
       return nil
     }
@@ -6635,7 +6635,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
       self = .parameterList(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(DifferentiabilityParamSyntax.self) {
         self = .parameter(node)
         return
@@ -6654,7 +6654,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .differentiabilityParamsClause else {
       return nil
     }
@@ -6798,7 +6798,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
 public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .differentiabilityParams else {
       return nil
     }
@@ -6960,7 +6960,7 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
 public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .differentiableAttributeArguments else {
       return nil
     }
@@ -7179,7 +7179,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
       self = .string(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(TokenSyntax.self) {
         self = .token(node)
         return
@@ -7198,7 +7198,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .documentationAttributeArgument else {
       return nil
     }
@@ -7367,7 +7367,7 @@ public struct DocumentationAttributeArgumentSyntax: SyntaxProtocol, SyntaxHashab
 public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .dynamicReplacementArguments else {
       return nil
     }
@@ -7509,7 +7509,7 @@ public struct DynamicReplacementArgumentsSyntax: SyntaxProtocol, SyntaxHashable 
 public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseElement else {
       return nil
     }
@@ -7681,7 +7681,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseParameterClause else {
       return nil
     }
@@ -7845,7 +7845,7 @@ public struct EnumCaseParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .enumCaseParameter else {
       return nil
     }
@@ -7860,7 +7860,7 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeModifiers: UnexpectedNodesSyntax? = nil,
       modifiers: ModifierListSyntax? = nil,
@@ -7871,7 +7871,7 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax? = nil,
       _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeAndDefaultArgument: UnexpectedNodesSyntax? = nil,
       defaultArgument: InitializerClauseSyntax? = nil,
       _ unexpectedBetweenDefaultArgumentAndTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -8114,7 +8114,7 @@ public struct EnumCaseParameterSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .exposeAttributeArguments else {
       return nil
     }
@@ -8256,7 +8256,7 @@ public struct ExposeAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .expressionSegment else {
       return nil
     }
@@ -8469,7 +8469,7 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .functionEffectSpecifiers else {
       return nil
     }
@@ -8585,7 +8585,7 @@ public struct FunctionEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .functionParameter else {
       return nil
     }
@@ -8600,7 +8600,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
       attributes: AttributeListSyntax? = nil,
@@ -8613,7 +8613,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil,
       ellipsis: TokenSyntax? = nil,
       _ unexpectedBetweenEllipsisAndDefaultArgument: UnexpectedNodesSyntax? = nil,
@@ -8921,7 +8921,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
 public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .functionSignature else {
       return nil
     }
@@ -9063,7 +9063,7 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericArgumentClause else {
       return nil
     }
@@ -9224,7 +9224,7 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericArgument else {
       return nil
     }
@@ -9239,10 +9239,10 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<A: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeArgumentType: UnexpectedNodesSyntax? = nil,
-      argumentType: A,
+      argumentType: some TypeSyntaxProtocol,
       _ unexpectedBetweenArgumentTypeAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -9340,7 +9340,7 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericParameterClause else {
       return nil
     }
@@ -9527,7 +9527,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericParameter else {
       return nil
     }
@@ -9542,7 +9542,7 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<I: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
       attributes: AttributeListSyntax? = nil,
@@ -9553,7 +9553,7 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax? = nil,
       _ unexpectedBetweenColonAndInheritedType: UnexpectedNodesSyntax? = nil,
-      inheritedType: I? = nil,
+      inheritedType: (some TypeSyntaxProtocol)? = nil,
       _ unexpectedBetweenInheritedTypeAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -9843,7 +9843,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       self = .layoutRequirement(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(SameTypeRequirementSyntax.self) {
         self = .sameTypeRequirement(node)
         return
@@ -9866,7 +9866,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericRequirement else {
       return nil
     }
@@ -9982,7 +9982,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .genericWhereClause else {
       return nil
     }
@@ -10153,7 +10153,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       self = .decls(node)
     }
     
-    public init<Node: ExprSyntaxProtocol>(_ node: Node) {
+    public init(_ node: some ExprSyntaxProtocol) {
       self = .postfixExpression(ExprSyntax(node))
     }
     
@@ -10161,7 +10161,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       self = .attributes(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(CodeBlockItemListSyntax.self) {
         self = .statements(node)
         return
@@ -10198,7 +10198,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .ifConfigClause else {
       return nil
     }
@@ -10213,12 +10213,12 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<C: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforePoundKeyword: UnexpectedNodesSyntax? = nil,
       poundKeyword: TokenSyntax,
       _ unexpectedBetweenPoundKeywordAndCondition: UnexpectedNodesSyntax? = nil,
-      condition: C? = nil,
+      condition: (some ExprSyntaxProtocol)? = nil,
       _ unexpectedBetweenConditionAndElements: UnexpectedNodesSyntax? = nil,
       elements: Elements? = nil,
       _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil,
@@ -10375,7 +10375,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .implementsAttributeArguments else {
       return nil
     }
@@ -10390,10 +10390,10 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeAndComma: UnexpectedNodesSyntax? = nil,
       comma: TokenSyntax = .commaToken(),
       _ unexpectedBetweenCommaAndDeclBaseName: UnexpectedNodesSyntax? = nil,
@@ -10547,7 +10547,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .inheritedType else {
       return nil
     }
@@ -10562,10 +10562,10 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeTypeName: UnexpectedNodesSyntax? = nil,
-      typeName: T,
+      typeName: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeNameAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -10663,7 +10663,7 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .initializerClause else {
       return nil
     }
@@ -10678,12 +10678,12 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<V: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeEqual: UnexpectedNodesSyntax? = nil,
       equal: TokenSyntax = .equalToken(),
       _ unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? = nil,
-      value: V,
+      value: some ExprSyntaxProtocol,
       _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -10809,7 +10809,7 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
       self = .optional(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(KeyPathPropertyComponentSyntax.self) {
         self = .property(node)
         return
@@ -10832,7 +10832,7 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .keyPathComponent else {
       return nil
     }
@@ -10948,7 +10948,7 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .keyPathOptionalComponent else {
       return nil
     }
@@ -11026,7 +11026,7 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .keyPathPropertyComponent else {
       return nil
     }
@@ -11168,7 +11168,7 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .keyPathSubscriptComponent else {
       return nil
     }
@@ -11329,7 +11329,7 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .labeledSpecializeEntry else {
       return nil
     }
@@ -11501,7 +11501,7 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
 public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .layoutRequirement else {
       return nil
     }
@@ -11516,10 +11516,10 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeTypeIdentifier: UnexpectedNodesSyntax? = nil,
-      typeIdentifier: T,
+      typeIdentifier: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeIdentifierAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndLayoutConstraint: UnexpectedNodesSyntax? = nil,
@@ -11773,7 +11773,7 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .matchingPatternCondition else {
       return nil
     }
@@ -11788,12 +11788,12 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeCaseKeyword: UnexpectedNodesSyntax? = nil,
       caseKeyword: TokenSyntax = .keyword(.case),
       _ unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodesSyntax? = nil,
-      pattern: P,
+      pattern: some PatternSyntaxProtocol,
       _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil,
       typeAnnotation: TypeAnnotationSyntax? = nil,
       _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil,
@@ -11941,7 +11941,7 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
 public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .memberDeclBlock else {
       return nil
     }
@@ -12102,7 +12102,7 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
 public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .memberDeclListItem else {
       return nil
     }
@@ -12117,10 +12117,10 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<D: DeclSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeDecl: UnexpectedNodesSyntax? = nil,
-      decl: D,
+      decl: some DeclSyntaxProtocol,
       _ unexpectedBetweenDeclAndSemicolon: UnexpectedNodesSyntax? = nil,
       semicolon: TokenSyntax? = nil,
       _ unexpectedAfterSemicolon: UnexpectedNodesSyntax? = nil,
@@ -12220,7 +12220,7 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
 public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .missing else {
       return nil
     }
@@ -12299,7 +12299,7 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
 public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .multipleTrailingClosureElement else {
       return nil
     }
@@ -12441,7 +12441,7 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
 public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .objCSelectorPiece else {
       return nil
     }
@@ -12557,7 +12557,7 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
 public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .opaqueReturnTypeOfAttributeArguments else {
       return nil
     }
@@ -12701,7 +12701,7 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
 public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .operatorPrecedenceAndTypes else {
       return nil
     }
@@ -12864,7 +12864,7 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
 public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .optionalBindingCondition else {
       return nil
     }
@@ -12879,12 +12879,12 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBindingKeyword: UnexpectedNodesSyntax? = nil,
       bindingKeyword: TokenSyntax,
       _ unexpectedBetweenBindingKeywordAndPattern: UnexpectedNodesSyntax? = nil,
-      pattern: P,
+      pattern: some PatternSyntaxProtocol,
       _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil,
       typeAnnotation: TypeAnnotationSyntax? = nil,
       _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil,
@@ -13032,7 +13032,7 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
 public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .originallyDefinedInArguments else {
       return nil
     }
@@ -13245,7 +13245,7 @@ public struct OriginallyDefinedInArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .parameterClause else {
       return nil
     }
@@ -13429,7 +13429,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       self = .getter(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(AccessorBlockSyntax.self) {
         self = .accessors(node)
         return
@@ -13448,7 +13448,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .patternBinding else {
       return nil
     }
@@ -13463,10 +13463,10 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil,
-      pattern: P,
+      pattern: some PatternSyntaxProtocol,
       _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil,
       typeAnnotation: TypeAnnotationSyntax? = nil,
       _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil,
@@ -13642,7 +13642,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
 public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .poundSourceLocationArgs else {
       return nil
     }
@@ -13888,7 +13888,7 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
 public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupAssignment else {
       return nil
     }
@@ -14031,7 +14031,7 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupAssociativity else {
       return nil
     }
@@ -14174,7 +14174,7 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
 public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupNameElement else {
       return nil
     }
@@ -14290,7 +14290,7 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .precedenceGroupRelation else {
       return nil
     }
@@ -14453,7 +14453,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
 public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .primaryAssociatedTypeClause else {
       return nil
     }
@@ -14614,7 +14614,7 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
 public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .primaryAssociatedType else {
       return nil
     }
@@ -14730,7 +14730,7 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .qualifiedDeclName else {
       return nil
     }
@@ -14745,10 +14745,10 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil,
-      baseType: B? = nil,
+      baseType: (some TypeSyntaxProtocol)? = nil,
       _ unexpectedBetweenBaseTypeAndDot: UnexpectedNodesSyntax? = nil,
       dot: TokenSyntax? = nil,
       _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil,
@@ -14940,7 +14940,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .returnClause else {
       return nil
     }
@@ -14955,12 +14955,12 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<R: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeArrow: UnexpectedNodesSyntax? = nil,
       arrow: TokenSyntax = .arrowToken(),
       _ unexpectedBetweenArrowAndReturnType: UnexpectedNodesSyntax? = nil,
-      returnType: R,
+      returnType: some TypeSyntaxProtocol,
       _ unexpectedAfterReturnType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -15056,7 +15056,7 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .sameTypeRequirement else {
       return nil
     }
@@ -15071,14 +15071,14 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<L: TypeSyntaxProtocol, R: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLeftTypeIdentifier: UnexpectedNodesSyntax? = nil,
-      leftTypeIdentifier: L,
+      leftTypeIdentifier: some TypeSyntaxProtocol,
       _ unexpectedBetweenLeftTypeIdentifierAndEqualityToken: UnexpectedNodesSyntax? = nil,
       equalityToken: TokenSyntax,
       _ unexpectedBetweenEqualityTokenAndRightTypeIdentifier: UnexpectedNodesSyntax? = nil,
-      rightTypeIdentifier: R,
+      rightTypeIdentifier: some TypeSyntaxProtocol,
       _ unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -15198,7 +15198,7 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .sourceFile else {
       return nil
     }
@@ -15333,7 +15333,7 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
 public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .stringSegment else {
       return nil
     }
@@ -15411,7 +15411,7 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .switchCaseLabel else {
       return nil
     }
@@ -15595,7 +15595,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
       self = .case(node)
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(SwitchDefaultLabelSyntax.self) {
         self = .default(node)
         return
@@ -15614,7 +15614,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .switchCase else {
       return nil
     }
@@ -15775,7 +15775,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .switchDefaultLabel else {
       return nil
     }
@@ -15891,7 +15891,7 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
 public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .targetFunctionEntry else {
       return nil
     }
@@ -16063,7 +16063,7 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
 public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tupleExprElement else {
       return nil
     }
@@ -16078,14 +16078,14 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil,
       label: TokenSyntax? = nil,
       _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax? = nil,
       _ unexpectedBetweenColonAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -16231,7 +16231,7 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tuplePatternElement else {
       return nil
     }
@@ -16246,14 +16246,14 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLabelName: UnexpectedNodesSyntax? = nil,
       labelName: TokenSyntax? = nil,
       _ unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? = nil,
       labelColon: TokenSyntax? = nil,
       _ unexpectedBetweenLabelColonAndPattern: UnexpectedNodesSyntax? = nil,
-      pattern: P,
+      pattern: some PatternSyntaxProtocol,
       _ unexpectedBetweenPatternAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -16399,7 +16399,7 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tupleTypeElement else {
       return nil
     }
@@ -16414,7 +16414,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeInOut: UnexpectedNodesSyntax? = nil,
       inOut: TokenSyntax? = nil,
@@ -16425,7 +16425,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax? = nil,
       _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil,
       ellipsis: TokenSyntax? = nil,
       _ unexpectedBetweenEllipsisAndInitializer: UnexpectedNodesSyntax? = nil,
@@ -16671,7 +16671,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .typeAnnotation else {
       return nil
     }
@@ -16686,12 +16686,12 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedAfterType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -16787,7 +16787,7 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
 public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .typeEffectSpecifiers else {
       return nil
     }
@@ -16903,7 +16903,7 @@ public struct TypeEffectSpecifiersSyntax: SyntaxProtocol, SyntaxHashable {
 public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .typeInheritanceClause else {
       return nil
     }
@@ -17038,7 +17038,7 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .typeInitializerClause else {
       return nil
     }
@@ -17053,12 +17053,12 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<V: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeEqual: UnexpectedNodesSyntax? = nil,
       equal: TokenSyntax = .equalToken(),
       _ unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? = nil,
-      value: V,
+      value: some TypeSyntaxProtocol,
       _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -17154,7 +17154,7 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .unavailableFromAsyncArguments else {
       return nil
     }
@@ -17296,7 +17296,7 @@ public struct UnavailableFromAsyncArgumentsSyntax: SyntaxProtocol, SyntaxHashabl
 public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .underscorePrivateAttributeArguments else {
       return nil
     }
@@ -17438,7 +17438,7 @@ public struct UnderscorePrivateAttributeArgumentsSyntax: SyntaxProtocol, SyntaxH
 public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .versionTuple else {
       return nil
     }
@@ -17637,7 +17637,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
 public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .whereClause else {
       return nil
     }
@@ -17652,12 +17652,12 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<G: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeWhereKeyword: UnexpectedNodesSyntax? = nil,
       whereKeyword: TokenSyntax = .keyword(.where),
       _ unexpectedBetweenWhereKeywordAndGuardResult: UnexpectedNodesSyntax? = nil,
-      guardResult: G,
+      guardResult: some ExprSyntaxProtocol,
       _ unexpectedAfterGuardResult: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -17753,7 +17753,7 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .yieldExprListElement else {
       return nil
     }
@@ -17768,10 +17768,10 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedBetweenExpressionAndComma: UnexpectedNodesSyntax? = nil,
       comma: TokenSyntax? = nil,
       _ unexpectedAfterComma: UnexpectedNodesSyntax? = nil,
@@ -17869,7 +17869,7 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
 public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .yieldList else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -2582,7 +2582,7 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil,
-      pattern: (some PatternSyntaxProtocol)? = nil,
+      pattern: (some PatternSyntaxProtocol)? = PatternSyntax?.none,
       _ unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? = nil,
       whereClause: WhereClauseSyntax? = nil,
       _ unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -2622,41 +2622,6 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
-  }
-  
-  /// This initializer exists solely because Swift 5.6 does not support
-  /// `Optional<ConcreteType>.none` as a default value of a generic parameter.
-  /// The above initializer thus defaults to `nil` instead, but that means it
-  /// is not actually callable when either not passing the defaulted parameter,
-  /// or passing `nil`.
-  ///
-  /// Hack around that limitation using this initializer, which takes a
-  /// `Missing*` syntax node instead. `Missing*` is used over the base type as
-  /// the base type would allow implicit conversion from a string literal,
-  /// which the above initializer doesn't support.
-  public init(
-      leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil,
-      pattern: MissingPatternSyntax? = nil,
-      _ unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? = nil,
-      whereClause: WhereClauseSyntax? = nil,
-      _ unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? = nil,
-      trailingComma: TokenSyntax? = nil,
-      _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
-      trailingTrivia: Trivia? = nil
-    
-  ) {
-    self.init(
-        leadingTrivia: leadingTrivia,
-        unexpectedBeforePattern,
-        pattern: Optional<PatternSyntax> .none,
-        unexpectedBetweenPatternAndWhereClause,
-        whereClause: whereClause,
-        unexpectedBetweenWhereClauseAndTrailingComma,
-        trailingComma: trailingComma,
-        unexpectedAfterTrailingComma, 
-        trailingTrivia: trailingTrivia
-      )
   }
   
   public var unexpectedBeforePattern: UnexpectedNodesSyntax? {
@@ -3572,7 +3537,7 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax? = nil,
       _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil,
-      type: (some TypeSyntaxProtocol)? = nil,
+      type: (some TypeSyntaxProtocol)? = TypeSyntax?.none,
       _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil,
       ellipsis: TokenSyntax? = nil,
       _ unexpectedBetweenEllipsisAndTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -3632,61 +3597,6 @@ public struct ClosureParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
-  }
-  
-  /// This initializer exists solely because Swift 5.6 does not support
-  /// `Optional<ConcreteType>.none` as a default value of a generic parameter.
-  /// The above initializer thus defaults to `nil` instead, but that means it
-  /// is not actually callable when either not passing the defaulted parameter,
-  /// or passing `nil`.
-  ///
-  /// Hack around that limitation using this initializer, which takes a
-  /// `Missing*` syntax node instead. `Missing*` is used over the base type as
-  /// the base type would allow implicit conversion from a string literal,
-  /// which the above initializer doesn't support.
-  public init(
-      leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-      attributes: AttributeListSyntax? = nil,
-      _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-      modifiers: ModifierListSyntax? = nil,
-      _ unexpectedBetweenModifiersAndFirstName: UnexpectedNodesSyntax? = nil,
-      firstName: TokenSyntax,
-      _ unexpectedBetweenFirstNameAndSecondName: UnexpectedNodesSyntax? = nil,
-      secondName: TokenSyntax? = nil,
-      _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil,
-      colon: TokenSyntax? = nil,
-      _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil,
-      type: MissingTypeSyntax? = nil,
-      _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil,
-      ellipsis: TokenSyntax? = nil,
-      _ unexpectedBetweenEllipsisAndTrailingComma: UnexpectedNodesSyntax? = nil,
-      trailingComma: TokenSyntax? = nil,
-      _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
-      trailingTrivia: Trivia? = nil
-    
-  ) {
-    self.init(
-        leadingTrivia: leadingTrivia,
-        unexpectedBeforeAttributes,
-        attributes: attributes,
-        unexpectedBetweenAttributesAndModifiers,
-        modifiers: modifiers,
-        unexpectedBetweenModifiersAndFirstName,
-        firstName: firstName,
-        unexpectedBetweenFirstNameAndSecondName,
-        secondName: secondName,
-        unexpectedBetweenSecondNameAndColon,
-        colon: colon,
-        unexpectedBetweenColonAndType,
-        type: Optional<TypeSyntax> .none,
-        unexpectedBetweenTypeAndEllipsis,
-        ellipsis: ellipsis,
-        unexpectedBetweenEllipsisAndTrailingComma,
-        trailingComma: trailingComma,
-        unexpectedAfterTrailingComma, 
-        trailingTrivia: trailingTrivia
-      )
   }
   
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
@@ -9553,7 +9463,7 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax? = nil,
       _ unexpectedBetweenColonAndInheritedType: UnexpectedNodesSyntax? = nil,
-      inheritedType: (some TypeSyntaxProtocol)? = nil,
+      inheritedType: (some TypeSyntaxProtocol)? = TypeSyntax?.none,
       _ unexpectedBetweenInheritedTypeAndTrailingComma: UnexpectedNodesSyntax? = nil,
       trailingComma: TokenSyntax? = nil,
       _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
@@ -9603,53 +9513,6 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
-  }
-  
-  /// This initializer exists solely because Swift 5.6 does not support
-  /// `Optional<ConcreteType>.none` as a default value of a generic parameter.
-  /// The above initializer thus defaults to `nil` instead, but that means it
-  /// is not actually callable when either not passing the defaulted parameter,
-  /// or passing `nil`.
-  ///
-  /// Hack around that limitation using this initializer, which takes a
-  /// `Missing*` syntax node instead. `Missing*` is used over the base type as
-  /// the base type would allow implicit conversion from a string literal,
-  /// which the above initializer doesn't support.
-  public init(
-      leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
-      attributes: AttributeListSyntax? = nil,
-      _ unexpectedBetweenAttributesAndEach: UnexpectedNodesSyntax? = nil,
-      each: TokenSyntax? = nil,
-      _ unexpectedBetweenEachAndName: UnexpectedNodesSyntax? = nil,
-      name: TokenSyntax,
-      _ unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? = nil,
-      colon: TokenSyntax? = nil,
-      _ unexpectedBetweenColonAndInheritedType: UnexpectedNodesSyntax? = nil,
-      inheritedType: MissingTypeSyntax? = nil,
-      _ unexpectedBetweenInheritedTypeAndTrailingComma: UnexpectedNodesSyntax? = nil,
-      trailingComma: TokenSyntax? = nil,
-      _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil,
-      trailingTrivia: Trivia? = nil
-    
-  ) {
-    self.init(
-        leadingTrivia: leadingTrivia,
-        unexpectedBeforeAttributes,
-        attributes: attributes,
-        unexpectedBetweenAttributesAndEach,
-        each: each,
-        unexpectedBetweenEachAndName,
-        name: name,
-        unexpectedBetweenNameAndColon,
-        colon: colon,
-        unexpectedBetweenColonAndInheritedType,
-        inheritedType: Optional<TypeSyntax> .none,
-        unexpectedBetweenInheritedTypeAndTrailingComma,
-        trailingComma: trailingComma,
-        unexpectedAfterTrailingComma, 
-        trailingTrivia: trailingTrivia
-      )
   }
   
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
@@ -10218,7 +10081,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       _ unexpectedBeforePoundKeyword: UnexpectedNodesSyntax? = nil,
       poundKeyword: TokenSyntax,
       _ unexpectedBetweenPoundKeywordAndCondition: UnexpectedNodesSyntax? = nil,
-      condition: (some ExprSyntaxProtocol)? = nil,
+      condition: (some ExprSyntaxProtocol)? = ExprSyntax?.none,
       _ unexpectedBetweenConditionAndElements: UnexpectedNodesSyntax? = nil,
       elements: Elements? = nil,
       _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil,
@@ -10256,41 +10119,6 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
-  }
-  
-  /// This initializer exists solely because Swift 5.6 does not support
-  /// `Optional<ConcreteType>.none` as a default value of a generic parameter.
-  /// The above initializer thus defaults to `nil` instead, but that means it
-  /// is not actually callable when either not passing the defaulted parameter,
-  /// or passing `nil`.
-  ///
-  /// Hack around that limitation using this initializer, which takes a
-  /// `Missing*` syntax node instead. `Missing*` is used over the base type as
-  /// the base type would allow implicit conversion from a string literal,
-  /// which the above initializer doesn't support.
-  public init(
-      leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforePoundKeyword: UnexpectedNodesSyntax? = nil,
-      poundKeyword: TokenSyntax,
-      _ unexpectedBetweenPoundKeywordAndCondition: UnexpectedNodesSyntax? = nil,
-      condition: MissingExprSyntax? = nil,
-      _ unexpectedBetweenConditionAndElements: UnexpectedNodesSyntax? = nil,
-      elements: Elements? = nil,
-      _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil,
-      trailingTrivia: Trivia? = nil
-    
-  ) {
-    self.init(
-        leadingTrivia: leadingTrivia,
-        unexpectedBeforePoundKeyword,
-        poundKeyword: poundKeyword,
-        unexpectedBetweenPoundKeywordAndCondition,
-        condition: Optional<ExprSyntax> .none,
-        unexpectedBetweenConditionAndElements,
-        elements: elements,
-        unexpectedAfterElements, 
-        trailingTrivia: trailingTrivia
-      )
   }
   
   public var unexpectedBeforePoundKeyword: UnexpectedNodesSyntax? {
@@ -14748,7 +14576,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil,
-      baseType: (some TypeSyntaxProtocol)? = nil,
+      baseType: (some TypeSyntaxProtocol)? = TypeSyntax?.none,
       _ unexpectedBetweenBaseTypeAndDot: UnexpectedNodesSyntax? = nil,
       dot: TokenSyntax? = nil,
       _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil,
@@ -14794,45 +14622,6 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
-  }
-  
-  /// This initializer exists solely because Swift 5.6 does not support
-  /// `Optional<ConcreteType>.none` as a default value of a generic parameter.
-  /// The above initializer thus defaults to `nil` instead, but that means it
-  /// is not actually callable when either not passing the defaulted parameter,
-  /// or passing `nil`.
-  ///
-  /// Hack around that limitation using this initializer, which takes a
-  /// `Missing*` syntax node instead. `Missing*` is used over the base type as
-  /// the base type would allow implicit conversion from a string literal,
-  /// which the above initializer doesn't support.
-  public init(
-      leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil,
-      baseType: MissingTypeSyntax? = nil,
-      _ unexpectedBetweenBaseTypeAndDot: UnexpectedNodesSyntax? = nil,
-      dot: TokenSyntax? = nil,
-      _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil,
-      name: TokenSyntax,
-      _ unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? = nil,
-      arguments: DeclNameArgumentsSyntax? = nil,
-      _ unexpectedAfterArguments: UnexpectedNodesSyntax? = nil,
-      trailingTrivia: Trivia? = nil
-    
-  ) {
-    self.init(
-        leadingTrivia: leadingTrivia,
-        unexpectedBeforeBaseType,
-        baseType: Optional<TypeSyntax> .none,
-        unexpectedBetweenBaseTypeAndDot,
-        dot: dot,
-        unexpectedBetweenDotAndName,
-        name: name,
-        unexpectedBetweenNameAndArguments,
-        arguments: arguments,
-        unexpectedAfterArguments, 
-        trailingTrivia: trailingTrivia
-      )
   }
   
   public var unexpectedBeforeBaseType: UnexpectedNodesSyntax? {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxPatternNodes.swift
@@ -18,7 +18,7 @@
 public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .expressionPattern else {
       return nil
     }
@@ -33,10 +33,10 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -96,7 +96,7 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .identifierPattern else {
       return nil
     }
@@ -174,7 +174,7 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .isTypePattern else {
       return nil
     }
@@ -189,12 +189,12 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<T: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeIsKeyword: UnexpectedNodesSyntax? = nil,
       isKeyword: TokenSyntax = .keyword(.is),
       _ unexpectedBetweenIsKeywordAndType: UnexpectedNodesSyntax? = nil,
-      type: T,
+      type: some TypeSyntaxProtocol,
       _ unexpectedAfterType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -290,7 +290,7 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .missingPattern else {
       return nil
     }
@@ -369,7 +369,7 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tuplePattern else {
       return nil
     }
@@ -530,7 +530,7 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .valueBindingPattern else {
       return nil
     }
@@ -545,12 +545,12 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<V: PatternSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBindingKeyword: UnexpectedNodesSyntax? = nil,
       bindingKeyword: TokenSyntax,
       _ unexpectedBetweenBindingKeywordAndValuePattern: UnexpectedNodesSyntax? = nil,
-      valuePattern: V,
+      valuePattern: some PatternSyntaxProtocol,
       _ unexpectedAfterValuePattern: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -646,7 +646,7 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .wildcardPattern else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -1719,7 +1719,7 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       _ unexpectedBeforeReturnKeyword: UnexpectedNodesSyntax? = nil,
       returnKeyword: TokenSyntax = .keyword(.return),
       _ unexpectedBetweenReturnKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: (some ExprSyntaxProtocol)? = nil,
+      expression: (some ExprSyntaxProtocol)? = ExprSyntax?.none,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1751,37 +1751,6 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return SyntaxData.forRoot(raw)
     }
     self.init(data)
-  }
-  
-  /// This initializer exists solely because Swift 5.6 does not support
-  /// `Optional<ConcreteType>.none` as a default value of a generic parameter.
-  /// The above initializer thus defaults to `nil` instead, but that means it
-  /// is not actually callable when either not passing the defaulted parameter,
-  /// or passing `nil`.
-  ///
-  /// Hack around that limitation using this initializer, which takes a
-  /// `Missing*` syntax node instead. `Missing*` is used over the base type as
-  /// the base type would allow implicit conversion from a string literal,
-  /// which the above initializer doesn't support.
-  public init(
-      leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforeReturnKeyword: UnexpectedNodesSyntax? = nil,
-      returnKeyword: TokenSyntax = .keyword(.return),
-      _ unexpectedBetweenReturnKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: MissingExprSyntax? = nil,
-      _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
-      trailingTrivia: Trivia? = nil
-    
-  ) {
-    self.init(
-        leadingTrivia: leadingTrivia,
-        unexpectedBeforeReturnKeyword,
-        returnKeyword: returnKeyword,
-        unexpectedBetweenReturnKeywordAndExpression,
-        expression: Optional<ExprSyntax> .none,
-        unexpectedAfterExpression, 
-        trailingTrivia: trailingTrivia
-      )
   }
   
   public var unexpectedBeforeReturnKeyword: UnexpectedNodesSyntax? {

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -18,7 +18,7 @@
 public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .breakStmt else {
       return nil
     }
@@ -134,7 +134,7 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .continueStmt else {
       return nil
     }
@@ -250,7 +250,7 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .deferStmt else {
       return nil
     }
@@ -366,7 +366,7 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .doStmt else {
       return nil
     }
@@ -527,7 +527,7 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .expressionStmt else {
       return nil
     }
@@ -542,10 +542,10 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -605,7 +605,7 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .fallthroughStmt else {
       return nil
     }
@@ -683,7 +683,7 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .forInStmt else {
       return nil
     }
@@ -698,7 +698,7 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: PatternSyntaxProtocol, S: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeForKeyword: UnexpectedNodesSyntax? = nil,
       forKeyword: TokenSyntax = .keyword(.for),
@@ -709,13 +709,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenAwaitKeywordAndCaseKeyword: UnexpectedNodesSyntax? = nil,
       caseKeyword: TokenSyntax? = nil,
       _ unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodesSyntax? = nil,
-      pattern: P,
+      pattern: some PatternSyntaxProtocol,
       _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil,
       typeAnnotation: TypeAnnotationSyntax? = nil,
       _ unexpectedBetweenTypeAnnotationAndInKeyword: UnexpectedNodesSyntax? = nil,
       inKeyword: TokenSyntax = .keyword(.in),
       _ unexpectedBetweenInKeywordAndSequenceExpr: UnexpectedNodesSyntax? = nil,
-      sequenceExpr: S,
+      sequenceExpr: some ExprSyntaxProtocol,
       _ unexpectedBetweenSequenceExprAndWhereClause: UnexpectedNodesSyntax? = nil,
       whereClause: WhereClauseSyntax? = nil,
       _ unexpectedBetweenWhereClauseAndBody: UnexpectedNodesSyntax? = nil,
@@ -1007,7 +1007,7 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct ForgetStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .forgetStmt else {
       return nil
     }
@@ -1022,12 +1022,12 @@ public struct ForgetStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeForgetKeyword: UnexpectedNodesSyntax? = nil,
       forgetKeyword: TokenSyntax = .keyword(._forget),
       _ unexpectedBetweenForgetKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1123,7 +1123,7 @@ public struct ForgetStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .guardStmt else {
       return nil
     }
@@ -1310,7 +1310,7 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .labeledStmt else {
       return nil
     }
@@ -1325,14 +1325,14 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<S: StmtSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLabelName: UnexpectedNodesSyntax? = nil,
       labelName: TokenSyntax,
       _ unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? = nil,
       labelColon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenLabelColonAndStatement: UnexpectedNodesSyntax? = nil,
-      statement: S,
+      statement: some StmtSyntaxProtocol,
       _ unexpectedAfterStatement: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1452,7 +1452,7 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .missingStmt else {
       return nil
     }
@@ -1531,7 +1531,7 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .repeatWhileStmt else {
       return nil
     }
@@ -1546,7 +1546,7 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<C: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeRepeatKeyword: UnexpectedNodesSyntax? = nil,
       repeatKeyword: TokenSyntax = .keyword(.repeat),
@@ -1555,7 +1555,7 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenBodyAndWhileKeyword: UnexpectedNodesSyntax? = nil,
       whileKeyword: TokenSyntax = .keyword(.while),
       _ unexpectedBetweenWhileKeywordAndCondition: UnexpectedNodesSyntax? = nil,
-      condition: C,
+      condition: some ExprSyntaxProtocol,
       _ unexpectedAfterCondition: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1699,7 +1699,7 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .returnStmt else {
       return nil
     }
@@ -1714,12 +1714,12 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeReturnKeyword: UnexpectedNodesSyntax? = nil,
       returnKeyword: TokenSyntax = .keyword(.return),
       _ unexpectedBetweenReturnKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E? = nil,
+      expression: (some ExprSyntaxProtocol)? = nil,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1846,7 +1846,7 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .throwStmt else {
       return nil
     }
@@ -1861,12 +1861,12 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: ExprSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeThrowKeyword: UnexpectedNodesSyntax? = nil,
       throwKeyword: TokenSyntax = .keyword(.throw),
       _ unexpectedBetweenThrowKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
+      expression: some ExprSyntaxProtocol,
       _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1962,7 +1962,7 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .whileStmt else {
       return nil
     }
@@ -2142,11 +2142,11 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       self = .yieldList(node)
     }
     
-    public init<Node: ExprSyntaxProtocol>(_ node: Node) {
+    public init(_ node: some ExprSyntaxProtocol) {
       self = .simpleYield(ExprSyntax(node))
     }
     
-    public init?<S: SyntaxProtocol>(_ node: S) {
+    public init?(_ node: some SyntaxProtocol) {
       if let node = node.as(YieldListSyntax.self) {
         self = .yieldList(node)
         return
@@ -2165,7 +2165,7 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .yieldStmt else {
       return nil
     }

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxTypeNodes.swift
@@ -18,7 +18,7 @@
 public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .arrayType else {
       return nil
     }
@@ -33,12 +33,12 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<E: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLeftSquareBracket: UnexpectedNodesSyntax? = nil,
       leftSquareBracket: TokenSyntax = .leftSquareBracketToken(),
       _ unexpectedBetweenLeftSquareBracketAndElementType: UnexpectedNodesSyntax? = nil,
-      elementType: E,
+      elementType: some TypeSyntaxProtocol,
       _ unexpectedBetweenElementTypeAndRightSquareBracket: UnexpectedNodesSyntax? = nil,
       rightSquareBracket: TokenSyntax = .rightSquareBracketToken(),
       _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil,
@@ -160,7 +160,7 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .attributedType else {
       return nil
     }
@@ -175,14 +175,14 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeSpecifier: UnexpectedNodesSyntax? = nil,
       specifier: TokenSyntax? = nil,
       _ unexpectedBetweenSpecifierAndAttributes: UnexpectedNodesSyntax? = nil,
       attributes: AttributeListSyntax? = nil,
       _ unexpectedBetweenAttributesAndBaseType: UnexpectedNodesSyntax? = nil,
-      baseType: B,
+      baseType: some TypeSyntaxProtocol,
       _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -321,7 +321,7 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .classRestrictionType else {
       return nil
     }
@@ -399,7 +399,7 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .compositionType else {
       return nil
     }
@@ -496,7 +496,7 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .constrainedSugarType else {
       return nil
     }
@@ -511,12 +511,12 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeSomeOrAnySpecifier: UnexpectedNodesSyntax? = nil,
       someOrAnySpecifier: TokenSyntax,
       _ unexpectedBetweenSomeOrAnySpecifierAndBaseType: UnexpectedNodesSyntax? = nil,
-      baseType: B,
+      baseType: some TypeSyntaxProtocol,
       _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -612,7 +612,7 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .dictionaryType else {
       return nil
     }
@@ -627,16 +627,16 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<K: TypeSyntaxProtocol, V: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeLeftSquareBracket: UnexpectedNodesSyntax? = nil,
       leftSquareBracket: TokenSyntax = .leftSquareBracketToken(),
       _ unexpectedBetweenLeftSquareBracketAndKeyType: UnexpectedNodesSyntax? = nil,
-      keyType: K,
+      keyType: some TypeSyntaxProtocol,
       _ unexpectedBetweenKeyTypeAndColon: UnexpectedNodesSyntax? = nil,
       colon: TokenSyntax = .colonToken(),
       _ unexpectedBetweenColonAndValueType: UnexpectedNodesSyntax? = nil,
-      valueType: V,
+      valueType: some TypeSyntaxProtocol,
       _ unexpectedBetweenValueTypeAndRightSquareBracket: UnexpectedNodesSyntax? = nil,
       rightSquareBracket: TokenSyntax = .rightSquareBracketToken(),
       _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil,
@@ -806,7 +806,7 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .functionType else {
       return nil
     }
@@ -1019,7 +1019,7 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .implicitlyUnwrappedOptionalType else {
       return nil
     }
@@ -1034,10 +1034,10 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
     self._syntaxNode = Syntax(data)
   }
   
-  public init<W: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeWrappedType: UnexpectedNodesSyntax? = nil,
-      wrappedType: W,
+      wrappedType: some TypeSyntaxProtocol,
       _ unexpectedBetweenWrappedTypeAndExclamationMark: UnexpectedNodesSyntax? = nil,
       exclamationMark: TokenSyntax = .exclamationMarkToken(),
       _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil,
@@ -1135,7 +1135,7 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
 public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .memberTypeIdentifier else {
       return nil
     }
@@ -1150,10 +1150,10 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil,
-      baseType: B,
+      baseType: some TypeSyntaxProtocol,
       _ unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? = nil,
       period: TokenSyntax = .periodToken(),
       _ unexpectedBetweenPeriodAndName: UnexpectedNodesSyntax? = nil,
@@ -1303,7 +1303,7 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .metatypeType else {
       return nil
     }
@@ -1318,10 +1318,10 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil,
-      baseType: B,
+      baseType: some TypeSyntaxProtocol,
       _ unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? = nil,
       period: TokenSyntax = .periodToken(),
       _ unexpectedBetweenPeriodAndTypeOrProtocol: UnexpectedNodesSyntax? = nil,
@@ -1445,7 +1445,7 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .missingType else {
       return nil
     }
@@ -1524,7 +1524,7 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .namedOpaqueReturnType else {
       return nil
     }
@@ -1539,12 +1539,12 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<B: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeGenericParameters: UnexpectedNodesSyntax? = nil,
       genericParameters: GenericParameterClauseSyntax,
       _ unexpectedBetweenGenericParametersAndBaseType: UnexpectedNodesSyntax? = nil,
-      baseType: B,
+      baseType: some TypeSyntaxProtocol,
       _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1640,7 +1640,7 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .optionalType else {
       return nil
     }
@@ -1655,10 +1655,10 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<W: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeWrappedType: UnexpectedNodesSyntax? = nil,
-      wrappedType: W,
+      wrappedType: some TypeSyntaxProtocol,
       _ unexpectedBetweenWrappedTypeAndQuestionMark: UnexpectedNodesSyntax? = nil,
       questionMark: TokenSyntax = .postfixQuestionMarkToken(),
       _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil,
@@ -1756,7 +1756,7 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .packExpansionType else {
       return nil
     }
@@ -1771,12 +1771,12 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeRepeatKeyword: UnexpectedNodesSyntax? = nil,
       repeatKeyword: TokenSyntax = .keyword(.repeat),
       _ unexpectedBetweenRepeatKeywordAndPatternType: UnexpectedNodesSyntax? = nil,
-      patternType: P,
+      patternType: some TypeSyntaxProtocol,
       _ unexpectedAfterPatternType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1872,7 +1872,7 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .packReferenceType else {
       return nil
     }
@@ -1887,12 +1887,12 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeEachKeyword: UnexpectedNodesSyntax? = nil,
       eachKeyword: TokenSyntax = .keyword(.each),
       _ unexpectedBetweenEachKeywordAndPackType: UnexpectedNodesSyntax? = nil,
-      packType: P,
+      packType: some TypeSyntaxProtocol,
       _ unexpectedAfterPackType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -1988,7 +1988,7 @@ public struct PackReferenceTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .simpleTypeIdentifier else {
       return nil
     }
@@ -2104,7 +2104,7 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .suppressedType else {
       return nil
     }
@@ -2119,12 +2119,12 @@ public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
   
-  public init<P: TypeSyntaxProtocol>(
+  public init(
       leadingTrivia: Trivia? = nil,
       _ unexpectedBeforeWithoutTilde: UnexpectedNodesSyntax? = nil,
       withoutTilde: TokenSyntax,
       _ unexpectedBetweenWithoutTildeAndPatternType: UnexpectedNodesSyntax? = nil,
-      patternType: P,
+      patternType: some TypeSyntaxProtocol,
       _ unexpectedAfterPatternType: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -2220,7 +2220,7 @@ public struct SuppressedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
-  public init?<S: SyntaxProtocol>(_ node: S) {
+  public init?(_ node: some SyntaxProtocol) {
     guard node.raw.kind == .tupleType else {
       return nil
     }

--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers.swift
@@ -121,7 +121,7 @@ extension ExprSyntax {
   /// to produce a literal as the outermost syntax node, or even to have a
   /// literal anywhere in its syntax tree. Use a convenience initializer on a
   /// specific type if you need that exact type in the syntax tree.
-  public init<Literal: ExpressibleByLiteralSyntax>(literal: Literal) {
+  public init(literal: some ExpressibleByLiteralSyntax) {
     self.init(literal.makeLiteralSyntax())
   }
 }
@@ -144,8 +144,8 @@ extension FunctionCallExprSyntax {
   /// A convenience initializer that allows passing in arguments using a result builder
   /// instead of having to wrap them in a `TupleExprElementList`.
   /// The presence of the parenthesis will be inferred based on the presence of arguments and the trailing closure.
-  public init<C: ExprSyntaxProtocol>(
-    callee: C,
+  public init(
+    callee: some ExprSyntaxProtocol,
     trailingClosure: ClosureExprSyntax? = nil,
     additionalTrailingClosures: MultipleTrailingClosureElementListSyntax? = nil,
     @TupleExprElementListBuilder argumentList: () -> TupleExprElementListSyntax = { [] }
@@ -303,7 +303,7 @@ extension StringLiteralExprSyntax {
 extension TupleExprElementSyntax {
   /// A convenience initializer that allows passing in label as an optional string.
   /// The presence of the colon will be inferred based on the presence of the label.
-  public init<E: ExprSyntaxProtocol>(label: String? = nil, expression: E) {
+  public init(label: String? = nil, expression: some ExprSyntaxProtocol) {
     self.init(
       label: label.map { .identifier($0) },
       colon: label == nil ? nil : .colonToken(),

--- a/Sources/SwiftSyntaxBuilder/ResultBuilderExtensions.swift
+++ b/Sources/SwiftSyntaxBuilder/ResultBuilderExtensions.swift
@@ -13,21 +13,21 @@
 import SwiftSyntax
 
 extension CodeBlockItemListBuilder {
-  public static func buildExpression<ExprType: ExprSyntaxProtocol>(_ expression: ExprType) -> Component {
+  public static func buildExpression(_ expression: some ExprSyntaxProtocol) -> Component {
     return buildExpression(CodeBlockItemSyntax(item: .expr(ExprSyntax(expression))))
   }
 
-  public static func buildExpression<StmtType: StmtSyntaxProtocol>(_ expression: StmtType) -> Component {
+  public static func buildExpression(_ expression: some StmtSyntaxProtocol) -> Component {
     return buildExpression(CodeBlockItemSyntax(item: .stmt(StmtSyntax(expression))))
   }
 
-  public static func buildExpression<DeclType: DeclSyntaxProtocol>(_ expression: DeclType) -> Component {
+  public static func buildExpression(_ expression: some DeclSyntaxProtocol) -> Component {
     return buildExpression(CodeBlockItemSyntax(item: .decl(DeclSyntax(expression))))
   }
 }
 
 extension ConditionElementListBuilder {
-  public static func buildExpression<ExprType: ExprSyntaxProtocol>(_ expression: ExprType) -> Component {
+  public static func buildExpression(_ expression: some ExprSyntaxProtocol) -> Component {
     return buildExpression(ConditionElementSyntax(condition: .expression(ExprSyntax(expression))))
   }
 
@@ -45,7 +45,7 @@ extension ConditionElementListBuilder {
 }
 
 extension MemberDeclListBuilder {
-  public static func buildExpression<DeclType: DeclSyntaxProtocol>(_ expression: DeclType) -> Component {
+  public static func buildExpression(_ expression: some DeclSyntaxProtocol) -> Component {
     return buildExpression(MemberDeclListItemSyntax(decl: expression))
   }
 }

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -68,7 +68,7 @@ extension SyntaxStringInterpolation: StringInterpolationProtocol {
   ) {
     let startIndex = sourceText.count
     let indentedNode: Node
-    if let lastIndentation = lastIndentation {
+    if let lastIndentation {
       indentedNode = Indenter.indent(node, indentation: lastIndentation)
     } else {
       indentedNode = node

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -97,8 +97,8 @@ extension SyntaxStringInterpolation: StringInterpolationProtocol {
     self.lastIndentation = nil
   }
 
-  public mutating func appendInterpolation<Buildable: SyntaxProtocol>(
-    _ buildable: Buildable,
+  public mutating func appendInterpolation(
+    _ buildable: some SyntaxProtocol,
     format: BasicFormat = BasicFormat()
   ) {
     self.appendInterpolation(buildable.formatted(using: format))
@@ -107,8 +107,8 @@ extension SyntaxStringInterpolation: StringInterpolationProtocol {
   /// Interpolates a literal or similar expression syntax equivalent to `value`.
   ///
   /// - SeeAlso: ``Expr/init(literal:)``
-  public mutating func appendInterpolation<Literal: ExpressibleByLiteralSyntax>(
-    literal value: Literal,
+  public mutating func appendInterpolation(
+    literal value: some ExpressibleByLiteralSyntax,
     format: BasicFormat = BasicFormat()
   ) {
     self.appendInterpolation(ExprSyntax(literal: value), format: format)

--- a/Sources/SwiftSyntaxMacros/BasicMacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacros/BasicMacroExpansionContext.swift
@@ -70,8 +70,8 @@ public class BasicMacroExpansionContext {
 extension BasicMacroExpansionContext {
   /// Note that the given node that was at the given position in the provided
   /// source file has been disconnected and is now a new root.
-  private func addDisconnected<Node: SyntaxProtocol>(
-    _ node: Node,
+  private func addDisconnected(
+    _ node: some SyntaxProtocol,
     at offset: AbsolutePosition,
     in sourceFile: SourceFileSyntax
   ) {
@@ -135,8 +135,8 @@ extension BasicMacroExpansionContext: MacroExpansionContext {
     diagnostics.append(diagnostic)
   }
 
-  public func location<Node: SyntaxProtocol>(
-    of node: Node,
+  public func location(
+    of node: some SyntaxProtocol,
     at position: PositionInSyntaxNode,
     filePathMode: SourceLocationFilePathMode
   ) -> AbstractSourceLocation? {

--- a/Sources/SwiftSyntaxMacros/FunctionParameterUtils.swift
+++ b/Sources/SwiftSyntaxMacros/FunctionParameterUtils.swift
@@ -11,7 +11,7 @@ extension FunctionParameterSyntax {
   /// respectively.
   var parameterName: TokenSyntax? {
     // If there were two names, the second is the parameter name.
-    if let secondName = secondName {
+    if let secondName {
       if secondName.text == "_" {
         return nil
       }

--- a/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
+++ b/Sources/SwiftSyntaxMacros/MacroExpansionContext.swift
@@ -42,8 +42,8 @@ public protocol MacroExpansionContext: AnyObject {
   /// - Returns: the source location within the given node, or `nil` if the
   ///   given syntax node is not rooted in a source file that the macro
   ///   expansion context knows about.
-  func location<Node: SyntaxProtocol>(
-    of node: Node,
+  func location(
+    of node: some SyntaxProtocol,
     at position: PositionInSyntaxNode,
     filePathMode: SourceLocationFilePathMode
   ) -> AbstractSourceLocation?
@@ -59,8 +59,8 @@ extension MacroExpansionContext {
   /// - Returns: the source location within the given node, or `nil` if the
   ///   given syntax node is not rooted in a source file that the macro
   ///   expansion context knows about.
-  public func location<Node: SyntaxProtocol>(
-    of node: Node
+  public func location(
+    of node: some SyntaxProtocol
   ) -> AbstractSourceLocation? {
     return location(of: node, at: .afterLeadingTrivia, filePathMode: .fileID)
   }
@@ -79,7 +79,7 @@ private struct ThrownErrorDiagnostic: DiagnosticMessage {
 
 extension MacroExpansionContext {
   /// Add diagnostics from the error thrown during macro expansion.
-  public func addDiagnostics<S: SyntaxProtocol>(from error: Error, node: S) {
+  public func addDiagnostics(from error: Error, node: some SyntaxProtocol) {
     // Inspect the error to form an appropriate set of diagnostics.
     var diagnostics: [Diagnostic]
     if let diagnosticsError = error as? DiagnosticsError {

--- a/Sources/SwiftSyntaxMacros/MacroReplacement.swift
+++ b/Sources/SwiftSyntaxMacros/MacroReplacement.swift
@@ -271,8 +271,8 @@ extension MacroDeclSyntax {
   /// Given a freestanding macro expansion syntax node that references this
   /// macro declaration, expand the macro by substituting the arguments from
   /// the macro expansion into the parameters that are used in the definition.
-  public func expand<Node: FreestandingMacroExpansionSyntax>(
-    _ node: Node,
+  public func expand(
+    _ node: some FreestandingMacroExpansionSyntax,
     definition: MacroExpansionExprSyntax,
     replacements: [MacroDefinition.Replacement]
   ) -> ExprSyntax {

--- a/Sources/SwiftSyntaxMacros/MacroSystem.swift
+++ b/Sources/SwiftSyntaxMacros/MacroSystem.swift
@@ -442,7 +442,7 @@ extension MacroApplication {
       do {
         let typedDecl = decl.asProtocol(DeclGroupSyntax.self)!
 
-        func expand<Decl: DeclGroupSyntax>(_ decl: Decl) throws -> [AttributeSyntax] {
+        func expand(_ decl: some DeclGroupSyntax) throws -> [AttributeSyntax] {
           return try attributeMacro.expansion(
             of: attribute,
             attachedTo: decl,
@@ -471,9 +471,9 @@ extension MacroApplication {
 extension SyntaxProtocol {
   /// Expand all uses of the given set of macros within this syntax
   /// node.
-  public func expand<Context: MacroExpansionContext>(
+  public func expand(
     macros: [String: Macro.Type],
-    in context: Context
+    in context: some MacroExpansionContext
   ) -> Syntax {
     // Build the macro system.
     var system = MacroSystem()

--- a/Sources/SwiftSyntaxMacros/Syntax+MacroEvaluation.swift
+++ b/Sources/SwiftSyntaxMacros/Syntax+MacroEvaluation.swift
@@ -28,9 +28,9 @@ extension SyntaxProtocol {
 extension MacroExpansionExprSyntax {
   /// Evaluate the given macro for this syntax node, producing the expanded
   /// result and (possibly) some diagnostics.
-  func evaluateMacro<Context: MacroExpansionContext>(
+  func evaluateMacro(
     _ macro: Macro.Type,
-    in context: Context
+    in context: some MacroExpansionContext
   ) -> ExprSyntax {
     guard let exprMacro = macro as? ExpressionMacro.Type else {
       return ExprSyntax(self)
@@ -49,9 +49,9 @@ extension MacroExpansionExprSyntax {
 extension MacroExpansionDeclSyntax {
   /// Evaluate the given macro for this syntax node, producing the expanded
   /// result and (possibly) some diagnostics.
-  func evaluateMacro<Context: MacroExpansionContext>(
+  func evaluateMacro(
     _ macro: Macro.Type,
-    in context: Context
+    in context: some MacroExpansionContext
   ) -> Syntax {
     // TODO: declaration/statement macros
 
@@ -82,9 +82,9 @@ extension Syntax {
   /// This operation only makes sense when `evaluatedMacroName` produces a
   /// non-nil value, indicating that this syntax node is a macro evaluation of
   /// some kind.
-  func evaluateMacro<Context: MacroExpansionContext>(
+  func evaluateMacro(
     with macroSystem: MacroSystem,
-    context: Context
+    context: some MacroExpansionContext
   ) -> Syntax {
     // If this isn't a macro evaluation node, do nothing.
     guard let macroName = evaluatedMacroName else {

--- a/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
+++ b/Sources/SwiftSyntaxMacrosTestSupport/Assertions.swift
@@ -58,9 +58,9 @@ public struct NoteSpec {
   }
 }
 
-func assertNote<T: SyntaxProtocol>(
+func assertNote(
   _ note: Note,
-  in tree: T,
+  in tree: some SyntaxProtocol,
   expected spec: NoteSpec
 ) {
   assertStringsEqualWithDiff(note.message, spec.message, "message of note does not match", file: spec.originatorFile, line: spec.originatorLine)
@@ -177,9 +177,9 @@ public struct DiagnosticSpec {
   }
 }
 
-func assertDiagnostic<T: SyntaxProtocol>(
+func assertDiagnostic(
   _ diag: Diagnostic,
-  in tree: T,
+  in tree: some SyntaxProtocol,
   expected spec: DiagnosticSpec
 ) {
   if let id = spec.id {

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxComparison.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxComparison.swift
@@ -32,8 +32,7 @@ public struct TreeDifference {
   public let baseline: Syntax
   public let reason: DifferenceReason
 
-  public init<Difference, Baseline>(node: Difference, baseline: Baseline, reason: DifferenceReason)
-  where Difference: SyntaxProtocol, Baseline: SyntaxProtocol {
+  public init(node: some SyntaxProtocol, baseline: some SyntaxProtocol, reason: DifferenceReason) {
     self.node = Syntax(node)
     self.baseline = Syntax(baseline)
     self.reason = reason
@@ -90,7 +89,7 @@ extension TreeDifference: CustomDebugStringConvertible {
 public extension SyntaxProtocol {
   /// Compares the current tree against a `baseline`, returning the first
   /// difference it finds.
-  func findFirstDifference<Tree: SyntaxProtocol>(baseline: Tree, includeTrivia: Bool = false) -> TreeDifference? {
+  func findFirstDifference(baseline: some SyntaxProtocol, includeTrivia: Bool = false) -> TreeDifference? {
     if let reason = isDifferent(baseline: baseline, includeTrivia: includeTrivia) {
       return TreeDifference(node: self, baseline: baseline, reason: reason)
     }
@@ -113,7 +112,7 @@ public extension SyntaxProtocol {
     return nil
   }
 
-  private func isDifferent<Tree: SyntaxProtocol>(baseline: Tree, includeTrivia: Bool = false) -> DifferenceReason? {
+  private func isDifferent(baseline: some SyntaxProtocol, includeTrivia: Bool = false) -> DifferenceReason? {
     if syntaxNodeType != baseline.syntaxNodeType {
       return .nodeType
     }

--- a/Sources/lit-test-helper/CommandLineArguments.swift
+++ b/Sources/lit-test-helper/CommandLineArguments.swift
@@ -61,7 +61,7 @@ struct CommandLineArguments {
         currentKey = nil
       }
     }
-    if let currentKey = currentKey {
+    if let currentKey {
       // The last key didn't have a value. Just add it with an empty string as
       // the value to the parsed args
       addArg(currentKey, "")

--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -39,7 +39,7 @@ private func withTemporaryFile<T>(contents: [UInt8], body: (URL) throws -> T) th
 
 private func getContentsOfSourceFile(at path: String?) throws -> [UInt8] {
   let source: Data
-  if let path = path {
+  if let path {
     let sourceURL = URL(fileURLWithPath: path)
     source = try Data(contentsOf: sourceURL)
   } else {

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -279,7 +279,7 @@ class FixItApplier: SyntaxRewriter {
       diagnostics
       .flatMap { $0.fixIts }
       .filter {
-        if let messages = messages {
+        if let messages {
           return messages.contains($0.message.message)
         } else {
           return true
@@ -577,7 +577,7 @@ func assertParse<S: SyntaxProtocol>(
   )
 
   // Substructure
-  if let expectedSubstructure = expectedSubstructure {
+  if let expectedSubstructure {
     let subtreeMatcher = SubtreeMatcher(Syntax(tree), markers: markerLocations)
     do {
       try subtreeMatcher.assertSameStructure(afterMarker: substructureAfterMarker, Syntax(expectedSubstructure), includeTrivia: options.contains(.substructureCheckTrivia), file: file, line: line)

--- a/Tests/SwiftSyntaxTestSupportTest/SyntaxComparisonTests.swift
+++ b/Tests/SwiftSyntaxTestSupportTest/SyntaxComparisonTests.swift
@@ -187,7 +187,7 @@ public class SyntaxComparisonTests: XCTestCase {
     indent: Int = 0
   ) -> FunctionDeclSyntax {
     let funcBody: CodeBlockSyntax
-    if let body = body {
+    if let body {
       funcBody = body
     } else {
       funcBody = makeBody()


### PR DESCRIPTION
Now that Xcode on CI nodes has been updated, we don’t need to support Swift 5.5 and 5.6 anymore.

- Increase swift-tools-version to 5.7 
- Convert to shorthand `if let` notation
  - I was able to do this using the script from https://github.com/apple/swift-syntax/pull/887
- Migrate generics to opaque parameter types (aka. `some` types)
  - This was quite a lot of manual work
- Remove `@frozen` attributes
  - These only existed as a workaround for a miscompute on Swift 5.5 and are no longer needed
- Remove functions that only existed for Swift 5.6 compatibility 
  - No longer needed