### PR TITLE
Add documentation for syntax nodes and their children

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -209,6 +209,31 @@ public let DECL_NODES: [Node] = [
   Node(
     name: "AssociatedtypeDecl",
     nameForDiagnostics: "associatedtype declaration",
+    description: """
+      An associated type declaration like the following.
+
+      ```swift
+      associatedtype Item
+      ```
+
+      An associated type declaration may contain a type initializer clause which represents a default type assignment for the associated type.
+
+      ```swift
+      associatedtype Item = Int
+      ```
+
+      An associated type declaration may be declared with an inheritance clause which specifies the required conformances.
+
+      ```swift
+      associatedtype Iterator: IteratorProtocol
+      ```
+
+      A generic where clause may be present, here is an example which shows an associated type containing an inheritance clauses and a generic where clause.
+
+      ```swift
+      associatedtype Iterator: IteratorProtocol where Iterator.Element == Item
+      ```
+      """,
     kind: "Decl",
     traits: [
       "IdentifiedDecl",
@@ -219,37 +244,44 @@ public let DECL_NODES: [Node] = [
         name: "Attributes",
         kind: .collection(kind: "AttributeList", collectionElementName: "Attribute"),
         nameForDiagnostics: "attributes",
+        description: "Attributes attached to the associated type declaration.",
         isOptional: true
       ),
       Child(
         name: "Modifiers",
         kind: .collection(kind: "ModifierList", collectionElementName: "Modifier"),
         nameForDiagnostics: "modifiers",
+        description: "Modifiers attached to the associated type declaration.",
         isOptional: true
       ),
       Child(
         name: "AssociatedtypeKeyword",
-        kind: .token(choices: [.keyword(text: "associatedtype")])
+        kind: .token(choices: [.keyword(text: "associatedtype")]),
+        description: "The `associatedtype` keyword for this declaration."
       ),
       Child(
         name: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")])
+        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        description: "The name of this associated type."
       ),
       Child(
         name: "InheritanceClause",
         kind: .node(kind: "TypeInheritanceClause"),
         nameForDiagnostics: "inheritance clause",
+        description: "The inheritance clause describing conformances for this associated type declaration.",
         isOptional: true
       ),
       Child(
         name: "Initializer",
         kind: .node(kind: "TypeInitializerClause"),
+        description: "The type initializer clause for this associated type declaration which represents a default type assignment for the associated type.",
         isOptional: true
       ),
       Child(
         name: "GenericWhereClause",
         kind: .node(kind: "GenericWhereClause"),
         nameForDiagnostics: "generic where clause",
+        description: "The `where` clause that applies to the generic parameters of this associated type declaration.",
         isOptional: true
       ),
     ]
@@ -265,6 +297,29 @@ public let DECL_NODES: [Node] = [
   Node(
     name: "ClassDecl",
     nameForDiagnostics: "class",
+    description: """
+      A class declaration like the following.
+
+      ```swift
+      class SomeClass {
+        let someMember: String
+
+        init(someMember: String) {
+          self.someMember = someMember
+        }
+
+        func foo() {
+          print(someMember)
+        }
+
+        static func bar() -> Int {
+          return 1
+        }
+      }
+      ```
+
+      A class declaration may be declared without any members.
+      """,
     kind: "Decl",
     traits: [
       "DeclGroup",
@@ -276,43 +331,51 @@ public let DECL_NODES: [Node] = [
         name: "Attributes",
         kind: .collection(kind: "AttributeList", collectionElementName: "Attribute"),
         nameForDiagnostics: "attributes",
+        description: "Attributes attached to the class declaration, such as an `@available` attribute.",
         isOptional: true
       ),
       Child(
         name: "Modifiers",
         kind: .collection(kind: "ModifierList", collectionElementName: "Modifier"),
         nameForDiagnostics: "modifiers",
+        description: "Modifiers attached to the class declaration, such as `public`.",
         isOptional: true
       ),
       Child(
         name: "ClassKeyword",
-        kind: .token(choices: [.keyword(text: "class")])
+        kind: .token(choices: [.keyword(text: "class")]),
+        description: "The `class` keyword for this declaration."
       ),
       Child(
         name: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")])
+        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        description: "The name of the class."
       ),
       Child(
         name: "GenericParameterClause",
         kind: .node(kind: "GenericParameterClause"),
         nameForDiagnostics: "generic parameter clause",
+        description: "The generic parameters, if any, of the class declaration.",
         isOptional: true
       ),
       Child(
         name: "InheritanceClause",
         kind: .node(kind: "TypeInheritanceClause"),
         nameForDiagnostics: "inheritance clause",
+        description: "The inheritance clause describing one or more conformances for this class declaration.",
         isOptional: true
       ),
       Child(
         name: "GenericWhereClause",
         kind: .node(kind: "GenericWhereClause"),
         nameForDiagnostics: "generic where clause",
+        description: "The `where` clause that applies to the generic parameters of this class declaration.",
         isOptional: true
       ),
       Child(
         name: "MemberBlock",
-        kind: .node(kind: "MemberDeclBlock")
+        kind: .node(kind: "MemberDeclBlock"),
+        description: "The members of the class declaration. As class extension declarations may declare additional members, the contents of this member block isn't guaranteed to be a complete list of members for this type."
       ),
     ]
   ),
@@ -992,6 +1055,13 @@ public let DECL_NODES: [Node] = [
   Node(
     name: "ImportDecl",
     nameForDiagnostics: "import",
+    description: """
+      An import declaration like the following.
+
+      ```swift
+      import Foundation
+      ```
+      """,
     kind: "Decl",
     traits: [
       "Attributed"
@@ -1001,26 +1071,31 @@ public let DECL_NODES: [Node] = [
         name: "Attributes",
         kind: .collection(kind: "AttributeList", collectionElementName: "Attribute"),
         nameForDiagnostics: "attributes",
+        description: "Attributes attached to the import declaration, for example `@testable`.",
         isOptional: true
       ),
       Child(
         name: "Modifiers",
         kind: .collection(kind: "ModifierList", collectionElementName: "Modifier"),
         nameForDiagnostics: "modifiers",
+        description: "Modifiers attached to the import declaration. Currently, no modifiers are supported by Swift.",
         isOptional: true
       ),
       Child(
         name: "ImportTok",
-        kind: .token(choices: [.keyword(text: "import")])
+        kind: .token(choices: [.keyword(text: "import")]),
+        description: "The `import` keyword for this declaration."
       ),
       Child(
         name: "ImportKind",
         kind: .token(choices: [.keyword(text: "typealias"), .keyword(text: "struct"), .keyword(text: "class"), .keyword(text: "enum"), .keyword(text: "protocol"), .keyword(text: "var"), .keyword(text: "let"), .keyword(text: "func"), .keyword(text: "inout")]),
+        description: "The kind of declaration being imported. For example, a struct can be imported from a specific module.",
         isOptional: true
       ),
       Child(
         name: "Path",
-        kind: .collection(kind: "AccessPath", collectionElementName: "PathComponent")
+        kind: .collection(kind: "AccessPath", collectionElementName: "PathComponent"),
+        description: "The path to the module, submodule or symbol being imported."
       ),
     ]
   ),
@@ -1715,6 +1790,15 @@ public let DECL_NODES: [Node] = [
   Node(
     name: "ProtocolDecl",
     nameForDiagnostics: "protocol",
+    description: """
+      A protocol declaration like the following.
+
+      ```swift
+      protocol Example {
+        var isValid: Bool { get }
+      }
+      ```
+      """,
     kind: "Decl",
     traits: [
       "DeclGroup",
@@ -1726,43 +1810,51 @@ public let DECL_NODES: [Node] = [
         name: "Attributes",
         kind: .collection(kind: "AttributeList", collectionElementName: "Attribute"),
         nameForDiagnostics: "attributes",
+        description: "Attributes attached to the protocol declaration, such as an `@available` attribute.",
         isOptional: true
       ),
       Child(
         name: "Modifiers",
         kind: .collection(kind: "ModifierList", collectionElementName: "Modifier"),
         nameForDiagnostics: "modifiers",
+        description: "Modifiers attached to the protocol declaration, such as `public`.",
         isOptional: true
       ),
       Child(
         name: "ProtocolKeyword",
-        kind: .token(choices: [.keyword(text: "protocol")])
+        kind: .token(choices: [.keyword(text: "protocol")]),
+        description: "The `protocol` keyword for this declaration."
       ),
       Child(
         name: "Identifier",
-        kind: .token(choices: [.token(tokenKind: "IdentifierToken")])
+        kind: .token(choices: [.token(tokenKind: "IdentifierToken")]),
+        description: "The name of the protocol."
       ),
       Child(
         name: "PrimaryAssociatedTypeClause",
         kind: .node(kind: "PrimaryAssociatedTypeClause"),
         nameForDiagnostics: "primary associated type clause",
+        description: "The primary associated type for the protocol.",
         isOptional: true
       ),
       Child(
         name: "InheritanceClause",
         kind: .node(kind: "TypeInheritanceClause"),
         nameForDiagnostics: "inheritance clause",
+        description: "The inheritance clause describing one or more conformances for this protocol declaration.",
         isOptional: true
       ),
       Child(
         name: "GenericWhereClause",
         kind: .node(kind: "GenericWhereClause"),
         nameForDiagnostics: "generic where clause",
+        description: "The `where` clause that applies to the generic parameters of this protocol declaration.",
         isOptional: true
       ),
       Child(
         name: "MemberBlock",
-        kind: .node(kind: "MemberDeclBlock")
+        kind: .node(kind: "MemberDeclBlock"),
+        description: "The members of the protocol declaration."
       ),
     ]
   ),

--- a/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/ExprNodes.swift
@@ -905,19 +905,31 @@ public let EXPR_NODES: [Node] = [
   Node(
     name: "IsExpr",
     nameForDiagnostics: "'is'",
+    description: """
+      An `is` expression like the following.
+
+      ```swift
+      value is Double
+      ```
+
+      This node is only generated after operators are folded using the `SwiftOperators` library. Beforehand, the parser does not know the precedences of operators and thus represents `is` by an `UnresolvedIsExpr`.
+      """,
     kind: "Expr",
     children: [
       Child(
         name: "Expression",
-        kind: .node(kind: "Expr")
+        kind: .node(kind: "Expr"),
+        description: "The expression which will be checked to determine whether it can be cast to a specific type."
       ),
       Child(
         name: "IsTok",
-        kind: .token(choices: [.keyword(text: "is")])
+        kind: .token(choices: [.keyword(text: "is")]),
+        description: "The `is` keyword for this expression."
       ),
       Child(
         name: "TypeName",
-        kind: .node(kind: "Type")
+        kind: .node(kind: "Type"),
+        description: "The type against which the expression will be checked to see if the expression can be cast to it."
       ),
     ]
   ),

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -563,7 +563,29 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - AssociatedtypeDeclSyntax
 
-
+/// An associated type declaration like the following.
+/// 
+/// ```swift
+/// associatedtype Item
+/// ```
+/// 
+/// An associated type declaration may contain a type initializer clause which represents a default type assignment for the associated type.
+/// 
+/// ```swift
+/// associatedtype Item = Int
+/// ```
+/// 
+/// An associated type declaration may be declared with an inheritance clause which specifies the required conformances.
+/// 
+/// ```swift
+/// associatedtype Iterator: IteratorProtocol
+/// ```
+/// 
+/// A generic where clause may be present, here is an example which shows an associated type containing an inheritance clauses and a generic where clause.
+/// 
+/// ```swift
+/// associatedtype Iterator: IteratorProtocol where Iterator.Element == Item
+/// ```
 public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -660,6 +682,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// Attributes attached to the associated type declaration.
   public var attributes: AttributeListSyntax? {
     get {
       return data.child(at: 1, parent: Syntax(self)).map(AttributeListSyntax.init)
@@ -697,6 +720,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// Modifiers attached to the associated type declaration.
   public var modifiers: ModifierListSyntax? {
     get {
       return data.child(at: 3, parent: Syntax(self)).map(ModifierListSyntax.init)
@@ -734,6 +758,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The `associatedtype` keyword for this declaration.
   public var associatedtypeKeyword: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 5, parent: Syntax(self))!)
@@ -752,6 +777,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The name of this associated type.
   public var identifier: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 7, parent: Syntax(self))!)
@@ -770,6 +796,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The inheritance clause describing conformances for this associated type declaration.
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
     get {
       return data.child(at: 9, parent: Syntax(self)).map(TypeInheritanceClauseSyntax.init)
@@ -788,6 +815,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The type initializer clause for this associated type declaration which represents a default type assignment for the associated type.
   public var initializer: TypeInitializerClauseSyntax? {
     get {
       return data.child(at: 11, parent: Syntax(self)).map(TypeInitializerClauseSyntax.init)
@@ -806,6 +834,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The `where` clause that applies to the generic parameters of this associated type declaration.
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
       return data.child(at: 13, parent: Syntax(self)).map(GenericWhereClauseSyntax.init)
@@ -847,7 +876,27 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - ClassDeclSyntax
 
-
+/// A class declaration like the following.
+/// 
+/// ```swift
+/// class SomeClass {
+///   let someMember: String
+/// 
+///   init(someMember: String) {
+///     self.someMember = someMember
+///   }
+/// 
+///   func foo() {
+///     print(someMember)
+///   }
+/// 
+///   static func bar() -> Int {
+///     return 1
+///   }
+/// }
+/// ```
+/// 
+/// A class declaration may be declared without any members.
 public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -950,6 +999,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// Attributes attached to the class declaration, such as an `@available` attribute.
   public var attributes: AttributeListSyntax? {
     get {
       return data.child(at: 1, parent: Syntax(self)).map(AttributeListSyntax.init)
@@ -987,6 +1037,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// Modifiers attached to the class declaration, such as `public`.
   public var modifiers: ModifierListSyntax? {
     get {
       return data.child(at: 3, parent: Syntax(self)).map(ModifierListSyntax.init)
@@ -1024,6 +1075,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The `class` keyword for this declaration.
   public var classKeyword: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 5, parent: Syntax(self))!)
@@ -1042,6 +1094,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The name of the class.
   public var identifier: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 7, parent: Syntax(self))!)
@@ -1060,6 +1113,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The generic parameters, if any, of the class declaration.
   public var genericParameterClause: GenericParameterClauseSyntax? {
     get {
       return data.child(at: 9, parent: Syntax(self)).map(GenericParameterClauseSyntax.init)
@@ -1078,6 +1132,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The inheritance clause describing one or more conformances for this class declaration.
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
     get {
       return data.child(at: 11, parent: Syntax(self)).map(TypeInheritanceClauseSyntax.init)
@@ -1096,6 +1151,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The `where` clause that applies to the generic parameters of this class declaration.
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
       return data.child(at: 13, parent: Syntax(self)).map(GenericWhereClauseSyntax.init)
@@ -1114,6 +1170,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The members of the class declaration. As class extension declarations may declare additional members, the contents of this member block isn't guaranteed to be a complete list of members for this type.
   public var memberBlock: MemberDeclBlockSyntax {
     get {
       return MemberDeclBlockSyntax(data.child(at: 15, parent: Syntax(self))!)
@@ -2726,7 +2783,11 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - ImportDeclSyntax
 
-
+/// An import declaration like the following.
+/// 
+/// ```swift
+/// import Foundation
+/// ```
 public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2811,6 +2872,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// Attributes attached to the import declaration, for example `@testable`.
   public var attributes: AttributeListSyntax? {
     get {
       return data.child(at: 1, parent: Syntax(self)).map(AttributeListSyntax.init)
@@ -2848,6 +2910,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// Modifiers attached to the import declaration. Currently, no modifiers are supported by Swift.
   public var modifiers: ModifierListSyntax? {
     get {
       return data.child(at: 3, parent: Syntax(self)).map(ModifierListSyntax.init)
@@ -2885,6 +2948,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The `import` keyword for this declaration.
   public var importTok: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 5, parent: Syntax(self))!)
@@ -2903,6 +2967,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The kind of declaration being imported. For example, a struct can be imported from a specific module.
   public var importKind: TokenSyntax? {
     get {
       return data.child(at: 7, parent: Syntax(self)).map(TokenSyntax.init)
@@ -2921,6 +2986,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The path to the module, submodule or symbol being imported.
   public var path: AccessPathSyntax {
     get {
       return AccessPathSyntax(data.child(at: 9, parent: Syntax(self))!)
@@ -4816,7 +4882,13 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
 // MARK: - ProtocolDeclSyntax
 
-
+/// A protocol declaration like the following.
+/// 
+/// ```swift
+/// protocol Example {
+///   var isValid: Bool { get }
+/// }
+/// ```
 public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -4919,6 +4991,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// Attributes attached to the protocol declaration, such as an `@available` attribute.
   public var attributes: AttributeListSyntax? {
     get {
       return data.child(at: 1, parent: Syntax(self)).map(AttributeListSyntax.init)
@@ -4956,6 +5029,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// Modifiers attached to the protocol declaration, such as `public`.
   public var modifiers: ModifierListSyntax? {
     get {
       return data.child(at: 3, parent: Syntax(self)).map(ModifierListSyntax.init)
@@ -4993,6 +5067,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The `protocol` keyword for this declaration.
   public var protocolKeyword: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 5, parent: Syntax(self))!)
@@ -5011,6 +5086,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The name of the protocol.
   public var identifier: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 7, parent: Syntax(self))!)
@@ -5029,6 +5105,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The primary associated type for the protocol.
   public var primaryAssociatedTypeClause: PrimaryAssociatedTypeClauseSyntax? {
     get {
       return data.child(at: 9, parent: Syntax(self)).map(PrimaryAssociatedTypeClauseSyntax.init)
@@ -5047,6 +5124,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The inheritance clause describing one or more conformances for this protocol declaration.
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
     get {
       return data.child(at: 11, parent: Syntax(self)).map(TypeInheritanceClauseSyntax.init)
@@ -5065,6 +5143,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The `where` clause that applies to the generic parameters of this protocol declaration.
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
       return data.child(at: 13, parent: Syntax(self)).map(GenericWhereClauseSyntax.init)
@@ -5083,6 +5162,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The members of the protocol declaration.
   public var memberBlock: MemberDeclBlockSyntax {
     get {
       return MemberDeclBlockSyntax(data.child(at: 15, parent: Syntax(self))!)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxExprNodes.swift
@@ -2611,7 +2611,13 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
 // MARK: - IsExprSyntax
 
-
+/// An `is` expression like the following.
+/// 
+/// ```swift
+/// value is Double
+/// ```
+/// 
+/// This node is only generated after operators are folded using the `SwiftOperators` library. Beforehand, the parser does not know the precedences of operators and thus represents `is` by an `UnresolvedIsExpr`.
 public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
   
@@ -2684,6 +2690,7 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The expression which will be checked to determine whether it can be cast to a specific type.
   public var expression: ExprSyntax {
     get {
       return ExprSyntax(data.child(at: 1, parent: Syntax(self))!)
@@ -2702,6 +2709,7 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The `is` keyword for this expression.
   public var isTok: TokenSyntax {
     get {
       return TokenSyntax(data.child(at: 3, parent: Syntax(self))!)
@@ -2720,6 +2728,7 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     }
   }
   
+  /// The type against which the expression will be checked to see if the expression can be cast to it.
   public var typeName: TypeSyntax {
     get {
       return TypeSyntax(data.child(at: 5, parent: Syntax(self))!)


### PR DESCRIPTION
As part of #1528, documentation needs added to some syntax nodes. This PR adds documentation to the following syntax nodes and their children:
- AssociatedtypeDeclSyntax
- ClassDeclSyntax
- ImportDeclSyntax
- IsExprSyntax
- ProtocolDeclSyntax