### PR TITLE
support parsing `discard` in place of `_forget`

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/KeywordSpec.swift
@@ -134,7 +134,8 @@ public let KEYWORDS: [KeywordSpec] = [
   KeywordSpec("fileprivate", isLexerClassified: true, requiresTrailingSpace: true),
   KeywordSpec("final"),
   KeywordSpec("for", isLexerClassified: true, requiresTrailingSpace: true),
-  KeywordSpec("_forget"),
+  KeywordSpec("_forget"),  // NOTE: support for deprecated _forget
+  KeywordSpec("discard"),
   KeywordSpec("forward"),
   KeywordSpec("func", isLexerClassified: true, requiresTrailingSpace: true),
   KeywordSpec("get"),

--- a/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/StmtNodes.swift
@@ -333,15 +333,18 @@ public let STMT_NODES: [Node] = [
     ]
   ),
 
-  // forget-stmt -> 'forget' expr ';'?
+  // discard-stmt -> 'discard' expr ';'?
   Node(
-    name: "ForgetStmt",
-    nameForDiagnostics: "'forget' statement",
+    name: "DiscardStmt",
+    nameForDiagnostics: "'discard' statement",
     kind: "Stmt",
     children: [
       Child(
-        name: "ForgetKeyword",
-        kind: .token(choices: [.keyword(text: "_forget")])
+        name: "DiscardKeyword",
+        kind: .token(choices: [
+          .keyword(text: "_forget"),  // NOTE: support for deprecated _forget
+          .keyword(text: "discard"),
+        ])
       ),
       Child(
         name: "Expression",

--- a/Sources/SwiftParser/TokenSpecSet.swift
+++ b/Sources/SwiftParser/TokenSpecSet.swift
@@ -80,7 +80,8 @@ enum CanBeStatementStart: TokenSpecSet {
   case doKeyword
   case fallthroughKeyword
   case forKeyword
-  case forgetKeyword
+  case forgetKeyword  // NOTE: support for deprecated _forget
+  case discardKeyword
   case guardKeyword
   case ifKeyword
   case repeatKeyword
@@ -99,6 +100,7 @@ enum CanBeStatementStart: TokenSpecSet {
     case TokenSpec(.fallthrough): self = .fallthroughKeyword
     case TokenSpec(.for): self = .forKeyword
     case TokenSpec(._forget): self = .forgetKeyword
+    case TokenSpec(.discard): self = .discardKeyword
     case TokenSpec(.guard): self = .guardKeyword
     case TokenSpec(.if): self = .ifKeyword
     case TokenSpec(.repeat): self = .repeatKeyword
@@ -120,6 +122,7 @@ enum CanBeStatementStart: TokenSpecSet {
     case .fallthroughKeyword: return .keyword(.fallthrough)
     case .forKeyword: return .keyword(.for)
     case .forgetKeyword: return TokenSpec(._forget, recoveryPrecedence: .stmtKeyword)
+    case .discardKeyword: return TokenSpec(.discard, recoveryPrecedence: .stmtKeyword)
     case .guardKeyword: return .keyword(.guard)
     case .ifKeyword: return .keyword(.if)
     case .repeatKeyword: return .keyword(.repeat)

--- a/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
+++ b/Sources/SwiftParserDiagnostics/generated/SyntaxKindNameForDiagnostics.swift
@@ -133,6 +133,8 @@ extension SyntaxKind {
       return "differentiability parameters"
     case .differentiableAttributeArguments:
       return "'@differentiable' arguments"
+    case .discardStmt:
+      return "'discard' statement"
     case .doStmt:
       return "'do' statement"
     case .documentationAttributeArgument:
@@ -173,8 +175,6 @@ extension SyntaxKind {
       return "'for' statement"
     case .forcedValueExpr:
       return "force unwrap"
-    case .forgetStmt:
-      return "'forget' statement"
     case .functionCallExpr:
       return "function call"
     case .functionDecl:

--- a/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/generated/SwiftSyntax.md
@@ -153,11 +153,11 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/BreakStmtSyntax>
 - <doc:SwiftSyntax/ContinueStmtSyntax>
 - <doc:SwiftSyntax/DeferStmtSyntax>
+- <doc:SwiftSyntax/DiscardStmtSyntax>
 - <doc:SwiftSyntax/DoStmtSyntax>
 - <doc:SwiftSyntax/ExpressionStmtSyntax>
 - <doc:SwiftSyntax/FallthroughStmtSyntax>
 - <doc:SwiftSyntax/ForInStmtSyntax>
-- <doc:SwiftSyntax/ForgetStmtSyntax>
 - <doc:SwiftSyntax/GuardStmtSyntax>
 - <doc:SwiftSyntax/LabeledStmtSyntax>
 - <doc:SwiftSyntax/RepeatWhileStmtSyntax>

--- a/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
+++ b/Sources/SwiftSyntax/generated/ChildNameForKeyPath.swift
@@ -1003,6 +1003,16 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "wildcard"
   case \DiscardAssignmentExprSyntax.unexpectedAfterWildcard:
     return "unexpectedAfterWildcard"
+  case \DiscardStmtSyntax.unexpectedBeforeDiscardKeyword:
+    return "unexpectedBeforeDiscardKeyword"
+  case \DiscardStmtSyntax.discardKeyword:
+    return "discardKeyword"
+  case \DiscardStmtSyntax.unexpectedBetweenDiscardKeywordAndExpression:
+    return "unexpectedBetweenDiscardKeywordAndExpression"
+  case \DiscardStmtSyntax.expression:
+    return "expression"
+  case \DiscardStmtSyntax.unexpectedAfterExpression:
+    return "unexpectedAfterExpression"
   case \DoStmtSyntax.unexpectedBeforeDoKeyword:
     return "unexpectedBeforeDoKeyword"
   case \DoStmtSyntax.doKeyword:
@@ -1317,16 +1327,6 @@ public func childName(_ keyPath: AnyKeyPath) -> String? {
     return "exclamationMark"
   case \ForcedValueExprSyntax.unexpectedAfterExclamationMark:
     return "unexpectedAfterExclamationMark"
-  case \ForgetStmtSyntax.unexpectedBeforeForgetKeyword:
-    return "unexpectedBeforeForgetKeyword"
-  case \ForgetStmtSyntax.forgetKeyword:
-    return "forgetKeyword"
-  case \ForgetStmtSyntax.unexpectedBetweenForgetKeywordAndExpression:
-    return "unexpectedBetweenForgetKeywordAndExpression"
-  case \ForgetStmtSyntax.expression:
-    return "expression"
-  case \ForgetStmtSyntax.unexpectedAfterExpression:
-    return "unexpectedAfterExpression"
   case \FunctionCallExprSyntax.unexpectedBeforeCalledExpression:
     return "unexpectedBeforeCalledExpression"
   case \FunctionCallExprSyntax.calledExpression:

--- a/Sources/SwiftSyntax/generated/Keyword.swift
+++ b/Sources/SwiftSyntax/generated/Keyword.swift
@@ -112,6 +112,7 @@ public enum Keyword: UInt8, Hashable {
   case final
   case `for`
   case _forget
+  case discard
   case forward
   case `func`
   case get
@@ -427,6 +428,8 @@ public enum Keyword: UInt8, Hashable {
         self = .dynamic
       case "_forget":
         self = ._forget
+      case "discard":
+        self = .discard
       case "forward":
         self = .forward
       case "message":
@@ -832,6 +835,7 @@ public enum Keyword: UInt8, Hashable {
       "final", 
       "for", 
       "_forget", 
+      "discard", 
       "forward", 
       "func", 
       "get", 

--- a/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxAnyVisitor.swift
@@ -741,6 +741,14 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
     visitAnyPost(node._syntaxNode)
   }
   
+  override open func visit(_ node: DiscardStmtSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+  
+  override open func visitPost(_ node: DiscardStmtSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  
   override open func visit(_ node: DoStmtSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
@@ -930,14 +938,6 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   }
   
   override open func visitPost(_ node: ForcedValueExprSyntax) {
-    visitAnyPost(node._syntaxNode)
-  }
-  
-  override open func visit(_ node: ForgetStmtSyntax) -> SyntaxVisitorContinueKind {
-    return visitAny(node._syntaxNode)
-  }
-  
-  override open func visitPost(_ node: ForgetStmtSyntax) {
     visitAnyPost(node._syntaxNode)
   }
   

--- a/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxBaseNodes.swift
@@ -483,7 +483,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   
   public init?<S: SyntaxProtocol>(_ node: S) {
     switch node.raw.kind {
-    case .breakStmt, .continueStmt, .deferStmt, .doStmt, .expressionStmt, .fallthroughStmt, .forInStmt, .forgetStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatWhileStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
+    case .breakStmt, .continueStmt, .deferStmt, .discardStmt, .doStmt, .expressionStmt, .fallthroughStmt, .forInStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatWhileStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
       self._syntaxNode = node._syntaxNode
     default:
       return nil
@@ -495,7 +495,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// is undefined.
   internal init(_ data: SyntaxData) {
     switch data.raw.kind {
-    case .breakStmt, .continueStmt, .deferStmt, .doStmt, .expressionStmt, .fallthroughStmt, .forInStmt, .forgetStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatWhileStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
+    case .breakStmt, .continueStmt, .deferStmt, .discardStmt, .doStmt, .expressionStmt, .fallthroughStmt, .forInStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatWhileStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
       break
     default:
       preconditionFailure("Unable to create StmtSyntax from \(data.raw.kind)")
@@ -534,11 +534,11 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           .node(BreakStmtSyntax.self),
           .node(ContinueStmtSyntax.self),
           .node(DeferStmtSyntax.self),
+          .node(DiscardStmtSyntax.self),
           .node(DoStmtSyntax.self),
           .node(ExpressionStmtSyntax.self),
           .node(FallthroughStmtSyntax.self),
           .node(ForInStmtSyntax.self),
-          .node(ForgetStmtSyntax.self),
           .node(GuardStmtSyntax.self),
           .node(LabeledStmtSyntax.self),
           .node(MissingStmtSyntax.self),
@@ -770,6 +770,7 @@ extension Syntax {
           .node(DifferentiabilityParamsSyntax.self),
           .node(DifferentiableAttributeArgumentsSyntax.self),
           .node(DiscardAssignmentExprSyntax.self),
+          .node(DiscardStmtSyntax.self),
           .node(DoStmtSyntax.self),
           .node(DocumentationAttributeArgumentSyntax.self),
           .node(DocumentationAttributeArgumentsSyntax.self),
@@ -794,7 +795,6 @@ extension Syntax {
           .node(FloatLiteralExprSyntax.self),
           .node(ForInStmtSyntax.self),
           .node(ForcedValueExprSyntax.self),
-          .node(ForgetStmtSyntax.self),
           .node(FunctionCallExprSyntax.self),
           .node(FunctionDeclSyntax.self),
           .node(FunctionEffectSpecifiersSyntax.self),

--- a/Sources/SwiftSyntax/generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxEnum.swift
@@ -102,6 +102,7 @@ public enum SyntaxEnum {
   case differentiabilityParams(DifferentiabilityParamsSyntax)
   case differentiableAttributeArguments(DifferentiableAttributeArgumentsSyntax)
   case discardAssignmentExpr(DiscardAssignmentExprSyntax)
+  case discardStmt(DiscardStmtSyntax)
   case doStmt(DoStmtSyntax)
   case documentationAttributeArgument(DocumentationAttributeArgumentSyntax)
   case documentationAttributeArguments(DocumentationAttributeArgumentsSyntax)
@@ -126,7 +127,6 @@ public enum SyntaxEnum {
   case floatLiteralExpr(FloatLiteralExprSyntax)
   case forInStmt(ForInStmtSyntax)
   case forcedValueExpr(ForcedValueExprSyntax)
-  case forgetStmt(ForgetStmtSyntax)
   case functionCallExpr(FunctionCallExprSyntax)
   case functionDecl(FunctionDeclSyntax)
   case functionEffectSpecifiers(FunctionEffectSpecifiersSyntax)
@@ -465,6 +465,8 @@ public extension Syntax {
       return .differentiableAttributeArguments(DifferentiableAttributeArgumentsSyntax(self)!)
     case .discardAssignmentExpr:
       return .discardAssignmentExpr(DiscardAssignmentExprSyntax(self)!)
+    case .discardStmt:
+      return .discardStmt(DiscardStmtSyntax(self)!)
     case .doStmt:
       return .doStmt(DoStmtSyntax(self)!)
     case .documentationAttributeArgument:
@@ -513,8 +515,6 @@ public extension Syntax {
       return .forInStmt(ForInStmtSyntax(self)!)
     case .forcedValueExpr:
       return .forcedValueExpr(ForcedValueExprSyntax(self)!)
-    case .forgetStmt:
-      return .forgetStmt(ForgetStmtSyntax(self)!)
     case .functionCallExpr:
       return .functionCallExpr(FunctionCallExprSyntax(self)!)
     case .functionDecl:

--- a/Sources/SwiftSyntax/generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxKind.swift
@@ -102,6 +102,7 @@ public enum SyntaxKind {
   case differentiabilityParams
   case differentiableAttributeArguments
   case discardAssignmentExpr
+  case discardStmt
   case doStmt
   case documentationAttributeArgument
   case documentationAttributeArguments
@@ -126,7 +127,6 @@ public enum SyntaxKind {
   case floatLiteralExpr
   case forInStmt
   case forcedValueExpr
-  case forgetStmt
   case functionCallExpr
   case functionDecl
   case functionEffectSpecifiers
@@ -580,6 +580,8 @@ public enum SyntaxKind {
       return DifferentiableAttributeArgumentsSyntax.self
     case .discardAssignmentExpr:
       return DiscardAssignmentExprSyntax.self
+    case .discardStmt:
+      return DiscardStmtSyntax.self
     case .doStmt:
       return DoStmtSyntax.self
     case .documentationAttributeArgument:
@@ -628,8 +630,6 @@ public enum SyntaxKind {
       return ForInStmtSyntax.self
     case .forcedValueExpr:
       return ForcedValueExprSyntax.self
-    case .forgetStmt:
-      return ForgetStmtSyntax.self
     case .functionCallExpr:
       return FunctionCallExprSyntax.self
     case .functionDecl:

--- a/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxRewriter.swift
@@ -627,6 +627,13 @@ open class SyntaxRewriter {
     return ExprSyntax(visitChildren(node))
   }
   
+  /// Visit a `DiscardStmtSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: DiscardStmtSyntax) -> StmtSyntax {
+    return StmtSyntax(visitChildren(node))
+  }
+  
   /// Visit a `DoStmtSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -793,13 +800,6 @@ open class SyntaxRewriter {
   ///   - Returns: the rewritten node
   open func visit(_ node: ForcedValueExprSyntax) -> ExprSyntax {
     return ExprSyntax(visitChildren(node))
-  }
-  
-  /// Visit a `ForgetStmtSyntax`.
-  ///   - Parameter node: the node that is being visited
-  ///   - Returns: the rewritten node
-  open func visit(_ node: ForgetStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(visitChildren(node))
   }
   
   /// Visit a `FunctionCallExprSyntax`.
@@ -3187,6 +3187,20 @@ open class SyntaxRewriter {
   }
   
   /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplDiscardStmtSyntax(_ data: SyntaxData) -> Syntax {
+    let node = DiscardStmtSyntax(data)
+    // Accessing _syntaxNode directly is faster than calling Syntax(node)
+    visitPre(node._syntaxNode)
+    defer {
+      visitPost(node._syntaxNode)
+    }
+    if let newNode = visitAny(node._syntaxNode) {
+      return newNode
+    }
+    return Syntax(visit(node))
+  }
+  
+  /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplDoStmtSyntax(_ data: SyntaxData) -> Syntax {
     let node = DoStmtSyntax(data)
     // Accessing _syntaxNode directly is faster than calling Syntax(node)
@@ -3511,20 +3525,6 @@ open class SyntaxRewriter {
   /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplForcedValueExprSyntax(_ data: SyntaxData) -> Syntax {
     let node = ForcedValueExprSyntax(data)
-    // Accessing _syntaxNode directly is faster than calling Syntax(node)
-    visitPre(node._syntaxNode)
-    defer {
-      visitPost(node._syntaxNode)
-    }
-    if let newNode = visitAny(node._syntaxNode) {
-      return newNode
-    }
-    return Syntax(visit(node))
-  }
-  
-  /// Implementation detail of visit(_:). Do not call directly.
-  private func visitImplForgetStmtSyntax(_ data: SyntaxData) -> Syntax {
-    let node = ForgetStmtSyntax(data)
     // Accessing _syntaxNode directly is faster than calling Syntax(node)
     visitPre(node._syntaxNode)
     defer {
@@ -5962,6 +5962,8 @@ open class SyntaxRewriter {
       return visitImplDifferentiableAttributeArgumentsSyntax
     case .discardAssignmentExpr:
       return visitImplDiscardAssignmentExprSyntax
+    case .discardStmt:
+      return visitImplDiscardStmtSyntax
     case .doStmt:
       return visitImplDoStmtSyntax
     case .documentationAttributeArgument:
@@ -6010,8 +6012,6 @@ open class SyntaxRewriter {
       return visitImplForInStmtSyntax
     case .forcedValueExpr:
       return visitImplForcedValueExprSyntax
-    case .forgetStmt:
-      return visitImplForgetStmtSyntax
     case .functionCallExpr:
       return visitImplFunctionCallExprSyntax
     case .functionDecl:
@@ -6510,6 +6510,8 @@ open class SyntaxRewriter {
       return visitImplDifferentiableAttributeArgumentsSyntax(data)
     case .discardAssignmentExpr:
       return visitImplDiscardAssignmentExprSyntax(data)
+    case .discardStmt:
+      return visitImplDiscardStmtSyntax(data)
     case .doStmt:
       return visitImplDoStmtSyntax(data)
     case .documentationAttributeArgument:
@@ -6558,8 +6560,6 @@ open class SyntaxRewriter {
       return visitImplForInStmtSyntax(data)
     case .forcedValueExpr:
       return visitImplForcedValueExprSyntax(data)
-    case .forgetStmt:
-      return visitImplForgetStmtSyntax(data)
     case .functionCallExpr:
       return visitImplFunctionCallExprSyntax(data)
     case .functionDecl:

--- a/Sources/SwiftSyntax/generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxTransform.swift
@@ -449,6 +449,11 @@ public protocol SyntaxTransformVisitor {
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: DiscardAssignmentExprSyntax) -> ResultType
   
+  /// Visiting `DiscardStmtSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: DiscardStmtSyntax) -> ResultType
+  
   /// Visiting `DoStmtSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -568,11 +573,6 @@ public protocol SyntaxTransformVisitor {
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: ForcedValueExprSyntax) -> ResultType
-  
-  /// Visiting `ForgetStmtSyntax` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: the sum of whatever the child visitors return.
-  func visit(_ node: ForgetStmtSyntax) -> ResultType
   
   /// Visiting `FunctionCallExprSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
@@ -1972,6 +1972,13 @@ extension SyntaxTransformVisitor {
     visitAny(Syntax(node))
   }
   
+  /// Visiting `DiscardStmtSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: DiscardStmtSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
+  
   /// Visiting `DoStmtSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
@@ -2137,13 +2144,6 @@ extension SyntaxTransformVisitor {
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
   public func visit(_ node: ForcedValueExprSyntax) -> ResultType {
-    visitAny(Syntax(node))
-  }
-  
-  /// Visiting `ForgetStmtSyntax` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: nil by default.
-  public func visit(_ node: ForgetStmtSyntax) -> ResultType {
     visitAny(Syntax(node))
   }
   
@@ -3429,6 +3429,8 @@ extension SyntaxTransformVisitor {
       return visit(derived)
     case .discardAssignmentExpr(let derived):
       return visit(derived)
+    case .discardStmt(let derived):
+      return visit(derived)
     case .doStmt(let derived):
       return visit(derived)
     case .documentationAttributeArgument(let derived):
@@ -3476,8 +3478,6 @@ extension SyntaxTransformVisitor {
     case .forInStmt(let derived):
       return visit(derived)
     case .forcedValueExpr(let derived):
-      return visit(derived)
-    case .forgetStmt(let derived):
       return visit(derived)
     case .functionCallExpr(let derived):
       return visit(derived)

--- a/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/generated/SyntaxVisitor.swift
@@ -1066,6 +1066,18 @@ open class SyntaxVisitor {
   open func visitPost(_ node: DiscardAssignmentExprSyntax) {
   }
   
+  /// Visiting `DiscardStmtSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: DiscardStmtSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+  
+  /// The function called after visiting `DiscardStmtSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: DiscardStmtSyntax) {
+  }
+  
   /// Visiting `DoStmtSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -1352,18 +1364,6 @@ open class SyntaxVisitor {
   /// The function called after visiting `ForcedValueExprSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: ForcedValueExprSyntax) {
-  }
-  
-  /// Visiting `ForgetStmtSyntax` specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: how should we continue visiting.
-  open func visit(_ node: ForgetStmtSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-  
-  /// The function called after visiting `ForgetStmtSyntax` and its descendents.
-  ///   - node: the node we just finished visiting.
-  open func visitPost(_ node: ForgetStmtSyntax) {
   }
   
   /// Visiting `FunctionCallExprSyntax` specifically.
@@ -4221,6 +4221,17 @@ open class SyntaxVisitor {
   }
   
   /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplDiscardStmtSyntax(_ data: SyntaxData) {
+    let node = DiscardStmtSyntax(data)
+    let needsChildren = (visit(node) == .visitChildren)
+    // Avoid calling into visitChildren if possible.
+    if needsChildren && !node.raw.layoutView!.children.isEmpty {
+      visitChildren(node)
+    }
+    visitPost(node)
+  }
+  
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplDoStmtSyntax(_ data: SyntaxData) {
     let node = DoStmtSyntax(data)
     let needsChildren = (visit(node) == .visitChildren)
@@ -4476,17 +4487,6 @@ open class SyntaxVisitor {
   /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplForcedValueExprSyntax(_ data: SyntaxData) {
     let node = ForcedValueExprSyntax(data)
-    let needsChildren = (visit(node) == .visitChildren)
-    // Avoid calling into visitChildren if possible.
-    if needsChildren && !node.raw.layoutView!.children.isEmpty {
-      visitChildren(node)
-    }
-    visitPost(node)
-  }
-  
-  /// Implementation detail of doVisit(_:_:). Do not call directly.
-  private func visitImplForgetStmtSyntax(_ data: SyntaxData) {
-    let node = ForgetStmtSyntax(data)
     let needsChildren = (visit(node) == .visitChildren)
     // Avoid calling into visitChildren if possible.
     if needsChildren && !node.raw.layoutView!.children.isEmpty {
@@ -6412,6 +6412,8 @@ open class SyntaxVisitor {
       visitImplDifferentiableAttributeArgumentsSyntax(data)
     case .discardAssignmentExpr:
       visitImplDiscardAssignmentExprSyntax(data)
+    case .discardStmt:
+      visitImplDiscardStmtSyntax(data)
     case .doStmt:
       visitImplDoStmtSyntax(data)
     case .documentationAttributeArgument:
@@ -6460,8 +6462,6 @@ open class SyntaxVisitor {
       visitImplForInStmtSyntax(data)
     case .forcedValueExpr:
       visitImplForcedValueExprSyntax(data)
-    case .forgetStmt:
-      visitImplForgetStmtSyntax(data)
     case .functionCallExpr:
       visitImplFunctionCallExprSyntax(data)
     case .functionDecl:

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxNodes.swift
@@ -7088,6 +7088,76 @@ public struct RawDiscardAssignmentExprSyntax: RawExprSyntaxNodeProtocol {
 }
 
 @_spi(RawSyntax)
+public struct RawDiscardStmtSyntax: RawStmtSyntaxNodeProtocol {
+  @_spi(RawSyntax)
+  public var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+  
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .discardStmt
+  }
+  
+  public var raw: RawSyntax
+  
+  init(raw: RawSyntax) {
+    precondition(Self.isKindOf(raw))
+    self.raw = raw
+  }
+  
+  private init(unchecked raw: RawSyntax) {
+    self.raw = raw
+  }
+  
+  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+    guard Self.isKindOf(other.raw) else {
+      return nil
+    }
+    self.init(unchecked: other.raw)
+  }
+  
+  public init(
+      _ unexpectedBeforeDiscardKeyword: RawUnexpectedNodesSyntax? = nil, 
+      discardKeyword: RawTokenSyntax, 
+      _ unexpectedBetweenDiscardKeywordAndExpression: RawUnexpectedNodesSyntax? = nil, 
+      expression: RawExprSyntax, 
+      _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
+      arena: __shared SyntaxArena
+    ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .discardStmt, uninitializedCount: 5, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeDiscardKeyword?.raw
+      layout[1] = discardKeyword.raw
+      layout[2] = unexpectedBetweenDiscardKeywordAndExpression?.raw
+      layout[3] = expression.raw
+      layout[4] = unexpectedAfterExpression?.raw
+    }
+    self.init(unchecked: raw)
+  }
+  
+  public var unexpectedBeforeDiscardKeyword: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var discardKeyword: RawTokenSyntax {
+    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  
+  public var unexpectedBetweenDiscardKeywordAndExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  
+  public var expression: RawExprSyntax {
+    layoutView.children[3].map(RawExprSyntax.init(raw:))!
+  }
+  
+  public var unexpectedAfterExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+}
+
+@_spi(RawSyntax)
 public struct RawDoStmtSyntax: RawStmtSyntaxNodeProtocol {
   @_spi(RawSyntax)
   public var layoutView: RawSyntaxLayoutView {
@@ -9105,76 +9175,6 @@ public struct RawForcedValueExprSyntax: RawExprSyntaxNodeProtocol {
   }
   
   public var unexpectedAfterExclamationMark: RawUnexpectedNodesSyntax? {
-    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-}
-
-@_spi(RawSyntax)
-public struct RawForgetStmtSyntax: RawStmtSyntaxNodeProtocol {
-  @_spi(RawSyntax)
-  public var layoutView: RawSyntaxLayoutView {
-    return raw.layoutView!
-  }
-  
-  public static func isKindOf(_ raw: RawSyntax) -> Bool {
-    return raw.kind == .forgetStmt
-  }
-  
-  public var raw: RawSyntax
-  
-  init(raw: RawSyntax) {
-    precondition(Self.isKindOf(raw))
-    self.raw = raw
-  }
-  
-  private init(unchecked raw: RawSyntax) {
-    self.raw = raw
-  }
-  
-  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
-    guard Self.isKindOf(other.raw) else {
-      return nil
-    }
-    self.init(unchecked: other.raw)
-  }
-  
-  public init(
-      _ unexpectedBeforeForgetKeyword: RawUnexpectedNodesSyntax? = nil, 
-      forgetKeyword: RawTokenSyntax, 
-      _ unexpectedBetweenForgetKeywordAndExpression: RawUnexpectedNodesSyntax? = nil, 
-      expression: RawExprSyntax, 
-      _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil, 
-      arena: __shared SyntaxArena
-    ) {
-    let raw = RawSyntax.makeLayout(
-      kind: .forgetStmt, uninitializedCount: 5, arena: arena) { layout in
-      layout.initialize(repeating: nil)
-      layout[0] = unexpectedBeforeForgetKeyword?.raw
-      layout[1] = forgetKeyword.raw
-      layout[2] = unexpectedBetweenForgetKeywordAndExpression?.raw
-      layout[3] = expression.raw
-      layout[4] = unexpectedAfterExpression?.raw
-    }
-    self.init(unchecked: raw)
-  }
-  
-  public var unexpectedBeforeForgetKeyword: RawUnexpectedNodesSyntax? {
-    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  
-  public var forgetKeyword: RawTokenSyntax {
-    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
-  }
-  
-  public var unexpectedBetweenForgetKeywordAndExpression: RawUnexpectedNodesSyntax? {
-    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
-  
-  public var expression: RawExprSyntax {
-    layoutView.children[3].map(RawExprSyntax.init(raw:))!
-  }
-  
-  public var unexpectedAfterExpression: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
@@ -18262,7 +18262,7 @@ public struct RawStmtSyntax: RawStmtSyntaxNodeProtocol {
   
   public static func isKindOf(_ raw: RawSyntax) -> Bool {
     switch raw.kind {
-    case .breakStmt, .continueStmt, .deferStmt, .doStmt, .expressionStmt, .fallthroughStmt, .forInStmt, .forgetStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatWhileStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
+    case .breakStmt, .continueStmt, .deferStmt, .discardStmt, .doStmt, .expressionStmt, .fallthroughStmt, .forInStmt, .guardStmt, .labeledStmt, .missingStmt, .repeatWhileStmt, .returnStmt, .throwStmt, .whileStmt, .yieldStmt:
       return true
     default:
       return false

--- a/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/generated/raw/RawSyntaxValidation.swift
@@ -993,6 +993,13 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.wildcard)]))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
+  case .discardStmt:
+    assert(layout.count == 5)
+    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.keyword("_forget"), .keyword("discard")]))
+    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
+    assertNoError(kind, 3, verify(layout[3], as: RawExprSyntax.self))
+    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
   case .doStmt:
     assert(layout.count == 7)
     assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
@@ -1208,13 +1215,6 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assertNoError(kind, 1, verify(layout[1], as: RawExprSyntax.self))
     assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
     assertNoError(kind, 3, verify(layout[3], as: RawTokenSyntax.self, tokenChoices: [.tokenKind(.exclamationMark)]))
-    assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
-  case .forgetStmt:
-    assert(layout.count == 5)
-    assertNoError(kind, 0, verify(layout[0], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 1, verify(layout[1], as: RawTokenSyntax.self, tokenChoices: [.keyword("_forget")]))
-    assertNoError(kind, 2, verify(layout[2], as: RawUnexpectedNodesSyntax?.self))
-    assertNoError(kind, 3, verify(layout[3], as: RawExprSyntax.self))
     assertNoError(kind, 4, verify(layout[4], as: RawUnexpectedNodesSyntax?.self))
   case .functionCallExpr:
     assert(layout.count == 13)

--- a/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/generated/syntaxNodes/SyntaxStmtNodes.swift
@@ -360,6 +360,122 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   }
 }
 
+// MARK: - DiscardStmtSyntax
+
+
+public struct DiscardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+  public let _syntaxNode: Syntax
+  
+  public init?<S: SyntaxProtocol>(_ node: S) {
+    guard node.raw.kind == .discardStmt else {
+      return nil
+    }
+    self._syntaxNode = node._syntaxNode
+  }
+  
+  /// Creates a `DiscardStmtSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    precondition(data.raw.kind == .discardStmt)
+    self._syntaxNode = Syntax(data)
+  }
+  
+  public init<E: ExprSyntaxProtocol>(
+      leadingTrivia: Trivia? = nil,
+      _ unexpectedBeforeDiscardKeyword: UnexpectedNodesSyntax? = nil,
+      discardKeyword: TokenSyntax,
+      _ unexpectedBetweenDiscardKeywordAndExpression: UnexpectedNodesSyntax? = nil,
+      expression: E,
+      _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
+      trailingTrivia: Trivia? = nil
+    
+  ) {
+    // Extend the lifetime of all parameters so their arenas don't get destroyed
+    // before they can be added as children of the new arena.
+    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (
+            unexpectedBeforeDiscardKeyword, 
+            discardKeyword, 
+            unexpectedBetweenDiscardKeywordAndExpression, 
+            expression, 
+            unexpectedAfterExpression
+          ))) {(arena, _) in
+      let layout: [RawSyntax?] = [
+          unexpectedBeforeDiscardKeyword?.raw, 
+          discardKeyword.raw, 
+          unexpectedBetweenDiscardKeywordAndExpression?.raw, 
+          expression.raw, 
+          unexpectedAfterExpression?.raw
+        ]
+      let raw = RawSyntax.makeLayout(
+        kind: SyntaxKind.discardStmt,
+        from: layout,
+        arena: arena,
+        leadingTrivia: leadingTrivia,
+        trailingTrivia: trailingTrivia
+        
+      )
+      return SyntaxData.forRoot(raw)
+    }
+    self.init(data)
+  }
+  
+  public var unexpectedBeforeDiscardKeyword: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = DiscardStmtSyntax(data.replacingChild(at: 0, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var discardKeyword: TokenSyntax {
+    get {
+      return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)
+    }
+    set(value) {
+      self = DiscardStmtSyntax(data.replacingChild(at: 1, with: value.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var unexpectedBetweenDiscardKeywordAndExpression: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 2, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = DiscardStmtSyntax(data.replacingChild(at: 2, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var expression: ExprSyntax {
+    get {
+      return ExprSyntax(data.child(at: 3, parent: Syntax(self))!)
+    }
+    set(value) {
+      self = DiscardStmtSyntax(data.replacingChild(at: 3, with: value.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
+    get {
+      return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
+    }
+    set(value) {
+      self = DiscardStmtSyntax(data.replacingChild(at: 4, with: value?.raw, arena: SyntaxArena()))
+    }
+  }
+  
+  public static var structure: SyntaxNodeStructure {
+    return .layout([
+          \Self.unexpectedBeforeDiscardKeyword, 
+          \Self.discardKeyword, 
+          \Self.unexpectedBetweenDiscardKeywordAndExpression, 
+          \Self.expression, 
+          \Self.unexpectedAfterExpression
+        ])
+  }
+}
+
 // MARK: - DoStmtSyntax
 
 
@@ -997,122 +1113,6 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
           \Self.unexpectedBetweenWhereClauseAndBody, 
           \Self.body, 
           \Self.unexpectedAfterBody
-        ])
-  }
-}
-
-// MARK: - ForgetStmtSyntax
-
-
-public struct ForgetStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  public let _syntaxNode: Syntax
-  
-  public init?<S: SyntaxProtocol>(_ node: S) {
-    guard node.raw.kind == .forgetStmt else {
-      return nil
-    }
-    self._syntaxNode = node._syntaxNode
-  }
-  
-  /// Creates a `ForgetStmtSyntax` node from the given `SyntaxData`. This assumes
-  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
-  /// is undefined.
-  internal init(_ data: SyntaxData) {
-    precondition(data.raw.kind == .forgetStmt)
-    self._syntaxNode = Syntax(data)
-  }
-  
-  public init<E: ExprSyntaxProtocol>(
-      leadingTrivia: Trivia? = nil,
-      _ unexpectedBeforeForgetKeyword: UnexpectedNodesSyntax? = nil,
-      forgetKeyword: TokenSyntax = .keyword(._forget),
-      _ unexpectedBetweenForgetKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-      expression: E,
-      _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil,
-      trailingTrivia: Trivia? = nil
-    
-  ) {
-    // Extend the lifetime of all parameters so their arenas don't get destroyed
-    // before they can be added as children of the new arena.
-    let data: SyntaxData = withExtendedLifetime((SyntaxArena(), (
-            unexpectedBeforeForgetKeyword, 
-            forgetKeyword, 
-            unexpectedBetweenForgetKeywordAndExpression, 
-            expression, 
-            unexpectedAfterExpression
-          ))) {(arena, _) in
-      let layout: [RawSyntax?] = [
-          unexpectedBeforeForgetKeyword?.raw, 
-          forgetKeyword.raw, 
-          unexpectedBetweenForgetKeywordAndExpression?.raw, 
-          expression.raw, 
-          unexpectedAfterExpression?.raw
-        ]
-      let raw = RawSyntax.makeLayout(
-        kind: SyntaxKind.forgetStmt,
-        from: layout,
-        arena: arena,
-        leadingTrivia: leadingTrivia,
-        trailingTrivia: trailingTrivia
-        
-      )
-      return SyntaxData.forRoot(raw)
-    }
-    self.init(data)
-  }
-  
-  public var unexpectedBeforeForgetKeyword: UnexpectedNodesSyntax? {
-    get {
-      return data.child(at: 0, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
-    }
-    set(value) {
-      self = ForgetStmtSyntax(data.replacingChild(at: 0, with: value?.raw, arena: SyntaxArena()))
-    }
-  }
-  
-  public var forgetKeyword: TokenSyntax {
-    get {
-      return TokenSyntax(data.child(at: 1, parent: Syntax(self))!)
-    }
-    set(value) {
-      self = ForgetStmtSyntax(data.replacingChild(at: 1, with: value.raw, arena: SyntaxArena()))
-    }
-  }
-  
-  public var unexpectedBetweenForgetKeywordAndExpression: UnexpectedNodesSyntax? {
-    get {
-      return data.child(at: 2, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
-    }
-    set(value) {
-      self = ForgetStmtSyntax(data.replacingChild(at: 2, with: value?.raw, arena: SyntaxArena()))
-    }
-  }
-  
-  public var expression: ExprSyntax {
-    get {
-      return ExprSyntax(data.child(at: 3, parent: Syntax(self))!)
-    }
-    set(value) {
-      self = ForgetStmtSyntax(data.replacingChild(at: 3, with: value.raw, arena: SyntaxArena()))
-    }
-  }
-  
-  public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
-    get {
-      return data.child(at: 4, parent: Syntax(self)).map(UnexpectedNodesSyntax.init)
-    }
-    set(value) {
-      self = ForgetStmtSyntax(data.replacingChild(at: 4, with: value?.raw, arena: SyntaxArena()))
-    }
-  }
-  
-  public static var structure: SyntaxNodeStructure {
-    return .layout([
-          \Self.unexpectedBeforeForgetKeyword, 
-          \Self.forgetKeyword, 
-          \Self.unexpectedBetweenForgetKeywordAndExpression, 
-          \Self.expression, 
-          \Self.unexpectedAfterExpression
         ])
   }
 }

--- a/Tests/SwiftParserTest/StatementTests.swift
+++ b/Tests/SwiftParserTest/StatementTests.swift
@@ -590,13 +590,15 @@ final class StatementTests: XCTestCase {
     )
   }
 
-  func testForget() {
+  func testDiscard() {
+    // ensure the old spelling '_forget' can be parsed for now.
     assertParse(
       """
       _forget self
       """,
       substructure: Syntax(
-        ForgetStmtSyntax(
+        DiscardStmtSyntax(
+          discardKeyword: .keyword(._forget),
           expression: IdentifierExprSyntax(identifier: .keyword(.`self`))
         )
       )
@@ -604,10 +606,23 @@ final class StatementTests: XCTestCase {
 
     assertParse(
       """
-      _forget Self
+      discard self
       """,
       substructure: Syntax(
-        ForgetStmtSyntax(
+        DiscardStmtSyntax(
+          discardKeyword: .keyword(.discard),
+          expression: IdentifierExprSyntax(identifier: .keyword(.`self`))
+        )
+      )
+    )
+
+    assertParse(
+      """
+      discard Self
+      """,
+      substructure: Syntax(
+        DiscardStmtSyntax(
+          discardKeyword: .keyword(.discard),
           expression: IdentifierExprSyntax(identifier: .keyword(.Self))
         )
       )
@@ -615,10 +630,11 @@ final class StatementTests: XCTestCase {
 
     assertParse(
       """
-      _forget SarahMarshall
+      discard SarahMarshall
       """,
       substructure: Syntax(
-        ForgetStmtSyntax(
+        DiscardStmtSyntax(
+          discardKeyword: .keyword(.discard),
           expression: IdentifierExprSyntax(identifier: .identifier("SarahMarshall"))
         )
       )
@@ -626,30 +642,30 @@ final class StatementTests: XCTestCase {
 
     assertParse(
       """
-      _forget 1️⃣case
+      discard 1️⃣case
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected expression in 'forget' statement", fixIts: ["insert expression"]),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected expression in 'discard' statement", fixIts: ["insert expression"]),
         DiagnosticSpec(locationMarker: "1️⃣", message: "'case' can only appear inside a 'switch' statement or 'enum' declaration"),
       ],
       fixedSource: """
-        _forget <#expression#>case
+        discard <#expression#>case
         """
     )
 
-    // It's important that we don't parse this one as a forget statement!
+    // It's important that we don't parse this one as a discard statement!
     assertParse(
       """
-      func _forget<T>(_ t: T) {}
+      func discard<T>(_ t: T) {}
 
       func caller() {
-        _forget(self)
+        discard(self)
       }
       """,
       substructure: Syntax(
         FunctionCallExprSyntax(
           callee: IdentifierExprSyntax(
-            identifier: .identifier("_forget")
+            identifier: .identifier("discard")
           ),
           argumentList: {
             TupleExprElementListSyntax([


### PR DESCRIPTION
SE-390 concluded with choosing the keyword `discard` rather than `forget`. This commit begins the process of deprecating the old keyword on the swift-syntax side.

rdar://108859077