### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -8,7 +8,7 @@ builder:
     - documentation_targets:
       # First item in the list is the "landing" (default) target
       - SwiftSyntax
-      - IDEUtils
+      - SwiftIDEUtils
       - SwiftBasicFormat
       - SwiftDiagnostics
       - SwiftOperators


### PR DESCRIPTION
Target name in .spi.yml has drifted from Package.swift.

See also https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2371