### PR TITLE
Verify that .spi.yml is up-to-date in swift-syntax-dev-utils

### DIFF
--- a/SwiftSyntaxDevUtils/Package.swift
+++ b/SwiftSyntaxDevUtils/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
   name: "swift-syntax-dev-utils",
   platforms: [
-    .macOS(.v10_15)
+    .macOS(.v13)
   ],
   products: [
     .executable(name: "swift-syntax-dev-utils", targets: ["swift-syntax-dev-utils"])


### PR DESCRIPTION
Motivated by https://github.com/apple/swift-syntax/pull/1634

---

.spi.yml got out of sync of the libraries we added to Package.swift. Add a verification script to make sure that they match. The idea is that for every library that every library that is exposed by SwiftSyntax should be documentated on swiftpackageindex.com.

rdar://108901461