### PR TITLE
[5.9] Add documentation for initializers that build a node from a header an

### DIFF
--- a/Tests/SwiftSyntaxBuilderTest/IfStmtTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/IfStmtTests.swift
@@ -97,6 +97,32 @@ final class IfStmtTests: XCTestCase {
         }
         """
       ),
+      #line: (
+        try IfExprSyntax(
+          "if x == 1",
+          bodyBuilder: {
+            StmtSyntax(#"return "one""#)
+          },
+          elseIf: IfExprSyntax(
+            "if x == 2",
+            bodyBuilder: {
+              StmtSyntax(#"return "two""#)
+            },
+            else: {
+              StmtSyntax(#"return "many""#)
+            }
+          )
+        ),
+        """
+        if x == 1 {
+            return "one"
+        } else if x == 2 {
+            return "two"
+        } else {
+            return "many"
+        }
+        """
+      ),
     ]
 
     for (line, testCase) in testCases {


### PR DESCRIPTION
* **Explanation**: Add some more documentation to SwiftSyntax
* **Scope**: Documentation-only
* **Risk**: Zero, just adds documentation
* **Testing**: None required
* **Issue**: rdar://108643660
* **Reviewer**: @bnbarham on https://github.com/apple/swift-syntax/pull/1617