### PR TITLE
Increase swift-tools-version to 5.7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 
 import PackageDescription
 import Foundation


### PR DESCRIPTION
We no longer need to support building SwiftSyntax with Swift <5.7 so we can increase the tools version.

rdar://108753223