### PR TITLE
Rename `AccessPathSyntax` to `ImportPathSyntax`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/DeclNodes.swift
@@ -11,9 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 public let DECL_NODES: [Node] = [
-  // FIXME: technically misnamed; should be "ImportPathComponent"
   Node(
-    name: "AccessPathComponent",
+    name: "ImportPathComponent",
     nameForDiagnostics: nil,
     kind: "Syntax",
     children: [
@@ -30,12 +29,11 @@ public let DECL_NODES: [Node] = [
     ]
   ),
 
-  // FIXME: technically misnamed; should be "ImportPath"
   Node(
-    name: "AccessPath",
+    name: "ImportPath",
     nameForDiagnostics: nil,
     kind: "SyntaxCollection",
-    element: "AccessPathComponent"
+    element: "ImportPathComponent"
   ),
 
   Node(
@@ -1094,7 +1092,7 @@ public let DECL_NODES: [Node] = [
       ),
       Child(
         name: "Path",
-        kind: .collection(kind: "AccessPath", collectionElementName: "PathComponent"),
+        kind: .collection(kind: "ImportPath", collectionElementName: "PathComponent"),
         description: "The path to the module, submodule or symbol being imported."
       ),
     ]

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -310,7 +310,7 @@ extension Parser {
   ) -> RawImportDeclSyntax {
     let (unexpectedBeforeImportKeyword, importKeyword) = self.eat(handle)
     let kind = self.parseImportKind()
-    let path = self.parseImportAccessPath()
+    let path = self.parseImportPath()
     return RawImportDeclSyntax(
       attributes: attrs.attributes,
       modifiers: attrs.modifiers,
@@ -369,22 +369,22 @@ extension Parser {
   }
 
   @_spi(RawSyntax)
-  public mutating func parseImportAccessPath() -> RawAccessPathSyntax {
-    var elements = [RawAccessPathComponentSyntax]()
+  public mutating func parseImportPath() -> RawImportPathSyntax {
+    var elements = [RawImportPathComponentSyntax]()
     var keepGoing: RawTokenSyntax? = nil
     var loopProgress = LoopProgressCondition()
     repeat {
       let name = self.parseAnyIdentifier()
       keepGoing = self.consume(if: .period)
       elements.append(
-        RawAccessPathComponentSyntax(
+        RawImportPathComponentSyntax(
           name: name,
           trailingDot: keepGoing,
           arena: self.arena
         )
       )
     } while keepGoing != nil && loopProgress.evaluate(currentToken)
-    return RawAccessPathSyntax(elements: elements, arena: self.arena)
+    return RawImportPathSyntax(elements: elements, arena: self.arena)
   }
 }
 

--- a/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/ChildNameForDiagnostics.swift
@@ -16,8 +16,6 @@ import SwiftSyntax
 
 private func childNameForDiagnostics(_ keyPath: AnyKeyPath) -> String? {
   switch keyPath {
-  case \AccessPathComponentSyntax.name:
-    return "name"
   case \AccessorDeclSyntax.attributes:
     return "attributes"
   case \AccessorDeclSyntax.modifier:
@@ -198,6 +196,8 @@ private func childNameForDiagnostics(_ keyPath: AnyKeyPath) -> String? {
     return "attributes"
   case \ImportDeclSyntax.modifiers:
     return "modifiers"
+  case \ImportPathComponentSyntax.name:
+    return "name"
   case \InitializerDeclSyntax.attributes:
     return "attributes"
   case \InitializerDeclSyntax.modifiers:

--- a/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
@@ -194,8 +194,6 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/SyntaxChildren>
 - <doc:SwiftSyntax/SyntaxChildrenIndex>
 - <doc:SwiftSyntax/SyntaxChildrenIndexData>
-- <doc:SwiftSyntax/AccessPathSyntax>
-- <doc:SwiftSyntax/AccessPathComponentSyntax>
 - <doc:SwiftSyntax/AccessorListSyntax>
 - <doc:SwiftSyntax/AccessorDeclSyntax>
 - <doc:SwiftSyntax/ArrayElementListSyntax>
@@ -250,6 +248,8 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/GenericRequirementSyntax>
 - <doc:SwiftSyntax/IfConfigClauseListSyntax>
 - <doc:SwiftSyntax/IfConfigClauseSyntax>
+- <doc:SwiftSyntax/ImportPathSyntax>
+- <doc:SwiftSyntax/ImportPathComponentSyntax>
 - <doc:SwiftSyntax/InheritedTypeListSyntax>
 - <doc:SwiftSyntax/InheritedTypeSyntax>
 - <doc:SwiftSyntax/KeyPathComponentListSyntax>

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -17,16 +17,6 @@
 @_spi(RawSyntax)
 public func childName(_ keyPath: AnyKeyPath) -> String? {
   switch keyPath {
-  case \AccessPathComponentSyntax.unexpectedBeforeName:
-    return "unexpectedBeforeName"
-  case \AccessPathComponentSyntax.name:
-    return "name"
-  case \AccessPathComponentSyntax.unexpectedBetweenNameAndTrailingDot:
-    return "unexpectedBetweenNameAndTrailingDot"
-  case \AccessPathComponentSyntax.trailingDot:
-    return "trailingDot"
-  case \AccessPathComponentSyntax.unexpectedAfterTrailingDot:
-    return "unexpectedAfterTrailingDot"
   case \AccessorBlockSyntax.unexpectedBeforeLeftBrace:
     return "unexpectedBeforeLeftBrace"
   case \AccessorBlockSyntax.leftBrace:
@@ -1689,6 +1679,16 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "path"
   case \ImportDeclSyntax.unexpectedAfterPath:
     return "unexpectedAfterPath"
+  case \ImportPathComponentSyntax.unexpectedBeforeName:
+    return "unexpectedBeforeName"
+  case \ImportPathComponentSyntax.name:
+    return "name"
+  case \ImportPathComponentSyntax.unexpectedBetweenNameAndTrailingDot:
+    return "unexpectedBetweenNameAndTrailingDot"
+  case \ImportPathComponentSyntax.trailingDot:
+    return "trailingDot"
+  case \ImportPathComponentSyntax.unexpectedAfterTrailingDot:
+    return "unexpectedAfterTrailingDot"
   case \InOutExprSyntax.unexpectedBeforeAmpersand:
     return "unexpectedBeforeAmpersand"
   case \InOutExprSyntax.ampersand:

--- a/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
@@ -53,22 +53,6 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
   
-  override open func visit(_ node: AccessPathComponentSyntax) -> SyntaxVisitorContinueKind {
-    return visitAny(node._syntaxNode)
-  }
-  
-  override open func visitPost(_ node: AccessPathComponentSyntax) {
-    visitAnyPost(node._syntaxNode)
-  }
-  
-  override open func visit(_ node: AccessPathSyntax) -> SyntaxVisitorContinueKind {
-    return visitAny(node._syntaxNode)
-  }
-  
-  override open func visitPost(_ node: AccessPathSyntax) {
-    visitAnyPost(node._syntaxNode)
-  }
-  
   override open func visit(_ node: AccessorBlockSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
@@ -1146,6 +1130,22 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   }
   
   override open func visitPost(_ node: ImportDeclSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  
+  override open func visit(_ node: ImportPathComponentSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+  
+  override open func visitPost(_ node: ImportPathComponentSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  
+  override open func visit(_ node: ImportPathSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+  
+  override open func visitPost(_ node: ImportPathSyntax) {
     visitAnyPost(node._syntaxNode)
   }
   

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -684,8 +684,6 @@ extension Syntax {
   public static var structure: SyntaxNodeStructure {
     return .choices([
           .node(TokenSyntax.self),
-          .node(AccessPathComponentSyntax.self),
-          .node(AccessPathSyntax.self),
           .node(AccessorBlockSyntax.self),
           .node(AccessorDeclSyntax.self),
           .node(AccessorEffectSpecifiersSyntax.self),
@@ -821,6 +819,8 @@ extension Syntax {
           .node(ImplementsAttributeArgumentsSyntax.self),
           .node(ImplicitlyUnwrappedOptionalTypeSyntax.self),
           .node(ImportDeclSyntax.self),
+          .node(ImportPathComponentSyntax.self),
+          .node(ImportPathSyntax.self),
           .node(InOutExprSyntax.self),
           .node(InfixOperatorExprSyntax.self),
           .node(InheritedTypeListSyntax.self),

--- a/Sources/SwiftSyntax/generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxCollections.swift
@@ -25,215 +25,6 @@ public extension SyntaxCollection {
   }
 }
 
-/// `AccessPathSyntax` represents a collection of one or more
-/// `AccessPathComponent` nodes. AccessPathSyntax behaves
-/// as a regular Swift collection, and has accessors that return new
-/// versions of the collection with different children.
-public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
-  public typealias Element = AccessPathComponentSyntax
-  
-  public let _syntaxNode: Syntax
-  
-  private var layoutView: RawSyntaxLayoutView {
-    data.raw.layoutView!
-  }
-  
-  public init?<S: SyntaxProtocol>(_ node: S) {
-    guard node.raw.kind == .accessPath else {
-      return nil
-    }
-    self._syntaxNode = node._syntaxNode
-  }
-  
-  /// Creates a Syntax node from the provided root and data. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
-  internal init(_ data: SyntaxData) {
-    precondition(data.raw.kind == .accessPath)
-    self._syntaxNode = Syntax(data)
-  }
-  
-  public init(_ children: [Element]) {
-    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
-      let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessPath,
-                                     from: children.map {
-          $0.raw
-        }, arena: arena)
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
-  }
-  
-  /// The number of elements, `present` or `missing`, in this collection.
-  public var count: Int {
-    return layoutView.children.count
-  }
-  
-  /// Creates a new `AccessPathSyntax` by replacing the underlying layout with
-  /// a different set of raw syntax nodes.
-  ///
-  /// - Parameter layout: The new list of raw syntax nodes underlying this
-  ///                     collection.
-  /// - Returns: A new `AccessPathSyntax` with the new layout underlying it.
-  internal func replacingLayout(_ layout: [RawSyntax?]) -> AccessPathSyntax {
-    let arena = SyntaxArena()
-    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
-    let newData = data.replacingSelf(newRaw, arena: arena)
-    return AccessPathSyntax(newData)
-  }
-  
-  /// Creates a new `AccessPathSyntax` by appending the provided syntax element
-  /// to the children.
-  ///
-  /// - Parameter syntax: The element to append.
-  /// - Returns: A new `AccessPathSyntax` with that element appended to the end.
-  public func appending(_ syntax: Element) -> AccessPathSyntax {
-    var newLayout = layoutView.formLayoutArray()
-    newLayout.append(syntax.raw)
-    return replacingLayout(newLayout)
-  }
-  
-  /// Creates a new `AccessPathSyntax` by prepending the provided syntax element
-  /// to the children.
-  ///
-  /// - Parameter syntax: The element to prepend.
-  /// - Returns: A new `AccessPathSyntax` with that element prepended to the
-  ///            beginning.
-  public func prepending(_ syntax: Element) -> AccessPathSyntax {
-    return inserting(syntax, at: 0)
-  }
-  
-  /// Creates a new `AccessPathSyntax` by inserting the provided syntax element
-  /// at the provided index in the children.
-  ///
-  /// - Parameters:
-  ///   - syntax: The element to insert.
-  ///   - index: The index at which to insert the element in the collection.
-  ///
-  /// - Returns: A new `AccessPathSyntax` with that element appended to the end.
-  public func inserting(_ syntax: Element, at index: Int) -> AccessPathSyntax {
-    var newLayout = layoutView.formLayoutArray()
-    /// Make sure the index is a valid insertion index (0 to 1 past the end)
-    precondition((newLayout.startIndex ... newLayout.endIndex).contains(index),
-                 "inserting node at invalid index \(index)")
-    newLayout.insert(syntax.raw, at: index)
-    return replacingLayout(newLayout)
-  }
-  
-  /// Creates a new `AccessPathSyntax` by replacing the syntax element
-  /// at the provided index.
-  ///
-  /// - Parameters:
-  ///   - index: The index at which to replace the element in the collection.
-  ///   - syntax: The element to replace with.
-  ///
-  /// - Returns: A new `AccessPathSyntax` with the new element at the provided index.
-  public func replacing(childAt index: Int, with syntax: Element) -> AccessPathSyntax {
-    var newLayout = layoutView.formLayoutArray()
-    /// Make sure the index is a valid index for replacing
-    precondition((newLayout.startIndex ..< newLayout.endIndex).contains(index),
-                 "replacing node at invalid index \(index)")
-    newLayout[index] = syntax.raw
-    return replacingLayout(newLayout)
-  }
-  
-  /// Creates a new `AccessPathSyntax` by removing the syntax element at the
-  /// provided index.
-  ///
-  /// - Parameter index: The index of the element to remove from the collection.
-  /// - Returns: A new `AccessPathSyntax` with the element at the provided index
-  ///            removed.
-  public func removing(childAt index: Int) -> AccessPathSyntax {
-    var newLayout = layoutView.formLayoutArray()
-    newLayout.remove(at: index)
-    return replacingLayout(newLayout)
-  }
-  
-  /// Creates a new `AccessPathSyntax` by removing the first element.
-  ///
-  /// - Returns: A new `AccessPathSyntax` with the first element removed.
-  public func removingFirst() -> AccessPathSyntax {
-    var newLayout = layoutView.formLayoutArray()
-    newLayout.removeFirst()
-    return replacingLayout(newLayout)
-  }
-  
-  /// Creates a new `AccessPathSyntax` by removing the last element.
-  ///
-  /// - Returns: A new `AccessPathSyntax` with the last element removed.
-  public func removingLast() -> AccessPathSyntax {
-    var newLayout = layoutView.formLayoutArray()
-    newLayout.removeLast()
-    return replacingLayout(newLayout)
-  }
-}
-
-/// Conformance for `AccessPathSyntax` to the `BidirectionalCollection` protocol.
-extension AccessPathSyntax: BidirectionalCollection {
-  public typealias Index = SyntaxChildrenIndex
-  
-  public struct Iterator: IteratorProtocol {
-    private let parent: Syntax
-    
-    private var iterator: RawSyntaxChildren.Iterator
-    
-
-    init(parent: Syntax, rawChildren: RawSyntaxChildren) {
-      self.parent = parent
-      self.iterator = rawChildren.makeIterator()
-    }
-    
-
-    public mutating func next() -> Element? {
-      guard let (raw, info) = self.iterator.next() else {
-        return nil
-      }
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
-      let data = SyntaxData(absoluteRaw, parent: parent)
-      return Element(data)
-    }
-  }
-  
-  public func makeIterator() -> Iterator {
-    return Iterator(parent: Syntax(self), rawChildren: rawChildren)
-  }
-  
-  private var rawChildren: RawSyntaxChildren {
-    // We know children in a syntax collection cannot be missing. So we can
-    // use the low-level and faster RawSyntaxChildren collection instead of
-    // NonNilRawSyntaxChildren.
-    return RawSyntaxChildren(self.data.absoluteRaw)
-  }
-  
-  public var startIndex: SyntaxChildrenIndex {
-    return rawChildren.startIndex
-  }
-  
-  public var endIndex: SyntaxChildrenIndex {
-    return rawChildren.endIndex
-  }
-  
-  public func index(after index: SyntaxChildrenIndex) -> SyntaxChildrenIndex {
-    return rawChildren.index(after: index)
-  }
-  
-  public func index(before index: SyntaxChildrenIndex) -> SyntaxChildrenIndex {
-    return rawChildren.index(before: index)
-  }
-  
-  public func distance(from start: SyntaxChildrenIndex, to end: SyntaxChildrenIndex)
-  -> Int {
-    return rawChildren.distance(from: start, to: end)
-  }
-  
-  public subscript(position: SyntaxChildrenIndex) -> Element {
-    let (raw, info) = rawChildren[position]
-    let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
-    let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return Element(data)
-  }
-}
-
 /// `AccessorListSyntax` represents a collection of one or more
 /// `AccessorDecl` nodes. AccessorListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
@@ -6053,6 +5844,215 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
 
 /// Conformance for `IfConfigClauseListSyntax` to the `BidirectionalCollection` protocol.
 extension IfConfigClauseListSyntax: BidirectionalCollection {
+  public typealias Index = SyntaxChildrenIndex
+  
+  public struct Iterator: IteratorProtocol {
+    private let parent: Syntax
+    
+    private var iterator: RawSyntaxChildren.Iterator
+    
+
+    init(parent: Syntax, rawChildren: RawSyntaxChildren) {
+      self.parent = parent
+      self.iterator = rawChildren.makeIterator()
+    }
+    
+
+    public mutating func next() -> Element? {
+      guard let (raw, info) = self.iterator.next() else {
+        return nil
+      }
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
+      let data = SyntaxData(absoluteRaw, parent: parent)
+      return Element(data)
+    }
+  }
+  
+  public func makeIterator() -> Iterator {
+    return Iterator(parent: Syntax(self), rawChildren: rawChildren)
+  }
+  
+  private var rawChildren: RawSyntaxChildren {
+    // We know children in a syntax collection cannot be missing. So we can
+    // use the low-level and faster RawSyntaxChildren collection instead of
+    // NonNilRawSyntaxChildren.
+    return RawSyntaxChildren(self.data.absoluteRaw)
+  }
+  
+  public var startIndex: SyntaxChildrenIndex {
+    return rawChildren.startIndex
+  }
+  
+  public var endIndex: SyntaxChildrenIndex {
+    return rawChildren.endIndex
+  }
+  
+  public func index(after index: SyntaxChildrenIndex) -> SyntaxChildrenIndex {
+    return rawChildren.index(after: index)
+  }
+  
+  public func index(before index: SyntaxChildrenIndex) -> SyntaxChildrenIndex {
+    return rawChildren.index(before: index)
+  }
+  
+  public func distance(from start: SyntaxChildrenIndex, to end: SyntaxChildrenIndex)
+  -> Int {
+    return rawChildren.distance(from: start, to: end)
+  }
+  
+  public subscript(position: SyntaxChildrenIndex) -> Element {
+    let (raw, info) = rawChildren[position]
+    let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
+    let data = SyntaxData(absoluteRaw, parent: Syntax(self))
+    return Element(data)
+  }
+}
+
+/// `ImportPathSyntax` represents a collection of one or more
+/// `ImportPathComponent` nodes. ImportPathSyntax behaves
+/// as a regular Swift collection, and has accessors that return new
+/// versions of the collection with different children.
+public struct ImportPathSyntax: SyntaxCollection, SyntaxHashable {
+  public typealias Element = ImportPathComponentSyntax
+  
+  public let _syntaxNode: Syntax
+  
+  private var layoutView: RawSyntaxLayoutView {
+    data.raw.layoutView!
+  }
+  
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .importPath else {
+      return nil
+    }
+    self._syntaxNode = node._syntaxNode
+  }
+  
+  /// Creates a Syntax node from the provided root and data. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    precondition(data.raw.kind == .importPath)
+    self._syntaxNode = Syntax(data)
+  }
+  
+  public init(_ children: [Element]) {
+    let data: SyntaxData = withExtendedLifetime(SyntaxArena()) { arena in
+      let raw = RawSyntax.makeLayout(kind: SyntaxKind.importPath,
+                                     from: children.map {
+          $0.raw
+        }, arena: arena)
+      return SyntaxData.forRoot(raw)
+    }
+    self.init(data)
+  }
+  
+  /// The number of elements, `present` or `missing`, in this collection.
+  public var count: Int {
+    return layoutView.children.count
+  }
+  
+  /// Creates a new `ImportPathSyntax` by replacing the underlying layout with
+  /// a different set of raw syntax nodes.
+  ///
+  /// - Parameter layout: The new list of raw syntax nodes underlying this
+  ///                     collection.
+  /// - Returns: A new `ImportPathSyntax` with the new layout underlying it.
+  internal func replacingLayout(_ layout: [RawSyntax?]) -> ImportPathSyntax {
+    let arena = SyntaxArena()
+    let newRaw = layoutView.replacingLayout(with: layout, arena: arena)
+    let newData = data.replacingSelf(newRaw, arena: arena)
+    return ImportPathSyntax(newData)
+  }
+  
+  /// Creates a new `ImportPathSyntax` by appending the provided syntax element
+  /// to the children.
+  ///
+  /// - Parameter syntax: The element to append.
+  /// - Returns: A new `ImportPathSyntax` with that element appended to the end.
+  public func appending(_ syntax: Element) -> ImportPathSyntax {
+    var newLayout = layoutView.formLayoutArray()
+    newLayout.append(syntax.raw)
+    return replacingLayout(newLayout)
+  }
+  
+  /// Creates a new `ImportPathSyntax` by prepending the provided syntax element
+  /// to the children.
+  ///
+  /// - Parameter syntax: The element to prepend.
+  /// - Returns: A new `ImportPathSyntax` with that element prepended to the
+  ///            beginning.
+  public func prepending(_ syntax: Element) -> ImportPathSyntax {
+    return inserting(syntax, at: 0)
+  }
+  
+  /// Creates a new `ImportPathSyntax` by inserting the provided syntax element
+  /// at the provided index in the children.
+  ///
+  /// - Parameters:
+  ///   - syntax: The element to insert.
+  ///   - index: The index at which to insert the element in the collection.
+  ///
+  /// - Returns: A new `ImportPathSyntax` with that element appended to the end.
+  public func inserting(_ syntax: Element, at index: Int) -> ImportPathSyntax {
+    var newLayout = layoutView.formLayoutArray()
+    /// Make sure the index is a valid insertion index (0 to 1 past the end)
+    precondition((newLayout.startIndex ... newLayout.endIndex).contains(index),
+                 "inserting node at invalid index \(index)")
+    newLayout.insert(syntax.raw, at: index)
+    return replacingLayout(newLayout)
+  }
+  
+  /// Creates a new `ImportPathSyntax` by replacing the syntax element
+  /// at the provided index.
+  ///
+  /// - Parameters:
+  ///   - index: The index at which to replace the element in the collection.
+  ///   - syntax: The element to replace with.
+  ///
+  /// - Returns: A new `ImportPathSyntax` with the new element at the provided index.
+  public func replacing(childAt index: Int, with syntax: Element) -> ImportPathSyntax {
+    var newLayout = layoutView.formLayoutArray()
+    /// Make sure the index is a valid index for replacing
+    precondition((newLayout.startIndex ..< newLayout.endIndex).contains(index),
+                 "replacing node at invalid index \(index)")
+    newLayout[index] = syntax.raw
+    return replacingLayout(newLayout)
+  }
+  
+  /// Creates a new `ImportPathSyntax` by removing the syntax element at the
+  /// provided index.
+  ///
+  /// - Parameter index: The index of the element to remove from the collection.
+  /// - Returns: A new `ImportPathSyntax` with the element at the provided index
+  ///            removed.
+  public func removing(childAt index: Int) -> ImportPathSyntax {
+    var newLayout = layoutView.formLayoutArray()
+    newLayout.remove(at: index)
+    return replacingLayout(newLayout)
+  }
+  
+  /// Creates a new `ImportPathSyntax` by removing the first element.
+  ///
+  /// - Returns: A new `ImportPathSyntax` with the first element removed.
+  public func removingFirst() -> ImportPathSyntax {
+    var newLayout = layoutView.formLayoutArray()
+    newLayout.removeFirst()
+    return replacingLayout(newLayout)
+  }
+  
+  /// Creates a new `ImportPathSyntax` by removing the last element.
+  ///
+  /// - Returns: A new `ImportPathSyntax` with the last element removed.
+  public func removingLast() -> ImportPathSyntax {
+    var newLayout = layoutView.formLayoutArray()
+    newLayout.removeLast()
+    return replacingLayout(newLayout)
+  }
+}
+
+/// Conformance for `ImportPathSyntax` to the `BidirectionalCollection` protocol.
+extension ImportPathSyntax: BidirectionalCollection {
   public typealias Index = SyntaxChildrenIndex
   
   public struct Iterator: IteratorProtocol {

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -16,8 +16,6 @@
 @frozen // FIXME: Not actually stable, works around a miscompile
 public enum SyntaxEnum {
   case token(TokenSyntax)
-  case accessPathComponent(AccessPathComponentSyntax)
-  case accessPath(AccessPathSyntax)
   case accessorBlock(AccessorBlockSyntax)
   case accessorDecl(AccessorDeclSyntax)
   case accessorEffectSpecifiers(AccessorEffectSpecifiersSyntax)
@@ -153,6 +151,8 @@ public enum SyntaxEnum {
   case implementsAttributeArguments(ImplementsAttributeArgumentsSyntax)
   case implicitlyUnwrappedOptionalType(ImplicitlyUnwrappedOptionalTypeSyntax)
   case importDecl(ImportDeclSyntax)
+  case importPathComponent(ImportPathComponentSyntax)
+  case importPath(ImportPathSyntax)
   case inOutExpr(InOutExprSyntax)
   case infixOperatorExpr(InfixOperatorExprSyntax)
   case inheritedTypeList(InheritedTypeListSyntax)
@@ -293,10 +293,6 @@ public extension Syntax {
     switch raw.kind {
     case .token:
       return .token(TokenSyntax(self)!)
-    case .accessPathComponent:
-      return .accessPathComponent(AccessPathComponentSyntax(self)!)
-    case .accessPath:
-      return .accessPath(AccessPathSyntax(self)!)
     case .accessorBlock:
       return .accessorBlock(AccessorBlockSyntax(self)!)
     case .accessorDecl:
@@ -567,6 +563,10 @@ public extension Syntax {
       return .implicitlyUnwrappedOptionalType(ImplicitlyUnwrappedOptionalTypeSyntax(self)!)
     case .importDecl:
       return .importDecl(ImportDeclSyntax(self)!)
+    case .importPathComponent:
+      return .importPathComponent(ImportPathComponentSyntax(self)!)
+    case .importPath:
+      return .importPath(ImportPathSyntax(self)!)
     case .inOutExpr:
       return .inOutExpr(InOutExprSyntax(self)!)
     case .infixOperatorExpr:

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -16,8 +16,6 @@
 @frozen // FIXME: Not actually stable, works around a miscompile
 public enum SyntaxKind {
   case token
-  case accessPathComponent
-  case accessPath
   case accessorBlock
   case accessorDecl
   case accessorEffectSpecifiers
@@ -153,6 +151,8 @@ public enum SyntaxKind {
   case implementsAttributeArguments
   case implicitlyUnwrappedOptionalType
   case importDecl
+  case importPathComponent
+  case importPath
   case inOutExpr
   case infixOperatorExpr
   case inheritedTypeList
@@ -288,8 +288,6 @@ public enum SyntaxKind {
   
   public var isSyntaxCollection: Bool {
     switch self {
-    case .accessPath:
-      return true
     case .accessorList:
       return true
     case .arrayElementList:
@@ -345,6 +343,8 @@ public enum SyntaxKind {
     case .genericRequirementList:
       return true
     case .ifConfigClauseList:
+      return true
+    case .importPath:
       return true
     case .inheritedTypeList:
       return true
@@ -408,10 +408,6 @@ public enum SyntaxKind {
     switch self {
     case .token:
       return TokenSyntax.self
-    case .accessPathComponent:
-      return AccessPathComponentSyntax.self
-    case .accessPath:
-      return AccessPathSyntax.self
     case .accessorBlock:
       return AccessorBlockSyntax.self
     case .accessorDecl:
@@ -682,6 +678,10 @@ public enum SyntaxKind {
       return ImplicitlyUnwrappedOptionalTypeSyntax.self
     case .importDecl:
       return ImportDeclSyntax.self
+    case .importPathComponent:
+      return ImportPathComponentSyntax.self
+    case .importPath:
+      return ImportPathSyntax.self
     case .inOutExpr:
       return InOutExprSyntax.self
     case .infixOperatorExpr:

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -25,20 +25,6 @@ open class SyntaxRewriter {
   public init() {
   }
   
-  /// Visit a `AccessPathComponentSyntax`.
-  ///   - Parameter node: the node that is being visited
-  ///   - Returns: the rewritten node
-  open func visit(_ node: AccessPathComponentSyntax) -> AccessPathComponentSyntax {
-    return Syntax(visitChildren(node)).cast(AccessPathComponentSyntax.self)
-  }
-  
-  /// Visit a `AccessPathSyntax`.
-  ///   - Parameter node: the node that is being visited
-  ///   - Returns: the rewritten node
-  open func visit(_ node: AccessPathSyntax) -> AccessPathSyntax {
-    return Syntax(visitChildren(node)).cast(AccessPathSyntax.self)
-  }
-  
   /// Visit a `AccessorBlockSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -982,6 +968,20 @@ open class SyntaxRewriter {
   ///   - Returns: the rewritten node
   open func visit(_ node: ImportDeclSyntax) -> DeclSyntax {
     return DeclSyntax(visitChildren(node))
+  }
+  
+  /// Visit a `ImportPathComponentSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: ImportPathComponentSyntax) -> ImportPathComponentSyntax {
+    return Syntax(visitChildren(node)).cast(ImportPathComponentSyntax.self)
+  }
+  
+  /// Visit a `ImportPathSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: ImportPathSyntax) -> ImportPathSyntax {
+    return Syntax(visitChildren(node)).cast(ImportPathSyntax.self)
   }
   
   /// Visit a `InOutExprSyntax`.
@@ -1980,34 +1980,6 @@ open class SyntaxRewriter {
   ///   - Returns: the rewritten node
   public func visit(_ node: TypeSyntax) -> TypeSyntax {
     return visit(node.data).cast(TypeSyntax.self)
-  }
-  
-  /// Implementation detail of visit(_:). Do not call directly.
-  private func visitImplAccessPathComponentSyntax(_ data: SyntaxData) -> Syntax {
-    let node = AccessPathComponentSyntax(data)
-    // Accessing _syntaxNode directly is faster than calling Syntax(node)
-    visitPre(node._syntaxNode)
-    defer {
-      visitPost(node._syntaxNode)
-    }
-    if let newNode = visitAny(node._syntaxNode) {
-      return newNode
-    }
-    return Syntax(visit(node))
-  }
-  
-  /// Implementation detail of visit(_:). Do not call directly.
-  private func visitImplAccessPathSyntax(_ data: SyntaxData) -> Syntax {
-    let node = AccessPathSyntax(data)
-    // Accessing _syntaxNode directly is faster than calling Syntax(node)
-    visitPre(node._syntaxNode)
-    defer {
-      visitPost(node._syntaxNode)
-    }
-    if let newNode = visitAny(node._syntaxNode) {
-      return newNode
-    }
-    return Syntax(visit(node))
   }
   
   /// Implementation detail of visit(_:). Do not call directly.
@@ -3889,6 +3861,34 @@ open class SyntaxRewriter {
   /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplImportDeclSyntax(_ data: SyntaxData) -> Syntax {
     let node = ImportDeclSyntax(data)
+    // Accessing _syntaxNode directly is faster than calling Syntax(node)
+    visitPre(node._syntaxNode)
+    defer {
+      visitPost(node._syntaxNode)
+    }
+    if let newNode = visitAny(node._syntaxNode) {
+      return newNode
+    }
+    return Syntax(visit(node))
+  }
+  
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplImportPathComponentSyntax(_ data: SyntaxData) -> Syntax {
+    let node = ImportPathComponentSyntax(data)
+    // Accessing _syntaxNode directly is faster than calling Syntax(node)
+    visitPre(node._syntaxNode)
+    defer {
+      visitPost(node._syntaxNode)
+    }
+    if let newNode = visitAny(node._syntaxNode) {
+      return newNode
+    }
+    return Syntax(visit(node))
+  }
+  
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplImportPathSyntax(_ data: SyntaxData) -> Syntax {
+    let node = ImportPathSyntax(data)
     // Accessing _syntaxNode directly is faster than calling Syntax(node)
     visitPre(node._syntaxNode)
     defer {
@@ -5790,10 +5790,6 @@ open class SyntaxRewriter {
     switch data.raw.kind {
     case .token:
       return visitImplTokenSyntax
-    case .accessPathComponent:
-      return visitImplAccessPathComponentSyntax
-    case .accessPath:
-      return visitImplAccessPathSyntax
     case .accessorBlock:
       return visitImplAccessorBlockSyntax
     case .accessorDecl:
@@ -6064,6 +6060,10 @@ open class SyntaxRewriter {
       return visitImplImplicitlyUnwrappedOptionalTypeSyntax
     case .importDecl:
       return visitImplImportDeclSyntax
+    case .importPathComponent:
+      return visitImplImportPathComponentSyntax
+    case .importPath:
+      return visitImplImportPathSyntax
     case .inOutExpr:
       return visitImplInOutExprSyntax
     case .infixOperatorExpr:
@@ -6338,10 +6338,6 @@ open class SyntaxRewriter {
     switch data.raw.kind {
     case .token:
       return visitImplTokenSyntax(data)
-    case .accessPathComponent:
-      return visitImplAccessPathComponentSyntax(data)
-    case .accessPath:
-      return visitImplAccessPathSyntax(data)
     case .accessorBlock:
       return visitImplAccessorBlockSyntax(data)
     case .accessorDecl:
@@ -6612,6 +6608,10 @@ open class SyntaxRewriter {
       return visitImplImplicitlyUnwrappedOptionalTypeSyntax(data)
     case .importDecl:
       return visitImplImportDeclSyntax(data)
+    case .importPathComponent:
+      return visitImplImportPathComponentSyntax(data)
+    case .importPath:
+      return visitImplImportPathSyntax(data)
     case .inOutExpr:
       return visitImplInOutExprSyntax(data)
     case .infixOperatorExpr:

--- a/Sources/SwiftSyntax/generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTransform.swift
@@ -19,16 +19,6 @@ public protocol SyntaxTransformVisitor {
   
   func visit(_ token: TokenSyntax) -> ResultType
   
-  /// Visiting `AccessPathComponentSyntax` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: the sum of whatever the child visitors return.
-  func visit(_ node: AccessPathComponentSyntax) -> ResultType
-  
-  /// Visiting `AccessPathSyntax` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: the sum of whatever the child visitors return.
-  func visit(_ node: AccessPathSyntax) -> ResultType
-  
   /// Visiting `AccessorBlockSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -704,6 +694,16 @@ public protocol SyntaxTransformVisitor {
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: ImportDeclSyntax) -> ResultType
   
+  /// Visiting `ImportPathComponentSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: ImportPathComponentSyntax) -> ResultType
+  
+  /// Visiting `ImportPathSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: ImportPathSyntax) -> ResultType
+  
   /// Visiting `InOutExprSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -1368,20 +1368,6 @@ public protocol SyntaxTransformVisitor {
 extension SyntaxTransformVisitor {
   public func visit(_ token: TokenSyntax) -> ResultType {
     visitAny(Syntax(token))
-  }
-  
-  /// Visiting `AccessPathComponentSyntax` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: nil by default.
-  public func visit(_ node: AccessPathComponentSyntax) -> ResultType {
-    visitAny(Syntax(node))
-  }
-  
-  /// Visiting `AccessPathSyntax` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: nil by default.
-  public func visit(_ node: AccessPathSyntax) -> ResultType {
-    visitAny(Syntax(node))
   }
   
   /// Visiting `AccessorBlockSyntax` specifically.
@@ -2329,6 +2315,20 @@ extension SyntaxTransformVisitor {
     visitAny(Syntax(node))
   }
   
+  /// Visiting `ImportPathComponentSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: ImportPathComponentSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
+  
+  /// Visiting `ImportPathSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: ImportPathSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
+  
   /// Visiting `InOutExprSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
@@ -3257,10 +3257,6 @@ extension SyntaxTransformVisitor {
     switch node.as(SyntaxEnum.self) {
     case .token(let node):
       return visit(node)
-    case .accessPathComponent(let derived):
-      return visit(derived)
-    case .accessPath(let derived):
-      return visit(derived)
     case .accessorBlock(let derived):
       return visit(derived)
     case .accessorDecl(let derived):
@@ -3530,6 +3526,10 @@ extension SyntaxTransformVisitor {
     case .implicitlyUnwrappedOptionalType(let derived):
       return visit(derived)
     case .importDecl(let derived):
+      return visit(derived)
+    case .importPathComponent(let derived):
+      return visit(derived)
+    case .importPath(let derived):
       return visit(derived)
     case .inOutExpr(let derived):
       return visit(derived)

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -34,30 +34,6 @@ open class SyntaxVisitor {
     visit(node.data)
   }
   
-  /// Visiting `AccessPathComponentSyntax` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: how should we continue visiting.
-  open func visit(_ node: AccessPathComponentSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-  
-  /// The function called after visiting `AccessPathComponentSyntax` and its descendents.
-  ///   - node: the node we just finished visiting.
-  open func visitPost(_ node: AccessPathComponentSyntax) {
-  }
-  
-  /// Visiting `AccessPathSyntax` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: how should we continue visiting.
-  open func visit(_ node: AccessPathSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-  
-  /// The function called after visiting `AccessPathSyntax` and its descendents.
-  ///   - node: the node we just finished visiting.
-  open func visitPost(_ node: AccessPathSyntax) {
-  }
-  
   /// Visiting `AccessorBlockSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -1678,6 +1654,30 @@ open class SyntaxVisitor {
   open func visitPost(_ node: ImportDeclSyntax) {
   }
   
+  /// Visiting `ImportPathComponentSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: ImportPathComponentSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+  
+  /// The function called after visiting `ImportPathComponentSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: ImportPathComponentSyntax) {
+  }
+  
+  /// Visiting `ImportPathSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: ImportPathSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+  
+  /// The function called after visiting `ImportPathSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: ImportPathSyntax) {
+  }
+  
   /// Visiting `InOutExprSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -3275,28 +3275,6 @@ open class SyntaxVisitor {
   }
   
   /// Implementation detail of doVisit(_:_:). Do not call directly.
-  private func visitImplAccessPathComponentSyntax(_ data: SyntaxData) {
-    let node = AccessPathComponentSyntax(data)
-    let needsChildren = (visit(node) == .visitChildren)
-    // Avoid calling into visitChildren if possible.
-    if needsChildren && !node.raw.layoutView!.children.isEmpty {
-      visitChildren(node)
-    }
-    visitPost(node)
-  }
-  
-  /// Implementation detail of doVisit(_:_:). Do not call directly.
-  private func visitImplAccessPathSyntax(_ data: SyntaxData) {
-    let node = AccessPathSyntax(data)
-    let needsChildren = (visit(node) == .visitChildren)
-    // Avoid calling into visitChildren if possible.
-    if needsChildren && !node.raw.layoutView!.children.isEmpty {
-      visitChildren(node)
-    }
-    visitPost(node)
-  }
-  
-  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplAccessorBlockSyntax(_ data: SyntaxData) {
     let node = AccessorBlockSyntax(data)
     let needsChildren = (visit(node) == .visitChildren)
@@ -4782,6 +4760,28 @@ open class SyntaxVisitor {
   }
   
   /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplImportPathComponentSyntax(_ data: SyntaxData) {
+    let node = ImportPathComponentSyntax(data)
+    let needsChildren = (visit(node) == .visitChildren)
+    // Avoid calling into visitChildren if possible.
+    if needsChildren && !node.raw.layoutView!.children.isEmpty {
+      visitChildren(node)
+    }
+    visitPost(node)
+  }
+  
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplImportPathSyntax(_ data: SyntaxData) {
+    let node = ImportPathSyntax(data)
+    let needsChildren = (visit(node) == .visitChildren)
+    // Avoid calling into visitChildren if possible.
+    if needsChildren && !node.raw.layoutView!.children.isEmpty {
+      visitChildren(node)
+    }
+    visitPost(node)
+  }
+  
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplInOutExprSyntax(_ data: SyntaxData) {
     let node = InOutExprSyntax(data)
     let needsChildren = (visit(node) == .visitChildren)
@@ -6240,10 +6240,6 @@ open class SyntaxVisitor {
       _ = visit(node)
       // No children to visit.
       visitPost(node)
-    case .accessPathComponent:
-      visitImplAccessPathComponentSyntax(data)
-    case .accessPath:
-      visitImplAccessPathSyntax(data)
     case .accessorBlock:
       visitImplAccessorBlockSyntax(data)
     case .accessorDecl:
@@ -6514,6 +6510,10 @@ open class SyntaxVisitor {
       visitImplImplicitlyUnwrappedOptionalTypeSyntax(data)
     case .importDecl:
       visitImplImportDeclSyntax(data)
+    case .importPathComponent:
+      visitImplImportPathComponentSyntax(data)
+    case .importPath:
+      visitImplImportPathSyntax(data)
     case .inOutExpr:
       visitImplInOutExprSyntax(data)
     case .infixOperatorExpr:

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -28,126 +28,6 @@ public protocol RawStmtSyntaxNodeProtocol: RawSyntaxNodeProtocol {}
 public protocol RawTypeSyntaxNodeProtocol: RawSyntaxNodeProtocol {}
 
 @_spi(RawSyntax)
-public struct RawAccessPathComponentSyntax: RawSyntaxNodeProtocol {
-  @_spi(RawSyntax)
-  public var layoutView: RawSyntaxLayoutView {
-    return raw.layoutView!
-  }
-  
-  public static func isKindOf(_ raw: RawSyntax) -> Bool {
-    return raw.kind == .accessPathComponent
-  }
-  
-  public var raw: RawSyntax
-  
-  init(raw: RawSyntax) {
-    precondition(Self.isKindOf(raw))
-    self.raw = raw
-  }
-  
-  private init(unchecked raw: RawSyntax) {
-    self.raw = raw
-  }
-  
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
-    guard Self.isKindOf(other.raw) else {
-      return nil
-    }
-    self.init(unchecked: other.raw)
-  }
-  
-  public init(
-      _ unexpectedBeforeName: RawUnexpectedNodesSyntax? = nil, 
-      name: RawTokenSyntax, 
-      _ unexpectedBetweenNameAndTrailingDot: RawUnexpectedNodesSyntax? = nil, 
-      trailingDot: RawTokenSyntax?, 
-      _ unexpectedAfterTrailingDot: RawUnexpectedNodesSyntax? = nil, 
-      arena: __shared SyntaxArena
-    ) {
-    let raw = RawSyntax.makeLayout(
-      kind: .accessPathComponent, uninitializedCount: 5, arena: arena) { layout in
-      layout.initialize(repeating: nil)
-      layout[0] = unexpectedBeforeName?.raw
-      layout[1] = name.raw
-      layout[2] = unexpectedBetweenNameAndTrailingDot?.raw
-      layout[3] = trailingDot?.raw
-      layout[4] = unexpectedAfterTrailingDot?.raw
-    }
-    self.init(unchecked: raw)
-  }
-  
-  public var unexpectedBeforeName: RawUnexpectedNodesSyntax? {
-    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  
-  public var name: RawTokenSyntax {
-    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
-  }
-  
-  public var unexpectedBetweenNameAndTrailingDot: RawUnexpectedNodesSyntax? {
-    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  
-  public var trailingDot: RawTokenSyntax? {
-    layoutView.children[3].map(RawTokenSyntax.init(raw:))
-  }
-  
-  public var unexpectedAfterTrailingDot: RawUnexpectedNodesSyntax? {
-    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-}
-
-@_spi(RawSyntax)
-public struct RawAccessPathSyntax: RawSyntaxNodeProtocol {
-  @_spi(RawSyntax)
-  public var layoutView: RawSyntaxLayoutView {
-    return raw.layoutView!
-  }
-  
-  public static func isKindOf(_ raw: RawSyntax) -> Bool {
-    return raw.kind == .accessPath
-  }
-  
-  public var raw: RawSyntax
-  
-  init(raw: RawSyntax) {
-    precondition(Self.isKindOf(raw))
-    self.raw = raw
-  }
-  
-  private init(unchecked raw: RawSyntax) {
-    self.raw = raw
-  }
-  
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
-    guard Self.isKindOf(other.raw) else {
-      return nil
-    }
-    self.init(unchecked: other.raw)
-  }
-  
-  public init(elements: [RawAccessPathComponentSyntax], arena: __shared SyntaxArena) {
-    let raw = RawSyntax.makeLayout(
-      kind: .accessPath, uninitializedCount: elements.count, arena: arena) { layout in
-        guard var ptr = layout.baseAddress else {
-          return
-        }
-        for elem in elements {
-          ptr.initialize(to: elem.raw)
-          ptr += 1
-        }
-    }
-    self.init(unchecked: raw)
-  }
-  
-  public var elements: [RawAccessPathComponentSyntax] {
-    layoutView.children.map {
-      RawAccessPathComponentSyntax(raw: $0!)
-    }
-  }
-}
-
-@_spi(RawSyntax)
 public struct RawAccessorBlockSyntax: RawSyntaxNodeProtocol {
   @_spi(RawSyntax)
   public var layoutView: RawSyntaxLayoutView {
@@ -11409,7 +11289,7 @@ public struct RawImportDeclSyntax: RawDeclSyntaxNodeProtocol {
       _ unexpectedBetweenImportTokAndImportKind: RawUnexpectedNodesSyntax? = nil, 
       importKind: RawTokenSyntax?, 
       _ unexpectedBetweenImportKindAndPath: RawUnexpectedNodesSyntax? = nil, 
-      path: RawAccessPathSyntax, 
+      path: RawImportPathSyntax, 
       _ unexpectedAfterPath: RawUnexpectedNodesSyntax? = nil, 
       arena: __shared SyntaxArena
     ) {
@@ -11467,12 +11347,132 @@ public struct RawImportDeclSyntax: RawDeclSyntaxNodeProtocol {
     layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
   
-  public var path: RawAccessPathSyntax {
-    layoutView.children[9].map(RawAccessPathSyntax.init(raw:))!
+  public var path: RawImportPathSyntax {
+    layoutView.children[9].map(RawImportPathSyntax.init(raw:))!
   }
   
   public var unexpectedAfterPath: RawUnexpectedNodesSyntax? {
     layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+}
+
+@_spi(RawSyntax)
+public struct RawImportPathComponentSyntax: RawSyntaxNodeProtocol {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+  
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .importPathComponent
+  }
+  
+  public var raw: RawSyntax
+  
+  init(raw: RawSyntax) {
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
+    self.raw = raw
+  }
+  
+  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+    guard Self.isKindOf(other.raw) else {
+      return nil
+    }
+    self.init(unchecked: other.raw)
+  }
+  
+  public init(
+      _ unexpectedBeforeName: RawUnexpectedNodesSyntax? = nil, 
+      name: RawTokenSyntax, 
+      _ unexpectedBetweenNameAndTrailingDot: RawUnexpectedNodesSyntax? = nil, 
+      trailingDot: RawTokenSyntax?, 
+      _ unexpectedAfterTrailingDot: RawUnexpectedNodesSyntax? = nil, 
+      arena: __shared SyntaxArena
+    ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .importPathComponent, uninitializedCount: 5, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeName?.raw
+      layout[1] = name.raw
+      layout[2] = unexpectedBetweenNameAndTrailingDot?.raw
+      layout[3] = trailingDot?.raw
+      layout[4] = unexpectedAfterTrailingDot?.raw
+    }
+    self.init(unchecked: raw)
+  }
+  
+  public var unexpectedBeforeName: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var name: RawTokenSyntax {
+    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  
+  public var unexpectedBetweenNameAndTrailingDot: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var trailingDot: RawTokenSyntax? {
+    layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  
+  public var unexpectedAfterTrailingDot: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+}
+
+@_spi(RawSyntax)
+public struct RawImportPathSyntax: RawSyntaxNodeProtocol {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+  
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .importPath
+  }
+  
+  public var raw: RawSyntax
+  
+  init(raw: RawSyntax) {
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
+    self.raw = raw
+  }
+  
+  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+    guard Self.isKindOf(other.raw) else {
+      return nil
+    }
+    self.init(unchecked: other.raw)
+  }
+  
+  public init(elements: [RawImportPathComponentSyntax], arena: __shared SyntaxArena) {
+    let raw = RawSyntax.makeLayout(
+      kind: .importPath, uninitializedCount: elements.count, arena: arena) { layout in
+        guard var ptr = layout.baseAddress else {
+          return
+        }
+        for elem in elements {
+          ptr.initialize(to: elem.raw)
+          ptr += 1
+        }
+    }
+    self.init(unchecked: raw)
+  }
+  
+  public var elements: [RawImportPathComponentSyntax] {
+    layoutView.children.map {
+      RawImportPathComponentSyntax(raw: $0!)
+    }
   }
 }
 

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -205,22 +205,6 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
   switch kind {
   case .token:
     assertionFailure("validateLayout for .token kind is not supported")
-  case .accessPathComponent:
-    assert(layout.count == 5)
-    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
-            .tokenKind(.identifier), 
-            .tokenKind(.binaryOperator), 
-            .tokenKind(.prefixOperator), 
-            .tokenKind(.postfixOperator)
-          ]))
-    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.period)]))
-    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-  case .accessPath:
-    for (index, element) in layout.enumerated() {
-      assertNoError(kind, index, verify(element, as: RawAccessPathComponentSyntax.self))
-    }
   case .accessorBlock:
     assert(layout.count == 7)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
@@ -1482,8 +1466,24 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
             .keyword("inout")
           ]))
     assertNoError(kind, 8, verify(layout[8], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 9, verify(layout[9], as: RawAccessPathSyntax.self))
+    assertNoError(kind, 9, verify(layout[9], as: RawImportPathSyntax.self))
     assertNoError(kind, 10, verify(layout[10], as: RawUnexpectedNodesSyntax?.self))
+  case .importPathComponent:
+    assert(layout.count == 5)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [
+            .tokenKind(.identifier), 
+            .tokenKind(.binaryOperator), 
+            .tokenKind(.prefixOperator), 
+            .tokenKind(.postfixOperator)
+          ]))
+    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax?.self, tokenChoices: [.tokenKind(.period)]))
+    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
+  case .importPath:
+    for (index, element) in layout.enumerated() {
+      assertNoError(kind, index, verify(element, as: RawImportPathComponentSyntax.self))
+    }
   case .inOutExpr:
     assert(layout.count == 5)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxDeclNodes.swift
@@ -2817,7 +2817,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       _ unexpectedBetweenImportTokAndImportKind: UnexpectedNodesSyntax? = nil,
       importKind: TokenSyntax? = nil,
       _ unexpectedBetweenImportKindAndPath: UnexpectedNodesSyntax? = nil,
-      path: AccessPathSyntax,
+      path: ImportPathSyntax,
       _ unexpectedAfterPath: UnexpectedNodesSyntax? = nil,
       trailingTrivia: Trivia? = nil
     
@@ -2987,9 +2987,9 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
   
   /// The path to the module, submodule or symbol being imported.
-  public var path: AccessPathSyntax {
+  public var path: ImportPathSyntax {
     get {
-      return AccessPathSyntax(data.child(at: 9, parent: Syntax(self))!)
+      return ImportPathSyntax(data.child(at: 9, parent: Syntax(self))!)
     }
     set(value) {
       self = ImportDeclSyntax(data.replacingChild(at: 9, with: value.raw, arena: SyntaxArena()))
@@ -3002,13 +3002,13 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                  `path` collection.
   /// - returns: A copy of the receiver with the provided `PathComponent`
   ///            appended to its `path` collection.
-  public func addPathComponent(_ element: AccessPathComponentSyntax) -> ImportDeclSyntax {
+  public func addPathComponent(_ element: ImportPathComponentSyntax) -> ImportDeclSyntax {
     var collection: RawSyntax
     let arena = SyntaxArena()
     if let col = raw.layoutView!.children[9] {
       collection = col.layoutView!.appending(element.raw, arena: arena)
     } else {
-      collection = RawSyntax.makeLayout(kind: SyntaxKind.accessPath,
+      collection = RawSyntax.makeLayout(kind: SyntaxKind.importPath,
                                         from: [element.raw], arena: arena)
     }
     let newData = data.replacingChild(at: 9, with: collection, arena: arena)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxNodes.swift
@@ -12,122 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// MARK: - AccessPathComponentSyntax
-
-
-public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
-  public let _syntaxNode: Syntax
-  
-  public init?<S: SyntaxProtocol>(_ node: S) {
-    guard node.raw.kind == .accessPathComponent else {
-      return nil
-    }
-    self._syntaxNode = node._syntaxNode
-  }
-  
-  /// Creates a `AccessPathComponentSyntax` node from the given `SyntaxData`. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
-  internal init(_ data: SyntaxData) {
-    precondition(data.raw.kind == .accessPathComponent)
-    self._syntaxNode = Syntax(data)
-  }
-  
-  public init(
-      leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforeName: UnexpectedNodesSyntax? = nil,
-      name: TokenSyntax,
-      _ unexpectedBetweenNameAndTrailingDot: UnexpectedNodesSyntax? = nil,
-      trailingDot: TokenSyntax? = nil,
-      _ unexpectedAfterTrailingDot: UnexpectedNodesSyntax? = nil,
-      trailingTrivia: Trivia? = nil
-    
-  ) {
-    // Extend the lifetime of all parameters so their arenas don't get destroyed
-    // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (
-            unexpectedBeforeName, 
-            name, 
-            unexpectedBetweenNameAndTrailingDot, 
-            trailingDot, 
-            unexpectedAfterTrailingDot
-          ))) {(arena, _) in
-      let layout: [RawSyntax?] = [
-          unexpectedBeforeName?.raw, 
-          name.raw, 
-          unexpectedBetweenNameAndTrailingDot?.raw, 
-          trailingDot?.raw, 
-          unexpectedAfterTrailingDot?.raw
-        ]
-      let raw = RawSyntax.makeLayout(
-        kind: SyntaxKind.accessPathComponent,
-        from: layout,
-        arena: arena,
-        leadingTrivia: leadingTrivia,
-        trailingTrivia: trailingTrivia
-        
-      )
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
-  }
-  
-  public var unexpectedBeforeName: UnexpectedNodesSyntax? {
-    get {
-      return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
-    }
-    set(value) {
-      self = AccessPathComponentSyntax(data.replacingChild(at: 0, with: value?.raw, arena: SyntaxArena()))
-    }
-  }
-  
-  public var name: TokenSyntax {
-    get {
-      return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)
-    }
-    set(value) {
-      self = AccessPathComponentSyntax(data.replacingChild(at: 1, with: value.raw, arena: SyntaxArena()))
-    }
-  }
-  
-  public var unexpectedBetweenNameAndTrailingDot: UnexpectedNodesSyntax? {
-    get {
-      return data.child(at: 2, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
-    }
-    set(value) {
-      self = AccessPathComponentSyntax(data.replacingChild(at: 2, with: value?.raw, arena: SyntaxArena()))
-    }
-  }
-  
-  public var trailingDot: TokenSyntax? {
-    get {
-      return data.child(at: 3, parent: Syntax(self)).map(TokenSyntax.init)
-    }
-    set(value) {
-      self = AccessPathComponentSyntax(data.replacingChild(at: 3, with: value?.raw, arena: SyntaxArena()))
-    }
-  }
-  
-  public var unexpectedAfterTrailingDot: UnexpectedNodesSyntax? {
-    get {
-      return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
-    }
-    set(value) {
-      self = AccessPathComponentSyntax(data.replacingChild(at: 4, with: value?.raw, arena: SyntaxArena()))
-    }
-  }
-  
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeName, 
-          \Self.name, 
-          \Self.unexpectedBetweenNameAndTrailingDot, 
-          \Self.trailingDot, 
-          \Self.unexpectedAfterTrailingDot
-        ])
-  }
-}
-
 // MARK: - AccessorBlockSyntax
 
 
@@ -10537,6 +10421,122 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
           \Self.unexpectedBetweenDeclBaseNameAndDeclNameArguments, 
           \Self.declNameArguments, 
           \Self.unexpectedAfterDeclNameArguments
+        ])
+  }
+}
+
+// MARK: - ImportPathComponentSyntax
+
+
+public struct ImportPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
+  public let _syntaxNode: Syntax
+  
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .importPathComponent else {
+      return nil
+    }
+    self._syntaxNode = node._syntaxNode
+  }
+  
+  /// Creates a `ImportPathComponentSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    precondition(data.raw.kind == .importPathComponent)
+    self._syntaxNode = Syntax(data)
+  }
+  
+  public init(
+      leadingTrivia: Trivia? = nil,
+      _ unexpectedBeforeName: UnexpectedNodesSyntax? = nil,
+      name: TokenSyntax,
+      _ unexpectedBetweenNameAndTrailingDot: UnexpectedNodesSyntax? = nil,
+      trailingDot: TokenSyntax? = nil,
+      _ unexpectedAfterTrailingDot: UnexpectedNodesSyntax? = nil,
+      trailingTrivia: Trivia? = nil
+    
+  ) {
+    // Extend the lifetime of all parameters so their arenas don't get destroyed
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (
+            unexpectedBeforeName, 
+            name, 
+            unexpectedBetweenNameAndTrailingDot, 
+            trailingDot, 
+            unexpectedAfterTrailingDot
+          ))) {(arena, _) in
+      let layout: [RawSyntax?] = [
+          unexpectedBeforeName?.raw, 
+          name.raw, 
+          unexpectedBetweenNameAndTrailingDot?.raw, 
+          trailingDot?.raw, 
+          unexpectedAfterTrailingDot?.raw
+        ]
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.importPathComponent,
+        from: layout,
+        arena: arena,
+        leadingTrivia: leadingTrivia,
+        trailingTrivia: trailingTrivia
+        
+      )
+      return SyntaxData.forRoot(raw)
+    }
+    self.init(data)
+  }
+  
+  public var unexpectedBeforeName: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = ImportPathComponentSyntax(data.replacingChild(at: 0, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var name: TokenSyntax {
+    get {
+      return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)
+    }
+    set(value) {
+      self = ImportPathComponentSyntax(data.replacingChild(at: 1, with: value.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var unexpectedBetweenNameAndTrailingDot: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 2, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = ImportPathComponentSyntax(data.replacingChild(at: 2, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var trailingDot: TokenSyntax? {
+    get {
+      return data.child(at: 3, parent: Syntax(self)).map(TokenSyntax.init)
+    }
+    set(value) {
+      self = ImportPathComponentSyntax(data.replacingChild(at: 3, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var unexpectedAfterTrailingDot: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = ImportPathComponentSyntax(data.replacingChild(at: 4, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public static var structure: SyntaxNodeStructure {
+    return .layout([
+          \Self.unexpectedBeforeName, 
+          \Self.name, 
+          \Self.unexpectedBetweenNameAndTrailingDot, 
+          \Self.trailingDot, 
+          \Self.unexpectedAfterTrailingDot
         ])
   }
 }

--- a/Sources/SwiftSyntaxBuilder/SwiftSyntaxBuilderCompatibility.swift
+++ b/Sources/SwiftSyntaxBuilder/SwiftSyntaxBuilderCompatibility.swift
@@ -10,18 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// This file provides compatiblity aliases to keep dependents of SwiftSyntax building.
+// This file provides compatiblity aliases to keep dependents of SwiftSyntaxBuilder building.
 // All users of the declarations in this file should transition away from them ASAP.
 
-public extension DeclGroupSyntax {
-  @available(*, deprecated, renamed: "memberBlock")
-  var members: MemberDeclBlockSyntax {
-    return self.memberBlock
-  }
-}
-
-@available(*, deprecated, renamed: "ImportPathSyntax")
-public typealias AccessPathSyntax = ImportPathSyntax
-
-@available(*, deprecated, renamed: "ImportPathComponentSyntax")
-public typealias AccessPathComponentSyntax = ImportPathComponentSyntax
+@available(*, deprecated, renamed: "ImportPathBuilder")
+public typealias AccessPathBuilder = ImportPathBuilder

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
@@ -14,13 +14,6 @@
 
 import SwiftSyntax
 
-/// `AccessPath` represents a collection of `AccessPathComponentSyntax`
-extension AccessPathSyntax: ExpressibleByArrayLiteral {
-  public init(arrayLiteral elements: Element...) {
-    self.init(elements)
-  }
-}
-
 /// `AccessorList` represents a collection of `AccessorDeclSyntax`
 extension AccessorListSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
@@ -218,6 +211,13 @@ extension GenericRequirementListSyntax: ExpressibleByArrayLiteral {
 
 /// `IfConfigClauseList` represents a collection of `IfConfigClauseSyntax`
 extension IfConfigClauseListSyntax: ExpressibleByArrayLiteral {
+  public init(arrayLiteral elements: Element...) {
+    self.init(elements)
+  }
+}
+
+/// `ImportPath` represents a collection of `ImportPathComponentSyntax`
+extension ImportPathSyntax: ExpressibleByArrayLiteral {
   public init(arrayLiteral elements: Element...) {
     self.init(elements)
   }

--- a/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ResultBuilders.swift
@@ -15,86 +15,6 @@
 import SwiftSyntax
 
 @resultBuilder
-public struct AccessPathBuilder {
-  /// The type of individual statement expressions in the transformed function,
-  /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = AccessPathComponentSyntax
-  
-  /// The type of a partial result, which will be carried through all of the
-  /// build methods.
-  public typealias Component = [Expression]
-  
-  /// The type of the final returned result, which defaults to Component if
-  /// buildFinalResult() is not provided.
-  public typealias FinalResult = AccessPathSyntax
-  
-  /// Required by every result builder to build combined results from
-  /// statement blocks.
-  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, provides contextual type information for statement
-  /// expressions to translate them into partial results.
-  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
-    return [expression]
-  }
-  
-  /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
-    return expression.map {
-      $0
-    }
-  }
-  
-  /// Enables support for `if` statements that do not have an `else`.
-  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
-    return component ?? []
-  }
-  
-  /// With buildEither(second:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(first component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// With buildEither(first:), enables support for 'if-else' and 'switch'
-  /// statements by folding conditional results into a single result.
-  public static func buildEither(second component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// Enables support for 'for..in' loops by combining the
-  /// results of all iterations into a single result.
-  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
-    return components.flatMap {
-      $0
-    }
-  }
-  
-  /// If declared, this will be called on the partial result of an 'if'
-  /// #available' block to allow the result builder to erase type
-  /// information.
-  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
-    return component
-  }
-  
-  /// If declared, this will be called on the partial result from the outermost
-  /// block statement to produce the final returned result.
-  public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
-  }
-}
-
-public extension AccessPathSyntax {
-  init(@AccessPathBuilder itemsBuilder: () throws -> AccessPathSyntax) rethrows {
-    self = try itemsBuilder()
-  }
-}
-
-@resultBuilder
 public struct AccessorListBuilder {
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
@@ -2390,6 +2310,86 @@ public struct IfConfigClauseListBuilder {
 
 public extension IfConfigClauseListSyntax {
   init(@IfConfigClauseListBuilder itemsBuilder: () throws -> IfConfigClauseListSyntax) rethrows {
+    self = try itemsBuilder()
+  }
+}
+
+@resultBuilder
+public struct ImportPathBuilder {
+  /// The type of individual statement expressions in the transformed function,
+  /// which defaults to Component if buildExpression() is not provided.
+  public typealias Expression = ImportPathComponentSyntax
+  
+  /// The type of a partial result, which will be carried through all of the
+  /// build methods.
+  public typealias Component = [Expression]
+  
+  /// The type of the final returned result, which defaults to Component if
+  /// buildFinalResult() is not provided.
+  public typealias FinalResult = ImportPathSyntax
+  
+  /// Required by every result builder to build combined results from
+  /// statement blocks.
+  public static func buildBlock(_ components: Self.Component...) -> Self.Component {
+    return components.flatMap {
+      $0
+    }
+  }
+  
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: Self.Expression) -> Self.Component {
+    return [expression]
+  }
+  
+  /// Add all the elements of `expression` to this result builder, effectively flattening them.
+  public static func buildExpression(_ expression: Self.FinalResult) -> Self.Component {
+    return expression.map {
+      $0
+    }
+  }
+  
+  /// Enables support for `if` statements that do not have an `else`.
+  public static func buildOptional(_ component: Self.Component?) -> Self.Component {
+    return component ?? []
+  }
+  
+  /// With buildEither(second:), enables support for 'if-else' and 'switch'
+  /// statements by folding conditional results into a single result.
+  public static func buildEither(first component: Self.Component) -> Self.Component {
+    return component
+  }
+  
+  /// With buildEither(first:), enables support for 'if-else' and 'switch'
+  /// statements by folding conditional results into a single result.
+  public static func buildEither(second component: Self.Component) -> Self.Component {
+    return component
+  }
+  
+  /// Enables support for 'for..in' loops by combining the
+  /// results of all iterations into a single result.
+  public static func buildArray(_ components: [Self.Component]) -> Self.Component {
+    return components.flatMap {
+      $0
+    }
+  }
+  
+  /// If declared, this will be called on the partial result of an 'if'
+  /// #available' block to allow the result builder to erase type
+  /// information.
+  public static func buildLimitedAvailability(_ component: Self.Component) -> Self.Component {
+    return component
+  }
+  
+  /// If declared, this will be called on the partial result from the outermost
+  /// block statement to produce the final returned result.
+  public static func buildFinalResult(_ component: Component) -> FinalResult {
+    return .init(component)
+  }
+}
+
+public extension ImportPathSyntax {
+  init(@ImportPathBuilder itemsBuilder: () throws -> ImportPathSyntax) rethrows {
     self = try itemsBuilder()
   }
 }

--- a/Tests/SwiftSyntaxBuilderTest/ImportDeclSyntaxTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ImportDeclSyntaxTests.swift
@@ -19,7 +19,7 @@ final class ImportDeclSyntaxTests: XCTestCase {
     let identifier = TokenSyntax.identifier("SwiftSyntax")
 
     let importDecl = ImportDeclSyntax(
-      path: AccessPathSyntax([AccessPathComponentSyntax(name: identifier)])
+      path: ImportPathSyntax([ImportPathComponentSyntax(name: identifier)])
     )
 
     assertBuildResult(importDecl, "import SwiftSyntax")
@@ -28,7 +28,7 @@ final class ImportDeclSyntaxTests: XCTestCase {
   func testImportWithAttribute() {
     let buildable = ImportDeclSyntax(
       attributes: [.attribute("@_exported")],
-      path: [AccessPathComponentSyntax(name: "SwiftSyntax")]
+      path: [ImportPathComponentSyntax(name: "SwiftSyntax")]
     )
 
     assertBuildResult(


### PR DESCRIPTION
`AccessPathSyntax` should be renamed to `ImportPathSyntax`. This PR renames `AccessPath` to `ImportPath`, `AccessPathComponent` to `ImportPathComponent`, generates the code and adds the following type aliases to keep existing clients building:

* `AccessPathBuilder` -> `ImportPathBuilder`
* `AccessPathSyntax` -> `ImportPathSyntax`
* `AccessPathComponentSyntax` -> `ImportPathComponentSyntax`

Resolves #1632 
