### PR TITLE
Run CodeGeneration with local dependencies

### DIFF
--- a/build-script.py
+++ b/build-script.py
@@ -141,6 +141,7 @@ def run_code_generation(
     env = dict(os.environ)
     env["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] = "1"
     env["SWIFTSYNTAX_ENABLE_RAWSYNTAX_VALIDATION"] = "1"
+    env["SWIFTCI_USE_LOCAL_DEPS"] = "1"
     check_call(swiftpm_call, env=env, verbose=verbose)
 
 


### PR DESCRIPTION
If we want to verify that the code-generated files match, we need to use local dependencies because CI doesn’t have internet access.

rdar://108902933