### PR TITLE
Migrate SwiftSyntax to shorthand `let` notation

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/TokenSpec.swift
@@ -48,7 +48,7 @@ public class TokenSpec {
     self.name = name
     self.kind = kind
     self.nameForDiagnostics = nameForDiagnostics
-    if let unprefixedKind = unprefixedKind {
+    if let unprefixedKind {
       self.unprefixedKind = unprefixedKind
     } else {
       self.unprefixedKind = kind

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxValidationFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/RawSyntaxValidationFile.swift
@@ -157,7 +157,7 @@ let rawSyntaxValidationFile = try! SourceFileSyntax(leadingTrivia: copyrightHead
               DeclSyntax(
                 #"""
                 func assertNoError(_ nodeKind: SyntaxKind, _ index: Int, _ error: ValidationError?) {
-                  if let error = error {
+                  if let error {
                     let (file, line) = error.fileAndLine
                     assertionFailure("""
                       Error validating child at index \(index) of \(nodeKind):

--- a/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
+++ b/CodeGeneration/Sources/generate-swiftsyntax/templates/swiftsyntax/SyntaxRewriterFile.swift
@@ -316,7 +316,7 @@ let syntaxRewriterFile = SourceFileSyntax(leadingTrivia: copyrightHeader) {
           }
         }
         
-        if let newLayout = newLayout {
+        if let newLayout {
           // A child node was rewritten. Build the updated node.
           
           // Sanity check, ensure the new children are the same length.

--- a/Sources/SwiftBasicFormat/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/BasicFormat.swift
@@ -55,7 +55,7 @@ open class BasicFormat: SyntaxRewriter {
   // MARK: - Updating indentation level
 
   public func increaseIndentationLevel(to userDefinedIndentation: Trivia? = nil) {
-    if let userDefinedIndentation = userDefinedIndentation {
+    if let userDefinedIndentation {
       indentationStack.append((indentation: userDefinedIndentation, isUserDefined: true))
     } else {
       indentationStack.append((indentation: currentIndentationLevel + indentationWidth, isUserDefined: false))

--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -221,7 +221,7 @@ public struct DiagnosticsFormatter {
     var annotatedSource = ""
 
     // If there was a filename, add it first.
-    if let fileName = fileName {
+    if let fileName {
       let header = colorizeBufferOutline("===")
       let firstLine =
         1

--- a/Sources/SwiftOperators/OperatorTable+Folding.swift
+++ b/Sources/SwiftOperators/OperatorTable+Folding.swift
@@ -413,8 +413,8 @@ extension OperatorTable {
         //   - missing precedence groups,
         //   - have unordered precedence groups, or
         //   - have the same precedence group with no associativity.
-        if let op1Precedence = op1Precedence,
-          let op2Precedence = op2Precedence
+        if let op1Precedence,
+          let op2Precedence
         {
           try errorHandler(
             .incomparableOperators(

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -173,7 +173,7 @@ extension Parser {
       elements.append(lastElement)
       elements.append(operatorExpr)
 
-      if let rhsExpr = rhsExpr {
+      if let rhsExpr {
         // Operator parsing returned the RHS.
         lastElement = rhsExpr
       } else if forDirective && self.currentToken.isAtStartOfLine {
@@ -1472,7 +1472,7 @@ extension Parser {
     let (unexpectedBeforeSlash, openSlash) = self.expect(.regexSlash)
 
     // If we had opening pounds, there should be no trivia for the slash.
-    if let openPounds = openPounds {
+    if let openPounds {
       precondition(openPounds.trailingTriviaByteLength == 0 && openSlash.leadingTriviaByteLength == 0)
     }
 

--- a/Sources/SwiftParser/Lexer/Cursor.swift
+++ b/Sources/SwiftParser/Lexer/Cursor.swift
@@ -172,7 +172,7 @@ extension Lexer.Cursor {
     mutating func perform(stateTransition: Lexer.StateTransition, stateAllocator: BumpPtrAllocator) {
       switch stateTransition {
       case .push(newState: let newState):
-        if let topState = topState {
+        if let topState {
           if let stateStack = stateStack {
             let newStateStack = stateAllocator.allocate(State.self, count: stateStack.count + 1)
             let (_, existingStateStackEndIndex) = newStateStack.initialize(from: stateStack)
@@ -190,7 +190,7 @@ extension Lexer.Cursor {
       case .replace(newState: let newState):
         topState = newState
       case .pop:
-        if let stateStack = stateStack {
+        if let stateStack {
           topState = stateStack.last!
           if stateStack.count == 1 {
             self.stateStack = nil
@@ -760,7 +760,7 @@ extension Lexer.Cursor {
     // Test for single-line string literals that resemble multiline delimiter.
     var sameLineCloseCheck = self
     _ = sameLineCloseCheck.advance()
-    if let openingRawStringDelimiters = openingRawStringDelimiters, openingRawStringDelimiters != 0 {
+    if let openingRawStringDelimiters, openingRawStringDelimiters != 0 {
       // Scan if the current line contains `"` followed by `openingRawStringDelimiters` `#` characters
       while sameLineCloseCheck.is(notAt: "\r", "\n") {
         if sameLineCloseCheck.advance(matching: #"""#) {

--- a/Sources/SwiftParser/Lexer/RegexLiteralLexer.swift
+++ b/Sources/SwiftParser/Lexer/RegexLiteralLexer.swift
@@ -174,7 +174,7 @@ fileprivate struct RegexLiteralLexer {
 
     // If we have a multi-line literal, make sure the closing delimiter
     // appears alone on a newline.
-    if let lastNewlineEnd = lastNewlineEnd {
+    if let lastNewlineEnd {
       var delimScan = lastNewlineEnd
       while delimScan.pointer < slashBegin.pointer {
         if !delimScan.advance(matching: " ", "\t") {
@@ -809,7 +809,7 @@ extension Lexer.Cursor {
 
     // Compute the new transition.
     let transition: Lexer.StateTransition?
-    if let existingPtr = existingPtr {
+    if let existingPtr {
       transition = lexemes.isEmpty ? .pop : .replace(newState: .inRegexLiteral(index: index, lexemes: existingPtr))
     } else {
       transition = lexemes.isEmpty ? nil : .pushRegexLexemes(index: index, lexemes: lexemes.base)

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -185,7 +185,7 @@ extension Parser {
       } else {
         generics = nil
       }
-      if let keepGoing = keepGoing {
+      if let keepGoing {
         result = RawTypeSyntax(
           RawMemberTypeIdentifierSyntax(
             baseType: result!,

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -148,7 +148,7 @@ public struct Parser {
     self.maximumNestingLevel = maximumNestingLevel ?? Self.defaultMaximumNestingLevel
 
     var sourceBuffer: UnsafeBufferPointer<UInt8>
-    if let arena = arena {
+    if let arena {
       self.arena = arena
       sourceBuffer = input
       precondition(arena.contains(text: SyntaxText(baseAddress: input.baseAddress, count: input.count)))

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -164,7 +164,7 @@ extension Parser {
     let colon = self.consume(if: .colon)
     var lookahead = self.lookahead()
     var type: RawTypeAnnotationSyntax?
-    if let colon = colon {
+    if let colon {
       let result = self.parseResultType()
       type = RawTypeAnnotationSyntax(
         colon: colon,

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -92,7 +92,7 @@ extension Parser.Lookahead {
       default:
         matchedSpec = nil
       }
-      if let matchedSpec = matchedSpec {
+      if let matchedSpec {
         return RecoveryConsumptionHandle(
           unexpectedTokens: self.tokensConsumed - initialTokensConsumed,
           tokenConsumptionHandle: TokenConsumptionHandle(spec: matchedSpec)

--- a/Sources/SwiftParser/StringLiterals.swift
+++ b/Sources/SwiftParser/StringLiterals.swift
@@ -72,7 +72,7 @@ fileprivate class StringLiteralExpressionIndentationChecker {
     var hasRewrittenChild = false
     var rewrittenChildren: [RawSyntax?] = []
     for child in layoutView.children {
-      if let child = child, let rewrittenChild = visit(node: child) {
+      if let child, let rewrittenChild = visit(node: child) {
         hasRewrittenChild = true
         rewrittenChildren.append(rewrittenChild)
       } else {
@@ -360,7 +360,7 @@ extension Parser {
     // -------------------------------------------------------------------------
     // Parse indentation of the closing quote
 
-    if let lastSegment = lastSegment,
+    if let lastSegment,
       let parsedTrivia = parseIndentationTrivia(text: lastSegment.content.tokenText)
     {
       indentationTrivia = parsedTrivia

--- a/Sources/SwiftParser/SyntaxUtils.swift
+++ b/Sources/SwiftParser/SyntaxUtils.swift
@@ -56,7 +56,7 @@ extension Array: UnexpectedNodesCombinable where Element: UnexpectedNodesCombina
 
 extension Optional: UnexpectedNodesCombinable where Wrapped: UnexpectedNodesCombinable {
   var elements: [RawSyntax] {
-    if let self = self {
+    if let self {
       return self.elements
     } else {
       return []

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -156,7 +156,7 @@ extension Parser {
 
     var base = self.parseSimpleType()
     guard self.atContextualPunctuator("&") else {
-      if let someOrAny = someOrAny {
+      if let someOrAny {
         return RawTypeSyntax(
           RawConstrainedSugarTypeSyntax(
             someOrAnySpecifier: someOrAny,
@@ -201,7 +201,7 @@ extension Parser {
       )
     }
 
-    if let someOrAny = someOrAny {
+    if let someOrAny {
       return RawTypeSyntax(
         RawConstrainedSugarTypeSyntax(
           someOrAnySpecifier: someOrAny,
@@ -545,7 +545,7 @@ extension Parser {
 
         // In the case that the input is "(foo bar)" we have to decide whether we parse it as "(foo: bar)" or "(foo, bar)".
         // As most people write identifiers lowercase and types capitalized, we decide on the first character of the first token
-        if let first = first,
+        if let first,
           second == nil,
           colon?.isMissing == true,
           first.tokenText.isStartingWithUppercase

--- a/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParserDiagnostics/DiagnosticExtensions.swift
@@ -141,10 +141,10 @@ extension FixIt.MultiNodeChange {
     var presentNode = MissingNodesBasicFormatter(viewMode: .fixedUp).visit(Syntax(node))
     presentNode = PresentMaker().rewrite(presentNode)
 
-    if let leadingTrivia = leadingTrivia {
+    if let leadingTrivia {
       presentNode = presentNode.with(\.leadingTrivia, leadingTrivia)
     }
-    if let trailingTrivia = trailingTrivia {
+    if let trailingTrivia {
       presentNode = presentNode.with(\.trailingTrivia, trailingTrivia)
     }
 

--- a/Sources/SwiftParserDiagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParserDiagnostics/MissingNodesError.swift
@@ -249,7 +249,7 @@ public struct MissingNodesError: ParserError {
     } else {
       missingExpr = nil
     }
-    if let missingExpr = missingExpr,
+    if let missingExpr,
       let exprList = missingExpr.parent?.as(ExprListSyntax.self),
       exprList.parent?.is(SequenceExprSyntax.self) ?? false,
       let previousSiblingIndex = exprList.index(missingExpr.index, offsetBy: -1, limitedBy: exprList.startIndex)
@@ -296,7 +296,7 @@ public struct MissingNodesError: ParserError {
   public var message: String {
     let (anchor, description) = nodesDescriptionAndCommonParent(missingNodes, format: true)
     var message = "expected \(description)"
-    if let afterClause = afterClause {
+    if let afterClause {
       message += " \(afterClause)"
     } else if let parentContextClause = parentContextClause(anchor: anchor?.parent ?? findCommonAncestor(missingNodes)) {
       message += " \(parentContextClause)"
@@ -389,7 +389,7 @@ extension ParseDiagnosticsGenerator {
     }
 
     let position: AbsolutePosition
-    if let overridePosition = overridePosition {
+    if let overridePosition {
       position = overridePosition
     } else if node.shouldBeInsertedAfterNextTokenTrivia, let nextToken = node.nextToken(viewMode: .sourceAccurate) {
       position = nextToken.positionAfterSkippingLeadingTrivia

--- a/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParserDiagnostics/ParseDiagnosticsGenerator.swift
@@ -1085,7 +1085,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
       } else {
         message = nil
       }
-      if let message = message {
+      if let message {
         let fixIts: [FixIt]
         if node.identifier.presence == .present {
           fixIts = [FixIt(message: RemoveNodesFixIt(unexpected), changes: .makeMissing(unexpected))]

--- a/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
+++ b/Sources/SwiftRefactor/OpaqueParameterToGeneric.swift
@@ -133,7 +133,7 @@ public struct OpaqueParameterToGeneric: RefactoringProvider {
     }
 
     var newGenericParams: [GenericParameterSyntax] = []
-    if let genericParams = genericParams {
+    if let genericParams {
       newGenericParams.append(contentsOf: genericParams.genericParameterList)
     }
 
@@ -152,7 +152,7 @@ public struct OpaqueParameterToGeneric: RefactoringProvider {
 
     let newGenericParamSyntax = GenericParameterListSyntax(newGenericParams)
     let newGenericParamClause: GenericParameterClauseSyntax
-    if let genericParams = genericParams {
+    if let genericParams {
       newGenericParamClause = genericParams.with(
         \.genericParameterList,
         newGenericParamSyntax

--- a/Sources/SwiftSyntax/IncrementalParseTransition.swift
+++ b/Sources/SwiftSyntax/IncrementalParseTransition.swift
@@ -238,7 +238,7 @@ public struct IncrementalParseLookup {
     }
     let prevPosition = AbsolutePosition(utf8Offset: prevOffset)
     let node = cursorLookup(prevPosition: prevPosition, kind: kind)
-    if let delegate = reusedDelegate, let node = node {
+    if let delegate = reusedDelegate, let node {
       delegate.parserReusedNode(
         range: ByteSourceRange(offset: newOffset, length: node.byteSize),
         previousNode: node

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -76,7 +76,7 @@ internal struct RawSyntaxData {
         }
       }
       set {
-        if let newValue = newValue {
+        if let newValue {
           self.tokenDiagnosticKind = newValue.kind
           self.tokenDiagnosticByteOffset = newValue.byteOffset
         } else {
@@ -130,7 +130,7 @@ internal struct RawSyntaxData {
         }
       }
       set {
-        if let newValue = newValue {
+        if let newValue {
           self.tokenDiagnosticKind = newValue.kind
           self.tokenDiagnosticByteOffset = newValue.byteOffset
         } else {

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -619,7 +619,7 @@ public extension SyntaxProtocol {
     mark: SyntaxProtocol? = nil,
     indentString: String
   ) {
-    if let mark = mark, self.id == mark.id {
+    if let mark, self.id == mark.id {
       target.write("*** ")
     }
 
@@ -639,7 +639,7 @@ public extension SyntaxProtocol {
 
     let allChildren = children(viewMode: .all)
 
-    if let converter = converter {
+    if let converter {
       let range = sourceRange(converter: converter)
       target.write(" [\(range.start)...\(range.end)]")
     }
@@ -648,7 +648,7 @@ public extension SyntaxProtocol {
       target.write(" MISSING")
     }
 
-    if let mark = mark, self.id == mark.id {
+    if let mark, self.id == mark.id {
       target.write(" ***")
     }
 

--- a/Sources/SwiftSyntax/SyntaxChildren.swift
+++ b/Sources/SwiftSyntax/SyntaxChildren.swift
@@ -302,7 +302,7 @@ struct NonNilRawSyntaxChildren: BidirectionalCollection {
         guard let (node, info) = self.iterator.next() else {
           return nil
         }
-        if let node = node, viewMode.shouldTraverse(node: node) {
+        if let node, viewMode.shouldTraverse(node: node) {
           return AbsoluteRawSyntax(raw: node, info: info)
         }
       }

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -295,7 +295,7 @@ struct SyntaxData {
   func replacingSelf(_ newRaw: RawSyntax, arena: SyntaxArena) -> SyntaxData {
     // If we have a parent already, then ask our current parent to copy itself
     // recursively up to the root.
-    if let parent = parent {
+    if let parent {
       let parentData = parent.replacingChild(at: indexInParent, with: newRaw, arena: arena)
       let newParent = Syntax(parentData)
       return SyntaxData(absoluteRaw.replacingSelf(newRaw, newRootId: parentData.nodeId.rootId), parent: newParent)

--- a/Sources/SwiftSyntax/Trivia.swift
+++ b/Sources/SwiftSyntax/Trivia.swift
@@ -133,7 +133,7 @@ extension Trivia: CustomStringConvertible {
 
 extension Trivia: CustomDebugStringConvertible {
   public var debugDescription: String {
-    if count == 1, let first = first {
+    if count == 1, let first {
       return first.debugDescription
     }
     return "[" + map(\.debugDescription).joined(separator: ", ") + "]"

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -6949,7 +6949,7 @@ open class SyntaxRewriter {
       }
     }
 
-    if let newLayout = newLayout {
+    if let newLayout {
       // A child node was rewritten. Build the updated node.
 
       // Sanity check, ensure the new children are the same length.

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -179,7 +179,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
       )
   }
   func assertNoError(_ nodeKind: SyntaxKind, _ index: Int, _ error: ValidationError?) {
-    if let error = error {
+    if let error {
       let (file, line) = error.fileAndLine
       assertionFailure("""
         Error validating child at index \(index) of \(nodeKind):

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -68,7 +68,7 @@ extension SyntaxStringInterpolation: StringInterpolationProtocol {
   ) {
     let startIndex = sourceText.count
     let indentedNode: Node
-    if let lastIndentation = lastIndentation {
+    if let lastIndentation {
       indentedNode = Indenter.indent(node, indentation: lastIndentation)
     } else {
       indentedNode = node

--- a/Sources/SwiftSyntaxMacros/FunctionParameterUtils.swift
+++ b/Sources/SwiftSyntaxMacros/FunctionParameterUtils.swift
@@ -11,7 +11,7 @@ extension FunctionParameterSyntax {
   /// respectively.
   var parameterName: TokenSyntax? {
     // If there were two names, the second is the parameter name.
-    if let secondName = secondName {
+    if let secondName {
       if secondName.text == "_" {
         return nil
       }

--- a/Sources/lit-test-helper/CommandLineArguments.swift
+++ b/Sources/lit-test-helper/CommandLineArguments.swift
@@ -61,7 +61,7 @@ struct CommandLineArguments {
         currentKey = nil
       }
     }
-    if let currentKey = currentKey {
+    if let currentKey {
       // The last key didn't have a value. Just add it with an empty string as
       // the value to the parsed args
       addArg(currentKey, "")

--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -39,7 +39,7 @@ private func withTemporaryFile<T>(contents: [UInt8], body: (URL) throws -> T) th
 
 private func getContentsOfSourceFile(at path: String?) throws -> [UInt8] {
   let source: Data
-  if let path = path {
+  if let path {
     let sourceURL = URL(fileURLWithPath: path)
     source = try Data(contentsOf: sourceURL)
   } else {

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -279,7 +279,7 @@ class FixItApplier: SyntaxRewriter {
       diagnostics
       .flatMap { $0.fixIts }
       .filter {
-        if let messages = messages {
+        if let messages {
           return messages.contains($0.message.message)
         } else {
           return true
@@ -575,7 +575,7 @@ func assertParse<S: SyntaxProtocol>(
   )
 
   // Substructure
-  if let expectedSubstructure = expectedSubstructure {
+  if let expectedSubstructure {
     let subtreeMatcher = SubtreeMatcher(Syntax(tree), markers: markerLocations)
     do {
       try subtreeMatcher.assertSameStructure(afterMarker: substructureAfterMarker, Syntax(expectedSubstructure), includeTrivia: options.contains(.substructureCheckTrivia), file: file, line: line)

--- a/Tests/SwiftSyntaxTestSupportTest/SyntaxComparisonTests.swift
+++ b/Tests/SwiftSyntaxTestSupportTest/SyntaxComparisonTests.swift
@@ -187,7 +187,7 @@ public class SyntaxComparisonTests: XCTestCase {
     indent: Int = 0
   ) -> FunctionDeclSyntax {
     let funcBody: CodeBlockSyntax
-    if let body = body {
+    if let body {
       funcBody = body
     } else {
       funcBody = makeBody()


### PR DESCRIPTION
Now that we no longer need to support Swift <5.7, we can use shorthand `let` syntax. I performed the migration using the script from https://github.com/apple/swift-syntax/pull/887.