### PR TITLE
Update Package.swift and `.spi.yml` to make them match

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -8,12 +8,15 @@ builder:
     - documentation_targets:
       # First item in the list is the "landing" (default) target
       - SwiftSyntax
-      - IDEUtils
       - SwiftBasicFormat
+      - SwiftCompilerPlugin
+      - SwiftCompilerPluginMessageHandling
       - SwiftDiagnostics
+      - SwiftIDEUtils
       - SwiftOperators
       - SwiftParser
       - SwiftParserDiagnostics
       - SwiftRefactor
       - SwiftSyntaxBuilder
-      - SwiftSyntaxParser
+      - SwiftSyntaxMacros
+      - SwiftSyntaxMacrosTestSupport

--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,7 @@ let package = Package(
     .macCatalyst(.v13),
   ],
   products: [
+    .library(name: "SwiftBasicFormat", targets: ["SwiftBasicFormat"]),
     .library(name: "SwiftCompilerPlugin", targets: ["SwiftCompilerPlugin"]),
     .library(name: "SwiftCompilerPluginMessageHandling", targets: ["SwiftCompilerPluginMessageHandling"]),
     .library(name: "SwiftDiagnostics", targets: ["SwiftDiagnostics"]),


### PR DESCRIPTION
Package.swift and `.spi.yml` have drifted apart and didn’t actually match anymore. The targets declared in `.spi.yml` should match the libraries declared in the package manifest. To fix this, update `.spi.yml` and also declare `SwiftBasicFormat` as a library in `Package.swift`. BasicFormat is being used in sufficently many places by now that we can’t really consider it an implementation detail of SwiftSyntax anymore.

I’m adding a script that verifies that Package.swift and `.spi.yml` match in https://github.com/apple/swift-syntax/pull/1635.

rdar://108902357